### PR TITLE
Add Zoom connector to ingest meeting transcripts

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -411,6 +411,7 @@ async def get_available_integrations() -> AvailableIntegrationsResponse:
             {"id": "microsoft_calendar", "name": "Microsoft Calendar", "description": "Outlook calendar events and meetings"},
             {"id": "microsoft_mail", "name": "Microsoft Mail", "description": "Outlook emails and communications"},
             {"id": "salesforce", "name": "Salesforce", "description": "CRM - Opportunities, Accounts"},
+            {"id": "zoom", "name": "Zoom", "description": "Meeting recordings and transcripts"},
         ]
     )
 
@@ -1046,6 +1047,7 @@ async def run_initial_sync(organization_id: str, provider: str) -> None:
     from connectors.gmail import GmailConnector
     from connectors.microsoft_calendar import MicrosoftCalendarConnector
     from connectors.microsoft_mail import MicrosoftMailConnector
+    from connectors.zoom import ZoomConnector
 
     connectors = {
         "hubspot": HubSpotConnector,
@@ -1055,6 +1057,7 @@ async def run_initial_sync(organization_id: str, provider: str) -> None:
         "gmail": GmailConnector,
         "microsoft_calendar": MicrosoftCalendarConnector,
         "microsoft_mail": MicrosoftMailConnector,
+        "zoom": ZoomConnector,
     }
 
     connector_class = connectors.get(provider)

--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -23,6 +23,7 @@ from connectors.microsoft_calendar import MicrosoftCalendarConnector
 from connectors.microsoft_mail import MicrosoftMailConnector
 from connectors.salesforce import SalesforceConnector
 from connectors.slack import SlackConnector
+from connectors.zoom import ZoomConnector
 from models.database import get_session
 from models.integration import Integration
 from models.organization import Organization
@@ -38,6 +39,7 @@ CONNECTORS = {
     "gmail": GmailConnector,
     "microsoft_calendar": MicrosoftCalendarConnector,
     "microsoft_mail": MicrosoftMailConnector,
+    "zoom": ZoomConnector,
 }
 
 # Simple in-memory sync status tracking (use Redis in production)

--- a/backend/config.py
+++ b/backend/config.py
@@ -41,6 +41,7 @@ class Settings(BaseSettings):
     NANGO_SALESFORCE_INTEGRATION_ID: str = "salesforce"
     NANGO_MICROSOFT_CALENDAR_INTEGRATION_ID: str = "microsoft"
     NANGO_MICROSOFT_MAIL_INTEGRATION_ID: str = "microsoft"
+    NANGO_ZOOM_INTEGRATION_ID: str = "zoom"
 
     # App
     SECRET_KEY: str = "dev-secret-change-in-production"
@@ -72,6 +73,7 @@ NANGO_INTEGRATION_IDS: dict[str, str] = {
     "salesforce": settings.NANGO_SALESFORCE_INTEGRATION_ID,
     "microsoft_calendar": settings.NANGO_MICROSOFT_CALENDAR_INTEGRATION_ID,
     "microsoft_mail": settings.NANGO_MICROSOFT_MAIL_INTEGRATION_ID,
+    "zoom": settings.NANGO_ZOOM_INTEGRATION_ID,
 }
 
 # Provider scope mapping: which integrations are user-scoped vs org-scoped
@@ -85,6 +87,7 @@ PROVIDER_SCOPES: dict[str, str] = {
     "gmail": "user",
     "microsoft_calendar": "user",
     "microsoft_mail": "user",
+    "zoom": "user",
 }
 
 

--- a/backend/connectors/__init__.py
+++ b/backend/connectors/__init__.py
@@ -7,6 +7,7 @@ from connectors.microsoft_calendar import MicrosoftCalendarConnector
 from connectors.microsoft_mail import MicrosoftMailConnector
 from connectors.salesforce import SalesforceConnector
 from connectors.slack import SlackConnector
+from connectors.zoom import ZoomConnector
 
 __all__ = [
     "BaseConnector",
@@ -17,4 +18,5 @@ __all__ = [
     "MicrosoftMailConnector",
     "SalesforceConnector",
     "SlackConnector",
+    "ZoomConnector",
 ]

--- a/backend/connectors/zoom.py
+++ b/backend/connectors/zoom.py
@@ -1,0 +1,296 @@
+"""
+Zoom connector implementation.
+
+Responsibilities:
+- Authenticate with Zoom using OAuth token
+- Fetch cloud recordings and meeting transcripts
+- Normalize Zoom transcript data to activity records
+- Handle pagination and transcript cleanup
+"""
+
+import logging
+import re
+import uuid
+from datetime import datetime, timedelta
+from typing import Any, Optional
+
+import httpx
+
+from connectors.base import BaseConnector
+from models.activity import Activity
+from models.database import get_session
+
+ZOOM_API_BASE = "https://api.zoom.us/v2"
+TRANSCRIPT_FILE_TYPES = {"TRANSCRIPT", "CC"}
+TRANSCRIPT_FILE_EXTENSIONS = {"vtt", "txt"}
+MAX_TRANSCRIPT_LENGTH = 10000
+
+logger = logging.getLogger(__name__)
+
+
+class ZoomConnector(BaseConnector):
+    """Connector for Zoom meeting transcripts."""
+
+    source_system = "zoom"
+
+    async def _get_headers(self) -> dict[str, str]:
+        """Get authorization headers for Zoom API."""
+        token, _ = await self.get_oauth_token()
+        return {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+    async def _make_request(
+        self,
+        method: str,
+        endpoint: str,
+        params: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        """Make an authenticated request to Zoom API."""
+        headers = await self._get_headers()
+        url = f"{ZOOM_API_BASE}{endpoint}"
+
+        logger.debug("Zoom API request: %s %s params=%s", method, url, params)
+
+        async with httpx.AsyncClient() as client:
+            response = await client.request(
+                method=method,
+                url=url,
+                headers=headers,
+                params=params,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            return response.json()
+
+    async def get_recordings(
+        self,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[dict[str, Any]]:
+        """Get cloud recordings for the authenticated user."""
+        recordings: list[dict[str, Any]] = []
+        next_page_token: Optional[str] = None
+
+        logger.info(
+            "Fetching Zoom recordings from %s to %s",
+            start_date.date(),
+            end_date.date(),
+        )
+
+        while True:
+            params: dict[str, Any] = {
+                "from": start_date.strftime("%Y-%m-%d"),
+                "to": end_date.strftime("%Y-%m-%d"),
+                "page_size": 300,
+                "trash": False,
+            }
+            if next_page_token:
+                params["next_page_token"] = next_page_token
+
+            data = await self._make_request("GET", "/users/me/recordings", params=params)
+            meetings = data.get("meetings", [])
+            recordings.extend(meetings)
+            logger.debug(
+                "Zoom recordings page fetched: %s meetings (total=%s)",
+                len(meetings),
+                len(recordings),
+            )
+
+            next_page_token = data.get("next_page_token")
+            if not next_page_token:
+                break
+
+        logger.info("Fetched %s Zoom meetings with recordings", len(recordings))
+        return recordings
+
+    async def _download_transcript(self, download_url: str) -> Optional[str]:
+        """Download transcript text using the OAuth token."""
+        token, _ = await self.get_oauth_token()
+
+        if not download_url:
+            return None
+
+        url = download_url
+        if "access_token=" not in url:
+            separator = "&" if "?" in url else "?"
+            url = f"{url}{separator}access_token={token}"
+
+        logger.debug("Downloading Zoom transcript from %s", url)
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, timeout=30.0, follow_redirects=True)
+            if response.status_code >= 400:
+                logger.warning(
+                    "Failed to download Zoom transcript (status=%s)",
+                    response.status_code,
+                )
+                return None
+
+            transcript_text = response.text.strip()
+            if not transcript_text:
+                return None
+
+            return self._clean_transcript(transcript_text)
+
+    def _clean_transcript(self, transcript_text: str) -> str:
+        """Clean VTT/SRT transcript text into readable plain text."""
+        lines = transcript_text.splitlines()
+        cleaned_lines: list[str] = []
+        timestamp_pattern = re.compile(r"^\d{2}:\d{2}:\d{2}\.\d{3}\s+-->\s+")
+
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped.upper() == "WEBVTT":
+                continue
+            if timestamp_pattern.match(stripped):
+                continue
+            if stripped.isdigit():
+                continue
+            cleaned_lines.append(stripped)
+
+        return " ".join(cleaned_lines)
+
+    def _parse_zoom_datetime(self, value: Optional[str]) -> Optional[datetime]:
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            return None
+
+    def _is_transcript_file(self, recording_file: dict[str, Any]) -> bool:
+        file_type = (recording_file.get("file_type") or "").upper()
+        file_extension = (recording_file.get("file_extension") or "").lower()
+        return file_type in TRANSCRIPT_FILE_TYPES or file_extension in TRANSCRIPT_FILE_EXTENSIONS
+
+    def _normalize_transcript(
+        self,
+        meeting: dict[str, Any],
+        recording_file: dict[str, Any],
+        transcript_text: str,
+    ) -> Activity:
+        """Transform Zoom transcript to our Activity model."""
+        meeting_id = str(meeting.get("id", ""))
+        meeting_uuid = meeting.get("uuid")
+        topic = meeting.get("topic") or "Zoom Meeting"
+
+        activity_date = self._parse_zoom_datetime(
+            recording_file.get("recording_start")
+        ) or self._parse_zoom_datetime(meeting.get("start_time"))
+
+        transcript_length = len(transcript_text)
+        truncated_text = transcript_text[:MAX_TRANSCRIPT_LENGTH]
+
+        source_id = f"{meeting_id}:{recording_file.get('id', '')}"
+
+        return Activity(
+            id=uuid.uuid4(),
+            organization_id=uuid.UUID(self.organization_id),
+            source_system=self.source_system,
+            source_id=source_id,
+            type="zoom_transcript",
+            subject=topic,
+            description=truncated_text,
+            activity_date=activity_date,
+            custom_fields={
+                "meeting_id": meeting_id,
+                "meeting_uuid": meeting_uuid,
+                "host_id": meeting.get("host_id"),
+                "topic": topic,
+                "duration_minutes": meeting.get("duration"),
+                "recording_file_id": recording_file.get("id"),
+                "recording_start": recording_file.get("recording_start"),
+                "recording_end": recording_file.get("recording_end"),
+                "file_type": recording_file.get("file_type"),
+                "file_extension": recording_file.get("file_extension"),
+                "transcript_length": transcript_length,
+                "transcript_truncated": transcript_length > MAX_TRANSCRIPT_LENGTH,
+            },
+        )
+
+    async def sync_deals(self) -> int:
+        """Zoom doesn't have deals - return 0."""
+        return 0
+
+    async def sync_accounts(self) -> int:
+        """Zoom doesn't have accounts - return 0."""
+        return 0
+
+    async def sync_contacts(self) -> int:
+        """Zoom doesn't have contacts - return 0."""
+        return 0
+
+    async def sync_activities(self) -> int:
+        """Sync Zoom meeting transcripts as activities."""
+        end_date = datetime.utcnow()
+        start_date = end_date - timedelta(days=30)
+
+        recordings = await self.get_recordings(start_date=start_date, end_date=end_date)
+        if not recordings:
+            logger.info("No Zoom recordings found for transcript sync")
+            return 0
+
+        count = 0
+        async with get_session() as session:
+            for meeting in recordings:
+                recording_files = meeting.get("recording_files", [])
+                transcript_files = [
+                    recording_file
+                    for recording_file in recording_files
+                    if self._is_transcript_file(recording_file)
+                ]
+
+                if not transcript_files:
+                    logger.debug(
+                        "No transcript files for meeting %s",
+                        meeting.get("id"),
+                    )
+                    continue
+
+                logger.info(
+                    "Processing %s transcript file(s) for meeting %s",
+                    len(transcript_files),
+                    meeting.get("id"),
+                )
+
+                for recording_file in transcript_files:
+                    transcript_text = await self._download_transcript(
+                        recording_file.get("download_url", "")
+                    )
+                    if not transcript_text:
+                        logger.warning(
+                            "Transcript download failed for meeting %s file %s",
+                            meeting.get("id"),
+                            recording_file.get("id"),
+                        )
+                        continue
+
+                    activity = self._normalize_transcript(
+                        meeting, recording_file, transcript_text
+                    )
+                    await session.merge(activity)
+                    count += 1
+
+            await session.commit()
+
+        logger.info("Zoom transcript sync complete: %s activity records", count)
+        return count
+
+    async def sync_all(self) -> dict[str, int]:
+        """Run all sync operations."""
+        activities_count = await self.sync_activities()
+
+        return {
+            "accounts": 0,
+            "deals": 0,
+            "contacts": 0,
+            "activities": activities_count,
+        }
+
+    async def fetch_deal(self, deal_id: str) -> dict[str, Any]:
+        """Zoom doesn't have deals."""
+        return {"error": "Zoom does not support deals"}

--- a/env.example
+++ b/env.example
@@ -24,6 +24,7 @@ NANGO_PUBLIC_KEY=your_nango_public_key
 # NANGO_SLACK_INTEGRATION_ID=slack
 # NANGO_GOOGLE_CALENDAR_INTEGRATION_ID=google-calendar
 # NANGO_SALESFORCE_INTEGRATION_ID=salesforce
+# NANGO_ZOOM_INTEGRATION_ID=zoom
 
 # App
 SECRET_KEY=your_secret_key_for_sessions_change_this_in_production

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -15,6 +15,7 @@ import {
   SiSalesforce,
   SiHubspot,
   SiSlack,
+  SiZoom,
   SiGooglecalendar,
   SiGmail,
 } from 'react-icons/si';
@@ -27,6 +28,7 @@ const ICON_MAP: Record<string, IconType> = {
   hubspot: SiHubspot,
   salesforce: SiSalesforce,
   slack: SiSlack,
+  zoom: SiZoom,
   'google-calendar': SiGooglecalendar,
   google_calendar: SiGooglecalendar,
   gmail: SiGmail,

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -194,6 +194,15 @@ const AVAILABLE_INTEGRATIONS: IntegrationConfig[] = [
     scope: "organization",
   },
   {
+    id: "zoom",
+    provider: "zoom",
+    name: "Zoom",
+    description: "Meeting recordings and transcripts",
+    icon: "zoom",
+    color: "from-blue-500 to-blue-600",
+    scope: "user",
+  },
+  {
     id: "google-calendar",
     provider: "google_calendar",
     name: "Google Calendar",


### PR DESCRIPTION
### Motivation
- Add a Zoom data source to ingest cloud recordings and meeting transcripts and normalize them into Activity records similar to the existing Slack/Calendar connectors.
- Wire Zoom into the OAuth/Nango flow as a user-scoped integration so meetings/transcripts can be fetched per user.

### Description
- Added `backend/connectors/zoom.py` implementing `ZoomConnector` with recording listing (`get_recordings`), transcript download (`_download_transcript`), transcript cleaning (`_clean_transcript`), normalization to `Activity` (`_normalize_transcript`), and `sync_activities` logic with logging and transcript truncation.
- Registered `ZoomConnector` in `backend/connectors/__init__.py`, added it to the sync registry in `backend/api/routes/sync.py`, and included it in the background initial-sync helper and available integrations in `backend/api/routes/auth.py`.
- Added Nango mapping and provider scope for Zoom in `backend/config.py` and documented the `NANGO_ZOOM_INTEGRATION_ID` override in `env.example`.
- Exposed Zoom in the frontend integration list and icon map by updating `frontend/src/store/index.ts` and `frontend/src/components/DataSources.tsx` (imports and `ICON_MAP`).

### Testing
- Ran `npm install` in `frontend/` which completed successfully with package audit warnings only; the frontend dependencies installed fine.
- Started the frontend dev server with `npm run dev -- --host 0.0.0.0 --port 4173` which started Vite successfully and served the app.
- Executed a Playwright script to load the frontend and capture a screenshot of the Data Sources UI, which produced an artifact confirming the Zoom integration appears in the UI.
- No backend unit or integration tests were run; backend changes have not been exercised against a running API/Nango instance in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69757a72d26c83219e3354c4d2d81da9)