### PR TITLE
Expose healthcheck at backend root

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -120,9 +120,17 @@ async def shutdown() -> None:
     logging.info("Database connections closed")
 
 
+@app.get("/")
+async def root_health_check() -> dict[str, str]:
+    """Root endpoint exposing the health check payload."""
+    logging.info("Root health check requested")
+    return await health_check()
+
+
 @app.get("/health")
 async def health_check() -> dict[str, str]:
     """Health check endpoint."""
+    logging.info("Health check requested")
     return {"status": "ok"}
 
 


### PR DESCRIPTION
### Motivation
- Make the backend root (`/`) expose the same health payload as `/health` so simple probes or web checks can use the root URL and provide a consistent health response.

### Description
- Add a new `@app.get("/")` route in `backend/api/main.py` that logs the request and returns the result of `health_check()`, and add a log line to the existing `@app.get("/health")` handler.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69799cf66c148321960384190c458dc7)