### PR TITLE
Add ESLint configuration for frontend

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,28 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2020: true,
+  },
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  plugins: ["@typescript-eslint", "react-hooks", "react-refresh"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
+  ],
+  rules: {
+    "react-refresh/only-export-components": [
+      "warn",
+      { allowConstantExport: true },
+    ],
+  },
+  ignorePatterns: ["dist", "node_modules"],
+};


### PR DESCRIPTION
### Motivation
- Fix the ESLint runtime error where ESLint could not find a configuration file for the frontend by adding a local config so linting can run with TypeScript and React settings.

### Description
- Add `frontend/.eslintrc.cjs` containing `@typescript-eslint` parser, `react-hooks` and `react-refresh` plugins, recommended extends, and basic rules/ignore patterns to enable linting for `.ts`/`.tsx` files.

### Testing
- No automated tests were run for this change and `npm run lint` was not executed as part of this update; please run `npm run lint` locally or in CI to validate the configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cfd3bdd548321838f392216259229)