### PR TITLE
Fix hook dependency warnings and unused-variable lint errors

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -9,7 +9,7 @@
  * - Artifact viewer for dashboards/reports
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Message } from './Message';
@@ -62,7 +62,6 @@ interface CrmApprovalState {
 
 export function Chat({ 
   userId, 
-  organizationId: _organizationId, 
   chatId, 
   sendMessage,
   isConnected,
@@ -105,7 +104,10 @@ export function Chat({
   pendingMessagesRef.current = pendingMessages;
 
   // Combined messages and thinking state (conversation + pending for new chats)
-  const messages = pendingMessages.length > 0 ? [...pendingMessages, ...conversationMessages] : conversationMessages;
+  const messages = useMemo(
+    () => (pendingMessages.length > 0 ? [...pendingMessages, ...conversationMessages] : conversationMessages),
+    [pendingMessages, conversationMessages]
+  );
   const isThinking = pendingThinking || conversationThinking;
 
   // Handle CRM approval
@@ -736,7 +738,6 @@ function MessageWithBlocks({
                 <AssistantTextBlock 
                   text={block.text} 
                   isStreaming={isLast && message.isStreaming}
-                  onArtifactClick={onArtifactClick}
                 />
               </div>
             );
@@ -768,11 +769,9 @@ function MessageWithBlocks({
 function AssistantTextBlock({
   text,
   isStreaming,
-  onArtifactClick: _onArtifactClick,
 }: {
   text: string;
   isStreaming?: boolean;
-  onArtifactClick?: (artifact: { id: string; type: string; title: string; data: Record<string, unknown> }) => void;
 }): JSX.Element {
   return (
     <div className="inline-block px-3 py-2 rounded-xl rounded-tl-sm bg-surface-800/80 text-surface-200 text-[13px] leading-relaxed">

--- a/frontend/src/components/OAuthCallback.tsx
+++ b/frontend/src/components/OAuthCallback.tsx
@@ -16,6 +16,9 @@ export function OAuthCallback(): JSX.Element {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (state !== 'processing') {
+      return;
+    }
     const handleCallback = async (): Promise<void> => {
       try {
         // Check URL for error params (OAuth errors)
@@ -76,7 +79,7 @@ export function OAuthCallback(): JSX.Element {
     };
 
     void handleCallback();
-  }, []);
+  }, [state]);
 
   return (
     <div className="min-h-screen flex items-center justify-center p-4">

--- a/frontend/src/components/SheetImporter.tsx
+++ b/frontend/src/components/SheetImporter.tsx
@@ -8,7 +8,7 @@
  * 4. Execute import and show results
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { SiGooglesheets } from 'react-icons/si';
 import { HiChevronLeft, HiChevronRight, HiCheck, HiX, HiRefresh, HiExclamation, HiInformationCircle } from 'react-icons/hi';
 import { API_BASE } from '../lib/api';
@@ -80,14 +80,7 @@ export function SheetImporter({ onClose }: SheetImporterProps): JSX.Element {
   const organizationId = organization?.id ?? '';
   const userId = user?.id ?? '';
 
-  // Load spreadsheets on mount
-  useEffect(() => {
-    if (step === 'select' && spreadsheets.length === 0) {
-      void loadSpreadsheets();
-    }
-  }, [step]);
-
-  const loadSpreadsheets = async (): Promise<void> => {
+  const loadSpreadsheets = useCallback(async (): Promise<void> => {
     setLoading(true);
     setError(null);
 
@@ -108,7 +101,14 @@ export function SheetImporter({ onClose }: SheetImporterProps): JSX.Element {
     } finally {
       setLoading(false);
     }
-  };
+  }, [organizationId, userId]);
+
+  // Load spreadsheets on mount
+  useEffect(() => {
+    if (step === 'select' && spreadsheets.length === 0) {
+      void loadSpreadsheets();
+    }
+  }, [step, loadSpreadsheets, spreadsheets.length]);
 
   const loadPreview = async (spreadsheetId: string): Promise<void> => {
     setLoading(true);

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -383,7 +383,8 @@ export const useAppStore = create<AppState>()(
         const shouldClearChat = currentChatId === id || conversationId === id;
         
         // Remove from conversations state
-        const { [id]: _, ...remainingConversations } = conversations;
+        const remainingConversations = { ...conversations };
+        delete remainingConversations[id];
 
         set({
           recentChats: updated,
@@ -590,8 +591,10 @@ export const useAppStore = create<AppState>()(
 
       clearConversation: (conversationId) => {
         const { conversations, activeTasksByConversation } = get();
-        const { [conversationId]: _, ...remaining } = conversations;
-        const { [conversationId]: __, ...remainingTasks } = activeTasksByConversation;
+        const remaining = { ...conversations };
+        delete remaining[conversationId];
+        const remainingTasks = { ...activeTasksByConversation };
+        delete remainingTasks[conversationId];
         set({
           conversations: remaining,
           activeTasksByConversation: remainingTasks,


### PR DESCRIPTION
### Motivation
- Fix ESLint/TypeScript lint errors about unused variables and React Hook dependency warnings found in chat, sheet importer, OAuth, and store code.
- Stabilize hook dependencies to avoid effects running on every render and to remove transient values from dependency lists.

### Description
- Guarded the OAuth callback effect by returning early when `state !== 'processing'` and added `state` to the effect dependencies in `frontend/src/components/OAuthCallback.tsx` to satisfy hook rules.
- Wrapped spreadsheet loader in `useCallback` and expanded the effect dependencies to include the memoized loader and `spreadsheets.length` to avoid stale closures in `frontend/src/components/SheetImporter.tsx`.
- Memoized the combined `messages` array with `useMemo`, removed an unused `organizationId` prop alias and dropped an unused `onArtifactClick` parameter from `AssistantTextBlock` to eliminate unused-var warnings and unstable dependencies in `frontend/src/components/Chat.tsx`.
- Replaced unused-object-rest destructuring patterns with explicit copies and `delete` for conversation removal paths in `frontend/src/store/index.ts` to avoid `_`/`__` unused-variable errors.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d0a38e7188321b7f895ebaf5cfbee)