### PR TITLE
Fix hook dependency warnings in AppLayout and Chat components

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -325,7 +325,8 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
   }, [
     setActiveTasks, setConversationActiveTask, setConversationThinking,
     addConversation, addConversationMessage, appendToConversationStreaming,
-    startConversationStreaming, markConversationMessageComplete, updateConversationToolMessage
+    startConversationStreaming, markConversationMessageComplete, updateConversationToolMessage,
+    setCurrentChatId
   ]);
 
   // Global WebSocket connection

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -70,7 +70,6 @@ export function Chat({
 }: ChatProps): JSX.Element {
   // Get per-conversation state from Zustand
   const conversationState = useConversationState(chatId ?? null);
-  const conversationMessages = conversationState?.messages ?? [];
   const chatTitle = conversationState?.title ?? 'New Chat';
   const conversationThinking = conversationState?.isThinking ?? false;
   const activeTaskId = conversationState?.activeTaskId ?? null;
@@ -104,10 +103,12 @@ export function Chat({
   pendingMessagesRef.current = pendingMessages;
 
   // Combined messages and thinking state (conversation + pending for new chats)
-  const messages = useMemo(
-    () => (pendingMessages.length > 0 ? [...pendingMessages, ...conversationMessages] : conversationMessages),
-    [pendingMessages, conversationMessages]
-  );
+  const messages = useMemo(() => {
+    const conversationMessages = conversationState?.messages ?? [];
+    return pendingMessages.length > 0
+      ? [...pendingMessages, ...conversationMessages]
+      : conversationMessages;
+  }, [pendingMessages, conversationState?.messages]);
   const isThinking = pendingThinking || conversationThinking;
 
   // Handle CRM approval


### PR DESCRIPTION
### Motivation
- Resolve `react-hooks/exhaustive-deps` warnings to prevent stale closures and ensure WebSocket message handling and memoized message lists remain stable and correct.

### Description
- Add the missing `setCurrentChatId` dependency to the WebSocket message handler hook in `AppLayout` by including `setCurrentChatId` in the hook dependency array (`handleWebSocketMessage`).
- Move derivation of combined conversation messages into the `useMemo` callback in `Chat` and reference `conversationState?.messages` in the dependency list to avoid recreating dependencies every render.
- Keep behavior identical while stabilizing hook dependencies to satisfy the linter and reduce risk of subtle runtime bugs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d0c5a06088321a2def5e4a63003a5)