### PR TITLE
Fix Data Sources header stacking (ensure header sits above connector icons)

### DIFF
--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -623,7 +623,7 @@ export function DataSources(): JSX.Element {
   return (
     <div className="flex-1 overflow-y-auto overflow-x-hidden">
       {/* Header - hidden on mobile since AppLayout has mobile header */}
-      <header className="hidden md:block sticky top-0 bg-surface-950 border-b border-surface-800 px-4 md:px-8 py-4 md:py-6">
+      <header className="hidden md:block sticky top-0 z-20 bg-surface-950 border-b border-surface-800 px-4 md:px-8 py-4 md:py-6">
         <h1 className="text-xl md:text-2xl font-bold text-surface-50">Data Sources</h1>
         <p className="text-surface-400 mt-1 text-sm md:text-base">
           Connect your sales tools to unlock AI-powered insights


### PR DESCRIPTION
### Motivation
- Connector icon graphics were scrolling over the Data Sources page header, so the sticky header needed a higher stacking context to keep icons at the same z-order as the connector names.

### Description
- Added `z-20` to the sticky header class in `frontend/src/components/DataSources.tsx` so the header uses a higher z-index (`<header className="... sticky top-0 z-20 ...">`).

### Testing
- Installed frontend dependencies with `npm install` and started the dev server with `npm run dev`, which reported Vite ready and served the app successfully. 
- Captured a full-page screenshot using a Playwright script which completed and produced `artifacts/data-sources.png`, confirming the header stacking visually; no automated test failures occurred.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d8c4b2d6c8321aa85af4b10b23530)