### PR TITLE
Auto-send pipeline deal questions

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -80,7 +80,9 @@ export function Chat({
   const setConversationTitle = useAppStore((s) => s.setConversationTitle);
   const setConversationThinking = useAppStore((s) => s.setConversationThinking);
   const pendingChatInput = useAppStore((s) => s.pendingChatInput);
+  const pendingChatAutoSend = useAppStore((s) => s.pendingChatAutoSend);
   const setPendingChatInput = useAppStore((s) => s.setPendingChatInput);
+  const setPendingChatAutoSend = useAppStore((s) => s.setPendingChatAutoSend);
   
   // Local state
   const [input, setInput] = useState<string>('');
@@ -217,15 +219,39 @@ export function Chat({
 
   // Consume pending chat input (from Search "Ask about" button)
   useEffect(() => {
-    if (pendingChatInput && chatId === null) {
-      setInput(pendingChatInput);
-      setPendingChatInput(null);
-      // Focus the input so user can see the pre-filled text
-      setTimeout(() => {
-        inputRef.current?.focus();
-      }, 100);
+    if (!pendingChatInput || chatId !== null) {
+      return;
     }
-  }, [pendingChatInput, chatId, setPendingChatInput]);
+
+    if (pendingChatAutoSend) {
+      if (!isConnected) {
+        console.log('[Chat] Waiting to auto-send pending input until connected');
+        return;
+      }
+      console.log('[Chat] Auto-sending pending input');
+      sendChatMessage(pendingChatInput, 'auto');
+      setPendingChatInput(null);
+      setPendingChatAutoSend(false);
+      return;
+    }
+
+    console.log('[Chat] Applying pending input to composer');
+    setInput(pendingChatInput);
+    setPendingChatInput(null);
+    setPendingChatAutoSend(false);
+    // Focus the input so user can see the pre-filled text
+    setTimeout(() => {
+      inputRef.current?.focus();
+    }, 100);
+  }, [
+    pendingChatInput,
+    pendingChatAutoSend,
+    chatId,
+    isConnected,
+    sendChatMessage,
+    setPendingChatInput,
+    setPendingChatAutoSend,
+  ]);
 
   // Load conversation when selecting an existing chat from sidebar
   useEffect(() => {
@@ -317,7 +343,7 @@ export function Chat({
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, isThinking]);
 
-  const sendChatMessage = useCallback((message: string, source: 'input' | 'suggestion'): void => {
+  const sendChatMessage = useCallback((message: string, source: 'input' | 'suggestion' | 'auto'): void => {
     if (!message.trim() || !isConnected) {
       console.log(`[Chat] sendChatMessage blocked (${source}) - empty or not connected`);
       return;

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -57,6 +57,7 @@ export function Home(): JSX.Element {
   const user = useAppStore((state) => state.user);
   const startNewChat = useAppStore((state) => state.startNewChat);
   const setPendingChatInput = useAppStore((state) => state.setPendingChatInput);
+  const setPendingChatAutoSend = useAppStore((state) => state.setPendingChatAutoSend);
   const setCurrentView = useAppStore((state) => state.setCurrentView);
   const [deals, setDeals] = useState<Deal[]>([]);
   const [pipelines, setPipelines] = useState<Pipeline[]>([]);
@@ -162,9 +163,10 @@ export function Home(): JSX.Element {
       pipelineName: deal.pipeline_name,
     });
     setPendingChatInput(question);
+    setPendingChatAutoSend(true);
     startNewChat();
     setCurrentView('chat');
-  }, [setPendingChatInput, setCurrentView, startNewChat]);
+  }, [setPendingChatInput, setPendingChatAutoSend, setCurrentView, startNewChat]);
 
   if (loading) {
     return (

--- a/frontend/src/components/Search.tsx
+++ b/frontend/src/components/Search.tsx
@@ -28,6 +28,7 @@ export function Search({ organizationId }: SearchProps): JSX.Element {
   const setCurrentView = useAppStore((state) => state.setCurrentView);
   const startNewChat = useAppStore((state) => state.startNewChat);
   const setPendingChatInput = useAppStore((state) => state.setPendingChatInput);
+  const setPendingChatAutoSend = useAppStore((state) => state.setPendingChatAutoSend);
 
   // Focus input on mount
   useEffect(() => {
@@ -92,16 +93,18 @@ export function Search({ organizationId }: SearchProps): JSX.Element {
   const handleAskAboutDeal = useCallback((deal: DealSearchResult) => {
     const question = `Tell me about the "${deal.name}" deal${deal.account_name ? ` with ${deal.account_name}` : ''}. What's the current status and any recent activity?`;
     setPendingChatInput(question);
+    setPendingChatAutoSend(false);
     startNewChat();
     setCurrentView('chat');
-  }, [startNewChat, setCurrentView, setPendingChatInput]);
+  }, [startNewChat, setCurrentView, setPendingChatAutoSend, setPendingChatInput]);
 
   const handleAskAboutAccount = useCallback((account: AccountSearchResult) => {
     const question = `Tell me about ${account.name}${account.domain ? ` (${account.domain})` : ''}. What deals do we have with them and what's been happening recently?`;
     setPendingChatInput(question);
+    setPendingChatAutoSend(false);
     startNewChat();
     setCurrentView('chat');
-  }, [startNewChat, setCurrentView, setPendingChatInput]);
+  }, [startNewChat, setCurrentView, setPendingChatAutoSend, setPendingChatInput]);
 
   const formatCurrency = (amount: number | null): string => {
     if (amount === null) return '—';

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -120,6 +120,7 @@ interface AppState {
   currentChatId: string | null;
   recentChats: ChatSummary[];
   pendingChatInput: string | null; // Pre-filled input for new chats
+  pendingChatAutoSend: boolean;
 
   // Per-conversation state (keyed by conversation ID)
   conversations: Record<string, ConversationState>;
@@ -149,6 +150,7 @@ interface AppState {
   setCurrentChatId: (id: string | null) => void;
   startNewChat: () => void;
   setPendingChatInput: (input: string | null) => void;
+  setPendingChatAutoSend: (autoSend: boolean) => void;
 
   // Actions - Conversations
   addConversation: (id: string, title: string) => void;
@@ -218,6 +220,7 @@ export const useAppStore = create<AppState>()(
       currentChatId: null,
       recentChats: [],
       pendingChatInput: null,
+      pendingChatAutoSend: false,
 
       // Per-conversation state
       conversations: {},
@@ -303,6 +306,7 @@ export const useAppStore = create<AppState>()(
       setCurrentChatId: (currentChatId) => set({ currentChatId }),
       startNewChat: () => set({ currentChatId: null, currentView: "chat" }),
       setPendingChatInput: (pendingChatInput) => set({ pendingChatInput }),
+      setPendingChatAutoSend: (pendingChatAutoSend) => set({ pendingChatAutoSend }),
 
       // Conversation actions
       addConversation: (id, title) => {


### PR DESCRIPTION
### Motivation
- Pipeline deal clicks should immediately run the generated question instead of only pre-filling the chat composer. 
- Keep search "Ask about" flows as pre-filled drafts (not auto-sent) to avoid surprising users. 

### Description
- Added a new persistent UI state `pendingChatAutoSend` and setter `setPendingChatAutoSend` in `frontend/src/store/index.ts` to control whether a pending chat input should be auto-sent. 
- Wired pipeline deal clicks in `frontend/src/components/Home.tsx` to set the pending question and enable `pendingChatAutoSend` so selecting a deal triggers an immediate question. 
- Updated `frontend/src/components/Chat.tsx` to consume `pendingChatAutoSend` and either auto-send the pending input (when connected) or prefill the composer when not auto-send; the chat now waits for connection before auto-sending and logs connection-aware events, and `sendChatMessage` accepts a new `'auto'` source. 
- Ensured search flows in `frontend/src/components/Search.tsx` continue to set `pendingChatAutoSend` to `false` so those prompts remain pre-filled and are not auto-sent. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d920b584c8321bfca6073e34fa49b)