### PR TITLE
Add Zoom domain verification meta tag to landing page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="zoom-domain-verification" content="ZOOM_verify_af19c3fe735741f985dd165f66127d9c" />
     <title>Revtops: Your Revenue Copilot</title>
     
     <!-- Open Graph / Social sharing -->


### PR DESCRIPTION
### Motivation
- Verify the revtops.com domain with Zoom by adding the required Zoom verification meta tag to the pre-login landing page.

### Description
- Add the Zoom domain verification meta tag `<meta name="zoom-domain-verification" content="ZOOM_verify_af19c3fe735741f985dd165f66127d9c">` into the `<head>` of `frontend/index.html` so the default/pre-login page serves the verification token.

### Testing
- No automated tests were run for this change because it is a static HTML update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ec47bd6cc83219c2bd8b35546687d)