### PR TITLE
Abort in-progress syncs when integration is disconnected

### DIFF
--- a/backend/tests/test_sync_cancellation.py
+++ b/backend/tests/test_sync_cancellation.py
@@ -1,0 +1,61 @@
+import asyncio
+
+from api.routes import sync as sync_routes
+from connectors.base import SyncCancelledError
+from workers.tasks import sync as sync_tasks
+
+
+class CancelledConnector:
+    def __init__(self, organization_id: str) -> None:
+        self.organization_id = organization_id
+
+    async def sync_all(self) -> dict[str, int]:
+        raise SyncCancelledError("hubspot integration disconnected during sync (sync_all:after_accounts)")
+
+    async def update_last_sync(self, counts: dict[str, int]) -> None:
+        return None
+
+    async def record_error(self, error: str) -> None:
+        return None
+
+
+def test_celery_sync_returns_cancelled_when_connector_disconnects(monkeypatch) -> None:
+    from connectors import hubspot
+
+    monkeypatch.setattr(hubspot, "HubSpotConnector", CancelledConnector)
+
+    result = asyncio.run(sync_tasks._sync_integration("11111111-1111-1111-1111-111111111111", "hubspot"))
+
+    assert result["status"] == "cancelled"
+    assert result["provider"] == "hubspot"
+    assert "disconnected during sync" in result["error"]
+
+
+def test_api_sync_status_marks_cancelled_when_connector_disconnects(monkeypatch) -> None:
+    provider = "test_cancel"
+    org_id = "11111111-1111-1111-1111-111111111111"
+    status_key = f"{org_id}:{provider}"
+
+    monkeypatch.setitem(sync_routes.CONNECTORS, provider, CancelledConnector)
+
+    emitted_events: list[tuple[str, str, dict[str, str]]] = []
+
+    async def _emit_event(event_type: str, organization_id: str, data: dict[str, str]) -> None:
+        emitted_events.append((event_type, organization_id, data))
+
+    monkeypatch.setattr("workers.events.emit_event", _emit_event)
+
+    sync_routes._sync_status[status_key] = {
+        "status": "syncing",
+        "started_at": None,
+        "completed_at": None,
+        "error": None,
+        "counts": None,
+    }
+
+    asyncio.run(sync_routes.sync_integration_data(org_id, provider))
+
+    assert sync_routes._sync_status[status_key]["status"] == "cancelled"
+    assert "disconnected during sync" in str(sync_routes._sync_status[status_key]["error"])
+    assert emitted_events
+    assert emitted_events[0][0] == "sync.cancelled"

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -48,6 +48,7 @@ async def _sync_integration(organization_id: str, provider: str) -> dict[str, An
     from connectors.microsoft_calendar import MicrosoftCalendarConnector
     from connectors.microsoft_mail import MicrosoftMailConnector
     from connectors.salesforce import SalesforceConnector
+    from connectors.base import SyncCancelledError
     from connectors.slack import SlackConnector
     from services.embedding_sync import generate_embeddings_for_organization
     from workers.events import emit_event
@@ -104,6 +105,16 @@ async def _sync_integration(organization_id: str, provider: str) -> dict[str, An
             "organization_id": organization_id,
             "provider": provider,
             "counts": counts,
+        }
+
+    except SyncCancelledError as e:
+        cancel_msg = str(e)
+        logger.info(f"Sync cancelled for {provider} in org {organization_id}: {cancel_msg}")
+        return {
+            "status": "cancelled",
+            "organization_id": organization_id,
+            "provider": provider,
+            "error": cancel_msg,
         }
 
     except Exception as e:


### PR DESCRIPTION
### Motivation
- Disconnecting a connector during an active sync should immediately stop the ongoing sync to avoid partial writes, stale tokens, or confusing status outcomes.
- The existing sync flow treated mid-sync disconnections as generic failures, which made it hard for callers to distinguish a deliberate cancellation from a real error.

### Description
- Add `SyncCancelledError` and `ensure_sync_active(stage)` to `BaseConnector` to re-check the `integrations` row and `is_active` flag during sync phases and raise a cancellation when the integration is removed or deactivated (`backend/connectors/base.py`).
- Call `ensure_sync_active` at the start of `sync_all()` and between each sync phase so in-flight syncs abort promptly if the integration is disconnected (`backend/connectors/base.py`).
- Catch `SyncCancelledError` in the Celery sync task and return a structured `"cancelled"` result instead of treating it as a failure (`backend/workers/tasks/sync.py`).
- Catch `SyncCancelledError` in the API background sync path, mark the in-memory `_sync_status` as `cancelled`, and emit a `sync.cancelled` event for downstream consumers (`backend/api/routes/sync.py`).
- Add regression tests for both the Celery path and API background-sync path that simulate a connector raising `SyncCancelledError` (`backend/tests/test_sync_cancellation.py`).

### Testing
- Ran `pytest backend/tests/test_sync_cancellation.py` without `PYTHONPATH` which failed during collection due to import path issues (module import error), fixed by setting `PYTHONPATH`.
- Ran `PYTHONPATH=backend pytest backend/tests/test_sync_cancellation.py -q` and the new cancellation tests passed (2 passed, 3 warnings).
- Ran `PYTHONPATH=backend pytest backend/tests/test_health.py -q` and the existing health checks passed (3 passed, 5 warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984edaa7ffc8321915df828db25d32b)