### PR TITLE
Improve Slack actor-to-user binding with connected-name fallback

### DIFF
--- a/backend/tests/test_slack_user_resolution.py
+++ b/backend/tests/test_slack_user_resolution.py
@@ -1,0 +1,90 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID
+
+from services import slack_conversations
+
+
+class _FakeScalarResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeExecuteResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return _FakeScalarResult(self._rows)
+
+
+class _FakeSession:
+    def __init__(self, query_results):
+        self._query_results = list(query_results)
+
+    async def execute(self, _query):
+        return _FakeExecuteResult(self._query_results.pop(0))
+
+
+class _FakeAdminSessionContext:
+    def __init__(self, query_results):
+        self._session = _FakeSession(query_results)
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeSlackConnector:
+    def __init__(self, organization_id: str):
+        self.organization_id = organization_id
+
+    async def get_user_info(self, slack_user_id: str):
+        assert slack_user_id == "U123"
+        return {
+            "name": "jane-doe",
+            "real_name": "Jane Doe",
+            "profile": {
+                "email": "",
+                "display_name": "Jane Doe",
+                "real_name": "Jane Doe",
+                "display_name_normalized": "Jane Doe",
+                "real_name_normalized": "Jane Doe",
+            },
+        }
+
+
+def test_resolve_revtops_user_falls_back_to_connected_slack_name_match(monkeypatch):
+    org_id = "11111111-1111-1111-1111-111111111111"
+    jane_id = UUID("22222222-2222-2222-2222-222222222222")
+    john_id = UUID("33333333-3333-3333-3333-333333333333")
+
+    users = [
+        SimpleNamespace(id=john_id, email="john@acme.com", name="John Smith"),
+        SimpleNamespace(id=jane_id, email="other@acme.com", name="  Jane   Doe  "),
+    ]
+    integrations = [
+        SimpleNamespace(user_id=jane_id, connected_by_user_id=None),
+    ]
+
+    monkeypatch.setattr(
+        slack_conversations,
+        "get_admin_session",
+        lambda: _FakeAdminSessionContext([users, integrations]),
+    )
+    monkeypatch.setattr(slack_conversations, "SlackConnector", _FakeSlackConnector)
+
+    resolved = asyncio.run(
+        slack_conversations.resolve_revtops_user_for_slack_actor(
+            organization_id=org_id,
+            slack_user_id="U123",
+        )
+    )
+
+    assert resolved is not None
+    assert resolved.id == jane_id


### PR DESCRIPTION
### Motivation
- Slack DMs and mentions may not expose an email address, so we need a safe fallback to bind a Slack actor to a RevTops user when possible.
- Avoid false-positive name matches by only attempting Slack-name matching for users who have actually connected Slack (either via `Integration.user_id` or `Integration.connected_by_user_id`).
- Improve observability with clearer logging to aid debugging when resolution succeeds or falls back.

### Description
- Implemented staged resolution in `resolve_revtops_user_for_slack_actor` to try `email` matching first and then Slack `name` matching only for users recorded as Slack-connected (in `backend/services/slack_conversations.py`).
- Added `_normalize_name` helper to perform case- and whitespace-normalized comparisons across multiple Slack name fields (`name`, `real_name`, and profile display/real normalized variants).
- Query Slack-related `Integration` rows and build `users_with_connected_slack` from `integration.user_id` and `integration.connected_by_user_id` to restrict name-based matching.
- Added detailed logging of candidate Slack names, counts of connected users, and outcomes; and added a unit test `backend/tests/test_slack_user_resolution.py` that verifies name fallback for a connected user.

### Testing
- Ran `PYTHONPATH=backend pytest -q backend/tests/test_slack_user_resolution.py backend/tests/test_sync_cancellation.py` and the test suite passed (`3 passed`, with warnings only).
- The new unit test verifies that when Slack email is blank, a RevTops user with a normalized name match is resolved only if they are present in the connected-Slack integration records.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984f3a35d84832188242e438f04630f)