### PR TITLE
Fix TypeScript lint failure in streaming chunk buffering

### DIFF
--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -719,7 +719,7 @@ export const useAppStore = create<AppState>()(
             content,
           );
           let newLastIndex = chunkIndex;
-          let newPendingChunks = [...current.pendingChunks];
+          const newPendingChunks = [...current.pendingChunks];
 
           // Apply any buffered chunks that are now in sequence
           newPendingChunks.sort((a, b) => a.index - b.index);


### PR DESCRIPTION
### Motivation
- Resolve an ESLint `prefer-const` violation in the frontend streaming chunk handling to eliminate lint failures during CI/lint runs.

### Description
- Replaced `let newPendingChunks = [...current.pendingChunks];` with `const newPendingChunks = [...current.pendingChunks];` in `frontend/src/store/index.ts` to satisfy the linter while preserving existing behavior (the array is still sorted and mutated).

### Testing
- Ran `cd frontend && npm run lint` and the lint step completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984f5f69f788321940a1478e92c132b)