### PR TITLE
Sync in-progress chat content across browser tabs

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -414,11 +414,14 @@ export function Chat({
 
     console.log(`[Chat] Sending message (${source}):`, message.substring(0, 30) + '...');
 
+    const clientCreatedAt = new Date();
+    const clientMessageId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
     const userMessage: ChatMessage = {
-      id: `user-${Date.now()}`,
+      id: clientMessageId,
       role: 'user',
       contentBlocks: [{ type: 'text', text: message }],
-      timestamp: new Date(),
+      timestamp: clientCreatedAt,
     };
 
     // Get current conversation ID
@@ -436,13 +439,14 @@ export function Chat({
     }
 
     // Send message with conversation context and timezone info
-    const now = new Date();
     sendMessage({
       type: 'send_message',
       message,
       conversation_id: currentConvId,
-      local_time: now.toISOString(),
+      local_time: clientCreatedAt.toISOString(),
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      client_message_id: clientMessageId,
+      client_created_at: clientCreatedAt.toISOString(),
     });
 
     console.log(`[Chat] Sent to WebSocket (${source})`);


### PR DESCRIPTION
### Motivation
- Ensure that when a user sends a message in one browser window, the same content and optimistic UI appear in any other open window for the same chat.
- Keep streaming and backend-driven updates consistent across tabs so conversations remain in sync during long-running tasks.

### Description
- Added cross-tab sync in `AppLayout` using `BroadcastChannel` with typed payloads (`ws_message`, `chat_send`), a per-tab id, and a dedupe set to avoid replaying the same optimistic send twice.
- Replayed backend websocket events to sibling tabs by broadcasting incoming WS messages and invoking the existing `handleWebSocketMessage` to reuse current parsing and state updates.
- Wrapped outgoing sends with `sendChatMessage` which forwards to the WebSocket and broadcasts a `chat_send` payload for optimistic user messages.
- Updated `Chat` to generate a stable `client_message_id` and `client_created_at`, use that for the optimistic message `id`/`timestamp`, and attach them to the `send_message` payload so other tabs can dedupe and render identical content.
- Gracefully logs and disables cross-tab sync if `BroadcastChannel` is not available in the runtime.

### Testing
- Built the frontend with `npm -C frontend run build`, which completed successfully.
- Ran `npm -C frontend run lint`, which failed due to an existing lint issue outside these changes (`frontend/src/store/index.ts` line 722 `prefer-const`).
- Manual runtime checks performed during development to verify optimistic messages and websocket events are applied in sibling tabs when `BroadcastChannel` is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69850e65715883219790ec929710876c)