### PR TITLE
Handle missing WeasyPrint system libraries gracefully

### DIFF
--- a/backend/tests/test_pdf_generator.py
+++ b/backend/tests/test_pdf_generator.py
@@ -1,0 +1,23 @@
+from services import pdf_generator
+
+
+def test_generate_pdf_raises_helpful_error_when_weasyprint_missing(monkeypatch):
+    monkeypatch.setattr(pdf_generator, "WEASYPRINT_IMPORT_ERROR", OSError("missing libgobject"))
+
+    try:
+        pdf_generator.generate_pdf("# hello")
+        raise AssertionError("Expected RuntimeError when WeasyPrint is unavailable")
+    except RuntimeError as exc:
+        assert "WeasyPrint is unavailable" in str(exc)
+        assert "installation" in str(exc)
+
+
+def test_generate_pdf_from_html_raises_helpful_error_when_weasyprint_missing(monkeypatch):
+    monkeypatch.setattr(pdf_generator, "WEASYPRINT_IMPORT_ERROR", OSError("missing libpango"))
+
+    try:
+        pdf_generator.generate_pdf_from_html("<h1>Hello</h1>")
+        raise AssertionError("Expected RuntimeError when WeasyPrint is unavailable")
+    except RuntimeError as exc:
+        assert "WeasyPrint is unavailable" in str(exc)
+        assert "troubleshooting" in str(exc)


### PR DESCRIPTION
### Motivation
- Prevent application startup from crashing when native WeasyPrint dependencies (libgobject/libpango, etc.) are not available and provide a clear actionable error when PDF generation is requested.

### Description
- Guard `weasyprint` imports in `backend/services/pdf_generator.py` with a try/except and capture the import exception in `WEASYPRINT_IMPORT_ERROR`, exposing a helpful `WEASYPRINT_INSTALL_HELP` message.
- Add `_ensure_weasyprint_available()` and call it at the start of `generate_pdf` and `generate_pdf_from_html` so PDF generation raises a controlled `RuntimeError` with installation/troubleshooting guidance when native libs are missing.
- Log the import failure and change the artifact download flow in `backend/api/routes/artifacts.py` to catch the `RuntimeError`, log context (`artifact_id` and `user_id`) and return HTTP `503` with the helpful error instead of allowing process-wide failures.
- Add unit tests `backend/tests/test_pdf_generator.py` that assert the service raises the helpful `RuntimeError` for both markdown and HTML PDF generation paths when `WEASYPRINT_IMPORT_ERROR` is simulated.

### Testing
- Running `pytest backend/tests/test_pdf_generator.py backend/tests/test_health.py` without `PYTHONPATH=backend` produced import errors for test collection due to test discovery environment (expected local-run issue).
- Running `PYTHONPATH=backend pytest backend/tests/test_pdf_generator.py` succeeded with `2 passed` (tests assert graceful failure behavior when WeasyPrint native libs are missing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69851923b7fc8321b3458cde4175cede)