### PR TITLE
docs: add WeasyPrint native deps and Plotly install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,46 @@ AI-powered revenue operations assistant that connects to HubSpot, Slack, Google 
 - Python 3.10+ (brew or venv; op-ed: use pyenv to force this globally)
 - Dependencies - python -m pip install -r requirements.txt (from the backend directory; again, be env mindful)
 
+#### Native dependencies for WeasyPrint (PDF generation)
+
+WeasyPrint requires system libraries in addition to the Python package. Install these before running `pip install -r requirements.txt`.
+
+**macOS (Homebrew):**
+
+```bash
+brew install cairo pango gdk-pixbuf libffi
+```
+
+**Ubuntu/Debian:**
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential \
+  python3-dev \
+  libcairo2 \
+  libpango-1.0-0 \
+  libpangocairo-1.0-0 \
+  libgdk-pixbuf-2.0-0 \
+  libffi-dev \
+  shared-mime-info
+```
+
+#### Plotly installation
+
+Plotly powers chart rendering in the frontend artifact viewer. It is installed via the frontend dependency set:
+
+```bash
+cd frontend
+npm install
+```
+
+If you need to install/refresh Plotly packages explicitly:
+
+```bash
+npm install plotly.js react-plotly.js @types/plotly.js @types/react-plotly.js --save
+```
+
 ### Setup
 
 1. **Clone and configure environment:**
@@ -84,6 +124,8 @@ cd frontend
 npm install
 npm run dev
 ```
+
+`npm install` will install Plotly dependencies defined in `frontend/package.json`.
 
 ## Railway Deployment
 


### PR DESCRIPTION
### Motivation
- Make it explicit how to install the native/system dependencies required by WeasyPrint and how to install Plotly in the frontend so developers can reliably build the backend PDF generator and frontend charts.

### Description
- Add a `Native dependencies for WeasyPrint` section with macOS (Homebrew) and Ubuntu/Debian install commands, and add a `Plotly installation` section describing `cd frontend && npm install` and an explicit `npm install plotly.js react-plotly.js @types/plotly.js @types/react-plotly.js` command; also clarify that `npm install` will pull Plotly dependencies from `frontend/package.json`.

### Testing
- None — documentation-only change, no automated tests were required or run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698519e290dc8321989459138f52fbb4)