### PR TITLE
Implement tiered sharing permissions across sources, chats, and workflows

### DIFF
--- a/backend/db/migrations/versions/038_add_sharing_permissions.py
+++ b/backend/db/migrations/versions/038_add_sharing_permissions.py
@@ -1,0 +1,36 @@
+"""add sharing permissions and user team graph
+
+Revision ID: 038_add_sharing_permissions
+Revises: 037_fix_users_rls_policy
+Create Date: 2026-02-06
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "038_add_sharing_permissions"
+down_revision = "037_fix_users_rls_policy"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("team_member_ids", postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default=sa.text("'[]'::jsonb")))
+
+    for table, default_tier in (
+        ("conversations", "me"),
+        ("workflows", "me"),
+        ("integrations", "team"),
+    ):
+        op.add_column(table, sa.Column("access_tier", sa.String(length=20), nullable=False, server_default=default_tier))
+        op.add_column(table, sa.Column("access_level", sa.String(length=20), nullable=False, server_default="edit"))
+
+
+def downgrade() -> None:
+    for table in ("integrations", "workflows", "conversations"):
+        op.drop_column(table, "access_level")
+        op.drop_column(table, "access_tier")
+
+    op.drop_column("users", "team_member_ids")

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -87,6 +87,8 @@ class Conversation(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
     )
+    access_tier: Mapped[str] = mapped_column(String(20), nullable=False, default="me")
+    access_level: Mapped[str] = mapped_column(String(20), nullable=False, default="edit")
 
     # Cached fields for fast list queries (denormalized)
     message_count: Mapped[int] = mapped_column(
@@ -118,6 +120,8 @@ class Conversation(Base):
             "summary": self.summary,
             "created_at": f"{self.created_at.isoformat()}Z" if self.created_at else None,
             "updated_at": f"{self.updated_at.isoformat()}Z" if self.updated_at else None,
+            "access_tier": self.access_tier,
+            "access_level": self.access_level,
         }
         if self.workflow_id:
             result["workflow_id"] = str(self.workflow_id)

--- a/backend/models/integration.py
+++ b/backend/models/integration.py
@@ -95,6 +95,8 @@ class Integration(Base):
     updated_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=True
     )
+    access_tier: Mapped[str] = mapped_column(String(20), nullable=False, default="team")
+    access_level: Mapped[str] = mapped_column(String(20), nullable=False, default="edit")
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for API responses."""
@@ -107,4 +109,6 @@ class Integration(Base):
             "last_error": self.last_error,
             "created_at": f"{self.created_at.isoformat()}Z" if self.created_at else None,
             "sync_stats": self.sync_stats,
+            "access_tier": self.access_tier,
+            "access_level": self.access_level,
         }

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -59,6 +59,8 @@ class User(Base):
         DateTime, default=datetime.utcnow, nullable=True
     )
     last_login: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    # Per-user team graph: list of org user IDs this user marks as "team"
+    team_member_ids: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
 
     # Relationships
     organization: Mapped[Optional["Organization"]] = relationship(
@@ -88,4 +90,5 @@ class User(Base):
             "status": self.status,
             "avatar_url": self.avatar_url,
             "organization_id": str(self.organization_id) if self.organization_id else None,
+            "team_member_ids": self.team_member_ids or [],
         }

--- a/backend/models/workflow.py
+++ b/backend/models/workflow.py
@@ -127,6 +127,8 @@ class Workflow(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
     )
+    access_tier: Mapped[str] = mapped_column(String(20), nullable=False, default="me")
+    access_level: Mapped[str] = mapped_column(String(20), nullable=False, default="edit")
 
     # Relationships
     runs: Mapped[list["WorkflowRun"]] = relationship(
@@ -159,6 +161,8 @@ class Workflow(Base):
             "last_error": self.last_error,
             "created_at": f"{self.created_at.isoformat()}Z",
             "updated_at": f"{self.updated_at.isoformat()}Z",
+            "access_tier": self.access_tier,
+            "access_level": self.access_level,
         }
     
     @property

--- a/backend/services/permissions.py
+++ b/backend/services/permissions.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Iterable
+from uuid import UUID
+
+from models.user import User
+
+
+class AccessTier(StrEnum):
+    ME = "me"
+    TEAM = "team"
+    ORG = "org"
+    GLOBAL = "global"
+
+
+class AccessLevel(StrEnum):
+    READ = "read"
+    EDIT = "edit"
+
+
+EMAIL_PROVIDERS = {"gmail", "microsoft_mail"}
+
+
+def normalize_tier(tier: str | None, default: AccessTier = AccessTier.ME) -> AccessTier:
+    if not tier:
+        return default
+    try:
+        return AccessTier(tier)
+    except ValueError:
+        return default
+
+
+def normalize_level(level: str | None, default: AccessLevel = AccessLevel.EDIT) -> AccessLevel:
+    if not level:
+        return default
+    try:
+        return AccessLevel(level)
+    except ValueError:
+        return default
+
+
+def team_member_ids_for_user(user: User) -> set[UUID]:
+    raw = user.team_member_ids or []
+    parsed: set[UUID] = set()
+    for item in raw:
+        try:
+            parsed.add(UUID(str(item)))
+        except ValueError:
+            continue
+    parsed.add(user.id)
+    return parsed
+
+
+def can_access_resource(
+    *,
+    owner_id: UUID | None,
+    viewer: User,
+    tier: str | None,
+) -> bool:
+    if owner_id == viewer.id:
+        return True
+
+    resolved = normalize_tier(tier)
+    if resolved == AccessTier.ME:
+        return False
+    if resolved in {AccessTier.ORG, AccessTier.GLOBAL}:
+        return True
+    if resolved == AccessTier.TEAM:
+        return owner_id in team_member_ids_for_user(viewer) if owner_id else False
+    return False
+
+
+def can_edit_resource(
+    *,
+    owner_id: UUID | None,
+    viewer: User,
+    tier: str | None,
+    access_level: str | None,
+) -> bool:
+    if owner_id == viewer.id:
+        return True
+    if not can_access_resource(owner_id=owner_id, viewer=viewer, tier=tier):
+        return False
+    return normalize_level(access_level) == AccessLevel.EDIT
+
+
+def get_default_integration_tier(provider: str) -> AccessTier:
+    if provider in EMAIL_PROVIDERS:
+        return AccessTier.ME
+    return AccessTier.TEAM

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -48,6 +48,9 @@ export interface ConversationSummary {
   updated_at: string;
   message_count: number;
   last_message_preview: string | null;
+  access_tier?: "me" | "team" | "org" | "global";
+  access_level?: "read" | "edit";
+  can_edit?: boolean;
 }
 
 export interface ConversationListResponse {
@@ -63,6 +66,9 @@ export interface ConversationDetailResponse {
   created_at: string;
   updated_at: string;
   type: "chat" | "workflow" | null;
+  access_tier?: "me" | "team" | "org" | "global";
+  access_level?: "read" | "edit";
+  can_edit?: boolean;
   messages: ChatMessage[];
 }
 
@@ -312,4 +318,20 @@ export async function searchData(
     limit: limit.toString(),
   });
   return apiRequest<SearchResponse>(`/search?${params.toString()}`);
+}
+
+
+export async function copyConversation(conversationId: string): Promise<ApiResponse<ConversationSummary>> {
+  return apiRequest<ConversationSummary>(`/chat/conversations/${conversationId}/copy`, { method: "POST" });
+}
+
+export async function updateConversationSharing(
+  conversationId: string,
+  accessTier: "me" | "team" | "org" | "global",
+  accessLevel: "read" | "edit",
+): Promise<ApiResponse<ConversationSummary>> {
+  return apiRequest<ConversationSummary>(`/chat/conversations/${conversationId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ access_tier: accessTier, access_level: accessLevel }),
+  });
 }

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -197,6 +197,16 @@ export function DataSources(): JSX.Element {
   // Live sync progress from WebSocket
   const [syncProgress, setSyncProgress] = useState<Record<string, number>>({});
 
+  const updateSharing = async (integrationId: string, accessTier: string, accessLevel: string): Promise<void> => {
+    if (!userId) return;
+    await fetch(`${API_BASE}/auth/integrations/${integrationId}/sharing?user_id=${userId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ access_tier: accessTier, access_level: accessLevel }),
+    });
+    void fetchIntegrations();
+  };
+
   const organizationId = organization?.id ?? '';
   const userId = user?.id ?? '';
   
@@ -698,6 +708,26 @@ export function DataSources(): JSX.Element {
                 )}
                 {buttonConfig.text}
               </button>
+            )}
+            {state === 'connected' && (
+              <div className="flex items-center gap-2">
+                <select
+                  value={integration.accessTier ?? 'team'}
+                  onChange={(e) => void updateSharing(integration.id, e.target.value, integration.accessLevel ?? 'edit')}
+                  disabled={!integration.canEdit}
+                  className="px-2 py-1 text-xs rounded bg-surface-800 border border-surface-700"
+                >
+                  <option value="me">Me</option><option value="team">Team</option><option value="org">Org</option><option value="global">Global</option>
+                </select>
+                <select
+                  value={integration.accessLevel ?? 'edit'}
+                  onChange={(e) => void updateSharing(integration.id, integration.accessTier ?? 'team', e.target.value)}
+                  disabled={!integration.canEdit}
+                  className="px-2 py-1 text-xs rounded bg-surface-800 border border-surface-700"
+                >
+                  <option value="read">Read</option><option value="edit">Edit</option>
+                </select>
+              </div>
             )}
             {state === 'connected' && integration.provider === 'google_sheets' && (
               <button

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -8,6 +8,7 @@
 export {
   useTeamMembers,
   useUpdateOrganization,
+  updateTeamStatus,
   organizationKeys,
   type Organization,
   type TeamMember,

--- a/frontend/src/hooks/useOrganization.ts
+++ b/frontend/src/hooks/useOrganization.ts
@@ -22,6 +22,7 @@ export interface TeamMember {
   email: string;
   role: string | null;
   avatarUrl: string | null;
+  teamStatus?: "team" | "org";
 }
 
 interface OrganizationApiResponse {
@@ -38,6 +39,7 @@ interface TeamMembersApiResponse {
     email: string;
     role: string | null;
     avatar_url: string | null;
+    team_status?: "team" | "org";
   }>;
 }
 
@@ -73,6 +75,7 @@ async function fetchTeamMembers(orgId: string, userId: string): Promise<TeamMemb
     email: m.email,
     role: m.role,
     avatarUrl: m.avatar_url,
+    teamStatus: m.team_status ?? "org",
   }));
 }
 
@@ -137,4 +140,14 @@ export function useUpdateOrganization() {
       });
     },
   });
+}
+
+
+export async function updateTeamStatus(orgId: string, userId: string, memberId: string, teamStatus: "team" | "org"): Promise<void> {
+  const response = await fetch(`${API_BASE}/auth/organizations/${orgId}/members/${memberId}/team-status?user_id=${userId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ team_status: teamStatus }),
+  });
+  if (!response.ok) throw new Error("Failed to update team status");
 }

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -69,6 +69,9 @@ export interface Integration {
   teamConnections: TeamConnection[];
   teamTotal: number;
   syncStats: SyncStats | null;
+  accessTier?: "me" | "team" | "org" | "global";
+  accessLevel?: "read" | "edit";
+  canEdit?: boolean;
 }
 
 export interface ChatSummary {
@@ -453,6 +456,9 @@ export const useAppStore = create<AppState>()(
             team_connections: Array<{ user_id: string; user_name: string }>;
             team_total: number;
             sync_stats: SyncStats | null;
+            access_tier?: "me" | "team" | "org" | "global";
+            access_level?: "read" | "edit";
+            can_edit?: boolean;
           }
 
           const data = (await response.json()) as {
@@ -475,6 +481,9 @@ export const useAppStore = create<AppState>()(
             })),
             teamTotal: i.team_total,
             syncStats: i.sync_stats,
+            accessTier: i.access_tier,
+            accessLevel: i.access_level,
+            canEdit: i.can_edit,
           }));
 
           console.log("[Store] Fetched", integrations.length, "integrations");


### PR DESCRIPTION
### Motivation
- Introduce a hierarchical sharing model (`me` → `team` → `org` → `global`) with `read`/`edit` semantics to control access to integrations, chats, and workflows.
- Ensure creators always have full edit rights and that visibility of workflow runs and conversations is gated by access so users cannot see runs/chats they are not allowed to view.
- Provide UX for per-connection and per-resource sharing (similar to Google Docs), allow copying view-only chats/workflows into user-owned copies, and expose a per-user team toggle in the Org UI.

### Description
- Added a central permission helper `backend/services/permissions.py` implementing `AccessTier`/`AccessLevel`, `can_access_resource`, `can_edit_resource`, and `get_default_integration_tier`.
- Schema + model changes: migration `038_add_sharing_permissions` and model updates to add `access_tier`/`access_level` to `conversations`, `workflows`, `integrations`, and `team_member_ids` to `users`, with source defaults (integrations default to `team`, email connectors default to `me`).
- Backend API changes: chat endpoints now enforce visibility/edit checks and return sharing metadata; added `POST /chat/conversations/{id}/copy` to clone view-only chats; workflows endpoints now accept `user_id`, enforce visibility and edit checks, filter workflow runs to only include runs whose conversation the caller can access, and added `POST /workflows/{org}/{wf}/copy`; integrations listing honors sharing and returns `access_tier`/`access_level`/`can_edit`; added `PATCH /auth/integrations/{integration_id}/sharing` and `PATCH /auth/organizations/{org_id}/members/{member_id}/team-status` to toggle per-user team membership.
- Frontend changes: propagate sharing metadata through `frontend/src/api/client.ts` and the Zustand store; added sharing controls in the chat header (`Chat.tsx`), workflow detail modal (`Workflows.tsx`), and per-connection controls on the Data Sources screen (`DataSources.tsx`); added Org panel member toggles (`OrganizationPanel.tsx`) and corresponding hook `updateTeamStatus` in `useOrganization.ts`.
- Defaults and UX: new conversations/workflows default to `me`+`edit`; new integrations default to `team` except `gmail`/`microsoft_mail` which default to `me`; copy actions create new resources owned by the caller with `me`+`edit`.

### Testing
- Backend static checks: `python -m py_compile` run across modified backend modules succeeded (no syntax errors).
- Full backend sanity: `cd backend && python -m py_compile $(rg --files -g '*.py')` succeeded.
- Frontend build: `cd frontend && npm run build` completed successfully (Vite produced chunk-size warnings only; production build succeeded and artifacts were produced).
- Basic UX verification: local dev server run and a screenshot of the updated UI was captured to validate controls rendering (artifact produced).

All automated checks ran to completion; no compile-time failures were observed. If desired, additional unit/integration tests and RLS policy migration verification can be added in follow-ups.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985824a83488321a46e1807b7f6fe86)