### PR TITLE
Document Railway-sourced Supabase environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ npm install plotly.js react-plotly.js @types/plotly.js @types/react-plotly.js --
 cp env.example .env
 # Edit .env with your credentials
 # Should all be in the .env or in Slack
+# Supabase values (SUPABASE_URL, SUPABASE_JWT_SECRET, VITE_SUPABASE_ANON_KEY)
+# should be copied from your Railway project variables.
 ```
 
 2. **Configure Nango integrations:**
@@ -420,6 +422,8 @@ We use [Nango](https://nango.dev) to handle all OAuth complexity:
 | `ANTHROPIC_API_KEY` | Anthropic API key for Claude        |
 | `SECRET_KEY`        | Application secret for sessions     |
 | `FRONTEND_URL`      | Frontend URL for CORS and redirects |
+| `SUPABASE_URL`      | Supabase project URL (from Railway) |
+| `SUPABASE_JWT_SECRET` | Supabase JWT secret (from Railway) |
 
 ### Nango Configuration
 

--- a/env.example
+++ b/env.example
@@ -32,6 +32,7 @@ ENVIRONMENT=development
 FRONTEND_URL=http://localhost:5173
 
 # Supabase configuration (backend)
+# Get these from your Railway project variables.
 # URL: Your Supabase project URL
 SUPABASE_URL=https://your-project.supabase.co
 # JWT Secret: Legacy HS256 secret (optional if using ES256 keys)
@@ -48,5 +49,6 @@ EMAIL_FROM=Revtops <hello@yourdomain.com>
 # Frontend (Vite) - prefix with VITE_ so they're exposed to the client
 VITE_API_URL=http://localhost:8000
 VITE_SUPABASE_URL=your_supabase_project_url
+# Get this from your Railway project variables.
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 VITE_NANGO_PUBLIC_KEY=your_nango_public_key


### PR DESCRIPTION
### Motivation
- Make it explicit where to obtain Supabase credentials required for running the app (so users know to pull them from their Railway project). 

### Description
- Added a setup note instructing users to copy `SUPABASE_URL`, `SUPABASE_JWT_SECRET`, and `VITE_SUPABASE_ANON_KEY` from Railway into their `.env` file. 
- Listed `SUPABASE_URL` and `SUPABASE_JWT_SECRET` in the backend environment variables table in `README.md`. 
- Annotated `env.example` to indicate the Supabase backend and Vite `ANON_KEY` values should be sourced from Railway. 

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698659d8d4448321a6e653bbd22df106)