### PR TITLE
Add env var debug warnings for backend and frontend startup

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -21,6 +21,7 @@ from fastapi.responses import JSONResponse
 from api.websockets import websocket_endpoint
 from api.routes import artifacts, auth, change_sessions, chat, data, deals, search, sheets, slack_events, sync, tool_settings, waitlist, workflows
 from models.database import init_db, close_db, get_pool_status
+from config import log_missing_env_vars
 
 # Configure logging
 logging.basicConfig(
@@ -115,6 +116,7 @@ async def startup() -> None:
     """Initialize database on startup."""
     # Note: init_db() skipped - Alembic handles migrations
     # await init_db()
+    log_missing_env_vars(logging.getLogger("config"))
     logging.info("Database connection pool ready")
 
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,6 +1,8 @@
 """Configuration management using Pydantic settings."""
 
 from datetime import date, datetime
+import logging
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -99,6 +101,35 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+EXPECTED_ENV_VARS: tuple[str, ...] = (
+    "DATABASE_URL",
+    "REDIS_URL",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "NANGO_SECRET_KEY",
+    "NANGO_PUBLIC_KEY",
+    "SECRET_KEY",
+    "ENVIRONMENT",
+    "FRONTEND_URL",
+    "SUPABASE_URL",
+    "SUPABASE_JWT_SECRET",
+    "ADMIN_KEY",
+    "RESEND_API_KEY",
+    "EMAIL_FROM",
+)
+
+
+def log_missing_env_vars(logger: logging.Logger) -> None:
+    """Log debug warnings for expected environment variables that are unset."""
+    for var_name in EXPECTED_ENV_VARS:
+        value = os.environ.get(var_name)
+        if value is None or value == "":
+            logger.debug(
+                "Warning: expected environment variable %s is not set.",
+                var_name,
+            )
 
 
 # Nango integration ID mapping

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -1,0 +1,19 @@
+type ExpectedEnvVar = {
+  key: string;
+  value: string | boolean | undefined;
+};
+
+const EXPECTED_ENV_VARS: ExpectedEnvVar[] = [
+  { key: 'VITE_API_URL', value: import.meta.env.VITE_API_URL },
+  { key: 'VITE_SUPABASE_URL', value: import.meta.env.VITE_SUPABASE_URL },
+  { key: 'VITE_SUPABASE_ANON_KEY', value: import.meta.env.VITE_SUPABASE_ANON_KEY },
+  { key: 'VITE_NANGO_PUBLIC_KEY', value: import.meta.env.VITE_NANGO_PUBLIC_KEY },
+];
+
+export function logMissingEnvVars(): void {
+  EXPECTED_ENV_VARS.forEach(({ key, value }) => {
+    if (value === undefined || value === '') {
+      console.debug(`[env] Warning: expected environment variable ${key} is not set.`);
+    }
+  });
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
+import { logMissingEnvVars } from './lib/env';
 import './index.css';
 
 // Configure React Query with sensible defaults
@@ -24,6 +25,8 @@ const rootElement = document.getElementById('root');
 if (!rootElement) {
   throw new Error('Root element not found');
 }
+
+logMissingEnvVars();
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>


### PR DESCRIPTION
### Motivation
- Ensure both backend and frontend emit debug warnings when expected environment variables are missing so developers can catch misconfiguration early.
- Align with existing logging practices by emitting low-importance debug messages rather than failing startup.

### Description
- Add `EXPECTED_ENV_VARS` and `log_missing_env_vars(logger)` to `backend/config.py` to enumerate expected server env vars and log missing ones using `logger.debug`.
- Invoke `log_missing_env_vars(logging.getLogger("config"))` during backend startup in `backend/api/main.py` so missing vars are reported at boot.
- Add `frontend/src/lib/env.ts` with `logMissingEnvVars()` that checks important `VITE_` vars and logs missing ones via `console.debug`, and call it from `frontend/src/main.tsx` on app init.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986606305d88321bcf2cfad29bb3f1b)