### PR TITLE
Preserve Slack message senders in activity sync

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -8,6 +8,7 @@ Responsibilities:
 - Handle pagination and rate limits
 """
 
+import logging
 import re
 import uuid
 from datetime import datetime
@@ -61,6 +62,7 @@ from models.activity import Activity
 from models.database import get_session
 
 SLACK_API_BASE = "https://slack.com/api"
+logger = logging.getLogger(__name__)
 
 
 class SlackConnector(BaseConnector):
@@ -205,6 +207,7 @@ class SlackConnector(BaseConnector):
         This captures communication activity that can be correlated
         with deals and accounts.
         """
+        logger.info("[Slack Sync] Starting Slack activity sync for org=%s", self.organization_id)
         # Broadcast that we're starting
         await broadcast_sync_progress(
             organization_id=self.organization_id,
@@ -215,6 +218,11 @@ class SlackConnector(BaseConnector):
         
         # Get channels
         channels = await self.get_channels()
+        logger.info(
+            "[Slack Sync] Retrieved %d channels for org=%s",
+            len(channels),
+            self.organization_id,
+        )
 
         # Calculate timestamp for last 7 days
         oldest = (datetime.utcnow().timestamp()) - (7 * 24 * 60 * 60)
@@ -224,6 +232,11 @@ class SlackConnector(BaseConnector):
             for channel in channels:
                 channel_id = channel.get("id", "")
                 channel_name = channel.get("name", "unknown")
+                logger.debug(
+                    "[Slack Sync] Fetching messages for channel=%s (%s)",
+                    channel_name,
+                    channel_id,
+                )
 
                 try:
                     messages = await self.get_channel_messages(
@@ -247,12 +260,45 @@ class SlackConnector(BaseConnector):
 
                 except Exception as e:
                     # Skip channels we can't access
-                    print(f"Error fetching messages from {channel_name}: {e}")
+                    logger.warning(
+                        "[Slack Sync] Error fetching messages from channel=%s (%s): %s",
+                        channel_name,
+                        channel_id,
+                        e,
+                        exc_info=True,
+                    )
                     continue
 
             await session.commit()
 
         return count
+
+    def _extract_sender_fields(self, slack_msg: dict[str, Any]) -> dict[str, Any]:
+        user_id = slack_msg.get("user")
+        bot_id = slack_msg.get("bot_id")
+        user_profile = slack_msg.get("user_profile") or {}
+        sender_name = (
+            user_profile.get("display_name")
+            or user_profile.get("real_name")
+            or slack_msg.get("username")
+            or ""
+        ).strip()
+        sender_real_name = (user_profile.get("real_name") or "").strip()
+        sender_email = (user_profile.get("email") or "").strip()
+        sender_fields: dict[str, Any] = {
+            "sender_id": user_id or bot_id,
+            "sender_type": "user" if user_id else ("bot" if bot_id else "unknown"),
+            "sender_name": sender_name or None,
+            "sender_real_name": sender_real_name or None,
+            "sender_email": sender_email or None,
+        }
+        if not sender_fields["sender_id"]:
+            logger.debug(
+                "[Slack Sync] Missing sender id in message ts=%s channel=%s",
+                slack_msg.get("ts"),
+                slack_msg.get("channel"),
+            )
+        return sender_fields
 
     def _normalize_message(
         self,
@@ -283,6 +329,7 @@ class SlackConnector(BaseConnector):
         # Create a unique source ID from channel and timestamp
         source_id = f"{channel_id}:{msg_ts}"
 
+        sender_fields = self._extract_sender_fields(slack_msg)
         return Activity(
             id=uuid.uuid4(),
             organization_id=uuid.UUID(self.organization_id),
@@ -296,6 +343,7 @@ class SlackConnector(BaseConnector):
                 "channel_id": channel_id,
                 "channel_name": channel_name,
                 "user_id": slack_msg.get("user"),
+                **sender_fields,
                 "thread_ts": slack_msg.get("thread_ts"),
                 "has_attachments": len(slack_msg.get("attachments", [])) > 0,
                 "has_files": len(slack_msg.get("files", [])) > 0,


### PR DESCRIPTION
### Motivation
- Ensure Slack messages imported into activities retain sender metadata (id, type, name, email) when available so the original sender is preserved for downstream queries and attribution.
- Improve observability of Slack sync operations with structured logging to aid debugging of channel access and sync progress.

### Description
- Add module logging (`logger`) and emit info/debug logs at the start of sync, after fetching channels, and when fetching per-channel messages. 
- Replace a `print` on channel fetch errors with `logger.warning(..., exc_info=True)` to preserve stack traces. 
- Add a `_extract_sender_fields` helper that extracts `sender_id`, `sender_type`, `sender_name`, `sender_real_name`, and `sender_email` from the Slack message payload and user profile. 
- Include the extracted sender fields into the `Activity.custom_fields` for `type='slack_message'` so sender information is stored alongside other channel metadata.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69866d1066148321a5dc719d00acd9e2)