### PR TITLE
Update web search unavailable message

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -1030,8 +1030,8 @@ async def _web_search(params: dict[str, Any]) -> dict[str, Any]:
     
     if not settings.PERPLEXITY_API_KEY:
         return {
-            "error": "Web search is not configured. PERPLEXITY_API_KEY is not set.",
-            "suggestion": "Add PERPLEXITY_API_KEY to your environment variables.",
+            "error": "We do not currently run external web interactions; coming soon!",
+            "suggestion": "Add PERPLEXITY_API_KEY to your environment variables to enable web search.",
         }
     
     try:


### PR DESCRIPTION
### Motivation
- Update the user-facing message shown when web search is disabled so it reflects that external web interactions are not currently performed and gives clearer guidance.

### Description
- Replace the unavailable-web-search message in `_web_search` (`backend/agents/tools.py`) with "We do not currently run external web interactions; coming soon!" and update the suggestion to reference `PERPLEXITY_API_KEY` for enabling web search.

### Testing
- No automated tests were run for this small copy-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698672b180208321951046d62b01a127)