### PR TITLE
Include Slack DMs and @mentions in recent chats

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -18,16 +18,20 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import select, func
+from sqlalchemy import and_, func, or_, select
 
 from api.auth_middleware import AuthContext, get_current_auth
 from models.database import get_session
 from models.chat_message import ChatMessage
 from models.conversation import Conversation
+from services.slack_conversations import get_slack_user_ids_for_revtops_user
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 # =============================================================================
@@ -116,15 +120,46 @@ async def list_conversations(
 ) -> ConversationListResponse:
     """List conversations for the authenticated user, ordered by most recent."""
     org_id = auth.organization_id_str
+    slack_user_ids: set[str] = set()
+    if org_id:
+        try:
+            slack_user_ids = await get_slack_user_ids_for_revtops_user(org_id, auth.user_id_str)
+        except Exception as exc:
+            logger.warning(
+                "[chat] Failed to resolve Slack user IDs for org=%s user=%s: %s",
+                org_id,
+                auth.user_id_str,
+                exc,
+                exc_info=True,
+            )
 
     async with get_session(organization_id=org_id) as session:
         # Simple query - message_count and last_message_preview are cached on the conversation
         # Filter out workflow conversations - they're accessed via Automations tab, not chat list
-        result = await session.execute(
+        query = (
             select(Conversation, func.count(Conversation.id).over().label("total_count"))
-            .where(Conversation.user_id == auth.user_id)
             .where(Conversation.type != "workflow")
-            .order_by(Conversation.updated_at.desc())
+        )
+        if slack_user_ids:
+            slack_filter = and_(
+                Conversation.source == "slack",
+                Conversation.source_user_id.in_(slack_user_ids),
+            )
+            if auth.organization_id:
+                slack_filter = and_(
+                    slack_filter,
+                    Conversation.organization_id == auth.organization_id,
+                )
+            query = query.where(or_(Conversation.user_id == auth.user_id, slack_filter))
+            logger.info(
+                "[chat] Listing conversations for user=%s with Slack IDs %s",
+                auth.user_id_str,
+                sorted(slack_user_ids),
+            )
+        else:
+            query = query.where(Conversation.user_id == auth.user_id)
+        result = await session.execute(
+            query.order_by(Conversation.updated_at.desc())
             .offset(offset)
             .limit(limit)
         )


### PR DESCRIPTION
### Motivation
- Recent chats list only considered `Conversation.user_id`, which excluded Slack DM/@mention conversations that have `source="slack"` and `source_user_id` set but no `user_id` mapping.
- The intent is to show conversations originating from Slack (DMs and mentions) in the web "Recent chats" view for users who have Slack integrations linked.

### Description
- Added `get_slack_user_ids_for_revtops_user` helper and factored `_extract_slack_user_ids` and `_normalize_name` into `backend/services/slack_conversations.py` to resolve Slack user IDs associated with a RevTops user and log resolution results.
- Updated `backend/api/routes/chat.py` to call `get_slack_user_ids_for_revtops_user` and expand the conversation query to include Slack conversations when `Conversation.source == 'slack'` and `Conversation.source_user_id` is in the resolved Slack IDs, while preserving existing behavior and organization scoping.
- Added logging around Slack-ID resolution and chat-listing logic and guarded resolution with a try/except so failures do not block the conversation listing.

### Testing
- No automated tests were run in this rollout.
- The change is designed to work with existing unit tests such as `backend/tests/test_slack_user_resolution.py`, but those tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698673e658388321a72435f8332df23a)