### PR TITLE
Improve Slack user matching for chat visibility

### DIFF
--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -232,6 +232,26 @@ async def resolve_revtops_user_for_slack_actor(
             sorted(slack_names),
         )
 
+    # 3) fallback name matching for any org user (helps when Slack email isn't available)
+    if slack_names:
+        for user in org_users:
+            user_name = _normalize_name(user.name)
+            if user_name and user_name in slack_names:
+                logger.info(
+                    "[slack_conversations] Matched Slack user=%s by name=%s to org user=%s (no connected Slack integration)",
+                    slack_user_id,
+                    user_name,
+                    user.id,
+                )
+                return user
+
+        logger.info(
+            "[slack_conversations] No org Slack-name match for Slack user=%s org=%s candidate_names=%s",
+            slack_user_id,
+            organization_id,
+            sorted(slack_names),
+        )
+
     logger.info(
         "[slack_conversations] Failed to resolve RevTops user for Slack actor user=%s org=%s",
         slack_user_id,


### PR DESCRIPTION
### Motivation
- Slack DMs or @mentions were sometimes not linked to RevTops users (and thus not showing in recent chats) when Slack email or a connected Slack integration metadata was unavailable.

### Description
- Add a fallback name-based matching pass in `resolve_revtops_user_for_slack_actor` to match Slack display names to any org `User` when prior email or connected-integration checks fail, implemented in `backend/services/slack_conversations.py`.
- Add additional logging to record when name-based resolution fails or succeeds to aid debugging.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698673e658388321a72435f8332df23a)