### PR TITLE
Log fetched Slack messages during sync

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -242,6 +242,13 @@ class SlackConnector(BaseConnector):
                     messages = await self.get_channel_messages(
                         channel_id, oldest=oldest, limit=100
                     )
+                    for msg in messages:
+                        logger.info(
+                            "[Slack Sync] Fetched message from channel=%s (%s): %s",
+                            channel_name,
+                            channel_id,
+                            msg,
+                        )
 
                     for msg in messages:
                         activity = self._normalize_message(msg, channel_id, channel_name)


### PR DESCRIPTION
### Motivation
- Provide backend visibility into Slack message syncs by emitting every fetched Slack message to logs for debugging and auditing.

### Description
- Added a per-message `logger.info` in `backend/connectors/slack.py` inside `SlackConnector.sync_activities` immediately after `get_channel_messages` to log the `channel_name`, `channel_id`, and the full `msg` payload.
- This change only adds logging and does not alter message normalization or persistence logic.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698689c8b5088321992863c397ff4944)