### PR TITLE
Persist org-scoped Slack user mappings and improve Slack identity resolution

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -404,6 +404,8 @@ class ChatOrchestrator:
         user_email: str | None = None,
         local_time: str | None = None,
         timezone: str | None = None,
+        source_user_id: str | None = None,
+        source_user_email: str | None = None,
         workflow_context: dict[str, Any] | None = None,
     ) -> None:
         """
@@ -416,6 +418,8 @@ class ChatOrchestrator:
             user_email: Email of the authenticated user
             local_time: ISO timestamp of user's local time
             timezone: User's timezone (e.g., "America/New_York")
+            source_user_id: External sender ID (e.g. Slack user ID)
+            source_user_email: External sender email (e.g. Slack profile email)
             workflow_context: Optional workflow context for auto-approvals:
                 - is_workflow: bool
                 - workflow_id: str
@@ -427,6 +431,8 @@ class ChatOrchestrator:
         self.user_email = user_email
         self.local_time = local_time
         self.timezone = timezone
+        self.source_user_id = source_user_id
+        self.source_user_email = source_user_email
         self.workflow_context = workflow_context
         self.client = AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
         # Track if we've saved the assistant message (for early save during tool execution)
@@ -995,6 +1001,8 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
                     user_id=user_uuid,
                     organization_id=UUID(self.organization_id) if self.organization_id else None,
                     role="user",
+                    source_user_id=self.source_user_id,
+                    source_user_email=self.source_user_email,
                     content_blocks=[{"type": "text", "text": user_msg}],
                 )
             )

--- a/backend/db/migrations/versions/041_add_slack_user_mappings_and_chat_message_sender_fields.py
+++ b/backend/db/migrations/versions/041_add_slack_user_mappings_and_chat_message_sender_fields.py
@@ -1,0 +1,76 @@
+"""Add Slack user mappings + sender fields on chat messages.
+
+Revision ID: 041
+Revises: 040
+Create Date: 2026-02-10
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "041"
+down_revision = "040"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "slack_user_mappings",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("organization_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("slack_user_id", sa.String(length=100), nullable=False),
+        sa.Column("slack_email", sa.String(length=255), nullable=True),
+        sa.Column("match_source", sa.String(length=50), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"]),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+    )
+    op.create_index(
+        "uq_slack_user_mappings_org_slack_user",
+        "slack_user_mappings",
+        ["organization_id", "slack_user_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_slack_user_mappings_org_user",
+        "slack_user_mappings",
+        ["organization_id", "user_id"],
+    )
+    op.create_index(
+        "ix_slack_user_mappings_org",
+        "slack_user_mappings",
+        ["organization_id"],
+    )
+    op.create_index(
+        "ix_slack_user_mappings_user",
+        "slack_user_mappings",
+        ["user_id"],
+    )
+
+    op.add_column(
+        "chat_messages",
+        sa.Column("source_user_id", sa.String(length=100), nullable=True),
+    )
+    op.add_column(
+        "chat_messages",
+        sa.Column("source_user_email", sa.String(length=255), nullable=True),
+    )
+    op.create_index(
+        "ix_chat_messages_source_user_id",
+        "chat_messages",
+        ["source_user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_chat_messages_source_user_id", table_name="chat_messages")
+    op.drop_column("chat_messages", "source_user_email")
+    op.drop_column("chat_messages", "source_user_id")
+
+    op.drop_index("ix_slack_user_mappings_user", table_name="slack_user_mappings")
+    op.drop_index("ix_slack_user_mappings_org", table_name="slack_user_mappings")
+    op.drop_index("ix_slack_user_mappings_org_user", table_name="slack_user_mappings")
+    op.drop_index("uq_slack_user_mappings_org_slack_user", table_name="slack_user_mappings")
+    op.drop_table("slack_user_mappings")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -19,6 +19,7 @@ from models.sheet_import import SheetImport
 from models.user_tool_setting import UserToolSetting
 from models.change_session import ChangeSession
 from models.record_snapshot import RecordSnapshot
+from models.slack_user_mapping import SlackUserMapping
 
 __all__ = [
     "Base",
@@ -46,4 +47,5 @@ __all__ = [
     "UserToolSetting",
     "ChangeSession",
     "RecordSnapshot",
+    "SlackUserMapping",
 ]

--- a/backend/models/chat_message.py
+++ b/backend/models/chat_message.py
@@ -42,6 +42,12 @@ class ChatMessage(Base):
     role: Mapped[str] = mapped_column(
         String(20), nullable=False
     )  # 'user' or 'assistant'
+    source_user_id: Mapped[Optional[str]] = mapped_column(
+        String(100), nullable=True, index=True
+    )  # External sender ID (e.g. Slack user ID)
+    source_user_email: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True
+    )  # External sender email (e.g. Slack profile email)
     
     # New: Array of content blocks [{type: 'text'|'tool_use', ...}]
     content_blocks: Mapped[Optional[list[dict[str, Any]]]] = mapped_column(

--- a/backend/models/slack_user_mapping.py
+++ b/backend/models/slack_user_mapping.py
@@ -1,0 +1,52 @@
+"""
+Slack user mapping model for high-confidence RevTops <-> Slack identity links.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.database import Base
+
+
+class SlackUserMapping(Base):
+    """Persisted mapping between RevTops users and Slack users."""
+
+    __tablename__ = "slack_user_mappings"
+    __table_args__ = (
+        Index(
+            "uq_slack_user_mappings_org_slack_user",
+            "organization_id",
+            "slack_user_id",
+            unique=True,
+        ),
+        Index(
+            "ix_slack_user_mappings_org_user",
+            "organization_id",
+            "user_id",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False, index=True
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True
+    )
+    slack_user_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    slack_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    match_source: Mapped[str] = mapped_column(String(50), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )


### PR DESCRIPTION
### Motivation

- Provide a durable, organization-scoped mapping between RevTops users and Slack users so identity resolution is reliable across integrations, email lookups, and explicit mappings.
- Preserve Slack sender metadata on inbound messages so activities and chat messages retain the original external sender information for recents and auditing.

### Description

- Added a new `SlackUserMapping` ORM model and Alembic migration to persist org-scoped mappings (`organization_id` included) and unique index on `(organization_id, slack_user_id)`. 
- Extended `ChatMessage` and the `ChatOrchestrator` to carry `source_user_id` and `source_user_email` so inbound Slack sender metadata is threaded into saved messages. 
- Enhanced `backend/services/slack_conversations.py` to: use stored mappings when resolving a Slack actor for a given `organization_id`, include mapping results when resolving Slack IDs for a RevTops user, add `_upsert_slack_user_mapping` with conflict target scoped to `organization_id`, add Slack info/email/display-name helpers, persist `sender_slack_id` and `sender_email` into `Activity.custom_fields`, and improve logging to surface mapping counts. 
- Removed an unused Slack display-name helper, updated `models/__init__.py` to export `SlackUserMapping`, and added a unit test to verify that stored mappings are used (and that the Slack connector is not called when a mapping exists). 

### Testing

- Ran `PYTHONPATH=backend pytest backend/tests/test_slack_user_resolution.py` and the suite completed successfully with `3 passed` (two warnings about Pydantic and a deprecation-related datetime warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986f4c7692083219c9581be24df9592)