### PR TITLE
Allow many-to-many Slack <-> RevTops user mappings

### DIFF
--- a/backend/db/migrations/versions/042_allow_multiple_slack_user_mappings.py
+++ b/backend/db/migrations/versions/042_allow_multiple_slack_user_mappings.py
@@ -1,0 +1,42 @@
+"""Allow multiple Slack user mappings per RevTops user and vice versa.
+
+Revision ID: 042
+Revises: 041
+Create Date: 2026-02-10
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "042"
+down_revision = "041"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("uq_slack_user_mappings_org_slack_user", table_name="slack_user_mappings")
+    op.create_index(
+        "ix_slack_user_mappings_org_slack_user",
+        "slack_user_mappings",
+        ["organization_id", "slack_user_id"],
+    )
+    op.create_index(
+        "uq_slack_user_mappings_org_user_slack_user",
+        "slack_user_mappings",
+        ["organization_id", "user_id", "slack_user_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_slack_user_mappings_org_user_slack_user",
+        table_name="slack_user_mappings",
+    )
+    op.drop_index("ix_slack_user_mappings_org_slack_user", table_name="slack_user_mappings")
+    op.create_index(
+        "uq_slack_user_mappings_org_slack_user",
+        "slack_user_mappings",
+        ["organization_id", "slack_user_id"],
+        unique=True,
+    )

--- a/backend/models/slack_user_mapping.py
+++ b/backend/models/slack_user_mapping.py
@@ -20,10 +20,16 @@ class SlackUserMapping(Base):
     __tablename__ = "slack_user_mappings"
     __table_args__ = (
         Index(
-            "uq_slack_user_mappings_org_slack_user",
+            "uq_slack_user_mappings_org_user_slack_user",
             "organization_id",
+            "user_id",
             "slack_user_id",
             unique=True,
+        ),
+        Index(
+            "ix_slack_user_mappings_org_slack_user",
+            "organization_id",
+            "slack_user_id",
         ),
         Index(
             "ix_slack_user_mappings_org_user",

--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -179,9 +179,8 @@ async def _upsert_slack_user_mapping(
                 created_at=now,
                 updated_at=now,
             ).on_conflict_do_update(
-                index_elements=["organization_id", "slack_user_id"],
+                index_elements=["organization_id", "user_id", "slack_user_id"],
                 set_={
-                    "user_id": user_id,
                     "slack_email": slack_email,
                     "match_source": match_source,
                     "updated_at": now,
@@ -277,11 +276,22 @@ async def resolve_revtops_user_for_slack_actor(
             .where(SlackUserMapping.slack_user_id == slack_user_id)
         )
         mappings_result = await session.execute(mappings_query)
-        existing_mapping = mappings_result.scalar_one_or_none()
+        existing_mappings = mappings_result.scalars().all()
 
-    if existing_mapping:
+    if existing_mappings:
+        latest_mapping = max(
+            existing_mappings,
+            key=lambda mapping: getattr(mapping, "updated_at", datetime.min),
+        )
+        if len(existing_mappings) > 1:
+            logger.info(
+                "[slack_conversations] Multiple Slack mappings found for user=%s (count=%d); using latest user=%s",
+                slack_user_id,
+                len(existing_mappings),
+                latest_mapping.user_id,
+            )
         for user in org_users:
-            if user.id == existing_mapping.user_id:
+            if user.id == latest_mapping.user_id:
                 logger.info(
                     "[slack_conversations] Resolved Slack user=%s via stored mapping to RevTops user=%s",
                     slack_user_id,
@@ -291,7 +301,7 @@ async def resolve_revtops_user_for_slack_actor(
         logger.info(
             "[slack_conversations] Stored mapping for Slack user=%s references missing user=%s",
             slack_user_id,
-            existing_mapping.user_id,
+            latest_mapping.user_id,
         )
 
     for integration in slack_integrations:


### PR DESCRIPTION
### Motivation
- Slack identities and RevTops users can be many-to-many in practice, so the mapping constraints need to permit multiple Slack IDs per user and multiple mappings for the same Slack ID across retries/updates.  
- Resolution and upsert logic should deterministically handle multiple stored mappings and prefer the most-recent mapping.  

### Description
- Update the `SlackUserMapping` model indexes to introduce a composite unique key `uq_slack_user_mappings_org_user_slack_user` on `organization_id,user_id,slack_user_id` and add a non-unique lookup index `ix_slack_user_mappings_org_slack_user` on `organization_id,slack_user_id` (file: `backend/models/slack_user_mapping.py`).  
- Change the upsert to use the composite key in the `on_conflict_do_update` `index_elements` so conflicts are evaluated against `organization_id,user_id,slack_user_id` (function: `_upsert_slack_user_mapping` in `backend/services/slack_conversations.py`).  
- Adjust resolution logic in `resolve_revtops_user_for_slack_actor` to fetch all existing mappings for a Slack ID, log when multiple mappings exist, and pick the most recently `updated_at` mapping to resolve the linked RevTops user (file: `backend/services/slack_conversations.py`).  
- Add an Alembic migration `backend/db/migrations/versions/042_allow_multiple_slack_user_mappings.py` to drop the old unique index and create the new indexes to support the many-to-many behavior.  

### Testing
- No automated tests were executed as part of this change.  
- Existing unit tests that exercise Slack resolution live at `backend/tests/test_slack_user_resolution.py` and should be run in CI to validate behavior after migration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ddd9788c832197cdc5133e28cd8d)