### PR TITLE
Expose Slack user mappings to LLM workers

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -278,6 +278,32 @@ SELECT id, name, email, role FROM users WHERE organization_id = :org_id
 SELECT * FROM users WHERE name ILIKE '%john%'
 ```
 
+### slack_user_mappings
+**Identity links** between internal users and Slack users.
+Use this table when the user asks about Slack identities, mentions, or when mapping Slack user IDs/emails to RevTops users.
+```
+id, organization_id, user_id, slack_user_id, slack_email, match_source, created_at, updated_at
+```
+- `user_id`: FK to `users.id`
+- `slack_user_id`: Slack user identifier (e.g., U123...)
+- `slack_email`: Slack profile email when available
+- `match_source`: How the mapping was established (e.g., "oauth", "profile_match")
+
+Example queries for slack user mappings:
+```sql
+-- Map a Slack user ID to a RevTops user
+SELECT u.id, u.name, u.email, m.slack_user_id, m.slack_email
+FROM slack_user_mappings m
+JOIN users u ON u.id = m.user_id
+WHERE m.slack_user_id = 'U12345678'
+
+-- Find all Slack mappings for a teammate
+SELECT m.slack_user_id, m.slack_email, m.match_source, m.updated_at
+FROM slack_user_mappings m
+JOIN users u ON u.id = m.user_id
+WHERE u.email = 'jane@example.com'
+```
+
 ### organizations
 Companies/tenants using the Revtops platform - the user's own company.
 ```

--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -102,6 +102,7 @@ Available tables:
 - pipeline_stages: Stages in pipelines (pipeline_id, name, probability)
 - integrations: Connected data sources (provider, is_active, last_sync_at)
 - users: Team members (email, name, role)
+- slack_user_mappings: Slack identity links (slack_user_id, slack_email, match_source)
 - organizations: User's company info (name, logo_url)
 
 IMPORTANT: Only SELECT queries are allowed. No INSERT, UPDATE, DELETE, DROP, etc.""",

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -139,7 +139,7 @@ class ToolProgressUpdater:
 # Note: Row-Level Security (RLS) handles organization filtering at the database level
 ALLOWED_TABLES: set[str] = {
     "deals", "accounts", "contacts", "activities", "meetings", "integrations", "users", "organizations",
-    "pipelines", "pipeline_stages", "workflows", "workflow_runs"
+    "pipelines", "pipeline_stages", "workflows", "workflow_runs", "slack_user_mappings"
 }
 
 


### PR DESCRIPTION
### Motivation
- Make the `slack_user_mappings` table available to the LLM/tools so workers can resolve Slack IDs/emails to RevTops users and answer Slack-related queries.

### Description
- Documented the `slack_user_mappings` table and example queries in the LLM schema prompt in `backend/agents/orchestrator.py` to mirror the existing `users` section.
- Added `slack_user_mappings` to the `run_sql_query` available tables list in `backend/agents/registry.py` so the tool descriptions surface the table.
- Whitelisted `slack_user_mappings` in the SQL access set `ALLOWED_TABLES` in `backend/agents/tools.py` so workers can query it at runtime.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e042d5a083219411ede73188968c)