### PR TITLE
Refresh Slack user mappings during Slack sync

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -417,6 +417,22 @@ class SlackConnector(BaseConnector):
     async def sync_all(self) -> dict[str, int]:
         """Run all sync operations."""
         activities_count = await self.sync_activities()
+        from services.slack_conversations import refresh_slack_user_mappings_for_org
+
+        try:
+            refreshed_count = await refresh_slack_user_mappings_for_org(self.organization_id)
+            logger.info(
+                "[Slack Sync] Refreshed %d Slack user mappings for org=%s",
+                refreshed_count,
+                self.organization_id,
+            )
+        except Exception as exc:
+            logger.warning(
+                "[Slack Sync] Failed to refresh Slack user mappings for org=%s: %s",
+                self.organization_id,
+                exc,
+                exc_info=True,
+            )
 
         # Broadcast completion
         await broadcast_sync_progress(


### PR DESCRIPTION
### Motivation
- Ensure Slack↔RevTops user mappings are refreshed whenever Slack data is synced so message processing and user resolution use up-to-date identity links. 
- Make mapping refresh best-effort and non-disruptive so syncs do not fail if mapping refresh has issues.

### Description
- Add `refresh_slack_user_mappings_for_org(organization_id: str)` in `backend/services/slack_conversations.py` which queries active Slack `Integration` rows for an org and calls `upsert_slack_user_mappings_from_metadata` for each integration, selecting `integration.user_id` or `integration.connected_by_user_id` as the target user and skipping integrations without user context. 
- Log progress, debug info, and warnings during refresh and return the total number of mappings created. 
- Invoke the refresh from `SlackConnector.sync_all` in `backend/connectors/slack.py` immediately after `sync_activities`, and wrap the call in a `try/except` so failures are logged but do not interrupt the sync flow. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e10cdd6483219f866a6f060cc7af)