### PR TITLE
Refresh Slack user mappings before activity sync

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -416,10 +416,13 @@ class SlackConnector(BaseConnector):
 
     async def sync_all(self) -> dict[str, int]:
         """Run all sync operations."""
-        activities_count = await self.sync_activities()
         from services.slack_conversations import refresh_slack_user_mappings_for_org
 
         try:
+            logger.info(
+                "[Slack Sync] Refreshing Slack user mappings before activity sync for org=%s",
+                self.organization_id,
+            )
             refreshed_count = await refresh_slack_user_mappings_for_org(self.organization_id)
             logger.info(
                 "[Slack Sync] Refreshed %d Slack user mappings for org=%s",
@@ -433,6 +436,8 @@ class SlackConnector(BaseConnector):
                 exc,
                 exc_info=True,
             )
+
+        activities_count = await self.sync_activities()
 
         # Broadcast completion
         await broadcast_sync_progress(


### PR DESCRIPTION
### Motivation
- Ensure Slack user mapping upserts run before importing activities so mapping updates are visible in logs and available during activity processing.

### Description
- In `SlackConnector.sync_all`, call `refresh_slack_user_mappings_for_org` before `sync_activities` and add a pre-sync `logger.info` message to make the upsert attempt explicit in logs, while preserving existing success and error logging.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989015b7d448321acc16ff98d16d9dc)