### PR TITLE
Use admin sessions for auth endpoints without org context

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel
 from sqlalchemy import select, text
 
 from config import settings, get_nango_integration_id, get_provider_scope
-from models.database import get_session
+from models.database import get_admin_session, get_session
 from models.integration import Integration
 from models.user import User
 from models.organization import Organization
@@ -122,7 +122,7 @@ async def get_current_user(user_id: Optional[str] = None) -> UserResponse:
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid user ID")
 
-    async with get_session() as session:
+    async with get_admin_session() as session:
         user = await session.get(User, user_uuid)
         if not user:
             raise HTTPException(status_code=404, detail="User not found")
@@ -158,7 +158,7 @@ async def update_profile(
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid user ID")
 
-    async with get_session() as session:
+    async with get_admin_session() as session:
         user = await session.get(User, user_uuid)
         if not user:
             raise HTTPException(status_code=404, detail="User not found")
@@ -255,7 +255,7 @@ async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid organization ID")
 
-    async with get_session() as session:
+    async with get_admin_session() as session:
         # Check if user already exists by ID
         existing = await session.get(User, user_uuid)
         
@@ -373,7 +373,7 @@ async def get_organization_by_domain(email_domain: str) -> OrganizationResponse:
     
     Used to check if an organization exists for a domain when a new user signs up.
     """
-    async with get_session() as session:
+    async with get_admin_session() as session:
         result = await session.execute(
             select(Organization).where(Organization.email_domain == email_domain)
         )


### PR DESCRIPTION
### Motivation
- Several auth routes call `get_session()` without an `organization_id`, which triggers RLS warnings and risks leaking RLS context on pooled connections.
- These endpoints perform system-level lookups/updates where an organization context may not be available, so an admin session should be used instead.

### Description
- Added `get_admin_session` to imports from `models.database` and replaced usages of `get_session()` with `get_admin_session()` for auth endpoints that lack org context.
- Updated `get_current_user`, `update_profile`, `sync_user`, and `get_organization_by_domain` to use `get_admin_session()` so RLS is intentionally bypassed for these lookups/updates.
- Kept tenant-scoped endpoints that do provide an `organization_id` unchanged so normal RLS behavior remains enforced.
- This change avoids noisy warnings like "get_session() called without organization_id - RLS context not set!" and reduces the risk of pooling-related RLS leaks for these system operations.

### Testing
- No automated tests were run as part of this change (CI/unit tests not executed locally).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989561d72f4832198883900f91eb345)