### PR TITLE
Improve Nango metadata extraction for Slack connections

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -29,7 +29,7 @@ from models.database import get_admin_session, get_session
 from models.integration import Integration
 from models.user import User
 from models.organization import Organization
-from services.nango import get_nango_client
+from services.nango import extract_connection_metadata, get_nango_client
 from services.slack_conversations import upsert_slack_user_mappings_from_metadata
 
 router = APIRouter()
@@ -842,11 +842,16 @@ async def confirm_integration(
         nango = get_nango_client()
         nango_integration_id = get_nango_integration_id(request.provider)
         connection = await nango.get_connection(nango_integration_id, nango_connection_id)
-        connection_metadata = connection.get("metadata")
+        connection_metadata = extract_connection_metadata(connection)
         if connection_metadata:
             print(
                 f"[Confirm] Retrieved Nango metadata for provider={request.provider}, "
                 f"connection_id={nango_connection_id}"
+            )
+        else:
+            print(
+                f"[Confirm] No Nango metadata found for provider={request.provider}, "
+                f"connection_id={nango_connection_id} keys={sorted(connection.keys())}"
             )
     except Exception as exc:
         print(

--- a/backend/services/nango.py
+++ b/backend/services/nango.py
@@ -20,6 +20,25 @@ NANGO_API_BASE = settings.NANGO_HOST
 logger = logging.getLogger(__name__)
 
 
+def extract_connection_metadata(connection: dict[str, Any]) -> dict[str, Any] | None:
+    """Return metadata dict from a Nango connection payload, if present."""
+    for key in ("metadata", "connection_metadata", "connectionMetadata"):
+        value = connection.get(key)
+        if isinstance(value, dict) and value:
+            return value
+
+    for config_key in ("connection_config", "connectionConfig"):
+        config_value = connection.get(config_key)
+        if not isinstance(config_value, dict):
+            continue
+        for key in ("metadata", "connection_metadata", "connectionMetadata"):
+            value = config_value.get(key)
+            if isinstance(value, dict) and value:
+                return value
+
+    return None
+
+
 class NangoClient:
     """Client for interacting with Nango API."""
 

--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -24,7 +24,7 @@ from models.database import get_admin_session, get_session
 from models.integration import Integration
 from models.slack_user_mapping import SlackUserMapping
 from models.user import User
-from services.nango import get_nango_client
+from services.nango import extract_connection_metadata, get_nango_client
 from config import get_nango_integration_id
 
 logger = logging.getLogger(__name__)
@@ -418,11 +418,12 @@ async def _hydrate_slack_integration_metadata(integration: Integration) -> None:
         nango = get_nango_client()
         integration_id = get_nango_integration_id("slack")
         connection = await nango.get_connection(integration_id, integration.nango_connection_id)
-        connection_metadata = connection.get("metadata") or {}
+        connection_metadata = extract_connection_metadata(connection) or {}
         if not connection_metadata:
             logger.info(
-                "[slack_conversations] Slack integration %s has no metadata in Nango connection",
+                "[slack_conversations] Slack integration %s has no metadata in Nango connection keys=%s",
                 integration.id,
+                sorted(connection.keys()),
             )
             return
 


### PR DESCRIPTION
### Motivation
- Nango connection payloads can store metadata under different keys or nested structures, causing Slack integration hydration and the auth confirm flow to miss Slack user IDs and fail to resolve connected users.

### Description
- Add `extract_connection_metadata` helper in `services/nango.py` to normalize extraction of metadata from a Nango connection payload. 
- Use `extract_connection_metadata` in the auth confirm flow (`backend/api/routes/auth.py`) to populate `extra_data` when confirming integrations and log connection keys when metadata is missing. 
- Use `extract_connection_metadata` in Slack metadata hydration (`backend/services/slack_conversations.py`) to recover metadata from alternate keys and log available connection keys when metadata is absent. 
- Update imports and logging messages to reflect the new helper and improved diagnostics.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69896c8765548321a2290e32c683d59f)