### PR TITLE
Use current user id for Slack mapping during sync

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -439,14 +439,14 @@ class SlackConnector(BaseConnector):
                     self.organization_id,
                 )
             else:
-                target_user_id = self._integration.user_id or self._integration.connected_by_user_id
-                if not target_user_id:
+                if not self.user_id:
                     logger.warning(
-                        "[Slack Sync] Missing user reference for Slack integration %s org=%s; skipping Nango user info mapping",
+                        "[Slack Sync] Missing current user id for Slack sync integration %s org=%s; skipping Nango user info mapping",
                         self._integration.id,
                         self.organization_id,
                     )
                 else:
+                    target_user_id = uuid.UUID(self.user_id)
                     logger.info(
                         "[Slack Sync] Executing Nango get-user-info action for org=%s integration=%s",
                         self.organization_id,

--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -355,13 +355,13 @@ async def upsert_slack_user_mapping_from_current_profile(
         )
         return 0
 
-    target_user_id = integration.user_id or integration.connected_by_user_id
-    if not target_user_id:
+    if not connector.user_id:
         logger.warning(
-            "[slack_conversations] Slack integration %s missing user_id for current profile mapping",
+            "[slack_conversations] Slack integration %s missing current user id for profile mapping",
             integration.id,
         )
         return 0
+    target_user_id = UUID(connector.user_id)
 
     slack_user_ids = _extract_slack_user_ids(integration.extra_data or {})
     if not slack_user_ids:


### PR DESCRIPTION
### Motivation
- Fix incorrect user mapping during Slack sync by using the current RevTops user ID driving the sync (`self.user_id`) instead of relying on the `Integration.user_id` or `Integration.connected_by_user_id` metadata.

### Description
- Update `backend/connectors/slack.py` to check `self.user_id`, convert it to a `UUID` (`target_user_id = uuid.UUID(self.user_id)`), and update the log message when the current user id is missing.
- Update `backend/services/slack_conversations.py` to use `connector.user_id` (converted via `UUID(connector.user_id)`) as the `target_user_id` in `upsert_slack_user_mapping_from_current_profile` and adjust the missing-id log message.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69897c599a608321bf19f199ee4b9912)