### PR TITLE
Store unmapped Slack users and use DB mappings for Slack verification

### DIFF
--- a/backend/db/migrations/versions/043_allow_nullable_slack_user_mappings_fields.py
+++ b/backend/db/migrations/versions/043_allow_nullable_slack_user_mappings_fields.py
@@ -1,0 +1,58 @@
+"""Allow nullable Slack user mapping fields and store RevTops email.
+
+Revision ID: 043
+Revises: 042
+Create Date: 2026-02-10
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "043"
+down_revision = "042"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "slack_user_mappings",
+        sa.Column("revtops_email", sa.String(length=255), nullable=True),
+    )
+    op.alter_column(
+        "slack_user_mappings",
+        "user_id",
+        existing_type=sa.dialects.postgresql.UUID(as_uuid=True),
+        nullable=True,
+    )
+    op.alter_column(
+        "slack_user_mappings",
+        "slack_user_id",
+        existing_type=sa.String(length=100),
+        nullable=True,
+    )
+    op.create_index(
+        "ix_slack_user_mappings_org_slack_email",
+        "slack_user_mappings",
+        ["organization_id", "slack_email"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_slack_user_mappings_org_slack_email",
+        table_name="slack_user_mappings",
+    )
+    op.alter_column(
+        "slack_user_mappings",
+        "slack_user_id",
+        existing_type=sa.String(length=100),
+        nullable=False,
+    )
+    op.alter_column(
+        "slack_user_mappings",
+        "user_id",
+        existing_type=sa.dialects.postgresql.UUID(as_uuid=True),
+        nullable=False,
+    )
+    op.drop_column("slack_user_mappings", "revtops_email")

--- a/backend/models/slack_user_mapping.py
+++ b/backend/models/slack_user_mapping.py
@@ -36,6 +36,11 @@ class SlackUserMapping(Base):
             "organization_id",
             "user_id",
         ),
+        Index(
+            "ix_slack_user_mappings_org_slack_email",
+            "organization_id",
+            "slack_email",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -44,10 +49,11 @@ class SlackUserMapping(Base):
     organization_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False, index=True
     )
-    user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True
+    user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True, index=True
     )
-    slack_user_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    revtops_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    slack_user_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     slack_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     match_source: Mapped[str] = mapped_column(String(50), nullable=False)
     created_at: Mapped[datetime] = mapped_column(

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -582,8 +582,19 @@ export function DataSources(): JSX.Element {
         }),
       });
       if (!response.ok) {
-        const text = await response.text();
-        throw new Error(text || `Failed to send code: ${response.status}`);
+        let message = `Failed to send code: ${response.status}`;
+        try {
+          const data = await response.json();
+          if (data && typeof data.detail === 'string') {
+            message = data.detail;
+          } else if (typeof data === 'string') {
+            message = data;
+          }
+        } catch {
+          const text = await response.text();
+          if (text) message = text;
+        }
+        throw new Error(message);
       }
       setSlackMappingStatus('Verification code sent via Slack DM.');
     } catch (error) {
@@ -609,8 +620,19 @@ export function DataSources(): JSX.Element {
         }),
       });
       if (!response.ok) {
-        const text = await response.text();
-        throw new Error(text || `Failed to verify code: ${response.status}`);
+        let message = `Failed to verify code: ${response.status}`;
+        try {
+          const data = await response.json();
+          if (data && typeof data.detail === 'string') {
+            message = data.detail;
+          } else if (typeof data === 'string') {
+            message = data;
+          }
+        } catch {
+          const text = await response.text();
+          if (text) message = text;
+        }
+        throw new Error(message);
       }
       setSlackMappingStatus('Slack account connected.');
       setSlackCodeInput('');


### PR DESCRIPTION
### Motivation
- Persist Slack directory entries even when they don't match a RevTops user so they can be matched/linked later. 
- Use the cached `slack_user_mappings` table (instead of scanning Slack on-demand) to power per-user Slack email verification and DM the matching Slack user. 
- Surface clearer error messages in the UI when verification cannot proceed and support nullable mapping data to represent unmapped Slack-only rows.

### Description
- Make mapping columns nullable and add a `revtops_email` column and `ix_slack_user_mappings_org_slack_email` index in the model and add migration `043_allow_nullable_slack_user_mappings_fields.py` to alter the table and create the index. 
- Update `SlackUserMapping` model to allow `user_id`, `slack_user_id`, and `revtops_email` to be optional and add the new index. 
- Change the mapping upsert logic in `services.slack_conversations._upsert_slack_user_mapping` to: skip when no `slack_user_id`, create unmapped Slack-only rows, promote an existing unmapped row to a linked RevTops user when a match is found, and persist `revtops_email` when available. 
- Modify directory refresh flow in `services.slack_conversations.refresh_slack_user_mappings_from_directory` to store unmapped Slack users instead of skipping them and to pass `revtops_email` when a RevTops user is matched. 
- Change the verification endpoint `POST /slack/user-mappings/request-code` to look up the matching Slack user from the `slack_user_mappings` table (by `slack_email`) and return a 404 with a helpful message if no mapping exists, then DM the mapped Slack user using `SlackConnector`. 
- Make `slack_user_id` nullable in the `SlackMappingResponse` schema so unmapped rows can be represented. 
- Improve frontend error handling in `frontend/src/components/DataSources.tsx` for `request-code` and `verify-code` so API `detail` messages are surfaced to the user.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a432efe788321bc754a5f7086c911)