### PR TITLE
Fix Slack chat access and pin icon

### DIFF
--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -164,7 +164,12 @@ export function ChatsList({ chats, onSelectChat, onNewChat }: ChatsListProps): J
                         </h3>
                         {isPinned && (
                           <svg className="w-4 h-4 text-primary-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7l-4-4-4 4m4-4v18m0 0l-4-4m4 4l4-4" />
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M12 21v-6m0 0l-3-3m3 3l3-3m-6.364-2.364L6 8m0 0l3.636-3.636a3 3 0 014.243 0L18 8m-12 0h12"
+                            />
                           </svg>
                         )}
                         {chat.type === 'workflow' && (
@@ -198,8 +203,18 @@ export function ChatsList({ chats, onSelectChat, onNewChat }: ChatsListProps): J
                     className="absolute right-3 top-3 p-1.5 rounded opacity-0 group-hover:opacity-100 hover:bg-surface-700 text-surface-500 hover:text-surface-200 transition-all"
                     title={isPinned ? "Unpin conversation" : "Pin conversation"}
                   >
-                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7l-4-4-4 4m4-4v18m0 0l-4-4m4 4l4-4" />
+                    <svg
+                      className={`w-4 h-4 ${isPinned ? "text-primary-400" : ""}`}
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M12 21v-6m0 0l-3-3m3 3l3-3m-6.364-2.364L6 8m0 0l3.636-3.636a3 3 0 014.243 0L18 8m-12 0h12"
+                      />
                     </svg>
                   </button>
                 </button>

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -594,6 +594,21 @@ export const useAppStore = create<AppState>()(
             data.conversations.length,
             "conversations",
           );
+          const slackPreviewGaps = data.conversations.filter(
+            (conv) =>
+              (conv.title ?? "").toLowerCase().includes("slack") &&
+              !conv.last_message_preview,
+          );
+          if (slackPreviewGaps.length > 0) {
+            console.debug(
+              "[Store] Slack conversations missing previews:",
+              slackPreviewGaps.map((conv) => ({
+                id: conv.id,
+                title: conv.title,
+                updated_at: conv.updated_at,
+              })),
+            );
+          }
 
           const recentChats: ChatSummary[] = data.conversations.map((conv) => ({
             id: conv.id,


### PR DESCRIPTION
### Motivation
- Ensure the recent chats UI uses a proper pin icon and clicking it visually reflects pin/unpin state. 
- Diagnose why Slack-origin conversations sometimes surface with blank/empty previews and add debugging to track missing content. 
- Allow a RevTops user to access conversations originating from linked Slack accounts so Slack users behave like the RevTops user for UI/query purposes.

### Description
- Updated the recent chats UI in `frontend/src/components/ChatsList.tsx` to use a pin-shaped SVG and apply `text-primary-400` when pinned so the icon reflects pinned state.
- Added `_get_slack_user_ids` and `_build_conversation_access_filter` helpers in `backend/api/routes/chat.py` and applied the access filter to `list_conversations`, `get_conversation`, `update_conversation`, `delete_conversation`, and the legacy `get_chat_history` endpoints so linked Slack conversations are visible to the corresponding RevTops user.
- Added server-side debug logging in `backend/api/routes/chat.py` to surface Slack conversation preview lengths and an info log when previews are missing.
- Reworked `get_slack_user_ids_for_revtops_user` in `backend/services/slack_conversations.py` to read Slack user mappings (and log when mappings are absent despite active Slack integrations) and rely on mappings to resolve accessible Slack user IDs.
- Added client-side debug logging in `frontend/src/store/index.ts` to list Slack conversations that appear to be missing `last_message_preview` so missing content can be diagnosed from the browser console.

### Testing
- Ran a headless Playwright script to render the updated pin icon as `artifacts/pin-icon-preview.png` for visual verification and it completed successfully.
- No additional automated unit/integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a59d8f7c88321a9a599c8693bc111)