### PR TITLE
Sync chat updates across tabs using BroadcastChannel

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -17,6 +17,7 @@ import { ArtifactViewer, type FileArtifact } from './ArtifactViewer';
 import { ArtifactTile } from './ArtifactTile';
 import { PendingApprovalCard, type ApprovalResult } from './PendingApprovalCard';
 import { getConversation, uploadChatFile, type UploadResponse } from '../api/client';
+import { crossTab } from '../lib/crossTab';
 import { 
   useAppStore,
   useConversationState,
@@ -465,6 +466,20 @@ export function Chat({
       // Add message to existing conversation
       addConversationMessage(currentConvId, userMessage);
       setConversationThinking(currentConvId, true);
+      if (crossTab.isAvailable) {
+        console.log('[Chat] Broadcasting optimistic message to other tabs', {
+          conversationId: currentConvId,
+          messageId: userMessage.id,
+        });
+        crossTab.postMessage({
+          kind: 'optimistic_message',
+          payload: {
+            conversationId: currentConvId,
+            message: userMessage,
+            setThinking: true,
+          },
+        });
+      }
     } else {
       // New conversation - store in pending state
       pendingTitleRef.current = generateTitle(message);

--- a/frontend/src/lib/crossTab.ts
+++ b/frontend/src/lib/crossTab.ts
@@ -1,0 +1,56 @@
+import type { ChatMessage } from "../store";
+
+export type CrossTabEvent =
+  | {
+      origin: string;
+      kind: "ws-event";
+      payload: { message: string };
+    }
+  | {
+      origin: string;
+      kind: "optimistic_message";
+      payload: {
+        conversationId: string;
+        message: ChatMessage;
+        setThinking: boolean;
+      };
+    };
+
+const channelName = "revtops-chat-sync";
+const isBrowser =
+  typeof window !== "undefined" && typeof window.BroadcastChannel !== "undefined";
+const channel = isBrowser ? new BroadcastChannel(channelName) : null;
+const tabId =
+  typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+export const crossTab = {
+  isAvailable: Boolean(channel),
+  tabId,
+  postMessage(event: Omit<CrossTabEvent, "origin">): void {
+    if (!channel) {
+      return;
+    }
+    channel.postMessage({ ...event, origin: tabId });
+  },
+};
+
+export function subscribeCrossTab(
+  handler: (event: CrossTabEvent) => void,
+): () => void {
+  if (!channel) {
+    return () => {};
+  }
+
+  const listener = (event: MessageEvent<CrossTabEvent>): void => {
+    const data = event.data;
+    if (!data || data.origin === tabId) {
+      return;
+    }
+    handler(data);
+  };
+
+  channel.addEventListener("message", listener);
+  return () => channel.removeEventListener("message", listener);
+}


### PR DESCRIPTION
### Motivation
- Keep chat UI consistent across multiple browser windows by ensuring optimistic messages and streaming/backend-driven WebSocket updates are reflected in all open tabs for the same chat.  
- Avoid forcing navigation or duplicate state updates when background tasks stream chunks to other tabs.  

### Description
- Add a cross-tab helper `frontend/src/lib/crossTab.ts` that wraps `BroadcastChannel` and exposes `postMessage` and `subscribeCrossTab` utilities.  
- Broadcast optimistic user messages from `Chat` by posting an `optimistic_message` event when a user posts a message in an existing conversation (`frontend/src/components/Chat.tsx`).  
- Re-broadcast selected WebSocket events (e.g., `task_started`, `task_chunk`, `task_complete`, `conversation_created`, `tool_progress`, `crm_approval_result`, `tool_approval_result`) from the primary receiving tab so other tabs can apply streamed/task updates without performing navigation (`frontend/src/components/AppLayout.tsx`).  
- Add a cross-tab subscription in `AppLayout` which: applies optimistic messages from other tabs (with duplicate detection by message `id`) and feeds rebroadcast WebSocket messages into the existing `handleWebSocketMessage` flow (new `source` param) so updates are applied identically.  
- Include defensive logging statements around broadcasting and receiving cross-tab events to aid debugging and to make flow of optimistic/streamed updates observable.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a7132c3e083219a95546119e301ed)