### PR TITLE
Rename slack_user_mappings -> user_mappings_for_identity, add source and external_* fields

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -285,30 +285,31 @@ SELECT id, name, email, role FROM users WHERE organization_id = :org_id
 SELECT * FROM users WHERE name ILIKE '%john%'
 ```
 
-### slack_user_mappings
+### user_mappings_for_identity
 **Identity links** between internal users and Slack users.
 Use this table when the user asks about Slack identities, mentions, or when mapping Slack user IDs/emails to RevTops users.
 ```
-id, organization_id, user_id, slack_user_id, slack_email, match_source, created_at, updated_at
+id, organization_id, user_id, external_userid, external_email, source, match_source, created_at, updated_at
 ```
 - `user_id`: FK to `users.id`
-- `slack_user_id`: Slack user identifier (e.g., U123...)
-- `slack_email`: Slack profile email when available
+- `external_userid`: Slack user identifier (e.g., U123...)
+- `external_email`: Slack profile email when available
+- `source`: identity provider (e.g., "slack")
 - `match_source`: How the mapping was established (e.g., "oauth", "profile_match")
 
-Example queries for slack user mappings:
+Example queries for Slack user mappings:
 ```sql
 -- Map a Slack user ID to a RevTops user
-SELECT u.id, u.name, u.email, m.slack_user_id, m.slack_email
-FROM slack_user_mappings m
+SELECT u.id, u.name, u.email, m.external_userid, m.external_email
+FROM user_mappings_for_identity m
 JOIN users u ON u.id = m.user_id
-WHERE m.slack_user_id = 'U12345678'
+WHERE m.external_userid = 'U12345678' AND m.source = 'slack'
 
 -- Find all Slack mappings for a teammate
-SELECT m.slack_user_id, m.slack_email, m.match_source, m.updated_at
-FROM slack_user_mappings m
+SELECT m.external_userid, m.external_email, m.match_source, m.updated_at
+FROM user_mappings_for_identity m
 JOIN users u ON u.id = m.user_id
-WHERE u.email = 'jane@example.com'
+WHERE u.email = 'jane@example.com' AND m.source = 'slack'
 ```
 
 ### organizations

--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -102,7 +102,7 @@ Available tables:
 - pipeline_stages: Stages in pipelines (pipeline_id, name, probability)
 - integrations: Connected data sources (provider, is_active, last_sync_at)
 - users: Team members (email, name, role)
-- slack_user_mappings: Slack identity links (slack_user_id, slack_email, match_source)
+- user_mappings_for_identity: Slack identity links (external_userid, external_email, match_source, source)
 - organizations: User's company info (name, logo_url)
 
 IMPORTANT: Only SELECT queries are allowed. No INSERT, UPDATE, DELETE, DROP, etc.""",

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -139,7 +139,11 @@ class ToolProgressUpdater:
 # Note: Row-Level Security (RLS) handles organization filtering at the database level
 ALLOWED_TABLES: set[str] = {
     "deals", "accounts", "contacts", "activities", "meetings", "integrations", "users", "organizations",
-    "pipelines", "pipeline_stages", "workflows", "workflow_runs", "slack_user_mappings"
+    "pipelines",
+    "pipeline_stages",
+    "workflows",
+    "workflow_runs",
+    "user_mappings_for_identity",
 }
 
 

--- a/backend/db/migrations/versions/044_rename_slack_user_mappings_to_identity_mappings.py
+++ b/backend/db/migrations/versions/044_rename_slack_user_mappings_to_identity_mappings.py
@@ -1,0 +1,134 @@
+"""Rename Slack user mappings table and add source metadata.
+
+Revision ID: 044
+Revises: 043
+Create Date: 2026-02-11
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "044"
+down_revision = "043"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.rename_table("slack_user_mappings", "user_mappings_for_identity")
+    op.alter_column(
+        "user_mappings_for_identity",
+        "slack_user_id",
+        new_column_name="external_userid",
+        existing_type=sa.String(length=100),
+        nullable=True,
+    )
+    op.alter_column(
+        "user_mappings_for_identity",
+        "slack_email",
+        new_column_name="external_email",
+        existing_type=sa.String(length=255),
+        nullable=True,
+    )
+    op.add_column(
+        "user_mappings_for_identity",
+        sa.Column(
+            "source",
+            sa.String(length=50),
+            nullable=False,
+            server_default=sa.text("'slack'"),
+        ),
+    )
+    op.drop_index(
+        "uq_slack_user_mappings_org_user_slack_user",
+        table_name="user_mappings_for_identity",
+    )
+    op.drop_index(
+        "ix_slack_user_mappings_org_slack_user",
+        table_name="user_mappings_for_identity",
+    )
+    op.drop_index(
+        "ix_slack_user_mappings_org_user",
+        table_name="user_mappings_for_identity",
+    )
+    op.drop_index(
+        "ix_slack_user_mappings_org_slack_email",
+        table_name="user_mappings_for_identity",
+    )
+    op.create_index(
+        "uq_identity_mappings_org_user_external_user_source",
+        "user_mappings_for_identity",
+        ["organization_id", "user_id", "external_userid", "source"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_identity_mappings_org_external_user_source",
+        "user_mappings_for_identity",
+        ["organization_id", "external_userid", "source"],
+    )
+    op.create_index(
+        "ix_identity_mappings_org_user",
+        "user_mappings_for_identity",
+        ["organization_id", "user_id"],
+    )
+    op.create_index(
+        "ix_identity_mappings_org_external_email_source",
+        "user_mappings_for_identity",
+        ["organization_id", "external_email", "source"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_identity_mappings_org_external_email_source",
+        table_name="user_mappings_for_identity",
+    )
+    op.drop_index(
+        "ix_identity_mappings_org_user",
+        table_name="user_mappings_for_identity",
+    )
+    op.drop_index(
+        "ix_identity_mappings_org_external_user_source",
+        table_name="user_mappings_for_identity",
+    )
+    op.drop_index(
+        "uq_identity_mappings_org_user_external_user_source",
+        table_name="user_mappings_for_identity",
+    )
+    op.drop_column("user_mappings_for_identity", "source")
+    op.alter_column(
+        "user_mappings_for_identity",
+        "external_userid",
+        new_column_name="slack_user_id",
+        existing_type=sa.String(length=100),
+        nullable=True,
+    )
+    op.alter_column(
+        "user_mappings_for_identity",
+        "external_email",
+        new_column_name="slack_email",
+        existing_type=sa.String(length=255),
+        nullable=True,
+    )
+    op.rename_table("user_mappings_for_identity", "slack_user_mappings")
+    op.create_index(
+        "uq_slack_user_mappings_org_user_slack_user",
+        "slack_user_mappings",
+        ["organization_id", "user_id", "slack_user_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_slack_user_mappings_org_slack_user",
+        "slack_user_mappings",
+        ["organization_id", "slack_user_id"],
+    )
+    op.create_index(
+        "ix_slack_user_mappings_org_user",
+        "slack_user_mappings",
+        ["organization_id", "user_id"],
+    )
+    op.create_index(
+        "ix_slack_user_mappings_org_slack_email",
+        "slack_user_mappings",
+        ["organization_id", "slack_email"],
+    )

--- a/backend/models/slack_user_mapping.py
+++ b/backend/models/slack_user_mapping.py
@@ -17,29 +17,32 @@ from models.database import Base
 class SlackUserMapping(Base):
     """Persisted mapping between RevTops users and Slack users."""
 
-    __tablename__ = "slack_user_mappings"
+    __tablename__ = "user_mappings_for_identity"
     __table_args__ = (
         Index(
-            "uq_slack_user_mappings_org_user_slack_user",
+            "uq_identity_mappings_org_user_external_user_source",
             "organization_id",
             "user_id",
-            "slack_user_id",
+            "external_userid",
+            "source",
             unique=True,
         ),
         Index(
-            "ix_slack_user_mappings_org_slack_user",
+            "ix_identity_mappings_org_external_user_source",
             "organization_id",
-            "slack_user_id",
+            "external_userid",
+            "source",
         ),
         Index(
-            "ix_slack_user_mappings_org_user",
+            "ix_identity_mappings_org_user",
             "organization_id",
             "user_id",
         ),
         Index(
-            "ix_slack_user_mappings_org_slack_email",
+            "ix_identity_mappings_org_external_email_source",
             "organization_id",
-            "slack_email",
+            "external_email",
+            "source",
         ),
     )
 
@@ -53,8 +56,9 @@ class SlackUserMapping(Base):
         UUID(as_uuid=True), ForeignKey("users.id"), nullable=True, index=True
     )
     revtops_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    slack_user_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
-    slack_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    external_userid: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    external_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    source: Mapped[str] = mapped_column(String(50), nullable=False, default="slack")
     match_source: Mapped[str] = mapped_column(String(50), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, nullable=False

--- a/backend/tests/test_slack_user_resolution.py
+++ b/backend/tests/test_slack_user_resolution.py
@@ -143,7 +143,7 @@ def test_resolve_revtops_user_uses_existing_mapping(monkeypatch):
     ]
     integrations = []
     mappings = [
-        SimpleNamespace(user_id=jane_id, slack_user_id="U999"),
+        SimpleNamespace(user_id=jane_id, external_userid="U999", source="slack"),
     ]
 
     monkeypatch.setattr(


### PR DESCRIPTION
### Motivation
- Generalize Slack-specific identity links into a provider-agnostic identity mappings table with explicit source metadata so multiple external identity providers can be supported. 
- Avoid ambiguity between internal RevTops emails and external provider identifiers by renaming Slack-specific fields to `external_userid`/`external_email` and tracking `source`.

### Description
- Renamed the model/table to `user_mappings_for_identity` and replaced `slack_user_id`/`slack_email` with `external_userid`/`external_email`, adding a `source` column defaulting to `slack` in the model and a new Alembic migration `044` to perform the rename and index rebuild. (files: `backend/models/slack_user_mapping.py`, `backend/db/migrations/versions/044_rename_slack_user_mappings_to_identity_mappings.py`)
- Updated all lookup/query logic to filter by `source` (default `slack`) and to reference the new `external_*` columns in service code and API routes. (files: `backend/services/slack_conversations.py`, `backend/api/routes/slack_user_mappings.py`)
- Ensured upserts/writes set the `source` field and use the new unique/index columns (`external_userid` + `source`) in conflict resolution. (file: `backend/services/slack_conversations.py`)
- Updated textual/docs and tooling references as well as test fixtures to use the renamed table/fields and source scoping. (files: `backend/agents/orchestrator.py`, `backend/agents/registry.py`, `backend/agents/tools.py`, `backend/tests/test_slack_user_resolution.py`)

### Testing
- No automated test suite was executed as part of this change; the migration and code were updated but not run here. 
- The unit test file `backend/tests/test_slack_user_resolution.py` was updated to reflect `external_userid` and `source` changes and should be run locally/CI (`pytest`) after applying the migration. 
- A new Alembic migration `044` was added and should be applied to the database before deploying the updated code (`alembic upgrade head`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a822695bc8321ba48222848db065a)