### PR TITLE
Rename slack_user_mappings -> user_mappings_for_identity, add `source`, and update lookups/writes

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -293,28 +293,28 @@ SELECT id, name, email, role FROM users WHERE organization_id = :org_id
 SELECT * FROM users WHERE name ILIKE '%john%'
 ```
 
-### slack_user_mappings
+### user_mappings_for_identity
 **Identity links** between internal users and Slack users.
 Use this table when the user asks about Slack identities, mentions, or when mapping Slack user IDs/emails to RevTops users.
 ```
-id, organization_id, user_id, slack_user_id, slack_email, match_source, created_at, updated_at
+id, organization_id, user_id, external_userid, external_email, match_source, created_at, updated_at
 ```
 - `user_id`: FK to `users.id`
-- `slack_user_id`: Slack user identifier (e.g., U123...)
-- `slack_email`: Slack profile email when available
+- `external_userid`: Slack user identifier (e.g., U123...)
+- `external_email`: Slack profile email when available
 - `match_source`: How the mapping was established (e.g., "oauth", "profile_match")
 
 Example queries for slack user mappings:
 ```sql
 -- Map a Slack user ID to a RevTops user
-SELECT u.id, u.name, u.email, m.slack_user_id, m.slack_email
-FROM slack_user_mappings m
+SELECT u.id, u.name, u.email, m.external_userid, m.external_email
+FROM user_mappings_for_identity m
 JOIN users u ON u.id = m.user_id
-WHERE m.slack_user_id = 'U12345678'
+WHERE m.external_userid = 'U12345678'
 
 -- Find all Slack mappings for a teammate
-SELECT m.slack_user_id, m.slack_email, m.match_source, m.updated_at
-FROM slack_user_mappings m
+SELECT m.external_userid, m.external_email, m.match_source, m.updated_at
+FROM user_mappings_for_identity m
 JOIN users u ON u.id = m.user_id
 WHERE u.email = 'jane@example.com'
 ```

--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -102,7 +102,7 @@ Available tables:
 - pipeline_stages: Stages in pipelines (pipeline_id, name, probability)
 - integrations: Connected data sources (provider, is_active, last_sync_at)
 - users: Team members (email, name, role)
-- slack_user_mappings: Slack identity links (slack_user_id, slack_email, match_source)
+- user_mappings_for_identity: Slack identity links (external_userid, external_email, match_source)
 - organizations: User's company info (name, logo_url)
 
 IMPORTANT: Only SELECT queries are allowed. No INSERT, UPDATE, DELETE, DROP, etc.""",

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -139,7 +139,7 @@ class ToolProgressUpdater:
 # Note: Row-Level Security (RLS) handles organization filtering at the database level
 ALLOWED_TABLES: set[str] = {
     "deals", "accounts", "contacts", "activities", "meetings", "integrations", "users", "organizations",
-    "pipelines", "pipeline_stages", "workflows", "workflow_runs", "slack_user_mappings"
+    "pipelines", "pipeline_stages", "workflows", "workflow_runs", "user_mappings_for_identity"
 }
 
 

--- a/backend/api/routes/slack_user_mappings.py
+++ b/backend/api/routes/slack_user_mappings.py
@@ -30,8 +30,8 @@ _CODE_TTL = timedelta(minutes=10)
 
 class SlackMappingResponse(BaseModel):
     id: str
-    slack_user_id: str | None
-    slack_email: str | None
+    external_userid: str | None
+    external_email: str | None
     match_source: str
     created_at: str
 
@@ -114,7 +114,7 @@ def _normalize_email(email: str) -> str:
         normalized = f"{local_part}@{domain}"
     if normalized != original:
         logger.debug(
-            "[slack_user_mappings] Normalized email from '%s' to '%s'",
+            "[user_mappings_for_identity] Normalized email from '%s' to '%s'",
             original,
             normalized,
         )
@@ -124,7 +124,7 @@ def _normalize_email(email: str) -> str:
 
 
 @router.get("/user-mappings", response_model=SlackMappingListResponse)
-async def list_slack_user_mappings(
+async def list_user_mappings_for_identity(
     user_id: str,
     organization_id: str | None = None,
 ) -> SlackMappingListResponse:
@@ -137,6 +137,7 @@ async def list_slack_user_mappings(
         result = await session.execute(
             select(SlackUserMapping)
             .where(SlackUserMapping.organization_id == org_uuid)
+            .where(SlackUserMapping.source == "slack")
             .where(SlackUserMapping.user_id == user_uuid)
             .order_by(SlackUserMapping.created_at.desc())
         )
@@ -145,8 +146,8 @@ async def list_slack_user_mappings(
     response = [
         SlackMappingResponse(
             id=str(mapping.id),
-            slack_user_id=mapping.slack_user_id,
-            slack_email=mapping.slack_email,
+            external_userid=mapping.external_userid,
+            external_email=mapping.external_email,
             match_source=mapping.match_source,
             created_at=mapping.created_at.isoformat() + "Z",
         )
@@ -174,22 +175,23 @@ async def request_slack_user_mapping_code(
         result = await session.execute(
             select(SlackUserMapping)
             .where(SlackUserMapping.organization_id == org_uuid)
-            .where(SlackUserMapping.slack_email == email)
+            .where(SlackUserMapping.source == "slack")
+            .where(SlackUserMapping.external_email == email)
             .order_by(SlackUserMapping.updated_at.desc())
         )
         matched_mapping = result.scalars().first()
 
     logger.info(
-        "[slack_user_mappings] Lookup Slack mapping for org=%s user=%s email=%s matched=%s",
+        "[user_mappings_for_identity] Lookup Slack mapping for org=%s user=%s email=%s matched=%s",
         org_uuid,
         user_uuid,
         email,
         bool(matched_mapping),
     )
 
-    if not matched_mapping or not matched_mapping.slack_user_id:
+    if not matched_mapping or not matched_mapping.external_userid:
         logger.warning(
-            "[slack_user_mappings] No Slack mapping found for org=%s user=%s email=%s",
+            "[user_mappings_for_identity] No Slack mapping found for org=%s user=%s email=%s",
             org_uuid,
             user_uuid,
             email,
@@ -212,7 +214,7 @@ async def request_slack_user_mapping_code(
     )
     if not was_set:
         logger.info(
-            "[slack_user_mappings] Slack verification code cooldown active org=%s user=%s",
+            "[user_mappings_for_identity] Slack verification code cooldown active org=%s user=%s",
             org_uuid,
             user_uuid,
         )
@@ -221,8 +223,8 @@ async def request_slack_user_mapping_code(
             detail="Please wait at least one minute before requesting another code.",
         )
     matched_user = {
-        "id": matched_mapping.slack_user_id,
-        "email": matched_mapping.slack_email or email,
+        "id": matched_mapping.external_userid,
+        "email": matched_mapping.external_email or email,
     }
 
     code = f"{secrets.randbelow(1000000):06d}"
@@ -237,7 +239,7 @@ async def request_slack_user_mapping_code(
     await redis_client.set(code_key, payload, ex=int(_CODE_TTL.total_seconds()))
 
     logger.info(
-        "[slack_user_mappings] Sending Slack verification code org=%s user=%s slack_user=%s",
+        "[user_mappings_for_identity] Sending Slack verification code org=%s user=%s slack_user=%s",
         org_uuid,
         user_uuid,
         matched_user["id"],
@@ -252,7 +254,7 @@ async def request_slack_user_mapping_code(
         text=message_text,
     )
     logger.info(
-        "[slack_user_mappings] Slack DM send response org=%s user=%s slack_user=%s keys=%s",
+        "[user_mappings_for_identity] Slack DM send response org=%s user=%s slack_user=%s keys=%s",
         org_uuid,
         user_uuid,
         matched_user["id"],
@@ -298,7 +300,7 @@ async def verify_slack_user_mapping_code(
     await redis_client.delete(code_key)
 
     logger.info(
-        "[slack_user_mappings] Verified Slack user mapping org=%s user=%s slack_user=%s",
+        "[user_mappings_for_identity] Verified Slack user mapping org=%s user=%s slack_user=%s",
         org_uuid,
         user_uuid,
         slack_user_id,
@@ -327,6 +329,7 @@ async def delete_slack_user_mapping(
             select(SlackUserMapping)
             .where(SlackUserMapping.id == mapping_uuid)
             .where(SlackUserMapping.organization_id == org_uuid)
+            .where(SlackUserMapping.source == "slack")
             .where(SlackUserMapping.user_id == user_uuid)
         )
         mapping = result.scalar_one_or_none()
@@ -337,7 +340,7 @@ async def delete_slack_user_mapping(
         await session.commit()
 
     logger.info(
-        "[slack_user_mappings] Deleted mapping id=%s org=%s user=%s",
+        "[user_mappings_for_identity] Deleted mapping id=%s org=%s user=%s",
         mapping_id,
         org_uuid,
         user_uuid,

--- a/backend/db/migrations/versions/042_add_slack_user_mappings_and_chat_message_sender_fields.py
+++ b/backend/db/migrations/versions/042_add_slack_user_mappings_and_chat_message_sender_fields.py
@@ -1,14 +1,14 @@
 """Add Slack user mappings + sender fields on chat messages.
 
-Revision ID: 041
-Revises: 040
+Revision ID: 042
+Revises: 041
 Create Date: 2026-02-10
 """
 from alembic import op
 import sqlalchemy as sa
 
-revision = "041"
-down_revision = "040"
+revision = "042"
+down_revision = "041"
 branch_labels = None
 depends_on = None
 

--- a/backend/db/migrations/versions/043_allow_multiple_slack_user_mappings.py
+++ b/backend/db/migrations/versions/043_allow_multiple_slack_user_mappings.py
@@ -1,14 +1,14 @@
 """Allow multiple Slack user mappings per RevTops user and vice versa.
 
-Revision ID: 042
-Revises: 041
+Revision ID: 043
+Revises: 042
 Create Date: 2026-02-10
 """
 from alembic import op
 import sqlalchemy as sa
 
-revision = "042"
-down_revision = "041"
+revision = "043"
+down_revision = "042"
 branch_labels = None
 depends_on = None
 

--- a/backend/db/migrations/versions/044_allow_nullable_slack_user_mappings_fields.py
+++ b/backend/db/migrations/versions/044_allow_nullable_slack_user_mappings_fields.py
@@ -1,15 +1,15 @@
 """Allow nullable Slack user mapping fields and store RevTops email.
 
-Revision ID: 043
-Revises: 042
+Revision ID: 044
+Revises: 043
 Create Date: 2026-02-10
 """
 from alembic import op
 import sqlalchemy as sa
 
 
-revision = "043"
-down_revision = "042"
+revision = "044"
+down_revision = "043"
 branch_labels = None
 depends_on = None
 

--- a/backend/db/migrations/versions/045_rename_slack_user_mappings_to_identity_user_mappings.py
+++ b/backend/db/migrations/versions/045_rename_slack_user_mappings_to_identity_user_mappings.py
@@ -1,0 +1,172 @@
+"""Rename Slack mappings table to generic identity mappings and add source.
+
+Revision ID: 045
+Revises: 044
+Create Date: 2026-02-10
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "045"
+down_revision = "044"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.rename_table("slack_user_mappings", "user_mappings_for_identity")
+
+    op.alter_column(
+        "user_mappings_for_identity",
+        "slack_user_id",
+        new_column_name="external_userid",
+        existing_type=sa.String(length=100),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "user_mappings_for_identity",
+        "slack_email",
+        new_column_name="external_email",
+        existing_type=sa.String(length=255),
+        existing_nullable=True,
+    )
+
+    op.add_column(
+        "user_mappings_for_identity",
+        sa.Column(
+            "source",
+            sa.String(length=50),
+            nullable=False,
+            server_default="revtops_unknown",
+        ),
+    )
+
+    op.execute(
+        sa.text(
+            """
+            UPDATE user_mappings_for_identity
+            SET source = 'slack'
+            WHERE source = 'revtops_unknown'
+            """
+        )
+    )
+
+    op.drop_index("ix_slack_user_mappings_user", table_name="user_mappings_for_identity")
+    op.drop_index("ix_slack_user_mappings_org", table_name="user_mappings_for_identity")
+    op.drop_index("ix_slack_user_mappings_org_user", table_name="user_mappings_for_identity")
+    op.drop_index(
+        "ix_slack_user_mappings_org_slack_user",
+        table_name="user_mappings_for_identity",
+    )
+    op.drop_index(
+        "ix_slack_user_mappings_org_slack_email",
+        table_name="user_mappings_for_identity",
+    )
+    op.drop_index(
+        "uq_slack_user_mappings_org_user_slack_user",
+        table_name="user_mappings_for_identity",
+    )
+
+    op.create_index(
+        "ix_user_mappings_for_identity_user",
+        "user_mappings_for_identity",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_user_mappings_for_identity_org",
+        "user_mappings_for_identity",
+        ["organization_id"],
+    )
+    op.create_index(
+        "ix_user_mappings_for_identity_org_user",
+        "user_mappings_for_identity",
+        ["organization_id", "user_id"],
+    )
+    op.create_index(
+        "ix_user_mappings_for_identity_org_external_user",
+        "user_mappings_for_identity",
+        ["organization_id", "external_userid"],
+    )
+    op.create_index(
+        "ix_user_mappings_for_identity_org_external_email",
+        "user_mappings_for_identity",
+        ["organization_id", "external_email"],
+    )
+    op.create_index(
+        "uq_user_mappings_for_identity_org_user_external_user",
+        "user_mappings_for_identity",
+        ["organization_id", "user_id", "external_userid"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_user_mappings_for_identity_org_user_external_user",
+        table_name="user_mappings_for_identity",
+    )
+    op.drop_index(
+        "ix_user_mappings_for_identity_org_external_email",
+        table_name="user_mappings_for_identity",
+    )
+    op.drop_index(
+        "ix_user_mappings_for_identity_org_external_user",
+        table_name="user_mappings_for_identity",
+    )
+    op.drop_index(
+        "ix_user_mappings_for_identity_org_user",
+        table_name="user_mappings_for_identity",
+    )
+    op.drop_index("ix_user_mappings_for_identity_org", table_name="user_mappings_for_identity")
+    op.drop_index("ix_user_mappings_for_identity_user", table_name="user_mappings_for_identity")
+
+    op.alter_column(
+        "user_mappings_for_identity",
+        "external_email",
+        new_column_name="slack_email",
+        existing_type=sa.String(length=255),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        "user_mappings_for_identity",
+        "external_userid",
+        new_column_name="slack_user_id",
+        existing_type=sa.String(length=100),
+        existing_nullable=True,
+    )
+
+    op.create_index(
+        "uq_slack_user_mappings_org_user_slack_user",
+        "user_mappings_for_identity",
+        ["organization_id", "user_id", "slack_user_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_slack_user_mappings_org_slack_email",
+        "user_mappings_for_identity",
+        ["organization_id", "slack_email"],
+    )
+    op.create_index(
+        "ix_slack_user_mappings_org_slack_user",
+        "user_mappings_for_identity",
+        ["organization_id", "slack_user_id"],
+    )
+    op.create_index(
+        "ix_slack_user_mappings_org_user",
+        "user_mappings_for_identity",
+        ["organization_id", "user_id"],
+    )
+    op.create_index(
+        "ix_slack_user_mappings_org",
+        "user_mappings_for_identity",
+        ["organization_id"],
+    )
+    op.create_index(
+        "ix_slack_user_mappings_user",
+        "user_mappings_for_identity",
+        ["user_id"],
+    )
+
+    op.drop_column("user_mappings_for_identity", "source")
+    op.rename_table("user_mappings_for_identity", "slack_user_mappings")

--- a/backend/models/slack_user_mapping.py
+++ b/backend/models/slack_user_mapping.py
@@ -17,29 +17,29 @@ from models.database import Base
 class SlackUserMapping(Base):
     """Persisted mapping between RevTops users and Slack users."""
 
-    __tablename__ = "slack_user_mappings"
+    __tablename__ = "user_mappings_for_identity"
     __table_args__ = (
         Index(
-            "uq_slack_user_mappings_org_user_slack_user",
+            "uq_user_mappings_for_identity_org_user_external_user",
             "organization_id",
             "user_id",
-            "slack_user_id",
+            "external_userid",
             unique=True,
         ),
         Index(
-            "ix_slack_user_mappings_org_slack_user",
+            "ix_user_mappings_for_identity_org_external_user",
             "organization_id",
-            "slack_user_id",
+            "external_userid",
         ),
         Index(
-            "ix_slack_user_mappings_org_user",
+            "ix_user_mappings_for_identity_org_user",
             "organization_id",
             "user_id",
         ),
         Index(
-            "ix_slack_user_mappings_org_slack_email",
+            "ix_user_mappings_for_identity_org_external_email",
             "organization_id",
-            "slack_email",
+            "external_email",
         ),
     )
 
@@ -53,8 +53,9 @@ class SlackUserMapping(Base):
         UUID(as_uuid=True), ForeignKey("users.id"), nullable=True, index=True
     )
     revtops_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    slack_user_id: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
-    slack_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    external_userid: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    external_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    source: Mapped[str] = mapped_column(String(50), nullable=False, default="revtops_unknown", server_default="revtops_unknown")
     match_source: Mapped[str] = mapped_column(String(50), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, nullable=False

--- a/backend/tests/test_slack_user_resolution.py
+++ b/backend/tests/test_slack_user_resolution.py
@@ -143,7 +143,7 @@ def test_resolve_revtops_user_uses_existing_mapping(monkeypatch):
     ]
     integrations = []
     mappings = [
-        SimpleNamespace(user_id=jane_id, slack_user_id="U999"),
+        SimpleNamespace(user_id=jane_id, external_userid="U999"),
     ]
 
     monkeypatch.setattr(


### PR DESCRIPTION
### Motivation
- Consolidate identity mappings into a generic, source-aware table so non-Slack identity sources can be recorded and Slack mappings are scoped by source by default.
- Normalize field names to make the table generic (`slack_user_id`/`slack_email` -> `external_userid`/`external_email`).
- Fix duplicate migration revision numbers and make the migration chain linear and deterministic.

### Description
- Renamed ORM table/indices and model: `slack_user_mappings` -> `user_mappings_for_identity`, `slack_user_id` -> `external_userid`, and `slack_email` -> `external_email`, and added a non-null `source` column with default/server_default `revtops_unknown` in `backend/models/slack_user_mapping.py`.
- Updated all Slack-related read queries to filter by `SlackUserMapping.source == "slack"` by default and updated writes/upserts to persist `source = "slack"` for Slack-origin rows in `backend/services/slack_conversations.py` and `backend/api/routes/slack_user_mappings.py`.
- Updated API route payload/response fields and route names to use `external_userid`/`external_email` and adjusted logging keys/messages accordingly in `backend/api/routes/slack_user_mappings.py`.
- Added an Alembic migration `045_rename_slack_user_mappings_to_identity_user_mappings.py` which renames the table/columns, adds the `source` column (server default `revtops_unknown`) and backfills existing entries to `source = 'slack'`, and adjusted index names; renumbered prior migrations to remove duplicate `041` revisions and produce the chain `041 -> 042 -> 043 -> 044 -> 045` under `backend/db/migrations/versions/`.
- Updated references/docs/tools/agents allowlist and tests to match the new names (`backend/agents/orchestrator.py`, `backend/agents/registry.py`, `backend/agents/tools.py`, `backend/tests/test_slack_user_resolution.py`).

### Testing
- Ran the slack-resolution unit tests with module path set: `PYTHONPATH=backend pytest -q backend/tests/test_slack_user_resolution.py` and all tests passed (`3 passed`).
- An initial test run without `PYTHONPATH` failed with an import error; after fixing the refactor wiring the targeted test run above succeeded. 
- Verified migration revision uniqueness via a quick script scanning `backend/db/migrations/versions/*.py` and confirmed no duplicate revision IDs after renumbering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ad366b4008321bb7c338f0730fcea)