### PR TITLE
Show only slack-sourced identity mappings in Slack mapping UI

### DIFF
--- a/backend/api/routes/slack_user_mappings.py
+++ b/backend/api/routes/slack_user_mappings.py
@@ -32,6 +32,7 @@ class SlackMappingResponse(BaseModel):
     id: str
     external_userid: str | None
     external_email: str | None
+    source: str
     match_source: str
     created_at: str
 
@@ -148,6 +149,7 @@ async def list_user_mappings_for_identity(
             id=str(mapping.id),
             external_userid=mapping.external_userid,
             external_email=mapping.external_email,
+            source=mapping.source,
             match_source=mapping.match_source,
             created_at=mapping.created_at.isoformat() + "Z",
         )


### PR DESCRIPTION
### Motivation
- Ensure the Slack mappings UI only shows identity mappings that actually originate from Slack (avoid showing unrelated identity rows). 
- Surface the mapping `source` from the backend so the frontend can reliably filter and display mappings by origin.

### Description
- Add `source` to the backend response model (`SlackMappingResponse`) and include `source` when building the response from `SlackUserMapping` rows. 
- The backend query already constrains results to Slack-origin rows via `where(SlackUserMapping.source == "slack")`, and the response now carries `source` for clarity. 
- Update the frontend `SlackUserMapping` interface to include `source` and replace prior `slack_user_id`/`slack_email` usages with `external_userid`/`external_email` to match the identity-table shape. 
- Hydrate and normalize mappings in `DataSources` and filter them client-side with `.filter((m) => m.source.toLowerCase().includes('slack'))` before rendering the "Linked Slack emails" UI.

### Testing
- Ran `npm --prefix frontend run build`, which completed successfully (with build warnings about chunk sizes). 
- Ran `python -m py_compile backend/api/routes/slack_user_mappings.py`, which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ada628a7c83218843814010cef4da)