### PR TITLE
Hide unsupported integrations from Data Sources UI

### DIFF
--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -104,6 +104,8 @@ const INTEGRATION_CONFIG: Record<string, { name: string; description: string; ic
   github: { name: 'GitHub', description: 'Track repos, commits, and pull requests by team', icon: 'github', color: 'from-gray-600 to-gray-700' },
 };
 
+const SUPPORTED_PROVIDERS = new Set(Object.keys(INTEGRATION_CONFIG));
+
 // Extended integration type with display info
 interface DisplayIntegration extends Integration {
   name: string;
@@ -423,14 +425,18 @@ export function DataSources(): JSX.Element {
   // Filter out raw "microsoft" integration - it's a meta-integration from Nango's OAuth.
   // The actual data sources are microsoft_calendar and microsoft_mail.
   const integrations: DisplayIntegration[] = rawIntegrations
-    .filter((integration) => integration.provider !== 'microsoft')
+    .filter((integration) => {
+      if (integration.provider === 'microsoft') {
+        return false;
+      }
+      if (!SUPPORTED_PROVIDERS.has(integration.provider)) {
+        console.warn('[DataSources] Hiding unsupported integration provider from UI:', integration.provider);
+        return false;
+      }
+      return true;
+    })
     .map((integration) => {
-      const config = INTEGRATION_CONFIG[integration.provider] ?? {
-        name: integration.provider,
-        description: 'Data source',
-        icon: integration.provider,
-        color: 'from-surface-500 to-surface-600',
-      };
+      const config = INTEGRATION_CONFIG[integration.provider]!;
       return {
         ...integration,
         ...config,


### PR DESCRIPTION
### Motivation
- The backend no longer exposes a Google Sheets connector (and other stale/unknown provider records may still exist), but the frontend could still render those providers; this change prevents stale connectors from appearing in the UI.

### Description
- Added a `SUPPORTED_PROVIDERS` allowlist derived from `INTEGRATION_CONFIG` and use it to filter backend-returned integrations before rendering in the Data Sources UI.
- Continue to filter out the `microsoft` meta-provider and now hide any provider not in the allowlist, emitting a `console.warn` for unsupported providers to aid debugging.
- Removed the fallback UI config for unknown providers and require `INTEGRATION_CONFIG` entries when mapping integrations so only explicitly supported connectors are shown.
- Changed file: `frontend/src/components/DataSources.tsx`.

### Testing
- Ran lint on the frontend with `npm run lint` and it succeeded.
- Built the frontend with `npm run build` and the build completed successfully.
- Attempted an automated Playwright screenshot run against the dev server but the Chromium process crashed in this environment (Playwright run failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d60f4f7708321955f43b8f80e3353)