### PR TITLE
Fix masquerade auth context so sidebar recents show impersonated user

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,7 +9,7 @@
  * the user - never trust user_id or organization_id from query parameters.
  */
 
-import { getAdminUserId } from "../store";
+import { getAdminUserId, getMasqueradeUserId } from "../store";
 import { supabase } from "./supabase";
 
 // Backend URL for production
@@ -69,6 +69,7 @@ export async function getAuthenticatedWsUrl(path: string): Promise<string | null
  * Automatically includes:
  * - Authorization header with Supabase JWT token
  * - X-Admin-User-Id header when masquerading
+ * - X-Masquerade-User-Id header when masquerading
  */
 export async function apiRequest<T>(
   endpoint: string,
@@ -89,6 +90,11 @@ export async function apiRequest<T>(
   const adminUserId = getAdminUserId();
   if (adminUserId) {
     (headers as Record<string, string>)["X-Admin-User-Id"] = adminUserId;
+  }
+
+  const masqueradeUserId = getMasqueradeUserId();
+  if (masqueradeUserId) {
+    (headers as Record<string, string>)["X-Masquerade-User-Id"] = masqueradeUserId;
   }
 
   try {

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1451,6 +1451,12 @@ export const getAdminUserId = (): string | null => {
   return state.masquerade?.originalUser.id ?? null;
 };
 
+// Get the target user ID when masquerading (for API impersonation headers)
+export const getMasqueradeUserId = (): string | null => {
+  const state = useAppStore.getState();
+  return state.masquerade?.masqueradingAs.id ?? null;
+};
+
 // Legacy chat selectors (for backwards compatibility)
 export const useMessages = () => useAppStore((state) => state.messages);
 export const useChatTitle = () => useAppStore((state) => state.chatTitle);


### PR DESCRIPTION
### Motivation
- Admins who masquerade as another user still saw the admin's recent conversations in the left sidebar because backend routes continued to use the admin's AuthContext instead of the impersonated user.

### Description
- Backend: updated `get_current_auth` in `backend/api/auth_middleware.py` to accept `X-Masquerade-User-Id` and `X-Admin-User-Id` headers, validate the masquerade UUID, enforce that only global admins can masquerade, verify optional admin header matches the authenticated JWT user, load the target user via an admin DB session, switch the `AuthContext` to the target user, and log when the context is switched.
- Frontend: added `getMasqueradeUserId()` selector in `frontend/src/store/index.ts` to expose the active impersonation target ID for header injection.
- Frontend: updated `frontend/src/lib/api.ts` to include `X-Masquerade-User-Id` on all API requests when a masquerade is active (in addition to the existing `X-Admin-User-Id`).

### Testing
- Ran `python -m py_compile backend/api/auth_middleware.py` which succeeded (syntax OK).
- Ran `npm -C frontend run lint` which succeeded (frontend lint OK).
- Ran `pytest -q backend/tests -k auth_middleware` which failed during test collection due to the environment test import path (errors: `ModuleNotFoundError: No module named 'api'` and `No module named 'services'`), so full integration tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d5f9cf5208321a47aa2edb1789c8e)