### PR TITLE
Codex-generated pull request

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -155,6 +155,7 @@ This helps users understand what you're thinking and what to expect.
 - **create_artifact**: Save a file the user can view and download — reports (.md/.pdf), charts (.html with Plotly), or data exports (.txt).
 - **send_email_from**: Send an email as the user from their connected Gmail/Outlook.
 - **send_slack**: Post a message to a Slack channel.
+- **create_github_issue**: File a new GitHub issue in a connected repository (owner/repo, title, optional body/labels/assignees).
 
 ### Automation
 - **create_workflow** / **run_workflow**: Create or run automated workflows on schedules or events.

--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -624,6 +624,55 @@ Examples:
 
 
 register_tool(
+    name="create_github_issue",
+    description="""Create a GitHub issue in a repository your organization has connected.
+
+Use this when the user asks to file/report an issue in GitHub.
+
+Required:
+- repo_full_name: Repository in owner/repo format (e.g. 'octocat/Hello-World')
+- title: Issue title
+
+Optional:
+- body: Markdown body content for the issue
+- labels: List of label names
+- assignees: List of GitHub usernames to assign
+
+This is an external write action and should be reviewed before sending unless auto-approved.""",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "repo_full_name": {
+                "type": "string",
+                "description": "Repository in owner/repo format (e.g., 'octocat/Hello-World')",
+            },
+            "title": {
+                "type": "string",
+                "description": "Issue title",
+            },
+            "body": {
+                "type": "string",
+                "description": "Issue body in Markdown (optional)",
+            },
+            "labels": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Label names to apply (optional)",
+            },
+            "assignees": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "GitHub usernames to assign (optional)",
+            },
+        },
+        "required": ["repo_full_name", "title"],
+    },
+    category=ToolCategory.EXTERNAL_WRITE,
+    default_requires_approval=True,
+)
+
+
+register_tool(
     name="trigger_sync",
     description="""Trigger a data sync for a specific integration.
 

--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -157,6 +157,7 @@ from agents.tools import (
     update_tool_call_result,
     execute_send_email_from,
     execute_send_slack,
+    execute_create_github_issue,
 )
 from models.conversation import Conversation
 from models.database import get_session
@@ -207,6 +208,7 @@ async def _execute_tool_approval(
         remove_pending_operation,
         execute_send_email_from,
         execute_send_slack,
+        execute_create_github_issue,
     )
     
     # First check if this is in our in-memory pending operations store
@@ -235,6 +237,10 @@ async def _execute_tool_approval(
             return result
         elif tool_name == "send_slack":
             result = await execute_send_slack(params, op_org_id)
+            result["tool_name"] = tool_name
+            return result
+        elif tool_name == "create_github_issue":
+            result = await execute_create_github_issue(params, op_org_id)
             result["tool_name"] = tool_name
             return result
         else:


### PR DESCRIPTION
Added a new external-write tool definition, create_github_issue, to the unified tool registry, including schema for repo_full_name, title, optional body, labels, and assignees, with approval required by default. 

Implemented full tool execution flow for GitHub issue creation in agents/tools.py, including:

routing in execute_tool,

validation + integration checks,

pending-approval preview creation,

post-approval execution with robust error handling/logging. 

Extended GitHubConnector with a reusable _gh_post helper and a create_issue(...) API wrapper that calls POST /repos/{owner}/{repo}/issues and returns normalized issue metadata. 

Wired approval execution so approved create_github_issue operations are handled correctly in the WebSocket approval path. 

Updated orchestrator tool guidance so the assistant knows and advertises this new capability in its tool instructions. 