### PR TITLE
Make save_memory approval-gated and expose 'Save Interim Values' permission in UI

### DIFF
--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -904,7 +904,9 @@ Do NOT save conversation-specific context (like "user asked about deal X") — o
         "required": ["content"],
     },
     category=ToolCategory.LOCAL_WRITE,
-    default_requires_approval=False,
+    # Saving memory changes persistent user state, so require explicit approval
+    # unless a user or workflow has opted into auto-approve.
+    default_requires_approval=True,
 )
 
 register_tool(

--- a/backend/api/routes/tool_settings.py
+++ b/backend/api/routes/tool_settings.py
@@ -115,7 +115,7 @@ async def update_tool_setting(
     Update the auto_approve setting for a specific tool.
     
     This controls whether the tool requires user approval before execution.
-    Only EXTERNAL_WRITE tools can have their approval settings changed.
+    Only approval-gated tools can have approval settings changed.
     """
     # Validate tool exists and requires approval by default
     all_tools = get_all_tools()
@@ -128,7 +128,7 @@ async def update_tool_setting(
         raise HTTPException(
             status_code=400, 
             detail=f"Tool '{tool_name}' does not require approval by default. "
-                   "Only EXTERNAL_WRITE tools can have approval settings changed."
+                   "Only tools that require approval by default can have approval settings changed."
         )
     
     # Upsert the setting

--- a/backend/tests/test_tool_approval_defaults.py
+++ b/backend/tests/test_tool_approval_defaults.py
@@ -1,0 +1,5 @@
+from agents.registry import requires_approval
+
+
+def test_save_memory_requires_approval_by_default() -> None:
+    assert requires_approval("save_memory") is True

--- a/frontend/src/components/ToolSettings.tsx
+++ b/frontend/src/components/ToolSettings.tsx
@@ -4,7 +4,7 @@
  * Similar to Cursor's "yolo mode" - allows users to auto-approve
  * certain tools that normally require explicit approval.
  * 
- * EXTERNAL_WRITE tools (CRM write, send email, post to Slack)
+ * Approval-gated tools (for example email send, Slack post, and memory save)
  * require approval by default but can be auto-approved here.
  */
 
@@ -30,6 +30,7 @@ const TOOL_LABELS: Record<string, string> = {
   send_email_from: 'Send Email',
   send_slack: 'Post to Slack',
   trigger_sync: 'Trigger Sync',
+  save_memory: 'Save Interim Values',
 };
 
 // Tool descriptions for the UI
@@ -38,6 +39,7 @@ const TOOL_DESCRIPTIONS: Record<string, string> = {
   send_email_from: 'Send emails from your connected Gmail or Outlook',
   send_slack: 'Post messages to your connected Slack workspace',
   trigger_sync: 'Trigger data sync from connected integrations',
+  save_memory: 'Store user-scoped preferences or interim facts for future conversations',
 };
 
 export function ToolSettings({ userId, onClose }: ToolSettingsProps): JSX.Element {
@@ -143,7 +145,7 @@ export function ToolSettings({ userId, onClose }: ToolSettingsProps): JSX.Elemen
           ) : (
             <div className="space-y-3">
               <div className="text-xs text-surface-500 uppercase tracking-wide mb-3">
-                External Actions (require approval by default)
+                Actions Requiring Approval
               </div>
               
               {tools.map(tool => {
@@ -198,7 +200,7 @@ export function ToolSettings({ userId, onClose }: ToolSettingsProps): JSX.Elemen
                   {autoApprovedCount} tool{autoApprovedCount !== 1 ? 's' : ''} will run without asking
                 </span>
               ) : (
-                'All external actions will ask for approval'
+                'All approval-gated actions will ask for approval'
               )}
             </div>
             <button

--- a/frontend/src/components/Workflows.tsx
+++ b/frontend/src/components/Workflows.tsx
@@ -72,6 +72,16 @@ interface WorkflowListResponse {
   total: number;
 }
 
+const TOOL_PERMISSION_LABELS: Record<string, string> = {
+  run_sql_query: 'Query Data',
+  run_workflow: 'Run Workflow',
+  loop_over: 'Loop Over Items',
+  send_slack: 'Post to Slack',
+  send_email_from: 'Send Email',
+  run_sql_write: 'Write Data',
+  save_memory: 'Save Interim Values',
+};
+
 // Fetch workflows for the organization
 async function fetchWorkflows(orgId: string): Promise<Workflow[]> {
   console.debug('[Workflows] Fetching workflows', { orgId });
@@ -425,7 +435,7 @@ function WorkflowDetail({
                     key={tool}
                     className="px-2 py-1 bg-surface-800 text-surface-300 rounded text-xs font-mono"
                   >
-                    {tool}
+                    {TOOL_PERMISSION_LABELS[tool] ?? tool}
                   </span>
                 ))}
               </div>
@@ -736,6 +746,7 @@ function WorkflowModal({
     { id: 'send_slack', label: 'Post to Slack', description: 'Send messages to Slack channels' },
     { id: 'send_email_from', label: 'Send Email', description: 'Send emails from your connected account' },
     { id: 'run_sql_write', label: 'Write Data', description: 'Insert, update, or delete records' },
+    { id: 'save_memory', label: 'Save Interim Values', description: 'Store user-scoped preferences or interim facts across conversations' },
   ];
 
   const toggleAutoApproveTool = (toolId: string): void => {


### PR DESCRIPTION
### Motivation
- Treat writing persistent user memories as a permission-gated action so workflows and agents cannot silently persist user state without explicit approval.
- Surface this permission in the workflow and user tool settings UI so orgs and users can opt workflows or themselves into allowing memory saves without pausing for approval.

### Description
- Flip `save_memory` to require approval by default by setting `default_requires_approval=True` in `backend/agents/registry.py` so memory writes are approval-gated.
- Add a readable label and option for the new permission (`Save Interim Values` bound to `save_memory`) in the workflow creation/edit UI and workflow detail rendering in `frontend/src/components/Workflows.tsx` so auto-approved tools show friendly names.
- Add `save_memory` label/description and adjust wording in the tool settings UI in `frontend/src/components/ToolSettings.tsx` to include the new approval-gated memory permission and use generic "approval-gated" phrasing.
- Update backend tool-settings messaging in `backend/api/routes/tool_settings.py` to refer to generic approval-gated tools rather than only `EXTERNAL_WRITE` tools.
- Add a regression test `backend/tests/test_tool_approval_defaults.py` asserting `requires_approval("save_memory") is True`.

### Testing
- Ran unit tests with `PYTHONPATH=backend pytest -q backend/tests/test_workflow_permissions.py backend/tests/test_tool_approval_defaults.py` and all tests passed (4 passed, 1 warning).
- Performed a manual frontend smoke by starting the dev server with `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173` and captured a Playwright screenshot showing the updated workflow permissions UI.
- Note: an initial `pytest` run failed in this environment due to missing `PYTHONPATH` settings, which was resolved by running tests with `PYTHONPATH=backend`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e5e730a688321a6f47e6a64ef128b)