### PR TITLE
Require explicit permission for save_memory and rename create_github_issue to github_issues_access

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -155,7 +155,7 @@ This helps users understand what you're thinking and what to expect.
 - **create_artifact**: Save a file the user can view and download — reports (.md/.pdf), charts (.html with Plotly), or data exports (.txt).
 - **send_email_from**: Send an email as the user from their connected Gmail/Outlook.
 - **send_slack**: Post a message to a Slack channel.
-- **create_github_issue**: File a new GitHub issue in a connected repository (owner/repo, title, optional body/labels/assignees).
+- **github_issues_access**: File a new GitHub issue in a connected repository (owner/repo, title, optional body/labels/assignees).
 
 ### Automation
 - **create_workflow** / **run_workflow**: Create or run automated workflows on schedules or events.

--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -624,7 +624,7 @@ Examples:
 
 
 register_tool(
-    name="create_github_issue",
+    name="github_issues_access",
     description="""Create a GitHub issue in a repository your organization has connected.
 
 Use this when the user asks to file/report issues in GitHub.
@@ -904,7 +904,7 @@ Do NOT save conversation-specific context (like "user asked about deal X") — o
         "required": ["content"],
     },
     category=ToolCategory.LOCAL_WRITE,
-    default_requires_approval=False,
+    default_requires_approval=True,
 )
 
 register_tool(

--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -162,7 +162,8 @@ from agents.tools import (
     update_tool_call_result,
     execute_send_email_from,
     execute_send_slack,
-    execute_create_github_issue,
+    execute_github_issues_access,
+    execute_save_memory,
 )
 from models.conversation import Conversation
 from models.database import get_session
@@ -213,7 +214,8 @@ async def _execute_tool_approval(
         remove_pending_operation,
         execute_send_email_from,
         execute_send_slack,
-        execute_create_github_issue,
+        execute_github_issues_access,
+        execute_save_memory,
     )
     
     # First check if this is in our in-memory pending operations store
@@ -244,8 +246,12 @@ async def _execute_tool_approval(
             result = await execute_send_slack(params, op_org_id)
             result["tool_name"] = tool_name
             return result
-        elif tool_name == "create_github_issue":
-            result = await execute_create_github_issue(params, op_org_id)
+        elif tool_name == "github_issues_access":
+            result = await execute_github_issues_access(params, op_org_id)
+            result["tool_name"] = tool_name
+            return result
+        elif tool_name == "save_memory":
+            result = await execute_save_memory(params, op_org_id, op_user_id)
             result["tool_name"] = tool_name
             return result
         else:

--- a/backend/tests/test_workflow_permissions.py
+++ b/backend/tests/test_workflow_permissions.py
@@ -1,4 +1,34 @@
-from workers.tasks.workflows import compute_effective_auto_approve_tools
+import asyncio
+from uuid import UUID
+
+from workers.tasks.workflows import (
+    apply_user_auto_approve_permissions,
+    compute_effective_auto_approve_tools,
+)
+
+
+class _FakeScalarResult:
+    def __init__(self, values: list[str]) -> None:
+        self._values = values
+
+    def all(self) -> list[str]:
+        return self._values
+
+
+class _FakeExecuteResult:
+    def __init__(self, values: list[str]) -> None:
+        self._values = values
+
+    def scalars(self) -> _FakeScalarResult:
+        return _FakeScalarResult(self._values)
+
+
+class _FakeSession:
+    def __init__(self, allowed_tools: list[str]) -> None:
+        self.allowed_tools = allowed_tools
+
+    async def execute(self, _query: object) -> _FakeExecuteResult:
+        return _FakeExecuteResult(self.allowed_tools)
 
 
 def test_root_workflow_keeps_configured_auto_approve_tools() -> None:
@@ -23,3 +53,31 @@ def test_child_workflow_cannot_escalate_if_parent_has_no_permissions() -> None:
         parent_auto_approve_tools=[],
     )
     assert effective == []
+
+
+def test_apply_user_permissions_removes_restricted_tools_without_explicit_allow() -> None:
+    session = _FakeSession(allowed_tools=[])
+
+    async def _run() -> list[str]:
+        return await apply_user_auto_approve_permissions(
+            session=session,
+            user_id=UUID("00000000-0000-0000-0000-000000000001"),
+            auto_approve_tools=["save_memory", "send_slack", "github_issues_access"],
+        )
+
+    effective = asyncio.run(_run())
+    assert effective == ["send_slack"]
+
+
+def test_apply_user_permissions_keeps_explicitly_allowed_restricted_tools() -> None:
+    session = _FakeSession(allowed_tools=["save_memory", "github_issues_access"])
+
+    async def _run() -> list[str]:
+        return await apply_user_auto_approve_permissions(
+            session=session,
+            user_id=UUID("00000000-0000-0000-0000-000000000001"),
+            auto_approve_tools=["save_memory", "send_slack", "github_issues_access"],
+        )
+
+    effective = asyncio.run(_run())
+    assert effective == ["save_memory", "send_slack", "github_issues_access"]

--- a/frontend/src/components/ToolSettings.tsx
+++ b/frontend/src/components/ToolSettings.tsx
@@ -30,7 +30,8 @@ const TOOL_LABELS: Record<string, string> = {
   send_email_from: 'Send Email',
   send_slack: 'Post to Slack',
   trigger_sync: 'Trigger Sync',
-  create_github_issue: 'Change GitHub Issues',
+  github_issues_access: 'GitHub Issues Access',
+  save_memory: 'Save Interim Values',
 };
 
 // Tool descriptions for the UI
@@ -39,7 +40,8 @@ const TOOL_DESCRIPTIONS: Record<string, string> = {
   send_email_from: 'Send emails from your connected Gmail or Outlook',
   send_slack: 'Post messages to your connected Slack workspace',
   trigger_sync: 'Trigger data sync from connected integrations',
-  create_github_issue: 'Create GitHub issues (no code changes)',
+  github_issues_access: 'Create GitHub issues (no code changes)',
+  save_memory: 'Allow workflows to persist interim values for later steps',
 };
 
 export function ToolSettings({ userId, onClose }: ToolSettingsProps): JSX.Element {
@@ -145,7 +147,7 @@ export function ToolSettings({ userId, onClose }: ToolSettingsProps): JSX.Elemen
           ) : (
             <div className="space-y-3">
               <div className="text-xs text-surface-500 uppercase tracking-wide mb-3">
-                External Actions (require approval by default)
+                Actions (require approval by default)
               </div>
               
               {tools.map(tool => {
@@ -200,7 +202,7 @@ export function ToolSettings({ userId, onClose }: ToolSettingsProps): JSX.Elemen
                   {autoApprovedCount} tool{autoApprovedCount !== 1 ? 's' : ''} will run without asking
                 </span>
               ) : (
-                'All external actions will ask for approval'
+                'All actions will ask for approval'
               )}
             </div>
             <button

--- a/frontend/src/components/Workflows.tsx
+++ b/frontend/src/components/Workflows.tsx
@@ -735,7 +735,8 @@ function WorkflowModal({
     { id: 'loop_over', label: 'Loop Over Items', description: 'Run a workflow for each item in a list' },
     { id: 'send_slack', label: 'Post to Slack', description: 'Send messages to Slack channels' },
     { id: 'send_email_from', label: 'Send Email', description: 'Send emails from your connected account' },
-    { id: 'create_github_issue', label: 'Change GitHub Issues', description: 'Create GitHub issues (no code write access)' },
+    { id: 'github_issues_access', label: 'GitHub Issues Access', description: 'Create GitHub issues (no code write access)' },
+    { id: 'save_memory', label: 'Save Interim Values', description: 'Store intermediate values and preferences for later workflow steps' },
     { id: 'run_sql_write', label: 'Write Data', description: 'Insert, update, or delete records' },
   ];
 


### PR DESCRIPTION
### Motivation
- Bind the memory-saving capability to an explicit permission exposed in the UI so workflows can optionally persist interim values only when the user has allowed it. 
- Make the GitHub issue tool name clearer and consistent with permission checks by renaming `create_github_issue` to `github_issues_access` while preserving backward compatibility. 

### Description
- Renamed the GitHub tool in the registry and docs from `create_github_issue` to `github_issues_access` and updated execution plumbing to support the new name while keeping a backward-compatible remap for legacy calls. 
- Made `save_memory` require approval by default in the registry and implemented a pending-approval flow in `tools.py` that stores memory-save operations and executes them on approval (`_save_memory` now supports `skip_approval` and `execute_save_memory`). 
- Enforced per-user explicit auto-approve permissions for restricted actions by updating `apply_user_auto_approve_permissions` to treat `github_issues_access` and `save_memory` as tools that require an explicit user setting to be auto-approved. 
- Wired approval routing and execution paths so web socket approvals execute `github_issues_access` and `save_memory` after approval, and surfaced the new permission in the frontend as `GitHub Issues Access` and `Save Interim Values`. 
- Added/updated unit tests to cover the new permission filtering behavior for workflow auto-approve tools. 

### Testing
- Ran the workflow permission unit tests with `PYTHONPATH=backend pytest backend/tests/test_workflow_permissions.py -q` which passed (`5 passed`, `1 warning`). 
- Verified Python modules compile with `PYTHONPATH=backend python -m py_compile backend/agents/tools.py backend/api/websockets.py backend/workers/tasks/workflows.py backend/agents/registry.py backend/agents/orchestrator.py` with no errors. 
- Built the frontend with `npm --prefix frontend run build` which succeeded and produced the production bundles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e676c9f848321aeb071b1936eab6d)