### PR TITLE
Harden legacy search/drive routes against IDOR by enforcing AuthContext

### DIFF
--- a/backend/tests/test_drive_idor_protection.py
+++ b/backend/tests/test_drive_idor_protection.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from api.auth_middleware import AuthContext, get_current_auth
+from api.main import app
+from api.routes import drive
+
+
+client = TestClient(app)
+
+
+def test_drive_search_requires_authentication() -> None:
+    response = client.get("/api/drive/search", params={"q": "pipeline"})
+    assert response.status_code == 401
+
+
+def test_drive_search_uses_auth_context_not_query_params(monkeypatch) -> None:
+    auth_user_id = uuid4()
+    auth_org_id = uuid4()
+    foreign_user_id = uuid4()
+    foreign_org_id = uuid4()
+
+    app.dependency_overrides[get_current_auth] = lambda: AuthContext(
+        user_id=auth_user_id,
+        organization_id=auth_org_id,
+        email="owner@example.com",
+        role="user",
+        is_global_admin=False,
+    )
+
+    captured: dict[str, str] = {}
+
+    class FakeDriveConnector:
+        def __init__(self, organization_id: str, user_id: str) -> None:
+            captured["organization_id"] = organization_id
+            captured["user_id"] = user_id
+
+        async def search_files(self, q: str, limit: int = 20):
+            return []
+
+    monkeypatch.setattr(drive, "GoogleDriveConnector", FakeDriveConnector)
+
+    try:
+        response = client.get(
+            "/api/drive/search",
+            params={
+                "q": "pipeline",
+                "user_id": str(foreign_user_id),
+                "organization_id": str(foreign_org_id),
+            },
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert captured["organization_id"] == str(auth_org_id)
+    assert captured["user_id"] == str(auth_user_id)

--- a/backend/tests/test_search_auth_required.py
+++ b/backend/tests/test_search_auth_required.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+client = TestClient(app)
+
+
+def test_search_requires_authentication() -> None:
+    response = client.get("/api/search", params={"q": "acme"})
+    assert response.status_code == 401


### PR DESCRIPTION
### Motivation
- Legacy search and Drive routes accepted `user_id`/`organization_id` query params and resolved org/user from those values, enabling an IDOR-style attack surface across tenants.
- The goal is to ensure all tenant and user scoping is derived from a verified `AuthContext` (JWT + DB lookup) so clients cannot impersonate or enumerate other tenants.

### Description
- Require `AuthContext = Depends(get_current_auth)` on `/api/search` and on Drive endpoints (`/api/drive/sync`, `/api/drive/search`, `/api/drive/files/{external_id}/content`) and remove reliance on client-provided `user_id` / `organization_id` query parameters.
- Replace legacy resolver with `_get_org_and_user(auth: AuthContext)` that derives `organization_id` and `user_id` exclusively from the verified `AuthContext`.
- Adjust imports and signatures in `backend/api/routes/search.py` and `backend/api/routes/drive.py` to use the auth dependency and remove unsafe parameter handling.
- Add regression tests `backend/tests/test_drive_idor_protection.py` and `backend/tests/test_search_auth_required.py` that assert auth is required and that Drive ignores foreign `user_id`/`organization_id` query params in favor of the authenticated context.

### Testing
- Ran targeted tests with `PYTHONPATH=backend pytest -q backend/tests/test_drive_idor_protection.py backend/tests/test_search_auth_required.py` and all tests passed.
- The new tests confirm `/api/search` and Drive search behavior require authentication and use verified auth-derived IDs rather than query params.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e75889604832183a31371b1691bc7)