### PR TITLE
Enforce stronger password policy for signup and reset

### DIFF
--- a/frontend/src/components/Auth.tsx
+++ b/frontend/src/components/Auth.tsx
@@ -8,6 +8,7 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
 import { isPersonalEmail } from '../lib/email';
+import { validateGoodPassword } from '../lib/password';
 
 interface AuthProps {
   onBack: () => void;
@@ -49,6 +50,13 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
 
     try {
       if (mode === 'signup') {
+        const passwordValidation = validateGoodPassword(password, email);
+        if (!passwordValidation.isValid) {
+          setError(passwordValidation.errors[0] ?? 'Password does not meet security requirements.');
+          setLoading(false);
+          return;
+        }
+
         const { error } = await supabase.auth.signUp({
           email,
           password,
@@ -70,8 +78,10 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
           setLoading(false);
           return;
         }
-        if (newPassword.length < 6) {
-          setError('Password must be at least 6 characters');
+
+        const passwordValidation = validateGoodPassword(newPassword, email);
+        if (!passwordValidation.isValid) {
+          setError(passwordValidation.errors[0] ?? 'Password does not meet security requirements.');
           setLoading(false);
           return;
         }
@@ -271,10 +281,15 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
                   required
-                  minLength={6}
+                  minLength={12}
                   className="input"
                   placeholder="••••••••"
                 />
+                {mode === 'signup' && (
+                  <p className="text-xs text-surface-500 mt-2">
+                    Use 12+ characters and at least 3 of: uppercase, lowercase, number, symbol.
+                  </p>
+                )}
               </div>
             )}
 
@@ -291,7 +306,7 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
                     value={newPassword}
                     onChange={(e) => setNewPassword(e.target.value)}
                     required
-                    minLength={6}
+                    minLength={12}
                     className="input"
                     placeholder="••••••••"
                   />
@@ -306,7 +321,7 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
                     required
-                    minLength={6}
+                    minLength={12}
                     className="input"
                     placeholder="••••••••"
                   />

--- a/frontend/src/lib/password.ts
+++ b/frontend/src/lib/password.ts
@@ -1,0 +1,97 @@
+/**
+ * Password strength helpers used by email/password auth flows.
+ *
+ * These checks are intentionally opinionated and align with common guidance:
+ * - Prefer longer passwords (12+ chars)
+ * - Require multiple character classes
+ * - Block obvious weak patterns
+ */
+
+export type PasswordValidationResult = {
+  isValid: boolean;
+  errors: string[];
+};
+
+const COMMON_WEAK_PASSWORDS = new Set([
+  'password',
+  'password123',
+  'qwerty',
+  'qwerty123',
+  'letmein',
+  'admin',
+  'welcome',
+  '123456',
+  '12345678',
+  '123456789',
+  '111111',
+  'abc123',
+]);
+
+/**
+ * Returns true for obvious keyboard/sequential runs often found in weak passwords.
+ */
+function hasSequentialPattern(value: string): boolean {
+  const lower = value.toLowerCase();
+  const sequences = [
+    'abcdefghijklmnopqrstuvwxyz',
+    'qwertyuiopasdfghjklzxcvbnm',
+    '0123456789',
+  ];
+
+  return sequences.some((sequence) => {
+    for (let i = 0; i <= sequence.length - 4; i += 1) {
+      const slice = sequence.slice(i, i + 4);
+      const reversed = slice.split('').reverse().join('');
+      if (lower.includes(slice) || lower.includes(reversed)) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+}
+
+/**
+ * Validate password against baseline "generally considered good" rules.
+ */
+export function validateGoodPassword(password: string, email?: string): PasswordValidationResult {
+  const errors: string[] = [];
+
+  if (password.length < 12) {
+    errors.push('Use at least 12 characters.');
+  }
+
+  const hasLower = /[a-z]/.test(password);
+  const hasUpper = /[A-Z]/.test(password);
+  const hasNumber = /\d/.test(password);
+  const hasSymbol = /[^A-Za-z0-9]/.test(password);
+
+  const classCount = [hasLower, hasUpper, hasNumber, hasSymbol].filter(Boolean).length;
+  if (classCount < 3) {
+    errors.push('Use at least 3 of: uppercase, lowercase, number, symbol.');
+  }
+
+  if (/(.)\1{2,}/.test(password)) {
+    errors.push('Avoid repeating the same character 3+ times in a row.');
+  }
+
+  if (hasSequentialPattern(password)) {
+    errors.push('Avoid common keyboard or sequential patterns (like 1234 or abcd).');
+  }
+
+  if (COMMON_WEAK_PASSWORDS.has(password.toLowerCase())) {
+    errors.push('This password is too common. Choose something less predictable.');
+  }
+
+  if (email) {
+    const localPart = email.split('@')[0]?.trim().toLowerCase();
+    if (localPart && localPart.length >= 3 && password.toLowerCase().includes(localPart)) {
+      errors.push('Avoid including your email name in your password.');
+    }
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+}


### PR DESCRIPTION
### Motivation
- Prevent weak or easily guessable passwords at account creation and reset by enforcing a baseline of "generally considered good" password rules on the frontend. 
- Provide immediate, actionable feedback to users before requests reach Supabase so weaker passwords are blocked earlier.

### Description
- Added a new helper `validateGoodPassword` in `frontend/src/lib/password.ts` that enforces: minimum 12 characters, at least 3 of 4 character classes (uppercase, lowercase, number, symbol), and blocks repeated characters, sequential/keyboard patterns, a small common-password blacklist, and inclusion of the email local-part.
- Integrated `validateGoodPassword` into the auth flows in `frontend/src/components/Auth.tsx` for both signup and password reset flows and surface the top validation error to the user.
- Tightened UI constraints by changing password inputs' `minLength` from `6` to `12` and added an inline hint in signup mode describing the stronger requirements.
- Kept behavior client-side to match the existing architecture where Supabase handles authentication, but now rejects weak passwords before making auth requests.

### Testing
- Built the frontend with `npm --prefix frontend run build` and the build completed successfully (typecheck and Vite build finished, with chunk size warnings only). 
- Launched the dev server with `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173` and performed a UI smoke check; a screenshot of the signup password guidance was captured via a Playwright script.
- No automated unit tests were modified or added; the manual build and dev smoke checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e7beec2ac83218d2f4e22bcd7a78a)