### PR TITLE
Replace waitlist admin_key auth with JWT global-admin auth

### DIFF
--- a/backend/api/routes/waitlist.py
+++ b/backend/api/routes/waitlist.py
@@ -9,19 +9,21 @@ Endpoints:
 from __future__ import annotations
 
 from datetime import datetime
+import logging
 from typing import Any, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, EmailStr
 from sqlalchemy import select
 
-from config import settings
+from api.auth_middleware import AuthContext, require_global_admin
 from models.database import get_session
 from models.user import User
 from services.email import send_invitation_email, send_waitlist_confirmation, send_waitlist_notification
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 # =============================================================================
@@ -154,24 +156,22 @@ async def submit_waitlist(request: WaitlistSubmitRequest) -> WaitlistSubmitRespo
 
 
 # =============================================================================
-# Admin Endpoints (key-based auth - legacy)
+# Admin Endpoints
 # =============================================================================
 
 
 @router.get("/admin", response_model=WaitlistListResponse)
 async def list_waitlist(
     status: Optional[str] = None,
-    admin_key: Optional[str] = None,
+    auth: AuthContext = Depends(require_global_admin),
 ) -> WaitlistListResponse:
     """
     List all waitlist entries.
     
-    Requires admin_key for authentication (simple auth for MVP).
+    Requires a valid JWT for a global admin user.
     Filter by status: 'waitlist', 'invited', or 'all'.
     """
-    # Simple admin auth for MVP
-    if admin_key != settings.ADMIN_KEY:
-        raise HTTPException(status_code=403, detail="Invalid admin key")
+    logger.info("Admin waitlist list requested by user_id=%s status=%s", auth.user_id, status)
 
     async with get_session() as session:
         query = select(User).where(User.waitlisted_at.isnot(None))
@@ -204,16 +204,14 @@ async def list_waitlist(
 @router.post("/admin/{user_id}/invite", response_model=InviteResponse)
 async def invite_user(
     user_id: str,
-    admin_key: Optional[str] = None,
+    auth: AuthContext = Depends(require_global_admin),
 ) -> InviteResponse:
     """
     Invite a user from the waitlist.
     
     Sets status to 'invited' and sends invitation email.
     """
-    # Simple admin auth for MVP
-    if admin_key != settings.ADMIN_KEY:
-        raise HTTPException(status_code=403, detail="Invalid admin key")
+    logger.info("Admin waitlist invite requested by user_id=%s target_user_id=%s", auth.user_id, user_id)
 
     try:
         user_uuid = UUID(user_id)
@@ -262,33 +260,10 @@ async def invite_user(
         )
 
 
-# =============================================================================
-# Admin Endpoints (role-based auth - new)
-# =============================================================================
-
-
-async def verify_global_admin(user_id: str) -> User:
-    """Verify that a user has global_admin role. Raises HTTPException if not."""
-    try:
-        user_uuid = UUID(user_id)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid user ID")
-
-    async with get_session() as session:
-        admin_user = await session.get(User, user_uuid)
-        if not admin_user:
-            raise HTTPException(status_code=404, detail="User not found")
-        
-        if "global_admin" not in (admin_user.roles or []):
-            raise HTTPException(status_code=403, detail="Access denied. Requires global_admin role.")
-        
-        return admin_user
-
-
 @router.get("/admin/list", response_model=WaitlistListResponse)
 async def list_waitlist_role_auth(
     status: Optional[str] = None,
-    user_id: Optional[str] = None,
+    auth: AuthContext = Depends(require_global_admin),
 ) -> WaitlistListResponse:
     """
     List all waitlist entries.
@@ -296,10 +271,7 @@ async def list_waitlist_role_auth(
     Requires user to have global_admin role.
     Filter by status: 'waitlist', 'invited', or 'all'.
     """
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Authentication required")
-    
-    await verify_global_admin(user_id)
+    logger.info("Admin waitlist list(v2) requested by user_id=%s status=%s", auth.user_id, status)
 
     async with get_session() as session:
         query = select(User).where(User.waitlisted_at.isnot(None))
@@ -332,7 +304,7 @@ async def list_waitlist_role_auth(
 @router.post("/admin/{target_user_id}/invite", response_model=InviteResponse)
 async def invite_user_role_auth(
     target_user_id: str,
-    user_id: Optional[str] = None,
+    auth: AuthContext = Depends(require_global_admin),
 ) -> InviteResponse:
     """
     Invite a user from the waitlist.
@@ -340,10 +312,7 @@ async def invite_user_role_auth(
     Requires user to have global_admin role.
     Sets status to 'invited' and sends invitation email.
     """
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Authentication required")
-    
-    await verify_global_admin(user_id)
+    logger.info("Admin waitlist invite(v2) requested by user_id=%s target_user_id=%s", auth.user_id, target_user_id)
 
     try:
         target_uuid = UUID(target_user_id)
@@ -420,7 +389,7 @@ class AdminUsersListResponse(BaseModel):
 
 @router.get("/admin/users", response_model=AdminUsersListResponse)
 async def list_admin_users(
-    user_id: Optional[str] = None,
+    auth: AuthContext = Depends(require_global_admin),
 ) -> AdminUsersListResponse:
     """
     List all users who are not on the waitlist (active or invited).
@@ -428,10 +397,7 @@ async def list_admin_users(
     Requires user to have global_admin role.
     Returns users with their organization info and last login time.
     """
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Authentication required")
-    
-    await verify_global_admin(user_id)
+    logger.info("Admin users list requested by user_id=%s", auth.user_id)
 
     from sqlalchemy.orm import selectinload
 
@@ -505,7 +471,7 @@ class AdminOrganizationsListResponse(BaseModel):
 
 @router.get("/admin/organizations", response_model=AdminOrganizationsListResponse)
 async def list_admin_organizations(
-    user_id: Optional[str] = None,
+    auth: AuthContext = Depends(require_global_admin),
 ) -> AdminOrganizationsListResponse:
     """
     List all organizations.
@@ -513,10 +479,7 @@ async def list_admin_organizations(
     Requires user to have global_admin role.
     Returns organizations with user counts.
     """
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Authentication required")
-    
-    await verify_global_admin(user_id)
+    logger.info("Admin organizations list requested by user_id=%s", auth.user_id)
 
     from models.organization import Organization
     from sqlalchemy import func

--- a/backend/tests/test_waitlist_admin_auth_required.py
+++ b/backend/tests/test_waitlist_admin_auth_required.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+client = TestClient(app)
+
+
+def test_waitlist_admin_list_requires_authentication() -> None:
+    response = client.get("/api/waitlist/admin")
+    assert response.status_code == 401
+
+
+def test_waitlist_admin_invite_requires_authentication() -> None:
+    response = client.post("/api/waitlist/admin/00000000-0000-0000-0000-000000000000/invite")
+    assert response.status_code == 401

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -460,20 +460,7 @@ function App(): JSX.Element {
 
   // Handle admin waitlist route
   if (path === '/admin/waitlist') {
-    const params = new URLSearchParams(window.location.search);
-    const adminKey = params.get('key');
-    if (adminKey) {
-      return <AdminWaitlist adminKey={adminKey} />;
-    }
-    // No key provided - show error
-    return (
-      <div className="min-h-screen flex items-center justify-center p-4">
-        <div className="text-center">
-          <h1 className="text-xl font-bold text-surface-50 mb-2">Access Denied</h1>
-          <p className="text-surface-400">Admin key required. Add ?key=YOUR_KEY to the URL.</p>
-        </div>
-      </div>
-    );
+    return <AdminWaitlist />;
   }
 
   // Loading state


### PR DESCRIPTION
### Motivation
- The waitlist admin endpoints used a shared `admin_key` query parameter which is easily leaked (URL, referrer, logs) and provides no identity/audit trail.  
- The change hardens admin access by enforcing JWT-based auth with `require_global_admin` so actions are tied to an authenticated global admin identity.  

### Description
- Replaced legacy `admin_key` query-parameter checks with a FastAPI dependency `Depends(require_global_admin)` on waitlist admin routes so only verified global-admin JWTs can call them, and switched handler signatures to accept `AuthContext`.  
- Added structured logging (`logger.info`) for privileged admin actions (list and invite) to record actor and target IDs for auditability.  
- Removed the older query-param / `user_id`/`admin_key` style checks and the separate `verify_global_admin` flow in `backend/api/routes/waitlist.py`.  
- Updated frontend admin UI to stop sending `admin_key` in URLs and to use the centralized `apiRequest` (which adds Authorization headers) by changing `frontend/src/components/AdminWaitlist.tsx` and routing in `frontend/src/App.tsx`, and added a backend test `backend/tests/test_waitlist_admin_auth_required.py` to assert unauthenticated access is rejected.  

### Testing
- Ran the backend tests with `PYTHONPATH=backend pytest -q backend/tests/test_waitlist_admin_auth_required.py backend/tests/test_search_auth_required.py`, which completed successfully.  
- Built the frontend with `cd frontend && npm run -s build`, which completed successfully.  
- End-to-end validation ensures admin waitlist endpoints now require JWT auth and unauthenticated requests return 401 as covered by the new test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e7cd9f3a08321a4fc9ceb79bc68cb)