### PR TITLE
Harden CORS checks and add CSRF guard for cookie-based requests

### DIFF
--- a/backend/tests/test_cors_csrf.py
+++ b/backend/tests/test_cors_csrf.py
@@ -1,0 +1,50 @@
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+client = TestClient(app)
+
+WAITLIST_PAYLOAD = {
+    "email": "csrf-check@example.com",
+    "name": "CSRF Check",
+    "title": "Engineer",
+    "company_name": "Revtops",
+    "num_employees": "1-10",
+    "apps_of_interest": ["salesforce"],
+    "core_needs": ["insights"],
+}
+
+
+def test_preflight_allows_known_origin() -> None:
+    response = client.options(
+        "/api/waitlist",
+        headers={
+            "Origin": "https://app.revtops.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "https://app.revtops.com"
+
+
+def test_csrf_middleware_blocks_unknown_origin_with_cookie() -> None:
+    response = client.post(
+        "/api/waitlist",
+        headers={"Origin": "https://evil.example", "Cookie": "session=abc"},
+        json=WAITLIST_PAYLOAD,
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "CSRF validation failed"
+
+
+def test_csrf_middleware_allows_non_cookie_requests_from_unknown_origin() -> None:
+    response = client.post(
+        "/api/does-not-exist",
+        headers={"Origin": "https://evil.example"},
+        json={"payload": "ok"},
+    )
+
+    assert response.status_code == 404


### PR DESCRIPTION
### Motivation
- Prevent subtle CORS allowlist mismatches (e.g. trailing slashes or duplicates) and ensure consistent origin checks across middleware and error paths.
- Provide a defense-in-depth CSRF protection for unsafe HTTP methods when browser cookies are present, while preserving bearer-token API flows from non-browser clients.

### Description
- Normalize and deduplicate configured origins via a `_normalize_origin` helper and use a normalized `allowed_origins` set when configuring `CORSMiddleware` and emitting CORS headers. (`backend/api/main.py`)
- Replace raw `cors_origins` usage with `allowed_origins` so the middleware and global error handler consistently echo an allowed, normalized origin. (`backend/api/main.py`)
- Add an HTTP middleware `csrf_protection_middleware` that blocks `POST/PUT/PATCH/DELETE` requests bearing cookies from origins not in the allowlist, logs a warning, and returns `403` with `{"detail": "CSRF validation failed"}`. (`backend/api/main.py`)
- Add focused tests exercising preflight CORS behavior and the CSRF middleware semantics. (`backend/tests/test_cors_csrf.py`)

### Testing
- Ran `PYTHONPATH=backend pytest -q backend/tests/test_cors_csrf.py backend/tests/test_health.py` and the test suite completed successfully with all tests passing (6 passed, several DeprecationWarnings noted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e7f3801e08321b0a71867ca2c219a)