### PR TITLE
Replace legacy waitlist `admin_key` with JWT `require_global_admin` enforcement

### DIFF
--- a/backend/api/auth_middleware.py
+++ b/backend/api/auth_middleware.py
@@ -379,12 +379,14 @@ async def get_current_auth(
 
         user = target_user
 
+    is_global_admin = user.role == "global_admin" or "global_admin" in (user.roles or [])
+
     return AuthContext(
         user_id=user.id,
         organization_id=user.organization_id,
         email=user.email,
         role=user.role or "user",
-        is_global_admin=user.role == "global_admin",
+        is_global_admin=is_global_admin,
     )
 
 
@@ -411,12 +413,13 @@ async def get_optional_auth(
         token = _extract_token(authorization)
         payload = await _verify_jwt(token)
         user = await _get_user_from_token(payload)
+        is_global_admin = user.role == "global_admin" or "global_admin" in (user.roles or [])
         return AuthContext(
             user_id=user.id,
             organization_id=user.organization_id,
             email=user.email,
             role=user.role or "user",
-            is_global_admin=user.role == "global_admin",
+            is_global_admin=is_global_admin,
         )
     except HTTPException:
         return None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -460,20 +460,7 @@ function App(): JSX.Element {
 
   // Handle admin waitlist route
   if (path === '/admin/waitlist') {
-    const params = new URLSearchParams(window.location.search);
-    const adminKey = params.get('key');
-    if (adminKey) {
-      return <AdminWaitlist adminKey={adminKey} />;
-    }
-    // No key provided - show error
-    return (
-      <div className="min-h-screen flex items-center justify-center p-4">
-        <div className="text-center">
-          <h1 className="text-xl font-bold text-surface-50 mb-2">Access Denied</h1>
-          <p className="text-surface-400">Admin key required. Add ?key=YOUR_KEY to the URL.</p>
-        </div>
-      </div>
-    );
+    return <AdminWaitlist />;
   }
 
   // Loading state

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useEffect, useState, useCallback } from 'react';
-import { API_BASE } from '../lib/api';
+import { API_BASE, apiRequest } from '../lib/api';
 import { useAppStore, type UserProfile, type OrganizationInfo } from '../store';
 
 type AdminTab = 'waitlist' | 'users' | 'organizations' | 'sources' | 'jobs';
@@ -121,21 +121,16 @@ export function AdminPanel(): JSX.Element {
     setError(null);
 
     try {
-      const response = await fetch(
-        `${API_BASE}/waitlist/admin/list?status=${filter}&user_id=${user.id}`
+      const { data, error: requestError } = await apiRequest<{ entries: WaitlistEntry[]; total: number }>(
+        `/waitlist/admin/list?status=${encodeURIComponent(filter)}`
       );
 
-      if (!response.ok) {
-        if (response.status === 403) {
-          setError('Access denied. You need global_admin role.');
-        } else {
-          setError('Failed to fetch waitlist');
-        }
+      if (requestError || !data) {
+        setError(requestError ?? 'Failed to fetch waitlist');
         setEntries([]);
         return;
       }
 
-      const data = await response.json() as { entries: WaitlistEntry[]; total: number };
       setEntries(data.entries);
     } catch (err) {
       setError('Failed to connect to server');
@@ -152,21 +147,16 @@ export function AdminPanel(): JSX.Element {
     setUsersError(null);
 
     try {
-      const response = await fetch(
-        `${API_BASE}/waitlist/admin/users?user_id=${user.id}`
+      const { data, error: requestError } = await apiRequest<{ users: AdminUser[]; total: number }>(
+        '/waitlist/admin/users'
       );
 
-      if (!response.ok) {
-        if (response.status === 403) {
-          setUsersError('Access denied. You need global_admin role.');
-        } else {
-          setUsersError('Failed to fetch users');
-        }
+      if (requestError || !data) {
+        setUsersError(requestError ?? 'Failed to fetch users');
         setAdminUsers([]);
         return;
       }
 
-      const data = await response.json() as { users: AdminUser[]; total: number };
       setAdminUsers(data.users);
     } catch (err) {
       setUsersError('Failed to connect to server');
@@ -183,21 +173,16 @@ export function AdminPanel(): JSX.Element {
     setOrgsError(null);
 
     try {
-      const response = await fetch(
-        `${API_BASE}/waitlist/admin/organizations?user_id=${user.id}`
+      const { data, error: requestError } = await apiRequest<{ organizations: AdminOrganization[]; total: number }>(
+        '/waitlist/admin/organizations'
       );
 
-      if (!response.ok) {
-        if (response.status === 403) {
-          setOrgsError('Access denied. You need global_admin role.');
-        } else {
-          setOrgsError('Failed to fetch organizations');
-        }
+      if (requestError || !data) {
+        setOrgsError(requestError ?? 'Failed to fetch organizations');
         setAdminOrgs([]);
         return;
       }
 
-      const data = await response.json() as { organizations: AdminOrganization[]; total: number };
       setAdminOrgs(data.organizations);
     } catch (err) {
       setOrgsError('Failed to connect to server');
@@ -308,18 +293,17 @@ export function AdminPanel(): JSX.Element {
 
   const handleInvite = async (targetUserId: string): Promise<void> => {
     if (!user) return;
-    
+
     setInviting(targetUserId);
 
     try {
-      const response = await fetch(
-        `${API_BASE}/waitlist/admin/${targetUserId}/invite?user_id=${user.id}`,
+      const { error: requestError } = await apiRequest<{ success: boolean; message: string }>(
+        `/waitlist/admin/${targetUserId}/invite`,
         { method: 'POST' }
       );
 
-      if (!response.ok) {
-        const data = await response.json() as { detail?: string };
-        throw new Error(data.detail ?? 'Failed to invite');
+      if (requestError) {
+        throw new Error(requestError);
       }
 
       // Refresh the list

--- a/frontend/src/components/AdminWaitlist.tsx
+++ b/frontend/src/components/AdminWaitlist.tsx
@@ -2,11 +2,11 @@
  * Admin Waitlist management page.
  * 
  * Allows admins to view and invite users from the waitlist.
- * Access controlled via admin_key query parameter.
+ * Access controlled via authenticated JWT + global_admin backend checks.
  */
 
 import { useEffect, useState, useCallback } from 'react';
-import { API_BASE } from '../lib/api';
+import { apiRequest } from '../lib/api';
 
 interface WaitlistEntry {
   id: string;
@@ -25,11 +25,7 @@ interface WaitlistEntry {
   created_at: string | null;
 }
 
-interface AdminWaitlistProps {
-  adminKey: string;
-}
-
-export function AdminWaitlist({ adminKey }: AdminWaitlistProps): JSX.Element {
+export function AdminWaitlist(): JSX.Element {
   const [entries, setEntries] = useState<WaitlistEntry[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -41,21 +37,16 @@ export function AdminWaitlist({ adminKey }: AdminWaitlistProps): JSX.Element {
     setError(null);
 
     try {
-      const response = await fetch(
-        `${API_BASE}/waitlist/admin?admin_key=${encodeURIComponent(adminKey)}&status=${filter}`
+      const { data, error: requestError } = await apiRequest<{ entries: WaitlistEntry[]; total: number }>(
+        `/waitlist/admin?status=${encodeURIComponent(filter)}`
       );
 
-      if (!response.ok) {
-        if (response.status === 403) {
-          setError('Invalid admin key');
-        } else {
-          setError('Failed to fetch waitlist');
-        }
+      if (requestError || !data) {
+        setError(requestError ?? 'Failed to fetch waitlist');
         setEntries([]);
         return;
       }
 
-      const data = await response.json() as { entries: WaitlistEntry[]; total: number };
       setEntries(data.entries);
     } catch (err) {
       setError('Failed to connect to server');
@@ -63,7 +54,7 @@ export function AdminWaitlist({ adminKey }: AdminWaitlistProps): JSX.Element {
     } finally {
       setLoading(false);
     }
-  }, [adminKey, filter]);
+  }, [filter]);
 
   useEffect(() => {
     void fetchWaitlist();
@@ -73,14 +64,13 @@ export function AdminWaitlist({ adminKey }: AdminWaitlistProps): JSX.Element {
     setInviting(userId);
 
     try {
-      const response = await fetch(
-        `${API_BASE}/waitlist/admin/${userId}/invite?admin_key=${encodeURIComponent(adminKey)}`,
+      const { error: requestError } = await apiRequest<{ success: boolean; message: string }>(
+        `/waitlist/admin/${userId}/invite`,
         { method: 'POST' }
       );
 
-      if (!response.ok) {
-        const data = await response.json() as { detail?: string };
-        throw new Error(data.detail ?? 'Failed to invite');
+      if (requestError) {
+        throw new Error(requestError);
       }
 
       // Refresh the list


### PR DESCRIPTION
### Motivation
- The legacy `admin_key` query parameter exposes a shared secret in URLs and lacks identity/auditability, so admin waitlist endpoints need JWT-based role checks and audit logging.
- Ensure existing global admins remain authorized after the migration by recognizing both `role == "global_admin"` and entries in the `roles` list.

### Description
- Replaced query-parameter key checks in waitlist admin endpoints with FastAPI dependency injection using `require_global_admin` so access is enforced from verified JWTs (`backend/api/routes/waitlist.py`).
- Enhanced `AuthContext` construction so admin detection treats either `role == "global_admin"` or `"global_admin"` present in `roles` as global admin (`backend/api/auth_middleware.py`).
- Added structured `logger.info(...)` calls around privileged actions (list/invite) and factored waitlist-fetching into `_fetch_waitlist_entries` for reuse (`backend/api/routes/waitlist.py`).
- Updated frontend admin flows to stop sending secrets in URLs and instead call backend via the authenticated helper `apiRequest(...)` (used in `AdminWaitlist` and `AdminPanel`), and removed the client-side `?key=` gate in the `/admin/waitlist` route (`frontend/src/components/AdminWaitlist.tsx`, `frontend/src/components/AdminPanel.tsx`, `frontend/src/App.tsx`).

### Testing
- Ran `python -m compileall backend/api/auth_middleware.py backend/api/routes/waitlist.py` successfully to validate Python modules compiled.
- Ran backend test suite with `pytest` and all tests passed (`16 passed, 0 failed`).
- Built the frontend with `npm run build` and the build succeeded (Vite produced non-blocking chunk-size warnings only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e813205fc8321857aee4fc4a56af6)