### PR TITLE
Add explicit guardrails against implicit child workflow execution

### DIFF
--- a/backend/tests/test_workflow_prompt_guardrails.py
+++ b/backend/tests/test_workflow_prompt_guardrails.py
@@ -1,0 +1,26 @@
+from workers.tasks.workflows import (
+    WORKFLOW_NESTING_GUARDRAIL,
+    format_child_workflows_for_prompt,
+)
+
+
+def test_child_workflow_prompt_marks_usage_as_explicit_only() -> None:
+    prompt_text = format_child_workflows_for_prompt(
+        [
+            {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "name": "Example Child",
+                "description": "Runs a specialist enrichment flow",
+                "input_schema": {"type": "object", "properties": {}},
+                "output_schema": {"type": "object", "properties": {}},
+            }
+        ]
+    )
+
+    assert prompt_text is not None
+    assert "only use run_workflow or loop_over when explicitly requested" in prompt_text
+
+
+def test_workflow_nesting_guardrail_mentions_explicit_requests() -> None:
+    assert "Do NOT create or invoke child workflows" in WORKFLOW_NESTING_GUARDRAIL
+    assert "explicitly asks" in WORKFLOW_NESTING_GUARDRAIL


### PR DESCRIPTION
### Motivation
- Prevent workflows from implicitly spawning or invoking child workflows unless explicitly requested by the user or the workflow prompt, matching the desired behavior for single-run orchestration.
- Make prompt-based workflow execution safer by clearly instructing the agent to avoid nested automation unless directed.
- Surface this rule in the prompt text so it is visible to the agent at planning time.

### Description
- Added a `WORKFLOW_NESTING_GUARDRAIL` constant and inject it into prompt-based execution in `backend/workers/tasks/workflows.py` to instruct agents not to create/invoke child workflows by default.
- Updated `format_child_workflows_for_prompt` wording to mark child-workflow usage as optional and explicitly-request-only in `backend/workers/tasks/workflows.py`.
- Added a focused unit test file `backend/tests/test_workflow_prompt_guardrails.py` that verifies the child-workflow prompt wording and that the guardrail string contains the expected instructions.

### Testing
- Running `pytest` without setting `PYTHONPATH` produced an import error during collection due to test environment invocation (`ModuleNotFoundError: No module named 'workers'`).
- Running `PYTHONPATH=backend pytest backend/tests/test_workflow_permissions.py backend/tests/test_workflow_prompt_guardrails.py` executed the suite and all tests passed with one deprecation warning, result: `7 passed, 1 warning`.
- The new tests exercise `format_child_workflows_for_prompt` and the `WORKFLOW_NESTING_GUARDRAIL` constant and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f5ff2d41083219845f6d6cc2ec6d2)