### PR TITLE
Only 5 workflow kids. 

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -940,6 +940,11 @@ async def _run_sql_write(
     # Prevent autonomous workflow fan-out: a workflow run cannot create other
     # workflows that are automatically runnable (enabled + non-manual trigger).
     if context and context.get("is_workflow") and table == "workflows":
+        if operation == "INSERT":
+            limit_error = _workflow_child_creation_limit_error(context)
+            if limit_error:
+                return limit_error
+
         if operation == "INSERT" and _workflow_insert_would_auto_run(query):
             logger.warning(
                 "[Tools._run_sql_write] Blocked workflow-created auto-run workflow INSERT"
@@ -1042,6 +1047,20 @@ async def _run_sql_write(
             # Execute the query
             result = await session.execute(text(final_query))
             await session.commit()
+
+            if (
+                context
+                and context.get("is_workflow")
+                and table == "workflows"
+                and operation == "INSERT"
+            ):
+                updated_count = int(context.get("created_workflow_count", 0)) + 1
+                context["created_workflow_count"] = updated_count
+                logger.info(
+                    "[Tools._run_sql_write] Workflow-created child count incremented: workflow_id=%s count=%d",
+                    context.get("workflow_id"),
+                    updated_count,
+                )
             
             rows_affected = result.rowcount
             
@@ -3815,11 +3834,41 @@ async def _trigger_sync(
 # Maximum depth for nested workflow calls to prevent infinite recursion
 MAX_WORKFLOW_CALL_DEPTH: int = 5
 
+# Maximum number of workflows a workflow execution tree may create.
+MAX_CREATED_CHILD_WORKFLOWS: int = 5
+
 # Maximum items that can be processed in loop_over
 MAX_LOOP_ITEMS: int = 500
 
 # Maximum concurrent workflow executions in loop_over
 MAX_CONCURRENT_WORKFLOWS: int = 10
+
+
+def _workflow_child_creation_limit_error(
+    context: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return an error when a workflow execution has created too many child workflows."""
+    if not context or not context.get("is_workflow"):
+        return None
+
+    created_count = int(context.get("created_workflow_count", 0))
+    if created_count < MAX_CREATED_CHILD_WORKFLOWS:
+        return None
+
+    workflow_id = context.get("workflow_id")
+    logger.warning(
+        "[Tools._run_sql_write] Blocked workflow child creation limit: workflow_id=%s created=%d limit=%d",
+        workflow_id,
+        created_count,
+        MAX_CREATED_CHILD_WORKFLOWS,
+    )
+    return {
+        "error": (
+            "Workflow child-creation limit reached. "
+            f"A workflow execution can create at most {MAX_CREATED_CHILD_WORKFLOWS} child workflows."
+        ),
+        "status": "rejected",
+    }
 
 
 async def _run_workflow(

--- a/backend/tests/test_workflow_child_creation_limits.py
+++ b/backend/tests/test_workflow_child_creation_limits.py
@@ -1,0 +1,28 @@
+from agents.tools import (
+    MAX_CREATED_CHILD_WORKFLOWS,
+    _workflow_child_creation_limit_error,
+)
+
+
+def test_workflow_child_creation_limit_allows_under_limit() -> None:
+    context = {
+        "is_workflow": True,
+        "workflow_id": "wf-123",
+        "created_workflow_count": MAX_CREATED_CHILD_WORKFLOWS - 1,
+    }
+
+    assert _workflow_child_creation_limit_error(context) is None
+
+
+def test_workflow_child_creation_limit_blocks_at_limit() -> None:
+    context = {
+        "is_workflow": True,
+        "workflow_id": "wf-123",
+        "created_workflow_count": MAX_CREATED_CHILD_WORKFLOWS,
+    }
+
+    error = _workflow_child_creation_limit_error(context)
+
+    assert error is not None
+    assert error["status"] == "rejected"
+    assert f"at most {MAX_CREATED_CHILD_WORKFLOWS} child workflows" in error["error"]

--- a/backend/tests/test_workflow_prompt_guardrails.py
+++ b/backend/tests/test_workflow_prompt_guardrails.py
@@ -24,3 +24,4 @@ def test_child_workflow_prompt_marks_usage_as_explicit_only() -> None:
 def test_workflow_nesting_guardrail_mentions_explicit_requests() -> None:
     assert "Do NOT create or invoke child workflows" in WORKFLOW_NESTING_GUARDRAIL
     assert "explicitly asks" in WORKFLOW_NESTING_GUARDRAIL
+    assert "at 5 or fewer" in WORKFLOW_NESTING_GUARDRAIL

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -31,8 +31,9 @@ logger = logging.getLogger(__name__)
 WORKFLOW_NESTING_GUARDRAIL = (
     "Execution guardrail: Do NOT create or invoke child workflows (via "
     "create_workflow, run_workflow, or loop_over) unless the user or workflow "
-    "prompt explicitly asks you to do so. Prefer completing the task in this "
-    "workflow directly."
+    "prompt explicitly asks you to do so. If you create child workflows, keep "
+    "the total created across this execution tree at 5 or fewer. Prefer "
+    "completing the task in this workflow directly."
 )
 
 


### PR DESCRIPTION
Added a workflow child-creation guard constant (MAX_CREATED_CHILD_WORKFLOWS = 5) plus a new helper that rejects creation attempts once the workflow execution context has already created 5 child workflows, with explicit warning logs for debugging. 

Enforced that limit in _run_sql_write for workflow-context INSERT operations to workflows, and incremented created_workflow_count only after successful commits (also with logging). 

Updated the workflow execution guardrail prompt text to explicitly state the 5-child-workflow cap for nested workflow creation. 

Added/updated tests to cover both the new limit helper behavior and the updated guardrail messaging. 