### PR TITLE
Clarify canonical field for workflow execution notes

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -735,14 +735,14 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
                 system_prompt += memory_context
         workflow_id: str | None = (self.workflow_context or {}).get("workflow_id")
         if workflow_id and self.organization_id:
-            system_prompt += "\n\n## Workflow Memory Rules\nIn workflow executions, NEVER use save_memory. Use keep_notes for workflow-scoped notes."
+            system_prompt += "\n\n## Workflow Memory Rules\nIn workflow executions, NEVER use save_memory. Use keep_notes for workflow-scoped notes. The canonical persistence field for workflow execution notes/state is workflow_runs.workflow_notes."
             workflow_notes = await self._load_workflow_notes(workflow_id)
             if workflow_notes:
                 notes_context = "\n\n## Workflow Notes\n"
                 notes_context += "These are notes saved by prior runs of this workflow. Use them as workflow memory.\n\n"
                 for note in workflow_notes:
                     notes_context += f"- {note}\n"
-                notes_context += "\nWhen a run needs to persist new workflow-scoped context, use keep_notes."
+                notes_context += "\nWhen a run needs to persist new workflow-scoped context, use keep_notes so it is stored on workflow_runs.workflow_notes for future runs of this workflow."
                 system_prompt += notes_context
 
 

--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -1045,6 +1045,8 @@ register_tool(
     name="keep_notes",
     description="""Store workflow-scoped notes that should be available to future runs of the same workflow.
 
+Notes are persisted on `workflow_runs.workflow_notes`, which is the canonical field for workflow execution notes/state shared across runs of the same workflow.
+
 Use this in workflow executions for interim findings, state, or progress breadcrumbs that future runs can reference.
 
 This is workflow-scoped memory, not user-wide memory.""",


### PR DESCRIPTION
### Motivation
- Make it explicit to agents and developers that workflow execution notes/state should be persisted on `workflow_runs.workflow_notes` so future runs of the same workflow can reliably access saved context.

### Description
- Updated `keep_notes` tool description in `backend/agents/registry.py` and the workflow system prompt in `backend/agents/orchestrator.py` to explicitly state that the canonical persistence field is `workflow_runs.workflow_notes` and that `keep_notes` should be used to store notes there.

### Testing
- Ran `python -m compileall backend/agents/orchestrator.py backend/agents/registry.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f9a5a3edc8321aab9b6111da212d4)