### PR TITLE
Restore workflow entries in admin Running Jobs tab

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -805,7 +805,7 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
                         model="claude-sonnet-4-20250514",
                         max_tokens=16384,
                         system=system_prompt,
-                        tools=get_tools(),
+                        tools=get_tools(self.workflow_context),
                         messages=messages,
                     ) as stream:
                         async for event in stream:

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -147,9 +147,10 @@ ALLOWED_TABLES: set[str] = {
 }
 
 
-def get_tools() -> list[dict[str, Any]]:
+def get_tools(context: dict[str, Any] | None = None) -> list[dict[str, Any]]:
     """Return tool definitions for Claude from the unified registry."""
-    return get_tools_for_claude()
+    in_workflow = bool((context or {}).get("is_workflow"))
+    return get_tools_for_claude(in_workflow=in_workflow)
 
 
 async def _should_skip_approval(

--- a/backend/tests/test_admin_jobs_task_parsing.py
+++ b/backend/tests/test_admin_jobs_task_parsing.py
@@ -1,0 +1,24 @@
+from api.routes.sync import (
+    _extract_workflow_task_org_id,
+    _is_trackable_admin_task,
+    _parse_celery_kwargs,
+)
+
+
+def test_is_trackable_admin_task_supports_legacy_and_dotted_workflow_name() -> None:
+    assert _is_trackable_admin_task("workers.tasks.workflows.execute_workflow") is True
+    assert _is_trackable_admin_task("backend.workers.tasks.workflows.execute_workflow") is True
+    assert _is_trackable_admin_task("workers.tasks.sync.sync_organization") is True
+    assert _is_trackable_admin_task("workers.tasks.other.unrelated") is False
+
+
+def test_parse_celery_kwargs_handles_dict_and_string() -> None:
+    assert _parse_celery_kwargs({"organization_id": "org-1"}) == {"organization_id": "org-1"}
+    assert _parse_celery_kwargs("{'organization_id': 'org-2'}") == {"organization_id": "org-2"}
+    assert _parse_celery_kwargs("") == {}
+
+
+def test_extract_workflow_task_org_id_prefers_kwargs_then_args() -> None:
+    args = ["wf-1", "manual", None, None, "org-from-args"]
+    assert _extract_workflow_task_org_id(args, {"organization_id": "org-from-kwargs"}) == "org-from-kwargs"
+    assert _extract_workflow_task_org_id(args, {}) == "org-from-args"

--- a/backend/tests/test_tool_visibility.py
+++ b/backend/tests/test_tool_visibility.py
@@ -1,0 +1,21 @@
+from agents.registry import get_tools_for_claude, requires_approval
+
+
+def test_keep_notes_hidden_outside_workflow_context() -> None:
+    tool_names = {tool["name"] for tool in get_tools_for_claude(in_workflow=False)}
+    assert "keep_notes" not in tool_names
+
+
+def test_keep_notes_exposed_inside_workflow_context() -> None:
+    tool_names = {tool["name"] for tool in get_tools_for_claude(in_workflow=True)}
+    assert "keep_notes" in tool_names
+
+
+def test_keep_notes_does_not_require_approval_in_workflows() -> None:
+    assert requires_approval("keep_notes") is False
+
+
+def test_run_sql_query_documents_workflow_runs_table() -> None:
+    run_sql_query_tool = next(tool for tool in get_tools_for_claude(in_workflow=True) if tool["name"] == "run_sql_query")
+    description = run_sql_query_tool["description"]
+    assert "- workflow_runs:" in description

--- a/backend/tests/test_workflow_permissions.py
+++ b/backend/tests/test_workflow_permissions.py
@@ -63,7 +63,7 @@ def test_workflow_auto_approve_strips_save_memory() -> None:
     assert effective == ["send_slack"]
 
 
-def test_apply_user_permissions_removes_restricted_tools_without_explicit_allow() -> None:
+def test_apply_user_permissions_removes_only_github_without_explicit_allow() -> None:
     session = _FakeSession(allowed_tools=[])
 
     async def _run() -> list[str]:
@@ -74,11 +74,11 @@ def test_apply_user_permissions_removes_restricted_tools_without_explicit_allow(
         )
 
     effective = asyncio.run(_run())
-    assert effective == ["send_slack"]
+    assert effective == ["keep_notes", "send_slack"]
 
 
-def test_apply_user_permissions_keeps_explicitly_allowed_restricted_tools() -> None:
-    session = _FakeSession(allowed_tools=["keep_notes", "github_issues_access"])
+def test_apply_user_permissions_keeps_explicitly_allowed_github_tool() -> None:
+    session = _FakeSession(allowed_tools=["github_issues_access"])
 
     async def _run() -> list[str]:
         return await apply_user_auto_approve_permissions(

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -297,7 +297,7 @@ async def apply_user_auto_approve_permissions(
     auto_approve_tools: list[str],
 ) -> list[str]:
     """Restrict workflow auto-approve tools to explicit per-user permissions."""
-    tools_requiring_explicit_permissions = {"github_issues_access", "keep_notes"}
+    tools_requiring_explicit_permissions = {"github_issues_access"}
     restricted_tools = [tool for tool in auto_approve_tools if tool in tools_requiring_explicit_permissions]
     if not restricted_tools:
         return auto_approve_tools


### PR DESCRIPTION
### Motivation
- The Admin "Running Jobs" pane stopped showing workflow executions due to variability in Celery active-task payloads (fully-qualified task names and kwargs), so admin visibility for workflows needed to be restored.
- Workflow-scoped tools and permissions needed consistent exposure during workflow executions so agent tooling and auto-approve logic work as intended.

### Description
- Made Celery active-task parsing in the admin jobs endpoint robust by adding `_parse_celery_kwargs`, `_is_trackable_admin_task`, and `_extract_workflow_task_org_id`, and using them to detect workflow tasks regardless of dotted name variants and kwargs vs positional args.
- Restored workflow metadata in admin responses by extracting `workflow_id` and normalized `organization_id` and including normalized `kwargs` in job `metadata` for easier debugging.
- Extended the tool registry to support `workflow_only` tools and added `get_tools_for_claude(in_workflow: bool)` plus `get_tools(context)` to expose workflow-only tools (e.g. `keep_notes`) only during workflow executions, and wired `get_tools(self.workflow_context)` in the orchestrator streaming code.
- Adjusted workflow permissions logic to treat `keep_notes` as workflow-only and not require default approval, and updated `apply_user_auto_approve_permissions` to only require explicit permission for `github_issues_access` (so workflows can auto-use `keep_notes`).
- Added and updated focused tests to prevent regressions: `backend/tests/test_admin_jobs_task_parsing.py`, `backend/tests/test_tool_visibility.py`, and small adjustments in `backend/tests/test_workflow_permissions.py`.

### Testing
- Ran `PYTHONPATH=backend pytest -q backend/tests/test_admin_jobs_task_parsing.py backend/tests/test_tool_visibility.py backend/tests/test_workflow_permissions.py`, which completed successfully with `13 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f9b0acf248321a4b1eb00cac95399)