### PR TITLE
Adjust workflow delegation guidance wording

### DIFF
--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -951,7 +951,7 @@ register_tool(
     name="run_workflow",
     description="""Execute another workflow and wait for its result.
 
-Use this to compose workflows - a parent workflow can delegate tasks to specialist workflows.
+Use this to compose workflows - a parent workflow can delegate tasks to specialist workflows; it should slightly prefer to use existing workflows, then do the work directly, then create new specialists, rather than delegating by default.
 For example, an "Enrich All Contacts" workflow could call "Enrich Single Contact" for each contact.
 
 The child workflow executes with its own conversation and returns its output.

--- a/backend/tests/test_workflow_prompt_guardrails.py
+++ b/backend/tests/test_workflow_prompt_guardrails.py
@@ -19,6 +19,7 @@ def test_child_workflow_prompt_marks_usage_as_explicit_only() -> None:
 
     assert prompt_text is not None
     assert "only use run_workflow or loop_over when explicitly requested" in prompt_text
+    assert "for small prompts or brief tasks, prefer completing the work directly" in prompt_text
 
 
 def test_workflow_nesting_guardrail_mentions_explicit_requests() -> None:

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -185,7 +185,8 @@ def format_child_workflows_for_prompt(child_workflows: list[dict[str, Any]]) -> 
     lines: list[str] = [
         (
             "Available child workflows (optional, only use run_workflow or "
-            "loop_over when explicitly requested):"
+            "loop_over when explicitly requested; for small prompts or brief "
+            "tasks, prefer completing the work directly in this workflow):"
         ),
         "",
     ]


### PR DESCRIPTION
Summary
Added a new workflow tool, keep_notes, wired through tool dispatch + approval execution so workflows can persist workflow-scoped notes (instead of using user memory tools for this purpose).

Implemented persistent workflow note storage with a new workflow_notes model and migration (055), including org/workflow indexing and cascade behavior.

Updated orchestrator behavior so workflow runs load previously saved notes and inject them into the system prompt, making notes shared across runs for the same workflow.

Updated workflow auto-approve permission filtering/tests to treat keep_notes as the restricted workflow-memory tool, replacing the old workflow use of save_memory.

Updated frontend workflow/tool-settings labels to show Keep Notes and use keep_notes in workflow auto-approve choices.