### PR TITLE
Surface active workflow_runs in admin running jobs

### DIFF
--- a/backend/tests/test_admin_jobs_task_parsing.py
+++ b/backend/tests/test_admin_jobs_task_parsing.py
@@ -1,5 +1,9 @@
 from api.routes.sync import (
+    _get_celery_task_args,
+    _get_celery_task_kwargs,
+    _build_workflow_run_admin_job,
     _extract_workflow_task_org_id,
+    _is_active_workflow_run_status,
     _is_trackable_admin_task,
     _parse_celery_kwargs,
 )
@@ -9,6 +13,7 @@ def test_is_trackable_admin_task_supports_legacy_and_dotted_workflow_name() -> N
     assert _is_trackable_admin_task("workers.tasks.workflows.execute_workflow") is True
     assert _is_trackable_admin_task("backend.workers.tasks.workflows.execute_workflow") is True
     assert _is_trackable_admin_task("workers.tasks.sync.sync_organization") is True
+    assert _is_trackable_admin_task("backend.workers.tasks.sync.sync_organization") is True
     assert _is_trackable_admin_task("workers.tasks.other.unrelated") is False
 
 
@@ -22,3 +27,48 @@ def test_extract_workflow_task_org_id_prefers_kwargs_then_args() -> None:
     args = ["wf-1", "manual", None, None, "org-from-args"]
     assert _extract_workflow_task_org_id(args, {"organization_id": "org-from-kwargs"}) == "org-from-kwargs"
     assert _extract_workflow_task_org_id(args, {}) == "org-from-args"
+
+
+def test_get_celery_task_args_supports_argsrepr_fallback() -> None:
+    task = {"args": "", "argsrepr": "('wf-1', 'manual', None, None, 'org-1')"}
+    assert _get_celery_task_args(task) == ["wf-1", "manual", None, None, "org-1"]
+
+
+def test_get_celery_task_kwargs_supports_kwargsrepr_fallback() -> None:
+    task = {"kwargs": "", "kwargsrepr": "{'organization_id': 'org-2', 'trigger': 'manual'}"}
+    assert _get_celery_task_kwargs(task) == {"organization_id": "org-2", "trigger": "manual"}
+
+
+def test_is_active_workflow_run_status_only_matches_in_progress_statuses() -> None:
+    assert _is_active_workflow_run_status("pending") is True
+    assert _is_active_workflow_run_status("running") is True
+    assert _is_active_workflow_run_status("completed") is False
+
+
+def test_build_workflow_run_admin_job_sets_expected_fields() -> None:
+    from datetime import datetime
+    from uuid import uuid4
+
+    from models.workflow import WorkflowRun
+
+    run = WorkflowRun(
+        id=uuid4(),
+        workflow_id=uuid4(),
+        organization_id=uuid4(),
+        triggered_by="manual",
+        status="running",
+        started_at=datetime(2025, 1, 1, 12, 0, 0),
+    )
+
+    admin_job = _build_workflow_run_admin_job(
+        run=run,
+        workflow_name="Nightly Enrichment",
+        organization_name="Acme Corp",
+    )
+
+    assert admin_job.type == "workflow"
+    assert admin_job.status == "running"
+    assert admin_job.title == "Workflow run: Nightly Enrichment"
+    assert admin_job.organization_name == "Acme Corp"
+    assert admin_job.metadata is not None
+    assert admin_job.metadata.get("source") == "workflow_runs"


### PR DESCRIPTION
### Motivation
- The Admin UI "Running Jobs" view could miss workflows that are actively executing but tracked in the `workflow_runs` table instead of appearing via Celery inspection. 
- The endpoint should aggregate both DB-backed workflow run visibility and in-flight worker tasks so admins see a complete picture.

### Description
- Imported `Workflow` and `WorkflowRun` and added a DB query to fetch `workflow_runs` joined to `workflows` and include `pending`/`running` runs in the `/api/sync/admin/jobs` response. 
- Added `_is_active_workflow_run_status` to centralize what counts as in-progress and `_build_workflow_run_admin_job` to normalize mapping a `WorkflowRun` row into an `AdminRunningJob` payload with `metadata.source="workflow_runs"`. 
- Hardened Celery parsing with `_get_celery_task_args` and `_get_celery_task_kwargs`, trimmed blank `args` handling in `_parse_celery_args`, and clarified workflow detection via `_is_workflow_task` while keeping and integrating existing Celery inspection logic. 
- Added logging that reports how many `workflow_runs` rows were included and expanded unit tests to cover the new helpers and parsing fallbacks.

### Testing
- Ran `PYTHONPATH=backend pytest backend/tests/test_admin_jobs_task_parsing.py` and all tests passed (`7 passed`, `1 warning`). 
- Modified files: `backend/api/routes/sync.py` and `backend/tests/test_admin_jobs_task_parsing.py` (unit tests exercised the new helpers and behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fa3ebee548321a1fae301755a20c3)