### PR TITLE
Enable RLS on workflow tables and ensure workflows can read workflow_runs

### DIFF
--- a/backend/db/migrations/versions/056_enable_rls_on_workflow_tables.py
+++ b/backend/db/migrations/versions/056_enable_rls_on_workflow_tables.py
@@ -1,0 +1,72 @@
+"""Enable RLS policies on workflow tables.
+
+Revision ID: 056_enable_rls_on_workflow_tables
+Revises: 055_add_workflow_notes
+Create Date: 2026-02-13
+"""
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text
+
+
+# revision identifiers, used by Alembic.
+revision: str = "056_enable_rls_on_workflow_tables"
+down_revision: Union[str, None] = "055_add_workflow_notes"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_WORKFLOW_TABLES = ["workflows", "workflow_runs"]
+
+
+def _table_has_org_id(conn, table: str) -> bool:
+    result = conn.execute(
+        text(
+            """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_name = :table_name
+                  AND column_name = 'organization_id'
+            )
+            """
+        ),
+        {"table_name": table},
+    )
+    return bool(result.scalar())
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    for table in _WORKFLOW_TABLES:
+        if not _table_has_org_id(conn, table):
+            continue
+
+        conn.execute(text(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY"))
+        conn.execute(text(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY"))
+        conn.execute(text(f"DROP POLICY IF EXISTS org_isolation ON {table}"))
+
+        conn.execute(
+            text(
+                f"""
+                CREATE POLICY org_isolation ON {table}
+                FOR ALL
+                USING (
+                    organization_id::text = COALESCE(
+                        NULLIF(current_setting('app.current_org_id', true), ''),
+                        '00000000-0000-0000-0000-000000000000'
+                    )
+                )
+                """
+            )
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    for table in _WORKFLOW_TABLES:
+        conn.execute(text(f"DROP POLICY IF EXISTS org_isolation ON {table}"))
+        conn.execute(text(f"ALTER TABLE {table} DISABLE ROW LEVEL SECURITY"))

--- a/backend/tests/test_tool_visibility.py
+++ b/backend/tests/test_tool_visibility.py
@@ -1,4 +1,5 @@
 from agents.registry import get_tools_for_claude, requires_approval
+from agents.tools import ALLOWED_TABLES
 
 
 def test_keep_notes_hidden_outside_workflow_context() -> None:
@@ -19,3 +20,7 @@ def test_run_sql_query_documents_workflow_runs_table() -> None:
     run_sql_query_tool = next(tool for tool in get_tools_for_claude(in_workflow=True) if tool["name"] == "run_sql_query")
     description = run_sql_query_tool["description"]
     assert "- workflow_runs:" in description
+
+
+def test_workflow_runs_is_queryable_from_run_sql_query() -> None:
+    assert "workflow_runs" in ALLOWED_TABLES


### PR DESCRIPTION
### Motivation
- Ensure workflows can safely read their execution history (`workflow_runs`) while running by applying Row-Level Security (RLS) consistent with other multi-tenant tables.
- Prevent accidental cross-tenant access by making `workflow_runs` and `workflows` obey the same `app.current_org_id` org isolation policy used elsewhere.

### Description
- Add Alembic migration `backend/db/migrations/versions/056_enable_rls_on_workflow_tables.py` to enable and force RLS on `workflows` and `workflow_runs`, create an `org_isolation` policy keyed to `app.current_org_id`, and include a downgrade that drops the policy and disables RLS; the migration checks for the presence of `organization_id` before applying changes.
- Update `backend/tests/test_tool_visibility.py` to import `ALLOWED_TABLES` and add `test_workflow_runs_is_queryable_from_run_sql_query` which asserts `"workflow_runs"` is present in the SQL query allowlist so `run_sql_query` remains able to read workflow run history.

### Testing
- Ran `cd backend && pytest -q tests/test_tool_visibility.py` which initially failed in the local environment due to import path configuration (`ModuleNotFoundError`), then reran with `PYTHONPATH=.` as `cd backend && PYTHONPATH=. pytest -q tests/test_tool_visibility.py` and all tests passed (`5 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fa6eccc688321915e0d654917c7cc)