### PR TITLE
Grant workflow runtime read access to workflow execution tables

### DIFF
--- a/backend/db/migrations/versions/056_grant_workflow_runs_read_access.py
+++ b/backend/db/migrations/versions/056_grant_workflow_runs_read_access.py
@@ -1,0 +1,33 @@
+"""Grant workflow execution tables read access to application role.
+
+Revision ID: 056_grant_workflow_runs_read_access
+Revises: 055_add_workflow_notes
+Create Date: 2026-02-13
+"""
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = "056_grant_workflow_runs_read_access"
+down_revision: Union[str, None] = "055_add_workflow_notes"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Workflows execute under revtops_app (via get_session + SET ROLE).
+    # Grant explicit SELECT access to ensure run_sql_query can read
+    # workflow definitions and run history during active workflow execution.
+    conn.execute(text("GRANT SELECT ON TABLE workflows TO revtops_app"))
+    conn.execute(text("GRANT SELECT ON TABLE workflow_runs TO revtops_app"))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(text("REVOKE SELECT ON TABLE workflow_runs FROM revtops_app"))
+    conn.execute(text("REVOKE SELECT ON TABLE workflows FROM revtops_app"))


### PR DESCRIPTION
### Motivation
- Workflow executions run under the `revtops_app` role (via `SET ROLE`) and must be able to read workflow definitions and execution history while running, so explicit SELECT permissions are required on the relevant internal tables.

### Description
- Add an Alembic migration at `backend/db/migrations/versions/056_grant_workflow_runs_read_access.py` that grants `SELECT` on `workflows` and `workflow_runs` to `revtops_app` in `upgrade()` and revokes those grants in `downgrade()`.

### Testing
- Ran `PYTHONPATH=backend pytest -q backend/tests/test_tool_visibility.py`, which completed successfully (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fa6eccc688321915e0d654917c7cc)