### PR TITLE
Hide workflow execution guardrail from workflow transcript UI

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -749,6 +749,11 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
                 notes_context += "\nWhen a run needs to persist new workflow-scoped context, use keep_notes so it is stored on workflow_runs.workflow_notes for future runs of this workflow."
                 system_prompt += notes_context
 
+        execution_guardrails: list[str] = (self.workflow_context or {}).get("execution_guardrails") or []
+        if execution_guardrails:
+            system_prompt += "\n\n## Workflow Execution Guardrails\n"
+            system_prompt += "\n".join(f"- {guardrail}" for guardrail in execution_guardrails)
+
 
         # Stream responses with tool handling loop
         async for chunk in self._stream_with_tools(messages, system_prompt, content_blocks):

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -762,9 +762,6 @@ async def _execute_workflow_via_agent(
     # Build the prompt with typed parameters or raw trigger data
     prompt = workflow.prompt
 
-    # Prevent unrequested nested workflow orchestration
-    prompt += f"\n\n{WORKFLOW_NESTING_GUARDRAIL}"
-    
     # If schema is defined, inject typed parameters; otherwise use raw trigger data
     typed_params = format_typed_parameters(user_trigger_data, input_schema)
     if typed_params:
@@ -821,6 +818,7 @@ async def _execute_workflow_via_agent(
         "workflow_run_id": str(run.id),
         "auto_approve_tools": effective_auto_approve_tools,
         "call_stack": call_stack,  # For nested workflow recursion detection
+        "execution_guardrails": [WORKFLOW_NESTING_GUARDRAIL],
     }
     
     orchestrator = ChatOrchestrator(


### PR DESCRIPTION
### Motivation
- The workflow nesting guardrail was being appended to the user-visible workflow prompt, exposing system-added instructions in the workflow conversation UI.
- The intent is to keep the guardrail active as an execution constraint while preventing it from appearing in transcripts visible to users.

### Description
- Stop appending `WORKFLOW_NESTING_GUARDRAIL` directly to the workflow `prompt` so the user-visible message only contains authored content and parameter/schema enrichments (change in `backend/workers/tasks/workflows.py`).
- Add `execution_guardrails` to the `workflow_context` passed to the `ChatOrchestrator` so guardrails persist as hidden execution metadata (change in `backend/workers/tasks/workflows.py`).
- Make the orchestrator inject any `execution_guardrails` from `workflow_context` into the hidden system prompt (`system_prompt`) used for agent calls so the guardrail is enforced without being part of the visible transcript (change in `backend/agents/orchestrator.py`).

### Testing
- Ran the prompt guardrail unit tests with `PYTHONPATH=backend pytest -q backend/tests/test_workflow_prompt_guardrails.py` and the suite completed successfully with `2 passed`.
- Observed an initial import error when running tests without `PYTHONPATH=backend`, which was environment-specific and not related to the code changes; tests passed after setting `PYTHONPATH`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fac8416b88321babe43ac26e47a76)