### PR TITLE
Hide internal execution guardrail from workflow execution UI

### DIFF
--- a/backend/tests/test_workflow_prompt_guardrails.py
+++ b/backend/tests/test_workflow_prompt_guardrails.py
@@ -1,5 +1,6 @@
 from workers.tasks.workflows import (
     WORKFLOW_NESTING_GUARDRAIL,
+    build_user_visible_workflow_prompt,
     format_child_workflows_for_prompt,
 )
 
@@ -26,3 +27,17 @@ def test_workflow_nesting_guardrail_mentions_explicit_requests() -> None:
     assert "Do NOT create or invoke child workflows" in WORKFLOW_NESTING_GUARDRAIL
     assert "explicitly asks" in WORKFLOW_NESTING_GUARDRAIL
     assert "at 5 or fewer" in WORKFLOW_NESTING_GUARDRAIL
+
+
+def test_user_visible_prompt_omits_execution_guardrail() -> None:
+    full_prompt = (
+        "Find the accounts with open renewals."
+        f"\n\n{WORKFLOW_NESTING_GUARDRAIL}"
+        "\n\nInput parameters:\n- owner (string, required): \"sam\""
+    )
+
+    visible_prompt = build_user_visible_workflow_prompt(full_prompt)
+
+    assert WORKFLOW_NESTING_GUARDRAIL not in visible_prompt
+    assert "Find the accounts with open renewals." in visible_prompt
+    assert "Input parameters:" in visible_prompt


### PR DESCRIPTION
### Motivation

- The system execution guardrail text is currently persisted into workflow run conversations and visible in the UI, which exposes internal orchestration instructions to users.

### Description

- Add `build_user_visible_workflow_prompt(full_prompt)` in `backend/workers/tasks/workflows.py` to remove the internal execution-only guardrail from prompts saved for UI display.
- Persist the sanitized prompt via `orchestrator._save_user_message(user_visible_prompt)` while still executing the full guarded prompt with `orchestrator.process_message(..., save_user_message=False)` so the guardrail applies during execution but is not shown to users.
- Add `test_user_visible_prompt_omits_execution_guardrail` to `backend/tests/test_workflow_prompt_guardrails.py` to assert the guardrail is omitted from the user-visible prompt text.

### Testing

- Ran the guardrail tests with `PYTHONPATH=backend pytest -q backend/tests/test_workflow_prompt_guardrails.py` and they passed (`3 passed`).
- A plain `pytest -q backend/tests/test_workflow_prompt_guardrails.py` run failed earlier due to import path resolution, which is addressed by using `PYTHONPATH=backend` when running the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fadaab04c8321b1e2c32403583530)