### PR TITLE
Fix Alembic down_revision in 056_grant_workflow_runs_read_access

### DIFF
--- a/backend/db/migrations/versions/056_grant_workflow_runs_read_access.py
+++ b/backend/db/migrations/versions/056_grant_workflow_runs_read_access.py
@@ -1,7 +1,7 @@
 """Grant workflow execution tables read access to application role.
 
 Revision ID: 056_grant_workflow_runs_read_access
-Revises: 055_add_workflow_notes
+Revises: 055
 Create Date: 2026-02-13
 """
 from typing import Sequence, Union
@@ -11,7 +11,7 @@ from sqlalchemy import text
 
 # revision identifiers, used by Alembic.
 revision: str = "056_grant_workflow_runs_read_access"
-down_revision: Union[str, None] = "055_add_workflow_notes"
+down_revision: Union[str, None] = "055"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
### Motivation
- Resolve Alembic graph resolution failure (`KeyError: '055_add_workflow_notes'`) caused by a migration referencing a non-existent symbolic revision name instead of the actual prior revision ID.

### Description
- Update `backend/db/migrations/versions/056_grant_workflow_runs_read_access.py` to set `Revises: 055` in the header and `down_revision = "055"` so the migration links to the actual previous revision.

### Testing
- Ran `cd backend && alembic heads` and `cd backend && alembic history | head -n 12` to validate the migration chain, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900a39b7bc8321b258ea3cca0f3343)