### PR TITLE
Fix Alembic migration ID overflow for workflow run grants

### DIFF
--- a/backend/db/migrations/versions/056_grant_workflow_runs_read_access.py
+++ b/backend/db/migrations/versions/056_grant_workflow_runs_read_access.py
@@ -1,6 +1,6 @@
 """Grant workflow execution tables read access to application role.
 
-Revision ID: 056_grant_workflow_runs_read_access
+Revision ID: 056_workflow_runs_read_access
 Revises: 055
 Create Date: 2026-02-13
 """
@@ -10,7 +10,7 @@ from alembic import op
 from sqlalchemy import text
 
 # revision identifiers, used by Alembic.
-revision: str = "056_grant_workflow_runs_read_access"
+revision: str = "056_workflow_runs_read_access"
 down_revision: Union[str, None] = "055"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/backend/db/migrations/versions/057_enable_workflow_runs_rls.py
+++ b/backend/db/migrations/versions/057_enable_workflow_runs_rls.py
@@ -1,7 +1,7 @@
 """Enable RLS on workflow_runs for tenant-safe workflow execution history reads.
 
 Revision ID: 057_enable_workflow_runs_rls
-Revises: 056_grant_workflow_runs_read_access
+Revises: 056_workflow_runs_read_access
 Create Date: 2026-02-13
 """
 from typing import Sequence, Union
@@ -11,7 +11,7 @@ from sqlalchemy import text
 
 # revision identifiers, used by Alembic.
 revision: str = "057_enable_workflow_runs_rls"
-down_revision: Union[str, None] = "056_grant_workflow_runs_read_access"
+down_revision: Union[str, None] = "056_workflow_runs_read_access"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
### Motivation
- An Alembic upgrade failed with `psycopg2.errors.StringDataRightTruncation` because the migration revision identifier exceeded the `alembic_version.version_num` `varchar(32)` limit, preventing schema migration progress.

### Description
- Shortened the revision identifier in `backend/db/migrations/versions/056_grant_workflow_runs_read_access.py` from `056_grant_workflow_runs_read_access` to `056_workflow_runs_read_access` and updated `down_revision` in `backend/db/migrations/versions/057_enable_workflow_runs_rls.py` to reference the new ID so the migration chain remains consistent.

### Testing
- Ran a Python script that scans `backend/db/migrations/versions` for `revision` values longer than 32 characters and confirmed no revision IDs exceed the limit (no offending results).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900be7bfb08321a3ef82bf543a3334)