### PR TITLE
Enable write_to_system_of_record tool execution path

### DIFF
--- a/backend/tests/test_tools_write_to_system_of_record.py
+++ b/backend/tests/test_tools_write_to_system_of_record.py
@@ -1,0 +1,51 @@
+import asyncio
+
+from agents import tools
+
+
+def test_write_to_system_of_record_routes_to_dispatcher(monkeypatch) -> None:
+    called: dict[str, object] = {}
+
+    async def _fake_should_skip_approval(
+        tool_name: str,
+        user_id: str | None,
+        context: dict[str, object] | None,
+    ) -> bool:
+        called["skip_tool_name"] = tool_name
+        called["skip_user_id"] = user_id
+        called["skip_context"] = context
+        return True
+
+    async def _fake_write_to_system_of_record(
+        params: dict[str, object],
+        organization_id: str,
+        user_id: str | None,
+        skip_approval: bool,
+        conversation_id: str | None = None,
+    ) -> dict[str, object]:
+        called["params"] = params
+        called["organization_id"] = organization_id
+        called["user_id"] = user_id
+        called["skip_approval"] = skip_approval
+        called["conversation_id"] = conversation_id
+        return {"status": "completed", "message": "ok"}
+
+    monkeypatch.setattr(tools, "_should_skip_approval", _fake_should_skip_approval)
+    monkeypatch.setattr(tools, "_write_to_system_of_record", _fake_write_to_system_of_record)
+
+    result = asyncio.run(
+        tools.execute_tool(
+            tool_name="write_to_system_of_record",
+            tool_input={"target_system": "hubspot", "record_type": "contact", "operation": "create", "records": [{"email": "a@b.com"}]},
+            organization_id="00000000-0000-0000-0000-000000000001",
+            user_id="00000000-0000-0000-0000-000000000002",
+            context={"conversation_id": "00000000-0000-0000-0000-000000000003"},
+        )
+    )
+
+    assert result["status"] == "completed"
+    assert called["skip_tool_name"] == "write_to_system_of_record"
+    assert called["organization_id"] == "00000000-0000-0000-0000-000000000001"
+    assert called["user_id"] == "00000000-0000-0000-0000-000000000002"
+    assert called["skip_approval"] is True
+    assert called["conversation_id"] == "00000000-0000-0000-0000-000000000003"


### PR DESCRIPTION
### Motivation
- Slack-driven and orchestrated agent conversations must be able to perform external system writes via the unified `write_to_system_of_record` dispatcher so the bot can create/update CRM/issue/repo records without hitting unknown-tool errors.
- The registry exposes `write_to_system_of_record` while internal routing previously relied on legacy `crm_write`, so explicit routing is needed to ensure the tool executes with proper org/user/conversation context.

### Description
- Add explicit routing in `execute_tool` so `write_to_system_of_record` maps to the `_write_to_system_of_record` dispatcher and passes `conversation_id` and `skip_approval` context through. 
- Register a handler entry for `write_to_system_of_record` in the `tool_handlers` dispatch table and preserve the existing `crm_write` path for backward compatibility. 
- Unify logging so both `crm_write` and `write_to_system_of_record` report a single write-to-system-of-record completion log. 
- Add a regression test `backend/tests/test_tools_write_to_system_of_record.py` to assert the tool routes to the dispatcher and that org/user/conversation context and approval-skipping are propagated.

### Testing
- Ran `PYTHONPATH=backend pytest -q backend/tests/test_tools_write_to_system_of_record.py backend/tests/test_workflow_permissions.py` which completed successfully with all tests passing (`7 passed, 1 warning`).
- An initial `pytest` run without `PYTHONPATH=backend` produced import errors during collection, which was resolved by running with `PYTHONPATH=backend` as above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990153961f88321b4f23914153acd06)