### PR TITLE
Limit agent global commands to 500 chars and add live counter

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -23,7 +23,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import select, text
 
 from config import settings, get_nango_integration_id, get_provider_scope
@@ -196,7 +196,7 @@ class UpdateProfileRequest(BaseModel):
 
     name: Optional[str] = None
     avatar_url: Optional[str] = None
-    agent_global_commands: Optional[str] = None
+    agent_global_commands: Optional[str] = Field(default=None, max_length=500)
 
 
 @router.patch("/me", response_model=UserResponse)

--- a/frontend/src/components/ProfilePanel.tsx
+++ b/frontend/src/components/ProfilePanel.tsx
@@ -11,6 +11,8 @@ import { useState } from 'react';
 import type { UserProfile } from './AppLayout';
 import { API_BASE } from '../lib/api';
 
+const AGENT_GLOBAL_COMMANDS_MAX_LENGTH = 500;
+
 interface ProfilePanelProps {
   user: UserProfile;
   onClose: () => void;
@@ -30,6 +32,12 @@ export function ProfilePanel({ user, onClose, onLogout, onUpdateUser }: ProfileP
   const avatarPreview = newAvatarFile ?? user.avatarUrl;
 
   const handleSave = async (): Promise<void> => {
+    const trimmedAgentGlobalCommands = agentGlobalCommands.trim();
+    if (trimmedAgentGlobalCommands.length > AGENT_GLOBAL_COMMANDS_MAX_LENGTH) {
+      setError(`Agent global commands must be ${AGENT_GLOBAL_COMMANDS_MAX_LENGTH} characters or less.`);
+      return;
+    }
+
     setIsSaving(true);
     setError(null);
     try {
@@ -39,7 +47,7 @@ export function ProfilePanel({ user, onClose, onLogout, onUpdateUser }: ProfileP
         body: JSON.stringify({
           name: name || null,
           avatar_url: avatarPreview,
-          agent_global_commands: agentGlobalCommands || null,
+          agent_global_commands: trimmedAgentGlobalCommands || null,
         }),
       });
 
@@ -174,7 +182,11 @@ export function ProfilePanel({ user, onClose, onLogout, onUpdateUser }: ProfileP
                 onChange={(e) => setAgentGlobalCommands(e.target.value)}
                 placeholder="Persistent instructions that should be included whenever prompts are sent to the agent"
                 className="input-field min-h-28"
+                maxLength={AGENT_GLOBAL_COMMANDS_MAX_LENGTH}
               />
+              <p className="mt-1 text-xs text-surface-500">
+                ({agentGlobalCommands.length})/{AGENT_GLOBAL_COMMANDS_MAX_LENGTH}
+              </p>
             </div>
 
             <div>


### PR DESCRIPTION
### Motivation
- Enforce a 500-character limit for per-user persistent agent instructions to prevent oversized prompts from being stored or sent to agents.
- Provide immediate client-side feedback so users can see how many characters they've typed and avoid accidental truncation or API validation errors.

### Description
- Add `AGENT_GLOBAL_COMMANDS_MAX_LENGTH = 500` and trim-on-save logic to `frontend/src/components/ProfilePanel.tsx` and send the trimmed value in the profile update payload.
- Enforce `maxLength={AGENT_GLOBAL_COMMANDS_MAX_LENGTH}` on the profile textarea and render a live `(<current>)/500` counter under the field in the profile panel UI.
- Add server-side validation by changing `UpdateProfileRequest.agent_global_commands` to `Optional[str] = Field(default=None, max_length=500)` in `backend/api/routes/auth.py` to ensure API-level limits match the UI.

### Testing
- Built the frontend with `npm --prefix frontend run build` and the build completed successfully.
- Compiled the modified backend file with `python -m compileall backend/api/routes/auth.py` and it compiled without errors.
- Launched the frontend dev server and captured an automated Playwright screenshot of the app home page to validate UI startup succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69914043f554832182b7dc2b223ed6ae)