### PR TITLE
Remove parentheses from agent global commands charcount

### DIFF
--- a/frontend/src/components/ProfilePanel.tsx
+++ b/frontend/src/components/ProfilePanel.tsx
@@ -185,7 +185,7 @@ export function ProfilePanel({ user, onClose, onLogout, onUpdateUser }: ProfileP
                 maxLength={AGENT_GLOBAL_COMMANDS_MAX_LENGTH}
               />
               <p className="mt-1 text-xs text-surface-500">
-                ({agentGlobalCommands.length})/{AGENT_GLOBAL_COMMANDS_MAX_LENGTH}
+                {agentGlobalCommands.length}/{AGENT_GLOBAL_COMMANDS_MAX_LENGTH}
               </p>
             </div>
 


### PR DESCRIPTION
### Motivation
- Align the Agent global commands live character counter with the desired format by removing the surrounding parentheses so it displays as `current/max`.

### Description
- Update `frontend/src/components/ProfilePanel.tsx` to render `{agentGlobalCommands.length}/{AGENT_GLOBAL_COMMANDS_MAX_LENGTH}` instead of `({agentGlobalCommands.length})/{AGENT_GLOBAL_COMMANDS_MAX_LENGTH}`.

### Testing
- Ran `npm run lint` in the `frontend` directory and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69914aa4f3f8832197363b95eec6d3ee)