### PR TITLE
Add Memories section to sidebar with UI and API for managing user and workflow memories

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -19,7 +19,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from api.websockets import websocket_endpoint
-from api.routes import apps, artifacts, auth, change_sessions, chat, data, deals, drive, search, slack_events, slack_user_mappings, sync, tool_settings, twilio_events, waitlist, workflows
+from api.routes import apps, artifacts, auth, change_sessions, chat, data, deals, drive, memories, search, slack_events, slack_user_mappings, sync, tool_settings, twilio_events, waitlist, workflows
 from models.database import init_db, close_db, get_pool_status
 from config import log_missing_env_vars
 
@@ -135,6 +135,7 @@ app.include_router(sync.router, prefix="/api/sync", tags=["sync"])
 app.include_router(waitlist.router, prefix="/api/waitlist", tags=["waitlist"])
 app.include_router(search.router, prefix="/api/search", tags=["search"])
 app.include_router(workflows.router, prefix="/api/workflows", tags=["workflows"])
+app.include_router(memories.router, prefix="/api/memories", tags=["memories"])
 app.include_router(drive.router, prefix="/api/drive", tags=["drive"])
 app.include_router(data.router, prefix="/api/data", tags=["data"])
 app.include_router(tool_settings.router, prefix="/api", tags=["tools"])

--- a/backend/api/routes/memories.py
+++ b/backend/api/routes/memories.py
@@ -1,0 +1,229 @@
+"""Memory and workflow-note management routes for the left-nav Memories UI."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import and_, desc, select
+
+from models.database import get_session
+from models.memory import Memory
+from models.user import User
+from models.workflow import Workflow, WorkflowRun
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+class UserMemoryResponse(BaseModel):
+    id: str
+    content: str
+    entity_type: str
+    category: str | None
+    created_by_user_id: str | None
+    created_at: str | None
+    updated_at: str | None
+
+
+class WorkflowNoteResponse(BaseModel):
+    note_id: str
+    run_id: str
+    workflow_id: str
+    workflow_name: str
+    note_index: int
+    content: str
+    created_at: str | None
+    created_by_user_id: str | None
+
+
+class MemoriesPageResponse(BaseModel):
+    agent_global_commands: str | None
+    user_memories: list[UserMemoryResponse]
+    workflow_notes: list[WorkflowNoteResponse]
+
+
+class UpdateMemoryRequest(BaseModel):
+    content: str = Field(min_length=1)
+
+
+@router.get("/{organization_id}", response_model=MemoriesPageResponse)
+async def list_memories_and_workflow_notes(organization_id: str, user_id: str) -> MemoriesPageResponse:
+    """Return user-stored memories and workflow-stored notes for memory management UI."""
+    try:
+        org_uuid = UUID(organization_id)
+        user_uuid = UUID(user_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    async with get_session(organization_id=organization_id) as session:
+        user = await session.get(User, user_uuid)
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+
+        memory_result = await session.execute(
+            select(Memory)
+            .where(
+                and_(
+                    Memory.organization_id == org_uuid,
+                    Memory.created_by_user_id == user_uuid,
+                )
+            )
+            .order_by(desc(Memory.updated_at), desc(Memory.created_at))
+        )
+        memories = memory_result.scalars().all()
+
+        runs_result = await session.execute(
+            select(WorkflowRun, Workflow.name)
+            .join(Workflow, Workflow.id == WorkflowRun.workflow_id)
+            .where(WorkflowRun.organization_id == org_uuid)
+            .order_by(desc(WorkflowRun.started_at))
+            .limit(200)
+        )
+
+        workflow_notes: list[WorkflowNoteResponse] = []
+        for run, workflow_name in runs_result.all():
+            notes = run.workflow_notes or []
+            for idx, note in enumerate(notes):
+                if not isinstance(note, dict):
+                    continue
+                content = str(note.get("content", "")).strip()
+                if not content:
+                    continue
+                workflow_notes.append(
+                    WorkflowNoteResponse(
+                        note_id=f"{run.id}:{idx}",
+                        run_id=str(run.id),
+                        workflow_id=str(run.workflow_id),
+                        workflow_name=workflow_name,
+                        note_index=idx,
+                        content=content,
+                        created_at=note.get("created_at"),
+                        created_by_user_id=note.get("created_by_user_id"),
+                    )
+                )
+
+        return MemoriesPageResponse(
+            agent_global_commands=user.agent_global_commands,
+            user_memories=[
+                UserMemoryResponse(
+                    id=str(memory.id),
+                    content=memory.content,
+                    entity_type=memory.entity_type,
+                    category=memory.category,
+                    created_by_user_id=str(memory.created_by_user_id) if memory.created_by_user_id else None,
+                    created_at=memory.created_at.isoformat() + "Z" if memory.created_at else None,
+                    updated_at=memory.updated_at.isoformat() + "Z" if memory.updated_at else None,
+                )
+                for memory in memories
+            ],
+            workflow_notes=workflow_notes,
+        )
+
+
+@router.patch("/{organization_id}/{memory_id}", response_model=UserMemoryResponse)
+async def update_memory(organization_id: str, memory_id: str, user_id: str, request: UpdateMemoryRequest) -> UserMemoryResponse:
+    """Update a user memory created by this user."""
+    try:
+        org_uuid = UUID(organization_id)
+        mem_uuid = UUID(memory_id)
+        user_uuid = UUID(user_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    async with get_session(organization_id=organization_id) as session:
+        result = await session.execute(
+            select(Memory).where(
+                and_(
+                    Memory.id == mem_uuid,
+                    Memory.organization_id == org_uuid,
+                    Memory.created_by_user_id == user_uuid,
+                )
+            )
+        )
+        memory = result.scalar_one_or_none()
+        if not memory:
+            raise HTTPException(status_code=404, detail="Memory not found")
+
+        memory.content = request.content.strip()
+        await session.commit()
+        await session.refresh(memory)
+
+        logger.info("[Memories API] Updated memory %s", memory_id)
+        return UserMemoryResponse(
+            id=str(memory.id),
+            content=memory.content,
+            entity_type=memory.entity_type,
+            category=memory.category,
+            created_by_user_id=str(memory.created_by_user_id) if memory.created_by_user_id else None,
+            created_at=memory.created_at.isoformat() + "Z" if memory.created_at else None,
+            updated_at=memory.updated_at.isoformat() + "Z" if memory.updated_at else None,
+        )
+
+
+@router.delete("/{organization_id}/{memory_id}")
+async def delete_memory(organization_id: str, memory_id: str, user_id: str) -> dict[str, str]:
+    """Delete a user memory created by this user."""
+    try:
+        org_uuid = UUID(organization_id)
+        mem_uuid = UUID(memory_id)
+        user_uuid = UUID(user_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    async with get_session(organization_id=organization_id) as session:
+        result = await session.execute(
+            select(Memory).where(
+                and_(
+                    Memory.id == mem_uuid,
+                    Memory.organization_id == org_uuid,
+                    Memory.created_by_user_id == user_uuid,
+                )
+            )
+        )
+        memory = result.scalar_one_or_none()
+        if not memory:
+            raise HTTPException(status_code=404, detail="Memory not found")
+
+        await session.delete(memory)
+        await session.commit()
+
+    logger.info("[Memories API] Deleted memory %s", memory_id)
+    return {"status": "deleted", "memory_id": memory_id}
+
+
+@router.delete("/{organization_id}/workflow-notes/{run_id}/{note_index}")
+async def delete_workflow_note(organization_id: str, run_id: str, note_index: int, user_id: str) -> dict[str, Any]:
+    """Delete a single workflow note by run + index."""
+    _ = user_id  # reserved for future permission checks
+    try:
+        org_uuid = UUID(organization_id)
+        run_uuid = UUID(run_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    async with get_session(organization_id=organization_id) as session:
+        result = await session.execute(
+            select(WorkflowRun).where(
+                and_(
+                    WorkflowRun.id == run_uuid,
+                    WorkflowRun.organization_id == org_uuid,
+                )
+            )
+        )
+        run = result.scalar_one_or_none()
+        if not run:
+            raise HTTPException(status_code=404, detail="Workflow run not found")
+
+        notes = list(run.workflow_notes or [])
+        if note_index < 0 or note_index >= len(notes):
+            raise HTTPException(status_code=404, detail="Workflow note not found")
+
+        notes.pop(note_index)
+        run.workflow_notes = notes
+        await session.commit()
+
+    logger.info("[Memories API] Deleted workflow note run=%s index=%s", run_id, note_index)
+    return {"status": "deleted", "run_id": run_id, "note_index": note_index}

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -42,6 +42,7 @@ import { Data } from './Data';
 import { Search } from './Search';
 import { Chat } from './Chat';
 import { Workflows } from './Workflows';
+import { Memories } from './Memories';
 import { AdminPanel } from './AdminPanel';
 import { PendingChangesPage } from './PendingChangesPage';
 import { AppsGallery } from './apps/AppsGallery';
@@ -277,6 +278,7 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
       '/data': 'data',
       '/search': 'search',
       '/workflows': 'workflows',
+      '/memories': 'memories',
       '/apps': 'apps',
       '/admin': 'admin',
       '/changes': 'pending-changes',
@@ -326,6 +328,7 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
         'data': '/data',
         'search': '/search',
         'workflows': '/workflows',
+        'memories': '/memories',
         'apps': '/apps',
         'app-view': '/apps',
         'admin': '/admin',
@@ -761,7 +764,7 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
     const handleNavigate = (event: Event): void => {
       const customEvent = event as CustomEvent<string>;
       if (customEvent.detail) {
-        setCurrentView(customEvent.detail as 'home' | 'chat' | 'data-sources' | 'search' | 'workflows' | 'admin');
+        setCurrentView(customEvent.detail as 'home' | 'chat' | 'data-sources' | 'search' | 'workflows' | 'memories' | 'admin');
       }
     };
     window.addEventListener('navigate', handleNavigate);
@@ -793,6 +796,7 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
     'data-sources': 'Data Sources',
     search: 'Search',
     workflows: 'Workflows',
+    memories: 'Memories',
     admin: 'Admin',
     'pending-changes': 'Pending Changes',
   };
@@ -919,6 +923,9 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
         )}
         {currentView === 'workflows' && (
           <Workflows />
+        )}
+        {currentView === 'memories' && (
+          <Memories user={user} organization={organization} onUpdateUser={(updates) => setUser({ ...user, ...updates })} />
         )}
         {currentView === 'apps' && (
           <AppsGallery />

--- a/frontend/src/components/Memories.tsx
+++ b/frontend/src/components/Memories.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useMemo, useState } from 'react';
+import { apiRequest } from '../lib/api';
+import type { OrganizationInfo, UserProfile } from './AppLayout';
+
+const AGENT_GLOBAL_COMMANDS_MAX_LENGTH = 500;
+
+interface UserMemory {
+  id: string;
+  content: string;
+  updated_at: string | null;
+}
+
+interface WorkflowNote {
+  note_id: string;
+  run_id: string;
+  workflow_name: string;
+  note_index: number;
+  content: string;
+  created_at: string | null;
+}
+
+interface MemoriesResponse {
+  agent_global_commands: string | null;
+  user_memories: UserMemory[];
+  workflow_notes: WorkflowNote[];
+}
+
+interface MemoriesProps {
+  user: UserProfile;
+  organization: OrganizationInfo;
+  onUpdateUser: (updates: Partial<UserProfile>) => void;
+}
+
+export function Memories({ user, organization, onUpdateUser }: MemoriesProps): JSX.Element {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<MemoriesResponse | null>(null);
+  const [globalCommands, setGlobalCommands] = useState(user.agentGlobalCommands ?? '');
+  const [isSavingCommands, setIsSavingCommands] = useState(false);
+  const [editingMemoryId, setEditingMemoryId] = useState<string | null>(null);
+  const [editingMemoryContent, setEditingMemoryContent] = useState('');
+  const [showUserStored, setShowUserStored] = useState(true);
+  const [showWorkflowStored, setShowWorkflowStored] = useState(true);
+
+  const fetchData = async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    const { data: response, error: requestError } = await apiRequest<MemoriesResponse>(
+      `/memories/${organization.id}?user_id=${user.id}`,
+    );
+    if (requestError || !response) {
+      setError(requestError ?? 'Failed to load memories');
+      setLoading(false);
+      return;
+    }
+    setData(response);
+    setGlobalCommands(response.agent_global_commands ?? user.agentGlobalCommands ?? '');
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    void fetchData();
+  }, [organization.id, user.id]);
+
+  const sortedUserMemories = useMemo(() => data?.user_memories ?? [], [data]);
+  const workflowNotes = useMemo(() => data?.workflow_notes ?? [], [data]);
+
+  const saveGlobalCommands = async (): Promise<void> => {
+    const trimmed = globalCommands.trim();
+    if (trimmed.length > AGENT_GLOBAL_COMMANDS_MAX_LENGTH) {
+      setError(`Agent global commands must be ${AGENT_GLOBAL_COMMANDS_MAX_LENGTH} characters or less.`);
+      return;
+    }
+
+    setIsSavingCommands(true);
+    setError(null);
+    const { data: updated, error: requestError } = await apiRequest<{ agent_global_commands: string | null }>(
+      `/auth/me?user_id=${user.id}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ agent_global_commands: trimmed || null }),
+      },
+    );
+
+    if (requestError || !updated) {
+      setError(requestError ?? 'Failed to save global commands');
+      setIsSavingCommands(false);
+      return;
+    }
+
+    onUpdateUser({ agentGlobalCommands: updated.agent_global_commands });
+    setIsSavingCommands(false);
+  };
+
+  const handleDeleteMemory = async (memoryId: string): Promise<void> => {
+    const { error: requestError } = await apiRequest(`/memories/${organization.id}/${memoryId}?user_id=${user.id}`, {
+      method: 'DELETE',
+    });
+    if (requestError) {
+      setError(requestError);
+      return;
+    }
+    await fetchData();
+  };
+
+  const startEditing = (memory: UserMemory): void => {
+    setEditingMemoryId(memory.id);
+    setEditingMemoryContent(memory.content);
+  };
+
+  const saveEditedMemory = async (): Promise<void> => {
+    if (!editingMemoryId || !editingMemoryContent.trim()) return;
+    const { error: requestError } = await apiRequest(
+      `/memories/${organization.id}/${editingMemoryId}?user_id=${user.id}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ content: editingMemoryContent.trim() }),
+      },
+    );
+    if (requestError) {
+      setError(requestError);
+      return;
+    }
+    setEditingMemoryId(null);
+    setEditingMemoryContent('');
+    await fetchData();
+  };
+
+  const handleDeleteWorkflowNote = async (note: WorkflowNote): Promise<void> => {
+    const { error: requestError } = await apiRequest(
+      `/memories/${organization.id}/workflow-notes/${note.run_id}/${note.note_index}?user_id=${user.id}`,
+      { method: 'DELETE' },
+    );
+    if (requestError) {
+      setError(requestError);
+      return;
+    }
+    await fetchData();
+  };
+
+  if (loading) return <div className="p-6 text-surface-400">Loading memories...</div>;
+
+  return (
+    <div className="h-full overflow-y-auto p-6 space-y-5">
+      <h1 className="text-2xl font-semibold text-surface-100">Memories</h1>
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+
+      <section className="card p-4 space-y-3">
+        <h2 className="text-sm font-medium text-surface-200">Global commands</h2>
+        <textarea
+          value={globalCommands}
+          onChange={(e) => setGlobalCommands(e.target.value)}
+          className="input-field min-h-28"
+          maxLength={AGENT_GLOBAL_COMMANDS_MAX_LENGTH}
+          placeholder="Persistent instructions included with prompts"
+        />
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-surface-500">{globalCommands.length}/{AGENT_GLOBAL_COMMANDS_MAX_LENGTH}</p>
+          <button onClick={() => void saveGlobalCommands()} disabled={isSavingCommands} className="btn-primary disabled:opacity-50">
+            {isSavingCommands ? 'Saving...' : 'Save global commands'}
+          </button>
+        </div>
+      </section>
+
+      <section className="card p-4">
+        <button onClick={() => setShowUserStored((prev) => !prev)} className="w-full flex items-center justify-between text-left">
+          <h2 className="text-sm font-medium text-surface-200">User stored ({sortedUserMemories.length})</h2>
+          <span className="text-surface-500">{showUserStored ? '−' : '+'}</span>
+        </button>
+        {showUserStored && (
+          <div className="mt-3 space-y-2">
+            {sortedUserMemories.length === 0 && <p className="text-sm text-surface-500">No user memories yet.</p>}
+            {sortedUserMemories.map((memory) => (
+              <div key={memory.id} className="rounded-lg border border-surface-800 p-3">
+                {editingMemoryId === memory.id ? (
+                  <div className="space-y-2">
+                    <textarea value={editingMemoryContent} onChange={(e) => setEditingMemoryContent(e.target.value)} className="input-field min-h-20" />
+                    <div className="flex gap-2 justify-end">
+                      <button className="btn-secondary" onClick={() => setEditingMemoryId(null)}>Cancel</button>
+                      <button className="btn-primary" onClick={() => void saveEditedMemory()}>Save</button>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <p className="text-sm text-surface-200 whitespace-pre-wrap">{memory.content}</p>
+                    <div className="mt-2 flex justify-end gap-2">
+                      <button className="btn-secondary" onClick={() => startEditing(memory)}>Edit</button>
+                      <button className="px-3 py-1.5 rounded bg-red-500/10 text-red-400 hover:bg-red-500/20" onClick={() => void handleDeleteMemory(memory.id)}>Delete</button>
+                    </div>
+                  </>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="card p-4">
+        <button onClick={() => setShowWorkflowStored((prev) => !prev)} className="w-full flex items-center justify-between text-left">
+          <h2 className="text-sm font-medium text-surface-200">Workflow stored ({workflowNotes.length})</h2>
+          <span className="text-surface-500">{showWorkflowStored ? '−' : '+'}</span>
+        </button>
+        {showWorkflowStored && (
+          <div className="mt-3 space-y-2">
+            {workflowNotes.length === 0 && <p className="text-sm text-surface-500">No workflow notes yet.</p>}
+            {workflowNotes.map((note) => (
+              <div key={note.note_id} className="rounded-lg border border-surface-800 p-3">
+                <p className="text-xs text-surface-500 mb-1">{note.workflow_name}</p>
+                <p className="text-sm text-surface-200 whitespace-pre-wrap">{note.content}</p>
+                <div className="mt-2 flex justify-end">
+                  <button className="px-3 py-1.5 rounded bg-red-500/10 text-red-400 hover:bg-red-500/20" onClick={() => void handleDeleteWorkflowNote(note)}>Delete</button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -397,7 +397,23 @@ export function Sidebar({
           {!collapsed && <span>Apps</span>}
         </button>
 
-        {/* Pending Changes - only visible when there are pending changes */}
+        
+        {/* Memories */}
+        <button
+          onClick={() => onViewChange('memories')}
+          className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
+            currentView === 'memories'
+              ? 'bg-surface-800 text-surface-100'
+              : 'text-surface-400 hover:text-surface-200 hover:bg-surface-800/50'
+          } ${collapsed ? 'justify-center' : ''}`}
+        >
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6M7 4h10a2 2 0 012 2v12a2 2 0 01-2 2H7a2 2 0 01-2-2V6a2 2 0 012-2z" />
+          </svg>
+          {!collapsed && <span>Memories</span>}
+        </button>
+
+{/* Pending Changes - only visible when there are pending changes */}
         {pendingChangesCount > 0 && (
           <button
             onClick={() => onViewChange('pending-changes')}

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -170,6 +170,7 @@ export type View =
   | "data"
   | "search"
   | "workflows"
+  | "memories"
   | "apps"
   | "app-view"
   | "admin"


### PR DESCRIPTION
### Motivation
- Provide a single, left-nav access point where users can review and manage both agent-stored memories and workflow-run notes. 
- Surface and allow editing/deleting of user-stored memories and deletion of workflow-scoped notes for better memory hygiene and product control.
- Move the existing agent global commands control to the top of this view so related memory settings are colocated.

### Description
- Added a new frontend view component `Memories` that groups entries into two collapsible sections: `User stored` and `Workflow stored`, and places `Global commands` at the top of the page. (frontend/src/components/Memories.tsx)
- Enabled editing and deleting of user-stored memories and deleting of workflow notes from the UI, and wired saving of `agent_global_commands` from the same screen. (frontend/src/components/Memories.tsx)
- Added a left-nav entry and URL routing for the new view (`/memories`) and integrated it into `AppLayout` and the sidebar so the Memories screen appears in the left navigation. (frontend/src/components/Sidebar.tsx, frontend/src/components/AppLayout.tsx, frontend/src/store/index.ts)
- Implemented backend HTTP endpoints to drive the UI: list memories+workflow notes + global commands, update/delete user memories, and delete individual workflow notes by run+index. (backend/api/routes/memories.py)
- Registered the new `memories` router with the FastAPI app so the endpoints are available under `/api/memories`. (backend/api/main.py)

### Testing
- Built the frontend to verify TypeScript and bundling with `npm --prefix frontend run build`, which completed successfully. 
- Compiled the new backend route file with `python -m compileall backend/api/routes/memories.py`, which succeeded without syntax errors. 
- Ran the front-end dev server and captured a Playwright screenshot to validate the new UI renders correctly in-browser.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994e7afb0b08321ab5e6bca4e321556)