### PR TITLE
Add persistent collapse toggles for memory stored groups

### DIFF
--- a/frontend/src/components/Memories.tsx
+++ b/frontend/src/components/Memories.tsx
@@ -4,6 +4,8 @@ import { apiRequest } from '../lib/api';
 import { useAppStore } from '../store';
 
 const AGENT_GLOBAL_COMMANDS_MAX_LENGTH = 500;
+const USER_STORED_COLLAPSE_STATE_KEY = 'memory_user_stored_collapsed';
+const WORKFLOW_STORED_COLLAPSE_STATE_KEY = 'memory_workflow_stored_collapsed';
 
 interface StoredMemory {
   id: string;
@@ -44,12 +46,24 @@ export function Memories(): JSX.Element {
   const [memoryDraft, setMemoryDraft] = useState<string>('');
   const [agentGlobalCommands, setAgentGlobalCommands] = useState<string>('');
   const [commandsError, setCommandsError] = useState<string | null>(null);
-  const [isUserStoredExpanded, setIsUserStoredExpanded] = useState<boolean>(true);
-  const [isWorkflowStoredExpanded, setIsWorkflowStoredExpanded] = useState<boolean>(true);
+  const [isUserStoredExpanded, setIsUserStoredExpanded] = useState<boolean>(() => {
+    return localStorage.getItem(USER_STORED_COLLAPSE_STATE_KEY) !== 'true';
+  });
+  const [isWorkflowStoredExpanded, setIsWorkflowStoredExpanded] = useState<boolean>(() => {
+    return localStorage.getItem(WORKFLOW_STORED_COLLAPSE_STATE_KEY) !== 'true';
+  });
 
   useEffect(() => {
     setAgentGlobalCommands(user?.agentGlobalCommands ?? '');
   }, [user?.agentGlobalCommands]);
+
+  useEffect(() => {
+    localStorage.setItem(USER_STORED_COLLAPSE_STATE_KEY, String(!isUserStoredExpanded));
+  }, [isUserStoredExpanded]);
+
+  useEffect(() => {
+    localStorage.setItem(WORKFLOW_STORED_COLLAPSE_STATE_KEY, String(!isWorkflowStoredExpanded));
+  }, [isWorkflowStoredExpanded]);
 
   const orgId = organization?.id;
   const userId = user?.id;
@@ -191,7 +205,12 @@ export function Memories(): JSX.Element {
 
             <section className="rounded-xl border border-surface-800 bg-surface-900/40 p-4 md:p-6">
               <div className="flex items-center justify-between gap-4">
-                <button className="text-left" onClick={() => setIsUserStoredExpanded((value) => !value)}>
+                <button
+                  className="flex items-center gap-2 text-left"
+                  onClick={() => setIsUserStoredExpanded((value) => !value)}
+                  aria-expanded={isUserStoredExpanded}
+                >
+                  <span className="text-surface-400 text-xs leading-none">{isUserStoredExpanded ? '▾' : '▸'}</span>
                   <h2 className="text-lg font-semibold text-surface-100">User stored</h2>
                 </button>
                 <span className="text-xs text-surface-500">Editable + deletable</span>
@@ -233,7 +252,12 @@ export function Memories(): JSX.Element {
 
             <section className="rounded-xl border border-surface-800 bg-surface-900/40 p-4 md:p-6">
               <div className="flex items-center justify-between gap-4">
-                <button className="text-left" onClick={() => setIsWorkflowStoredExpanded((value) => !value)}>
+                <button
+                  className="flex items-center gap-2 text-left"
+                  onClick={() => setIsWorkflowStoredExpanded((value) => !value)}
+                  aria-expanded={isWorkflowStoredExpanded}
+                >
+                  <span className="text-surface-400 text-xs leading-none">{isWorkflowStoredExpanded ? '▾' : '▸'}</span>
                   <h2 className="text-lg font-semibold text-surface-100">Workflow stored</h2>
                 </button>
                 <span className="text-xs text-surface-500">Deletable</span>


### PR DESCRIPTION
### Motivation
- Make the Memory UI easier to scan by letting users collapse/expand the “User stored” and “Workflow stored” sections and keep their preference across visits.

### Description
- Added two persistent keys `memory_user_stored_collapsed` and `memory_workflow_stored_collapsed` and used them to initialize the collapse state in `frontend/src/components/Memories.tsx`.
- Persist each section's collapsed state to `localStorage` via `useEffect` so the preference is retained between page loads.
- Replaced plain header text with explicit toggle buttons that show caret indicators (`▾` / `▸`) and set `aria-expanded` for improved UX and accessibility.

### Testing
- Ran `npm run build` in the `frontend/` directory and the build completed successfully (Vite chunk-size warnings only). 
- Launched the dev server (`npm run dev`) and loaded the UI via an automated Playwright script which produced a screenshot showing the updated toggles, confirming the UI renders and toggles behave as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994ed85aff88321b977ebd9fdc450e8)