### PR TITLE
Unify Search into Data UI: multi-target typeahead, grouped results, and Start Chat

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -39,7 +39,6 @@ import { Sidebar } from './Sidebar';
 import { Home } from './Home';
 import { DataSources } from './DataSources';
 import { Data } from './Data';
-import { Search } from './Search';
 import { Chat } from './Chat';
 import { Workflows } from './Workflows';
 import { AdminPanel } from './AdminPanel';
@@ -275,7 +274,6 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
       '/chat': 'chat',
       '/sources': 'data-sources',
       '/data': 'data',
-      '/search': 'search',
       '/workflows': 'workflows',
       '/apps': 'apps',
       '/admin': 'admin',
@@ -324,7 +322,6 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
         'chat': '/chat',
         'data-sources': '/sources',
         'data': '/data',
-        'search': '/search',
         'workflows': '/workflows',
         'apps': '/apps',
         'app-view': '/apps',
@@ -761,7 +758,7 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
     const handleNavigate = (event: Event): void => {
       const customEvent = event as CustomEvent<string>;
       if (customEvent.detail) {
-        setCurrentView(customEvent.detail as 'home' | 'chat' | 'data-sources' | 'search' | 'workflows' | 'admin');
+        setCurrentView(customEvent.detail as 'home' | 'chat' | 'data-sources' | 'data' | 'workflows' | 'admin');
       }
     };
     window.addEventListener('navigate', handleNavigate);
@@ -791,7 +788,7 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
     home: 'Home',
     chat: 'Chat',
     'data-sources': 'Data Sources',
-    search: 'Search',
+    data: 'Search Data',
     workflows: 'Workflows',
     admin: 'Admin',
     'pending-changes': 'Pending Changes',
@@ -913,9 +910,6 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
         )}
         {currentView === 'data' && (
           <Data />
-        )}
-        {currentView === 'search' && (
-          <Search organizationId={organization.id} />
         )}
         {currentView === 'workflows' && (
           <Workflows />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -342,22 +342,7 @@ export function Sidebar({
           <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
           </svg>
-          {!collapsed && <span>Data</span>}
-        </button>
-
-        {/* Search */}
-        <button
-          onClick={() => onViewChange('search')}
-          className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors ${
-            currentView === 'search'
-              ? 'bg-surface-800 text-surface-100'
-              : 'text-surface-400 hover:text-surface-200 hover:bg-surface-800/50'
-          } ${collapsed ? 'justify-center' : ''}`}
-        >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-          </svg>
-          {!collapsed && <span>Search</span>}
+          {!collapsed && <span>Search Data</span>}
         </button>
 
         {/* Workflows */}

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -168,7 +168,6 @@ export type View =
   | "chat"
   | "data-sources"
   | "data"
-  | "search"
   | "workflows"
   | "apps"
   | "app-view"


### PR DESCRIPTION
### Motivation
- Simplify navigation by removing the separate Search view and consolidating search workflows into the Data inspector page to avoid duplicate UI surface and preserve the data target selector.
- Enable richer data exploration by allowing selection of multiple data targets and grouping returned results so users can compare across types easily.
- Provide a frictionless handoff from data inspection into chat by offering a quick way to start a chat with a prompt summarising current results.

### Description
- Removed the standalone `Search` view from routing and the `View` union, and updated layout/title mapping to show the Data page as "Search Data" instead of a separate Search entry (changes in `AppLayout.tsx` and `store/index.ts`).
- Updated the left navigation label to "Search Data" and removed the dedicated Search nav button so the sidebar points users to the unified Data page (`Sidebar.tsx`).
- Reworked the Data UI to support selecting multiple data targets concurrently, fetch results for each selected table in parallel, and render results grouped by table/type; preserved and improved the target selector behavior (`Data.tsx`).
- Added a debounced typeahead input (300ms) so queries run as users type while preserving a clean search input and page state, and adjusted `All Sources` selector typography to match the target buttons for consistent sizing (`Data.tsx`).
- Added a `Start Chat` button in the Data UI that composes a `Summarise this data:` prompt from grouped results, sets pending chat input, and switches into the chat view with auto-send enabled (`Data.tsx`).
- Minor TypeScript and UI fixes to support the multi-target model and to avoid undefined indexing when no table is selected (`Data.tsx`).

### Testing
- Ran `npm run build` (frontend) which succeeded and produced a production build of the frontend assets.
- Launched the dev server and verified the Data UI loads and the updated page (a screenshot was captured) and that multi-target selection, debounced input, grouped rendering, and the Start Chat action navigate to Chat successfully in local dev.
- Ran `npm run lint` (frontend) which fails due to pre-existing ESLint issues in `src/components/apps/SandpackAppRenderer.tsx` unrelated to these changes; TypeScript compilation errors encountered during development were fixed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994e6f7e6c48321b5fa2c4c552d87c1)