### PR TITLE
Memory UI: default collapsed and use primary green for stored-group toggles

### DIFF
--- a/frontend/src/components/Memories.tsx
+++ b/frontend/src/components/Memories.tsx
@@ -47,10 +47,10 @@ export function Memories(): JSX.Element {
   const [agentGlobalCommands, setAgentGlobalCommands] = useState<string>('');
   const [commandsError, setCommandsError] = useState<string | null>(null);
   const [isUserStoredExpanded, setIsUserStoredExpanded] = useState<boolean>(() => {
-    return localStorage.getItem(USER_STORED_COLLAPSE_STATE_KEY) !== 'true';
+    return localStorage.getItem(USER_STORED_COLLAPSE_STATE_KEY) === 'false';
   });
   const [isWorkflowStoredExpanded, setIsWorkflowStoredExpanded] = useState<boolean>(() => {
-    return localStorage.getItem(WORKFLOW_STORED_COLLAPSE_STATE_KEY) !== 'true';
+    return localStorage.getItem(WORKFLOW_STORED_COLLAPSE_STATE_KEY) === 'false';
   });
 
   useEffect(() => {
@@ -206,12 +206,12 @@ export function Memories(): JSX.Element {
             <section className="rounded-xl border border-surface-800 bg-surface-900/40 p-4 md:p-6">
               <div className="flex items-center justify-between gap-4">
                 <button
-                  className="flex items-center gap-2 text-left"
+                  className="flex items-center gap-2 text-left text-primary-400 hover:text-primary-300 transition-colors"
                   onClick={() => setIsUserStoredExpanded((value) => !value)}
                   aria-expanded={isUserStoredExpanded}
                 >
-                  <span className="text-surface-400 text-xs leading-none">{isUserStoredExpanded ? '▾' : '▸'}</span>
-                  <h2 className="text-lg font-semibold text-surface-100">User stored</h2>
+                  <span className="text-xs leading-none">{isUserStoredExpanded ? '▾' : '▸'}</span>
+                  <h2 className="text-lg font-semibold">User stored</h2>
                 </button>
                 <span className="text-xs text-surface-500">Editable + deletable</span>
               </div>
@@ -253,12 +253,12 @@ export function Memories(): JSX.Element {
             <section className="rounded-xl border border-surface-800 bg-surface-900/40 p-4 md:p-6">
               <div className="flex items-center justify-between gap-4">
                 <button
-                  className="flex items-center gap-2 text-left"
+                  className="flex items-center gap-2 text-left text-primary-400 hover:text-primary-300 transition-colors"
                   onClick={() => setIsWorkflowStoredExpanded((value) => !value)}
                   aria-expanded={isWorkflowStoredExpanded}
                 >
-                  <span className="text-surface-400 text-xs leading-none">{isWorkflowStoredExpanded ? '▾' : '▸'}</span>
-                  <h2 className="text-lg font-semibold text-surface-100">Workflow stored</h2>
+                  <span className="text-xs leading-none">{isWorkflowStoredExpanded ? '▾' : '▸'}</span>
+                  <h2 className="text-lg font-semibold">Workflow stored</h2>
                 </button>
                 <span className="text-xs text-surface-500">Deletable</span>
               </div>


### PR DESCRIPTION
### Motivation
- Make the Memory page UX default to collapsed for the saved-memory groups so the UI is less noisy on first load.
- Use the app’s bright green primary accent for the collapse toggle controls so expand/collapse affordances match the product design.

### Description
- Default both `User stored` and `Workflow stored` sections to closed by changing the initialization logic to read the persisted localStorage key and only treat an explicit `false` value as expanded (`frontend/src/components/Memories.tsx`).
- Preserve the existing persistence behavior by continuing to write collapse state into `USER_STORED_COLLAPSE_STATE_KEY` and `WORKFLOW_STORED_COLLAPSE_STATE_KEY` in localStorage.
- Update the toggle button styling for both groups to use the primary green accent (`text-primary-400` with a `hover:text-primary-300` transition) and remove the previous surface color overrides so the chevron + heading visually match the bright green UX color.

### Testing
- Built the frontend with `npm --prefix frontend run build`, which completed successfully. 
- Launched the dev server with `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173` to validate the change visually; the dev server started and served the app (backend proxy requests produced connection errors but did not block the visual check).
- Captured a visual screenshot of the Memory page using a Playwright script to confirm the collapsed sections and updated green toggles, and the screenshot artifact was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994f1ab14888321ada0005fb6dc3f30)