### PR TITLE
Default memory stored sections to collapsed and use primary green toggles

### DIFF
--- a/frontend/src/components/Memories.tsx
+++ b/frontend/src/components/Memories.tsx
@@ -47,10 +47,12 @@ export function Memories(): JSX.Element {
   const [agentGlobalCommands, setAgentGlobalCommands] = useState<string>('');
   const [commandsError, setCommandsError] = useState<string | null>(null);
   const [isUserStoredExpanded, setIsUserStoredExpanded] = useState<boolean>(() => {
-    return localStorage.getItem(USER_STORED_COLLAPSE_STATE_KEY) !== 'true';
+    const isUserStoredCollapsed = localStorage.getItem(USER_STORED_COLLAPSE_STATE_KEY);
+    return isUserStoredCollapsed === 'false';
   });
   const [isWorkflowStoredExpanded, setIsWorkflowStoredExpanded] = useState<boolean>(() => {
-    return localStorage.getItem(WORKFLOW_STORED_COLLAPSE_STATE_KEY) !== 'true';
+    const isWorkflowStoredCollapsed = localStorage.getItem(WORKFLOW_STORED_COLLAPSE_STATE_KEY);
+    return isWorkflowStoredCollapsed === 'false';
   });
 
   useEffect(() => {
@@ -210,8 +212,8 @@ export function Memories(): JSX.Element {
                   onClick={() => setIsUserStoredExpanded((value) => !value)}
                   aria-expanded={isUserStoredExpanded}
                 >
-                  <span className="text-surface-400 text-xs leading-none">{isUserStoredExpanded ? '▾' : '▸'}</span>
-                  <h2 className="text-lg font-semibold text-surface-100">User stored</h2>
+                  <span className="text-primary-400 text-xs leading-none">{isUserStoredExpanded ? '▾' : '▸'}</span>
+                  <h2 className="text-lg font-semibold text-primary-400">User stored</h2>
                 </button>
                 <span className="text-xs text-surface-500">Editable + deletable</span>
               </div>
@@ -257,8 +259,8 @@ export function Memories(): JSX.Element {
                   onClick={() => setIsWorkflowStoredExpanded((value) => !value)}
                   aria-expanded={isWorkflowStoredExpanded}
                 >
-                  <span className="text-surface-400 text-xs leading-none">{isWorkflowStoredExpanded ? '▾' : '▸'}</span>
-                  <h2 className="text-lg font-semibold text-surface-100">Workflow stored</h2>
+                  <span className="text-primary-400 text-xs leading-none">{isWorkflowStoredExpanded ? '▾' : '▸'}</span>
+                  <h2 className="text-lg font-semibold text-primary-400">Workflow stored</h2>
                 </button>
                 <span className="text-xs text-surface-500">Deletable</span>
               </div>


### PR DESCRIPTION
### Motivation
- Ensure the Memory UI's `User stored` and `Workflow stored` groups use the bright green primary UX color for their toggle affordances and default to closed when no prior localStorage setting exists.

### Description
- Changed initialization logic in `frontend/src/components/Memories.tsx` so both sections default to collapsed when the collapse keys are not present in `localStorage` and continue to honor persisted state when set via the stored keys.
- Kept existing persistence behavior by continuing to write `String(!is...Expanded)` to the same keys so previously saved states remain supported.
- Updated the caret and section heading styles for both groups to use the bright green primary color class `text-primary-400`.

### Testing
- Ran `npm --prefix frontend run lint`, which failed due to unrelated pre-existing ESLint errors in `frontend/src/components/apps/SandpackAppRenderer.tsx` and not caused by these changes. (failed)
- Started the frontend with `npm run dev` in `frontend` to validate the build and UI served correctly, which launched successfully. (succeeded)
- Captured a Memory page screenshot via a Playwright script to verify visual changes to the collapse toggles. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994f1ab14888321ada0005fb6dc3f30)