### PR TITLE
Track Slack thread participants on conversations and use them for recents access

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -63,7 +63,10 @@ def _build_conversation_access_filter(
         return base_filter
     slack_filter = and_(
         Conversation.source == "slack",
-        Conversation.source_user_id.in_(slack_user_ids),
+        or_(
+            Conversation.source_user_id.in_(slack_user_ids),
+            Conversation.participating_user_ids.overlap(list(slack_user_ids)),
+        ),
     )
     if auth.organization_id:
         slack_filter = and_(slack_filter, Conversation.organization_id == auth.organization_id)

--- a/backend/db/migrations/versions/068_conv_participants.py
+++ b/backend/db/migrations/versions/068_conv_participants.py
@@ -1,0 +1,40 @@
+"""Add participating_user_ids to conversations for multi-user Slack threads.
+
+Revision ID: 068_conv_participants
+Revises: 067_artifact_user_id_nullable
+Create Date: 2026-02-18
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "068_conv_participants"
+down_revision = "067_artifact_user_id_nullable"
+branch_labels = None
+depends_on = None
+
+assert len(revision) <= 32
+assert isinstance(down_revision, str) and len(down_revision) <= 32
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversations",
+        sa.Column(
+            "participating_user_ids",
+            sa.ARRAY(sa.String(length=100)),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+    )
+    op.create_index(
+        "ix_conversations_participating_user_ids",
+        "conversations",
+        ["participating_user_ids"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_conversations_participating_user_ids", table_name="conversations")
+    op.drop_column("conversations", "participating_user_ids")

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from typing import Any, Literal, Optional
 
 from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from models.database import Base
@@ -58,6 +58,9 @@ class Conversation(Base):
     source_user_id: Mapped[Optional[str]] = mapped_column(
         String(100), nullable=True
     )  # External user ID (e.g., Slack user ID)
+    participating_user_ids: Mapped[list[str]] = mapped_column(
+        ARRAY(String(100)), nullable=False, default=list
+    )
     
     # Conversation type: 'agent' for interactive, 'workflow' for automated
     type: Mapped[str] = mapped_column(
@@ -141,6 +144,8 @@ class Conversation(Base):
             result["source_channel_id"] = self.source_channel_id
         if self.source_user_id:
             result["source_user_id"] = self.source_user_id
+        if self.participating_user_ids:
+            result["participating_user_ids"] = self.participating_user_ids
         return result
     
     @property

--- a/backend/tests/test_slack_conversation_participants.py
+++ b/backend/tests/test_slack_conversation_participants.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+from sqlalchemy.dialects import postgresql
+
+from api.routes.chat import _build_conversation_access_filter
+from services.slack_conversations import _merge_participating_user_ids
+
+
+def test_merge_participating_user_ids_adds_latest_without_duplicates():
+    merged = _merge_participating_user_ids(["U1", "U2", "U1"], "U3")
+    assert merged == ["U1", "U2", "U3"]
+
+
+def test_merge_participating_user_ids_keeps_existing_order():
+    merged = _merge_participating_user_ids(["U9", "U7"], "U7")
+    assert merged == ["U9", "U7"]
+
+
+def test_conversation_access_filter_includes_participant_overlap():
+    auth = SimpleNamespace(
+        user_id="11111111-1111-1111-1111-111111111111",
+        organization_id="22222222-2222-2222-2222-222222222222",
+    )
+
+    filt = _build_conversation_access_filter(auth, {"U1", "U2"})
+    sql = str(
+        filt.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+    assert "participating_user_ids" in sql
+    assert "&&" in sql


### PR DESCRIPTION
### Motivation
- Make multi-user Slack threads visible in users' recent conversations by recording all Slack identities that participate in a conversation, not just the latest speaker.
- Preserve the latest-speaker semantics for reply context while avoiding stale RevTops user context when the current speaker is unmapped.
- Provide an efficient DB-side filter so recents queries can include Slack conversations where the auth user is any thread participant.

### Description
- Added a new `participating_user_ids` array column to the `Conversation` model and included it in the `to_dict()` serialization so APIs can expose participant lists (`backend/models/conversation.py`).
- Implemented `_merge_participating_user_ids` to deduplicate and preserve ordering when merging new Slack user IDs into a conversation, and updated Slack conversation upsert logic to maintain this list while still updating `source_user_id` to the most recent speaker (`backend/services/slack_conversations.py`).
- Seeded new Slack conversations with the initiating Slack user in `participating_user_ids` and changed thread-reply orchestration to use the most-recent speaker's mapped RevTops identity when available (avoiding carrying stale conversation `user_id`).
- Updated recent-conversation access filtering so Slack conversations are included when the authenticated user is either the `source_user_id` or appears in `participating_user_ids` using a GIN/array overlap filter (`Conversation.participating_user_ids.overlap(...)`) (`backend/api/routes/chat.py`).
- Added an Alembic migration `068_conv_participants` that creates the `participating_user_ids` array column with a GIN index and includes preflight assertions to enforce revision ID length rules required by migrations (`backend/db/migrations/versions/068_conv_participants.py`).
- Added unit tests for participant-merge behavior and to assert the SQL access-filter uses array overlap semantics (`backend/tests/test_slack_conversation_participants.py`).

### Testing
- Ran unit tests: `cd backend && pytest -q tests/test_slack_conversation_participants.py tests/test_slack_user_resolution.py`, and all tests passed (6 passed, 2 warnings). 
- Verified migration naming preflight assertions by checking `len(revision)` and `len(down_revision)` are <= 32 and the check succeeded.
- New tests exercise `_merge_participating_user_ids` behavior and the generated SQL for `_build_conversation_access_filter` to ensure the array overlap operator (`&&`) is used; these tests passed as part of the pytest run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995122d28dc832193e57c8f0a054c9d)