### PR TITLE
Show all valid organizations for each user in Admin panel

### DIFF
--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -39,6 +39,7 @@ interface AdminUser {
   created_at: string | null;
   organization_id: string | null;
   organization_name: string | null;
+  organizations: string[];
 }
 
 interface AdminOrganization {
@@ -444,11 +445,13 @@ export function AdminPanel(): JSX.Element {
     const firstName = (u.first_name ?? '').toLowerCase();
     const lastName = (u.last_name ?? '').toLowerCase();
     const orgName = (u.organization_name ?? '').toLowerCase();
+    const orgNames = (u.organizations ?? []).map((name) => name.toLowerCase()).join(' ');
     const email = u.email.toLowerCase();
     return (
       firstName.includes(searchLower) ||
       lastName.includes(searchLower) ||
       orgName.includes(searchLower) ||
+      orgNames.includes(searchLower) ||
       email.includes(searchLower)
     );
   });
@@ -758,7 +761,20 @@ export function AdminPanel(): JSX.Element {
                           </div>
                         </td>
                         <td className="px-4 py-3">
-                          <div className="text-surface-200">{u.organization_name ?? '—'}</div>
+                          {(u.organizations ?? []).length > 0 ? (
+                            <div className="flex flex-wrap gap-1.5">
+                              {(u.organizations ?? []).map((organizationName) => (
+                                <span
+                                  key={`${u.id}-${organizationName}`}
+                                  className="px-2 py-0.5 rounded-full text-xs border border-primary-500/30 bg-primary-500/10 text-primary-300"
+                                >
+                                  {organizationName}
+                                </span>
+                              ))}
+                            </div>
+                          ) : (
+                            <div className="text-surface-200">{u.organization_name ?? '—'}</div>
+                          )}
                         </td>
                         <td className="px-4 py-3">{getStatusBadge(u.status)}</td>
                         <td className="px-4 py-3 text-sm text-surface-400">


### PR DESCRIPTION
### Motivation
- Admins need to see every organization a user belongs to (multi-org support) rather than only the single active org for that user.
- Improve discoverability and searching of users across organizations in the Admin UI while preserving existing single-org compatibility fields.
- Avoid database/schema changes by reading existing `org_members` and `organizations` tables from the admin endpoint.

### Description
- Backend: added an `organizations: list[str]` field to `AdminUserResponse` and in `list_admin_users` query `org_members` joined with `organizations` to collect all active organization names per user and attach them to the response (keeps `organization_id` / `organization_name` for backwards compatibility). (`backend/api/routes/waitlist.py`)
- Frontend: extended `AdminUser` type with `organizations: string[]`, included org names in the in-memory user search, and rendered all memberships as inline badges in the Organization column of the Admin Users table. (`frontend/src/components/AdminPanel.tsx`)
- No DB migration was required and existing API fields remain unchanged to avoid breaking consumers.

### Testing
- Ran `python -m compileall backend/api/routes/waitlist.py` which succeeded and validated the backend code compiles. (success)
- Built the frontend with `npm run -s build` from `frontend/` which completed successfully. (success)
- Attempted `npm run -s typecheck` but the script is not defined in `package.json`, so a typecheck run was not performed. (no-op / not available)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69954a4aa2c8832185d7d5386c077408)