### PR TITLE
Prefer latest Slack participant as conversation primary user

### DIFF
--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -1251,16 +1251,16 @@ def _resolve_current_revtops_user_id(
     linked_user: User | None,
     conversation: Conversation,
 ) -> str | None:
-    """Pick the current user context using most recent speaker first, then fallback participants."""
+    """Pick the current user context using most recent speaker first, then historical fallback."""
     if linked_user:
         return str(linked_user.id)
-
-    if conversation.user_id:
-        return str(conversation.user_id)
 
     participant_ids: list[UUID] = list(conversation.participating_user_ids or [])
     if participant_ids:
         return str(participant_ids[-1])
+
+    if conversation.user_id:
+        return str(conversation.user_id)
 
     return None
 

--- a/backend/tests/test_slack_user_resolution.py
+++ b/backend/tests/test_slack_user_resolution.py
@@ -200,7 +200,7 @@ def test_merge_participating_user_ids_moves_duplicate_to_end_for_recency():
     ]
 
 
-def test_resolve_current_revtops_user_id_prefers_linked_user_then_primary_current_user():
+def test_resolve_current_revtops_user_id_prefers_linked_user_then_latest_participant():
     linked_user = SimpleNamespace(id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
     conversation = SimpleNamespace(
         user_id=UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
@@ -217,7 +217,7 @@ def test_resolve_current_revtops_user_id_prefers_linked_user_then_primary_curren
         linked_user=None,
         conversation=conversation,
     )
-    assert resolved_without_link == "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    assert resolved_without_link == "cccccccc-cccc-cccc-cccc-cccccccccccc"
 
 
 def test_resolve_current_revtops_user_id_uses_last_participant_when_primary_missing():
@@ -234,3 +234,16 @@ def test_resolve_current_revtops_user_id_uses_last_participant_when_primary_miss
         conversation=conversation,
     )
     assert resolved_fallback == "dddddddd-dddd-dddd-dddd-dddddddddddd"
+
+
+def test_resolve_current_revtops_user_id_falls_back_to_primary_when_no_participants():
+    conversation = SimpleNamespace(
+        user_id=UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+        participating_user_ids=[],
+    )
+
+    resolved_fallback = slack_conversations._resolve_current_revtops_user_id(
+        linked_user=None,
+        conversation=conversation,
+    )
+    assert resolved_fallback == "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"


### PR DESCRIPTION
### Motivation
- Ensure conversation context follows the most recent speaker in multi-user Slack threads instead of always falling back to a stale `conversation.user_id` when the incoming message is not directly linked to a RevTops user. 
- Keep explicit linked-user resolution as the highest priority so known speakers still immediately become the current user.

### Description
- Change ` _resolve_current_revtops_user_id` in `backend/services/slack_conversations.py` to prefer `participating_user_ids[-1]` before falling back to `conversation.user_id`. 
- Preserve the top priority of a directly `linked_user` so linked users still override participant history. 
- Update and expand `backend/tests/test_slack_user_resolution.py` to reflect the new precedence, rename an existing test, and add a test that verifies fallback to `conversation.user_id` when no participants exist. 
- Add logging-preserving, minimal refactor to docstring to describe the new behavior.

### Testing
- Ran `cd backend && pytest -q tests/test_slack_user_resolution.py` and all tests in that suite passed. 
- Result: `8 passed` (with warnings), indicating the new precedence and added test behave as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69954e62cd888321a7cd58f9d62c64ae)