### PR TITLE
Customizable Home tab, app improvements, and multi-org fixes

### DIFF
--- a/backend/db/migrations/versions/066_add_home_app_id_to_organizations.py
+++ b/backend/db/migrations/versions/066_add_home_app_id_to_organizations.py
@@ -1,0 +1,31 @@
+"""Add home_app_id to organizations for customizable Home tab.
+
+Revision ID: 066_add_home_app_id
+Revises: 065_create_apps_table
+Create Date: 2026-02-17
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "066_add_home_app_id"
+down_revision = "065_create_apps_table"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "organizations",
+        sa.Column(
+            "home_app_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("apps.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("organizations", "home_app_id")

--- a/backend/db/migrations/versions/067_add_home_app_id_to_organizations.py
+++ b/backend/db/migrations/versions/067_add_home_app_id_to_organizations.py
@@ -1,0 +1,31 @@
+"""Add home_app_id to organizations for customizable Home tab.
+
+Revision ID: 066_add_home_app_id
+Revises: 065_create_apps_table
+Create Date: 2026-02-17
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "067_add_home_app_id"
+down_revision = "066_embeddings_to_pgvector"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "organizations",
+        sa.Column(
+            "home_app_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("apps.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("organizations", "home_app_id")

--- a/backend/models/organization.py
+++ b/backend/models/organization.py
@@ -53,6 +53,11 @@ class Organization(Base):
     )
     last_sync_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
+    # Home app: the app shown on the Home tab for this organization
+    home_app_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("apps.id", ondelete="SET NULL"), nullable=True
+    )
+
     # Relationships
     users: Mapped[list["User"]] = relationship(
         "User", back_populates="organization", foreign_keys="User.organization_id"

--- a/backend/scripts/seed_cro_metrics_app.py
+++ b/backend/scripts/seed_cro_metrics_app.py
@@ -1,0 +1,366 @@
+"""
+One-time seed script: create a CRO Metrics Dashboard app for the demo org
+and set it as the organization's home app.
+
+Usage:
+    cd backend && python -m scripts.seed_cro_metrics_app
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+
+# Ensure the backend package root is on sys.path so config/models resolve
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import select, text
+from models.database import get_admin_session
+from models.organization import Organization
+from models.app import App
+
+DEMO_ORG_ID = "3ac0ef74-d82a-45b3-86d4-d510815689fa"  # Cro Metrics
+
+# The first user in the org will be used as the owner
+QUERIES: dict[str, dict[str, object]] = {
+    "pipeline_summary": {
+        "sql": """
+SELECT
+  COUNT(*)::int                                        AS total_deals,
+  COALESCE(SUM(d.amount), 0)::float                    AS total_value,
+  COALESCE(AVG(d.amount), 0)::float                    AS avg_deal_size,
+  COALESCE(SUM(d.amount * COALESCE(d.probability, 50) / 100.0), 0)::float AS weighted_value
+FROM deals d
+LEFT JOIN pipeline_stages ps
+  ON ps.pipeline_id = d.pipeline_id AND ps.name = d.stage
+WHERE d.organization_id = :org_id
+  AND (ps.id IS NULL OR (ps.is_closed_won = false AND ps.is_closed_lost = false))
+  AND (
+    :period = 'all'
+    OR (:period = '30d'     AND d.created_date >= NOW() - INTERVAL '30 days')
+    OR (:period = 'quarter' AND d.created_date >= DATE_TRUNC('quarter', NOW()))
+    OR (:period = 'ytd'     AND d.created_date >= DATE_TRUNC('year', NOW()))
+  )
+""",
+        "params": {"period": "all"},
+    },
+    "deals_by_stage": {
+        "sql": """
+SELECT
+  COALESCE(d.stage, 'Unknown') AS stage,
+  COUNT(*)::int                AS deal_count,
+  COALESCE(SUM(d.amount), 0)::float AS total_value
+FROM deals d
+LEFT JOIN pipeline_stages ps
+  ON ps.pipeline_id = d.pipeline_id AND ps.name = d.stage
+WHERE d.organization_id = :org_id
+  AND (ps.id IS NULL OR (ps.is_closed_won = false AND ps.is_closed_lost = false))
+  AND (
+    :period = 'all'
+    OR (:period = '30d'     AND d.created_date >= NOW() - INTERVAL '30 days')
+    OR (:period = 'quarter' AND d.created_date >= DATE_TRUNC('quarter', NOW()))
+    OR (:period = 'ytd'     AND d.created_date >= DATE_TRUNC('year', NOW()))
+  )
+GROUP BY d.stage
+ORDER BY total_value DESC
+""",
+        "params": {"period": "all"},
+    },
+    "win_rate": {
+        "sql": """
+SELECT
+  COUNT(*) FILTER (WHERE ps.is_closed_won)::int  AS won,
+  COUNT(*) FILTER (WHERE ps.is_closed_lost)::int AS lost,
+  CASE
+    WHEN COUNT(*) FILTER (WHERE ps.is_closed_won OR ps.is_closed_lost) = 0 THEN 0
+    ELSE ROUND(
+      100.0 * COUNT(*) FILTER (WHERE ps.is_closed_won)
+            / COUNT(*) FILTER (WHERE ps.is_closed_won OR ps.is_closed_lost), 1
+    )::float
+  END AS win_rate_pct
+FROM deals d
+JOIN pipeline_stages ps
+  ON ps.pipeline_id = d.pipeline_id AND ps.name = d.stage
+WHERE d.organization_id = :org_id
+  AND (ps.is_closed_won OR ps.is_closed_lost)
+  AND (
+    :period = 'all'
+    OR (:period = '30d'     AND d.close_date >= CURRENT_DATE - 30)
+    OR (:period = 'quarter' AND d.close_date >= DATE_TRUNC('quarter', CURRENT_DATE))
+    OR (:period = 'ytd'     AND d.close_date >= DATE_TRUNC('year', CURRENT_DATE))
+  )
+""",
+        "params": {"period": "all"},
+    },
+    "upcoming_closes": {
+        "sql": """
+SELECT
+  d.name,
+  COALESCE(d.amount, 0)::float AS amount,
+  d.stage,
+  d.close_date::text AS close_date
+FROM deals d
+LEFT JOIN pipeline_stages ps
+  ON ps.pipeline_id = d.pipeline_id AND ps.name = d.stage
+WHERE d.organization_id = :org_id
+  AND d.close_date BETWEEN CURRENT_DATE AND CURRENT_DATE + 30
+  AND (ps.id IS NULL OR (ps.is_closed_won = false AND ps.is_closed_lost = false))
+ORDER BY d.close_date ASC
+LIMIT 20
+""",
+        "params": {},
+    },
+}
+
+FRONTEND_CODE = r'''
+import React, { useState, useMemo } from "react";
+import { useAppQuery, useDateRange, Spinner, ErrorBanner } from "@revtops/app-sdk";
+import Plot from "react-plotly.js";
+
+const PERIODS = [
+  { value: "30d", label: "Last 30 days" },
+  { value: "quarter", label: "This Quarter" },
+  { value: "ytd", label: "Year to Date" },
+  { value: "all", label: "All Time" },
+];
+
+function KPICard({ label, value, prefix = "", suffix = "" }) {
+  return (
+    <div style={{
+      background: "rgba(255,255,255,0.04)",
+      border: "1px solid rgba(255,255,255,0.1)",
+      borderRadius: 12,
+      padding: "20px 24px",
+      flex: "1 1 0",
+      minWidth: 160,
+    }}>
+      <div style={{ fontSize: 12, color: "#94a3b8", marginBottom: 4, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+        {label}
+      </div>
+      <div style={{ fontSize: 28, fontWeight: 600, color: "#f1f5f9", fontVariantNumeric: "tabular-nums" }}>
+        {prefix}{typeof value === "number" ? value.toLocaleString("en-US", { maximumFractionDigits: 1 }) : value}{suffix}
+      </div>
+    </div>
+  );
+}
+
+export default function CROMetrics() {
+  const [period, setPeriod] = useState("all");
+
+  const summary = useAppQuery("pipeline_summary", { period });
+  const stages = useAppQuery("deals_by_stage", { period });
+  const winRate = useAppQuery("win_rate", { period });
+  const upcoming = useAppQuery("upcoming_closes", {});
+
+  const isLoading = summary.loading || stages.loading || winRate.loading || upcoming.loading;
+  const anyError = summary.error || stages.error || winRate.error || upcoming.error;
+
+  const summaryRow = summary.data?.[0] ?? {};
+  const winRow = winRate.data?.[0] ?? {};
+
+  const stageNames = (stages.data ?? []).map((r) => r.stage);
+  const stageCounts = (stages.data ?? []).map((r) => r.deal_count);
+  const stageValues = (stages.data ?? []).map((r) => r.total_value);
+
+  const fmt = (n) =>
+    n >= 1_000_000
+      ? `$${(n / 1_000_000).toFixed(1)}M`
+      : n >= 1_000
+      ? `$${(n / 1_000).toFixed(0)}K`
+      : `$${Math.round(n)}`;
+
+  return (
+    <div style={{ padding: "24px 32px", maxWidth: 1200, margin: "0 auto", fontFamily: "system-ui, sans-serif" }}>
+      {/* Period selector */}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 24 }}>
+        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: "#f1f5f9" }}>CRO Metrics Dashboard</h1>
+        <div style={{ display: "flex", gap: 6 }}>
+          {PERIODS.map((p) => (
+            <button
+              key={p.value}
+              onClick={() => setPeriod(p.value)}
+              style={{
+                padding: "6px 14px",
+                borderRadius: 8,
+                border: period === p.value ? "1px solid #6366f1" : "1px solid rgba(255,255,255,0.12)",
+                background: period === p.value ? "rgba(99,102,241,0.15)" : "transparent",
+                color: period === p.value ? "#a5b4fc" : "#94a3b8",
+                cursor: "pointer",
+                fontSize: 13,
+                fontWeight: 500,
+              }}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {anyError && <ErrorBanner message={anyError} />}
+
+      {isLoading ? (
+        <Spinner />
+      ) : (
+        <>
+          {/* KPI cards */}
+          <div style={{ display: "flex", gap: 16, marginBottom: 28, flexWrap: "wrap" }}>
+            <KPICard label="Total Pipeline" value={fmt(summaryRow.total_value ?? 0)} />
+            <KPICard label="Weighted Pipeline" value={fmt(summaryRow.weighted_value ?? 0)} />
+            <KPICard label="Avg Deal Size" value={fmt(summaryRow.avg_deal_size ?? 0)} />
+            <KPICard label="Win Rate" value={winRow.win_rate_pct ?? 0} suffix="%" />
+          </div>
+
+          {/* Deals by stage chart */}
+          <div style={{
+            background: "rgba(255,255,255,0.04)",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: 12,
+            padding: 24,
+            marginBottom: 28,
+          }}>
+            <h2 style={{ margin: "0 0 16px", fontSize: 15, fontWeight: 600, color: "#e2e8f0" }}>
+              Deals by Stage
+            </h2>
+            <Plot
+              data={[
+                {
+                  type: "bar",
+                  x: stageNames,
+                  y: stageValues,
+                  text: stageValues.map((v) => fmt(v)),
+                  textposition: "auto",
+                  marker: { color: "#6366f1" },
+                  hovertemplate: "%{x}<br>%{y:$,.0f}<br>%{customdata} deals<extra></extra>",
+                  customdata: stageCounts,
+                },
+              ]}
+              layout={{
+                paper_bgcolor: "transparent",
+                plot_bgcolor: "transparent",
+                font: { color: "#94a3b8", size: 12 },
+                xaxis: { tickangle: -30, gridcolor: "rgba(255,255,255,0.06)" },
+                yaxis: { gridcolor: "rgba(255,255,255,0.06)", tickprefix: "$" },
+                margin: { l: 60, r: 20, t: 10, b: 80 },
+                height: 320,
+                bargap: 0.3,
+              }}
+              config={{ displayModeBar: false, responsive: true }}
+              style={{ width: "100%" }}
+            />
+          </div>
+
+          {/* Upcoming closes table */}
+          <div style={{
+            background: "rgba(255,255,255,0.04)",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: 12,
+            overflow: "hidden",
+          }}>
+            <div style={{ padding: "16px 24px", borderBottom: "1px solid rgba(255,255,255,0.08)" }}>
+              <h2 style={{ margin: 0, fontSize: 15, fontWeight: 600, color: "#e2e8f0" }}>
+                Upcoming Closes (Next 30 days)
+              </h2>
+            </div>
+            {(upcoming.data ?? []).length === 0 ? (
+              <div style={{ padding: 32, textAlign: "center", color: "#64748b", fontSize: 14 }}>
+                No deals closing in the next 30 days
+              </div>
+            ) : (
+              <table style={{ width: "100%", borderCollapse: "collapse" }}>
+                <thead>
+                  <tr style={{ borderBottom: "1px solid rgba(255,255,255,0.08)" }}>
+                    <th style={{ textAlign: "left", padding: "10px 24px", fontSize: 11, fontWeight: 600, color: "#64748b", textTransform: "uppercase", letterSpacing: "0.05em" }}>Deal</th>
+                    <th style={{ textAlign: "left", padding: "10px 16px", fontSize: 11, fontWeight: 600, color: "#64748b", textTransform: "uppercase", letterSpacing: "0.05em" }}>Stage</th>
+                    <th style={{ textAlign: "right", padding: "10px 16px", fontSize: 11, fontWeight: 600, color: "#64748b", textTransform: "uppercase", letterSpacing: "0.05em" }}>Amount</th>
+                    <th style={{ textAlign: "right", padding: "10px 24px", fontSize: 11, fontWeight: 600, color: "#64748b", textTransform: "uppercase", letterSpacing: "0.05em" }}>Close Date</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(upcoming.data ?? []).map((row, i) => (
+                    <tr key={i} style={{ borderBottom: "1px solid rgba(255,255,255,0.05)" }}>
+                      <td style={{ padding: "10px 24px", color: "#e2e8f0", fontSize: 14 }}>{row.name}</td>
+                      <td style={{ padding: "10px 16px" }}>
+                        <span style={{
+                          display: "inline-block",
+                          padding: "2px 8px",
+                          borderRadius: 4,
+                          background: "rgba(99,102,241,0.15)",
+                          color: "#a5b4fc",
+                          fontSize: 12,
+                          fontWeight: 500,
+                        }}>
+                          {row.stage ?? "—"}
+                        </span>
+                      </td>
+                      <td style={{ padding: "10px 16px", textAlign: "right", color: "#cbd5e1", fontVariantNumeric: "tabular-nums", fontSize: 14 }}>
+                        ${row.amount.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
+                      </td>
+                      <td style={{ padding: "10px 24px", textAlign: "right", color: "#94a3b8", fontSize: 13 }}>{row.close_date}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+'''
+
+
+async def main() -> None:
+    """Create the CRO Metrics app and set it as home for the demo org."""
+    app_id: uuid.UUID = uuid.uuid4()
+
+    async with get_admin_session() as session:
+        # Find a user in the demo org to use as owner
+        result = await session.execute(
+            text("SELECT id FROM users WHERE organization_id = :org_id LIMIT 1"),
+            {"org_id": DEMO_ORG_ID},
+        )
+        row = result.first()
+        if row is None:
+            print(f"No users found for org {DEMO_ORG_ID}")
+            return
+        owner_id: uuid.UUID = row[0]
+
+        # Check if app already exists
+        existing = await session.execute(
+            text("SELECT id FROM apps WHERE organization_id = :org_id AND title = :title LIMIT 1"),
+            {"org_id": DEMO_ORG_ID, "title": "CRO Metrics Dashboard"},
+        )
+        if existing.first() is not None:
+            print("CRO Metrics Dashboard app already exists, skipping insert.")
+            existing_row = await session.execute(
+                text("SELECT id FROM apps WHERE organization_id = :org_id AND title = :title LIMIT 1"),
+                {"org_id": DEMO_ORG_ID, "title": "CRO Metrics Dashboard"},
+            )
+            app_id = existing_row.first()[0]  # type: ignore[index]
+        else:
+            app = App(
+                id=app_id,
+                user_id=owner_id,
+                organization_id=DEMO_ORG_ID,
+                title="CRO Metrics Dashboard",
+                description="Pipeline overview with KPIs, deals by stage, win rate, and upcoming closes.",
+                queries=QUERIES,
+                frontend_code=FRONTEND_CODE,
+            )
+            session.add(app)
+            await session.flush()
+            print(f"Created CRO Metrics Dashboard app: {app_id}")
+
+        # Set as home app
+        await session.execute(
+            text("UPDATE organizations SET home_app_id = :app_id WHERE id = :org_id"),
+            {"app_id": str(app_id), "org_id": DEMO_ORG_ID},
+        )
+        await session.commit()
+        print(f"Set home_app_id = {app_id} for org {DEMO_ORG_ID}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,12 +1,27 @@
 /**
- * Home view - VP Sales lens: total pipeline value first, deal details below.
- * Open deals only (excludes closed won/lost). Deal rows link to details (chat or CRM).
+ * Home view - displays either a custom app (if configured for the org)
+ * or the default VP Sales pipeline view.
+ *
+ * A gear icon in the header lets users pick which app to show.
  */
 
 import { useEffect, useState, useMemo, useCallback } from 'react';
-import { API_BASE } from '../lib/api';
+import { apiRequest, API_BASE } from '../lib/api';
 import { formatDateOnly } from '../lib/dates';
 import { useAppStore, useIntegrations } from '../store';
+import { SandpackAppRenderer } from './apps/SandpackAppRenderer';
+import { HomeAppPicker } from './apps/HomeAppPicker';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface HomeAppData {
+  id: string;
+  title: string;
+  description: string | null;
+  frontendCode: string;
+}
 
 interface Deal {
   id: string;
@@ -61,30 +76,62 @@ interface PipelineWithDeals {
   totalProbAdjusted: number;
 }
 
+// ---------------------------------------------------------------------------
+// Home Component
+// ---------------------------------------------------------------------------
+
 export function Home(): JSX.Element {
   const organization = useAppStore((state) => state.organization);
   const startNewChat = useAppStore((state) => state.startNewChat);
   const setPendingChatInput = useAppStore((state) => state.setPendingChatInput);
   const setPendingChatAutoSend = useAppStore((state) => state.setPendingChatAutoSend);
   const setCurrentView = useAppStore((state) => state.setCurrentView);
+
+  // Home app state
+  const [homeApp, setHomeApp] = useState<HomeAppData | null>(null);
+  const [homeAppLoading, setHomeAppLoading] = useState<boolean>(true);
+  const [showPicker, setShowPicker] = useState<boolean>(false);
+  const [orgAppCount, setOrgAppCount] = useState<number>(0);
+
+  // Pipeline view state
   const [deals, setDeals] = useState<Deal[]>([]);
   const [pipelines, setPipelines] = useState<Pipeline[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   
-  // Check if the organization has any connected data sources (from Zustand store)
   const integrations = useIntegrations();
-  const hasConnectedSources = integrations.some((i) => i.isActive);
+  const hasConnectedSources: boolean = integrations.some((i) => i.isActive);
 
+  // Fetch the home app preference + org app count (re-run on org switch)
+  useEffect(() => {
+    setHomeApp(null);
+    setHomeAppLoading(true);
+    setOrgAppCount(0);
+    const fetchHomeApp = async (): Promise<void> => {
+      const resp = await apiRequest<{ app: HomeAppData | null; app_count: number }>('/apps/home');
+      if (resp.data) {
+        setHomeApp(resp.data.app);
+        setOrgAppCount(resp.data.app_count);
+      }
+      setHomeAppLoading(false);
+    };
+    void fetchHomeApp();
+  }, [organization?.id]);
+
+  // Fetch pipeline data (only when no home app is set)
   useEffect(() => {
     if (!organization?.id) return;
+    if (homeAppLoading) return;
+    if (homeApp !== null) {
+      setLoading(false);
+      return;
+    }
 
     const fetchData = async (): Promise<void> => {
       setLoading(true);
       setError(null);
 
       try {
-        // Fetch all pipelines
         const pipelinesRes = await fetch(
           `${API_BASE}/deals/pipelines?organization_id=${organization.id}`,
           { credentials: 'include' }
@@ -95,7 +142,6 @@ export function Home(): JSX.Element {
           setPipelines(pipelinesData.pipelines);
         }
 
-        // Fetch all open deals (not just default pipeline, exclude closed won/lost)
         const dealsRes = await fetch(
           `${API_BASE}/deals?organization_id=${organization.id}&limit=200&open_only=true`,
           { credentials: 'include' }
@@ -123,9 +169,9 @@ export function Home(): JSX.Element {
     };
 
     void fetchData();
-  }, [organization?.id]);
+  }, [organization?.id, homeAppLoading, homeApp]);
 
-  // Group deals by pipeline and compute value totals (all vs probability-adjusted)
+  // Group deals by pipeline
   const pipelinesWithDeals = useMemo((): PipelineWithDeals[] => {
     const sortedPipelines = [...pipelines].sort((a, b) => {
       if (a.is_default && !b.is_default) return -1;
@@ -144,12 +190,7 @@ export function Home(): JSX.Element {
           (d.amount ?? 0) * ((d.stage_probability ?? DEFAULT_STAGE_PROBABILITY) / 100),
         0
       );
-      return {
-        pipeline,
-        deals: pipelineDeals,
-        totalAll,
-        totalProbAdjusted,
-      };
+      return { pipeline, deals: pipelineDeals, totalAll, totalProbAdjusted };
     });
 
     const orphanedDeals = deals.filter(
@@ -174,7 +215,7 @@ export function Home(): JSX.Element {
     return result;
   }, [pipelines, deals]);
 
-  const totalDeals = deals.length;
+  const totalDeals: number = deals.length;
   const grandTotalAll = useMemo(
     () => pipelinesWithDeals.reduce((sum, p) => sum + p.totalAll, 0),
     [pipelinesWithDeals]
@@ -201,18 +242,32 @@ export function Home(): JSX.Element {
 
   const handleDealClick = useCallback((deal: Deal) => {
     const question = `Summarize the "${deal.name}" deal${deal.pipeline_name ? ` in the ${deal.pipeline_name} pipeline` : ''}. Include current stage, next steps, and recent activity.`;
-    console.log('[Home] Starting deal summary chat for:', {
-      dealId: deal.id,
-      dealName: deal.name,
-      pipelineName: deal.pipeline_name,
-    });
     setPendingChatInput(question);
     setPendingChatAutoSend(true);
     startNewChat();
     setCurrentView('chat');
   }, [setPendingChatAutoSend, setPendingChatInput, setCurrentView, startNewChat]);
 
-  if (loading) {
+  const handleAppSelected = useCallback((appId: string | null) => {
+    if (appId === null) {
+      setHomeApp(null);
+    }
+    setShowPicker(false);
+    const reload = async (): Promise<void> => {
+      const resp = await apiRequest<{ app: HomeAppData | null; app_count: number }>('/apps/home');
+      if (resp.data) {
+        setHomeApp(resp.data.app);
+        setOrgAppCount(resp.data.app_count);
+      }
+    };
+    void reload();
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Loading state
+  // ---------------------------------------------------------------------------
+
+  if (homeAppLoading || loading) {
     return (
       <div className="flex-1 flex items-center justify-center">
         <div className="flex items-center gap-3 text-surface-400">
@@ -220,11 +275,60 @@ export function Home(): JSX.Element {
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
           </svg>
-          <span>Loading deals...</span>
+          <span>Loading...</span>
         </div>
       </div>
     );
   }
+
+  // ---------------------------------------------------------------------------
+  // Custom Home App view
+  // ---------------------------------------------------------------------------
+
+  if (homeApp !== null) {
+    return (
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <header className="hidden md:flex h-14 border-b border-surface-800 items-center justify-between px-4 md:px-6">
+          <div className="flex items-center gap-2">
+            <h1 className="text-lg font-semibold text-surface-100">{homeApp.title}</h1>
+            <span className="px-1.5 py-0.5 text-[10px] font-medium bg-primary-500/20 text-primary-400 rounded">
+              Home App
+            </span>
+          </div>
+          <button
+            onClick={() => setShowPicker(true)}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md hover:bg-surface-800 text-surface-400 hover:text-surface-200 transition-colors text-xs"
+            title="Customize Home"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            Customize
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-hidden">
+          <SandpackAppRenderer
+            appId={homeApp.id}
+            frontendCode={homeApp.frontendCode}
+          />
+        </div>
+
+        {showPicker && (
+          <HomeAppPicker
+            currentAppId={homeApp.id}
+            onSelect={handleAppSelected}
+            onClose={() => setShowPicker(false)}
+          />
+        )}
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Default Pipeline View
+  // ---------------------------------------------------------------------------
 
   if (error) {
     return (
@@ -239,12 +343,77 @@ export function Home(): JSX.Element {
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
-      <header className="hidden md:flex h-14 border-b border-surface-800 items-center px-4 md:px-6">
+      <header className="hidden md:flex h-14 border-b border-surface-800 items-center justify-between px-4 md:px-6">
         <h1 className="text-lg font-semibold text-surface-100">Pipelines</h1>
+        {orgAppCount > 0 && (
+          <button
+            onClick={() => setShowPicker(true)}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md hover:bg-surface-800 text-surface-400 hover:text-surface-200 transition-colors text-xs"
+            title="Customize Home"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+            Customize
+          </button>
+        )}
       </header>
 
       <div className="flex-1 overflow-auto p-4 md:p-6">
-        {/* Connect data sources banner - only shown when no sources connected */}
+        {/* Banner: "Choose App" when org has apps, "Ask Penny" when none */}
+        {orgAppCount > 0 ? (
+          <div className="mb-4 md:mb-6 bg-surface-800/60 border border-surface-700 rounded-xl p-4">
+            <div className="flex items-center gap-3">
+              <div className="flex-shrink-0 w-9 h-9 rounded-lg bg-primary-500/20 flex items-center justify-center">
+                <svg className="w-4.5 h-4.5 text-primary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                </svg>
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-surface-300 text-sm">
+                  <span className="font-medium text-surface-200">Customize your Home tab</span>
+                  {' '}— replace this view with any app from the Apps gallery.
+                </p>
+              </div>
+              <button
+                onClick={() => setShowPicker(true)}
+                className="flex-shrink-0 px-3 py-1.5 bg-primary-600 hover:bg-primary-500 text-white text-xs font-medium rounded-lg transition-colors"
+              >
+                Choose App
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="mb-4 md:mb-6 bg-surface-800/60 border border-surface-700 rounded-xl p-4">
+            <div className="flex items-center gap-3">
+              <div className="flex-shrink-0 w-9 h-9 rounded-lg bg-primary-500/20 flex items-center justify-center">
+                <svg className="w-4.5 h-4.5 text-primary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+                </svg>
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-surface-300 text-sm">
+                  <span className="font-medium text-surface-200">Make this Home tab your own</span>
+                  {' '}— ask Penny to build a custom dashboard and it will appear here for your whole team.
+                </p>
+              </div>
+              <button
+                onClick={() => {
+                  setPendingChatInput('Create a dashboard app for our Home tab with key pipeline metrics, deals by stage, and upcoming closes.');
+                  setPendingChatAutoSend(false);
+                  startNewChat();
+                  setCurrentView('chat');
+                }}
+                className="flex-shrink-0 px-3 py-1.5 bg-primary-600 hover:bg-primary-500 text-white text-xs font-medium rounded-lg transition-colors"
+              >
+                Ask Penny
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Connect data sources banner */}
         {!hasConnectedSources && (
           <div className="mb-4 md:mb-6 bg-gradient-to-r from-primary-500/20 to-primary-600/10 border border-primary-500/30 rounded-xl p-4 md:p-5">
             <div className="flex flex-col sm:flex-row items-start gap-3 md:gap-4">
@@ -262,7 +431,6 @@ export function Home(): JSX.Element {
                 </p>
                 <button
                   onClick={() => {
-                    // Navigate to data sources - dispatch a custom event that Sidebar listens to
                     window.dispatchEvent(new CustomEvent('navigate', { detail: 'data-sources' }));
                   }}
                   className="inline-flex items-center gap-2 px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white text-sm font-medium rounded-lg transition-colors"
@@ -324,7 +492,7 @@ export function Home(): JSX.Element {
               </section>
             )}
 
-            {/* Deal list: details below, with link to view details (chat) */}
+            {/* Deal list */}
             <section>
               <h2 className="text-sm font-medium text-surface-500 uppercase tracking-wider mb-3">
                 Deal list — {totalDeals} open deal{totalDeals !== 1 ? 's' : ''}
@@ -402,6 +570,14 @@ export function Home(): JSX.Element {
           </>
         )}
       </div>
+
+      {showPicker && (
+        <HomeAppPicker
+          currentAppId={null}
+          onSelect={handleAppSelected}
+          onClose={() => setShowPicker(false)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/apps/HomeAppPicker.tsx
+++ b/frontend/src/components/apps/HomeAppPicker.tsx
@@ -1,0 +1,145 @@
+/**
+ * Modal for selecting which app to display on the Home tab.
+ *
+ * Fetches all apps for the org and lets the user pick one (or clear).
+ */
+
+import { useEffect, useState, useCallback } from "react";
+import { apiRequest } from "../../lib/api";
+
+interface AppListItem {
+  id: string;
+  title: string | null;
+  description: string | null;
+  creator_name: string | null;
+}
+
+interface HomeAppPickerProps {
+  currentAppId: string | null;
+  onSelect: (appId: string | null) => void;
+  onClose: () => void;
+}
+
+export function HomeAppPicker({
+  currentAppId,
+  onSelect,
+  onClose,
+}: HomeAppPickerProps): JSX.Element {
+  const [apps, setApps] = useState<AppListItem[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [saving, setSaving] = useState<boolean>(false);
+
+  useEffect(() => {
+    const fetchApps = async (): Promise<void> => {
+      const resp = await apiRequest<{ apps: AppListItem[] }>("/apps");
+      if (resp.data) {
+        setApps(resp.data.apps);
+      }
+      setLoading(false);
+    };
+    void fetchApps();
+  }, []);
+
+  const handleSelect = useCallback(
+    async (appId: string | null): Promise<void> => {
+      setSaving(true);
+      const resp = await apiRequest<{ status: string }>("/apps/home", {
+        method: "PATCH",
+        body: JSON.stringify({ app_id: appId }),
+      });
+      setSaving(false);
+      if (resp.data?.status === "success") {
+        onSelect(appId);
+      }
+    },
+    [onSelect],
+  );
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/60" onClick={onClose} />
+
+      {/* Modal */}
+      <div className="relative w-full max-w-md mx-4 bg-surface-900 border border-surface-700 rounded-xl shadow-2xl overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-surface-700">
+          <div>
+            <h2 className="text-base font-semibold text-surface-100">
+              Customize Home
+            </h2>
+            <p className="text-xs text-surface-400 mt-0.5">
+              Choose an app to display on your Home tab
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-surface-400 hover:text-surface-200 p-1"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="max-h-80 overflow-y-auto p-3">
+          {loading ? (
+            <div className="flex justify-center py-8">
+              <div className="w-6 h-6 border-2 border-surface-600 border-t-primary-500 rounded-full animate-spin" />
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {/* Default (no app) option */}
+              <button
+                onClick={() => void handleSelect(null)}
+                disabled={saving}
+                className={`w-full text-left px-4 py-3 rounded-lg border transition-colors ${
+                  currentAppId === null
+                    ? "border-primary-500 bg-primary-500/10"
+                    : "border-surface-700 hover:border-surface-600 hover:bg-surface-800/50"
+                }`}
+              >
+                <div className="font-medium text-surface-200 text-sm">
+                  Default Pipeline View
+                </div>
+                <div className="text-xs text-surface-400 mt-0.5">
+                  Show the built-in deals &amp; pipeline summary
+                </div>
+              </button>
+
+              {/* App options */}
+              {apps.map((app) => (
+                <button
+                  key={app.id}
+                  onClick={() => void handleSelect(app.id)}
+                  disabled={saving}
+                  className={`w-full text-left px-4 py-3 rounded-lg border transition-colors ${
+                    currentAppId === app.id
+                      ? "border-primary-500 bg-primary-500/10"
+                      : "border-surface-700 hover:border-surface-600 hover:bg-surface-800/50"
+                  }`}
+                >
+                  <div className="font-medium text-surface-200 text-sm">
+                    {app.title ?? "Untitled App"}
+                  </div>
+                  {app.description && (
+                    <div className="text-xs text-surface-400 mt-0.5 truncate">
+                      {app.description}
+                    </div>
+                  )}
+                </button>
+              ))}
+
+              {apps.length === 0 && (
+                <div className="text-center py-6 text-surface-500 text-sm">
+                  No apps yet. Ask Penny to create one!
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/apps/SandpackAppRenderer.tsx
+++ b/frontend/src/components/apps/SandpackAppRenderer.tsx
@@ -78,9 +78,12 @@ function transformAppCode(code: string): { transformed: string; appName: string 
   return { transformed, appName };
 }
 
+/** Closing tag as a constant so the bundler/linter never sees a raw close-script. */
+const CS = "<" + "/script>";
+
 /** Escape a string for safe embedding inside an HTML <script> block. */
 function escapeForScript(s: string): string {
-  return s.replace(/<\/script>/gi, "<\\/script>");
+  return s.replace(new RegExp(CS, "gi"), "<\\/script>");
 }
 
 // ---- build the srcdoc HTML ------------------------------------------------
@@ -99,10 +102,10 @@ function buildSrcdocHtml(opts: {
 <html>
 <head>
 <meta charset="UTF-8" />
-<script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"><\/script>
-<script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"><\/script>
-<script src="https://cdn.plot.ly/plotly-2.35.3.min.js"><\/script>
-<script src="https://unpkg.com/@babel/standalone@7/babel.min.js"><\/script>
+<script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js">${CS}
+<script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js">${CS}
+<script src="https://cdn.plot.ly/plotly-2.35.3.min.js">${CS}
+<script src="https://unpkg.com/@babel/standalone@7/babel.min.js">${CS}
 <style>${escapeForScript(APP_STYLES)}</style>
 </head>
 <body>
@@ -123,7 +126,7 @@ window.onerror = function(msg, url, line, col, err) {
   }
   try { window.parent.postMessage({ type:"app-error", error: String(msg) }, "*"); } catch(_){}
 };
-<\/script>
+${CS}
 
 <script type="text/babel">
 /* ---- React destructured ---- */
@@ -149,7 +152,7 @@ try {
     '<div style="color:#fca5a5;padding:1rem;font-family:monospace;font-size:12px;white-space:pre-wrap;">' + e.message + '<' + '/div>';
   try { window.parent.postMessage({ type:"app-error", error: e.message }, "*"); } catch(_){}
 }
-<\/script>
+${CS}
 </body>
 </html>`;
 }


### PR DESCRIPTION
## Summary

- **Customizable Home tab**: Organizations can now set any app as their Home tab content via a new `home_app_id` column on the Organization model. A gear icon and picker modal let admins choose from existing apps, or fall back to the default pipeline view with an "Ask Penny" prompt when no apps exist yet.
- **CRO Metrics Dashboard**: Seeded a full-featured CRO dashboard app (pipeline KPIs, deals by stage chart, win rate, upcoming closes table) for the Cro Metrics demo org.
- **App query `org_id` injection**: The backend now auto-injects `org_id` from the authenticated token into all app query bound params, so SQL queries can securely filter by organization.
- **Script tag fix in SandpackAppRenderer**: Replaced broken `<${"/"}>script>` closing tags (which produced `</>script>`) with a `CS` constant pattern that correctly produces `</script>`, fixing blank iframe rendering.
- **Multi-org Home state**: The Home component now re-fetches the home app preference when the user switches organizations, preventing stale cross-org data.
- **Conditional customize banner**: The "Customize Home" banner and gear icon only appear when the org has apps; orgs with no apps see an "Ask Penny to build a dashboard" prompt instead.

## Test plan

- [ ] Switch between orgs and verify the Home tab shows the correct content (custom app vs default pipeline view)
- [ ] On Cro Metrics org, verify the CRO Metrics Dashboard renders with KPI cards, chart, and table
- [ ] On an org with no apps, verify the "Ask Penny" banner appears instead of "Choose App"
- [ ] Click "Customize" gear icon, select/clear an app, verify Home updates
- [ ] Verify apps appear in the Apps gallery page
- [ ] Verify app queries execute without `org_id` errors


Made with [Cursor](https://cursor.com)