### PR TITLE
Make memories the sole source of user global_commands

### DIFF
--- a/backend/db/migrations/versions/069_global_cmd_unique.py
+++ b/backend/db/migrations/versions/069_global_cmd_unique.py
@@ -1,0 +1,60 @@
+"""Enforce single global command memory per user.
+
+Revision ID: 069_global_cmd_unique
+Revises: 068_global_cmd_memory
+Create Date: 2026-02-18
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "069_global_cmd_unique"
+down_revision = "068_global_cmd_memory"
+branch_labels = None
+depends_on = None
+
+
+# Migration safety preflight checks
+assert len(revision) <= 32
+assert isinstance(down_revision, str) and len(down_revision) <= 32
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Keep only the latest command per (organization_id, entity_id) pair.
+    conn.execute(
+        text(
+            """
+            DELETE FROM memories AS m
+            USING (
+                SELECT id
+                FROM (
+                    SELECT
+                        id,
+                        row_number() OVER (
+                            PARTITION BY organization_id, entity_id
+                            ORDER BY updated_at DESC NULLS LAST, created_at DESC NULLS LAST, id DESC
+                        ) AS row_num
+                    FROM memories
+                    WHERE entity_type = 'user'
+                      AND category = 'global_commands'
+                ) AS ranked
+                WHERE ranked.row_num > 1
+            ) AS duplicates
+            WHERE m.id = duplicates.id
+            """
+        )
+    )
+
+    op.create_index(
+        "ux_memories_user_global_commands",
+        "memories",
+        ["organization_id", "entity_id"],
+        unique=True,
+        postgresql_where=text("entity_type = 'user' AND category = 'global_commands'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ux_memories_user_global_commands", table_name="memories")


### PR DESCRIPTION
### Motivation
- Ensure the agent `global_commands` are sourced exclusively from the `memories` table so runtime behavior is consistent and not duplicated across schema locations.
- Remove the possibility of multiple `global_commands` rows per user and proactively clean up duplicates to avoid ambiguity at runtime.
- Enforce this constraint at the database level to prevent future duplicate inserts and keep application logic simple.

### Description
- Updated `_set_user_global_commands` in `backend/api/routes/auth.py` to query `memories` ordered by recency, keep the newest memory row, and delete any duplicate `global_commands` memories while emitting a warning via `logger`.
- Added Alembic migration `backend/db/migrations/versions/069_global_cmd_unique.py` which deduplicates existing `global_commands` entries (keeping the latest) and creates a partial unique index `ux_memories_user_global_commands` on `('organization_id','entity_id')` for user-scoped `global_commands`.
- Included migration preflight assertions to ensure `revision` and `down_revision` meet the project rule that IDs must be <= 32 characters.

### Testing
- Ran `pytest -q backend/tests/test_health.py` and the test passed (3 tests, 0 failures).
- Ran `python -m py_compile backend/api/routes/auth.py backend/db/migrations/versions/069_global_cmd_unique.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995fb45e3bc8321ba93bb2357614f2a)