### PR TITLE
Make sure that a Conversation has access to the memories members table for all participating users, and uses the global context of the most recent user

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -459,6 +459,7 @@ async def send_message(
             conversation = Conversation(
                 user_id=auth.user_id,
                 organization_id=auth.organization_id,
+                participating_user_ids=[auth.user_id],
                 title=None,  # Will be set after first message
             )
             session.add(conversation)

--- a/backend/api/routes/workflows.py
+++ b/backend/api/routes/workflows.py
@@ -433,6 +433,7 @@ async def trigger_workflow(
             conversation = Conversation(
                 user_id=workflow.created_by_user_id,
                 organization_id=workflow.organization_id,
+                participating_user_ids=[workflow.created_by_user_id] if workflow.created_by_user_id else [],
                 type="workflow",
                 workflow_id=workflow.id,
                 title=f"Workflow: {workflow.name}",

--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -517,6 +517,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                             id=conv_uuid,
                             user_id=UUID(user_id_str), 
                             organization_id=UUID(organization_id) if organization_id else None,
+                            participating_user_ids=[UUID(user_id_str)],
                             title=title,
                         )
                         session.add(conversation)

--- a/backend/services/sms_conversations.py
+++ b/backend/services/sms_conversations.py
@@ -216,6 +216,7 @@ async def find_or_create_sms_conversation(
         conversation = Conversation(
             organization_id=UUID(organization_id),
             user_id=UUID(user_id),
+            participating_user_ids=[UUID(user_id)],
             source="sms",
             source_channel_id=phone_number,
             source_user_id=phone_number,

--- a/backend/tests/test_orchestrator_participants.py
+++ b/backend/tests/test_orchestrator_participants.py
@@ -1,0 +1,28 @@
+from uuid import UUID
+
+from agents import orchestrator
+
+
+def test_merge_participating_user_ids_preserves_order_and_appends_fallback_as_most_recent():
+    user_a = UUID("11111111-1111-1111-1111-111111111111")
+    user_b = UUID("22222222-2222-2222-2222-222222222222")
+
+    merged = orchestrator._merge_participating_user_ids(
+        conversation_user_id=None,
+        participating_user_ids=[user_a, user_b],
+        fallback_user_id=str(user_a),
+    )
+
+    assert merged == [user_b, user_a]
+
+
+def test_merge_participating_user_ids_includes_conversation_user_when_not_in_participants():
+    conversation_user = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+    merged = orchestrator._merge_participating_user_ids(
+        conversation_user_id=conversation_user,
+        participating_user_ids=[],
+        fallback_user_id=None,
+    )
+
+    assert merged == [conversation_user]

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -754,6 +754,7 @@ async def _execute_workflow_via_agent(
             conversation = Conversation(
                 user_id=workflow.created_by_user_id,
                 organization_id=workflow.organization_id,
+                participating_user_ids=[workflow.created_by_user_id] if workflow.created_by_user_id else [],
                 type="workflow",
                 workflow_id=workflow.id,
                 title=f"Workflow: {workflow.name}",
@@ -766,6 +767,7 @@ async def _execute_workflow_via_agent(
         conversation = Conversation(
             user_id=workflow.created_by_user_id,
             organization_id=workflow.organization_id,
+            participating_user_ids=[workflow.created_by_user_id] if workflow.created_by_user_id else [],
             type="workflow",
             workflow_id=workflow.id,
             title=f"Workflow: {workflow.name}",


### PR DESCRIPTION
Updated ChatOrchestrator to build participant-aware context by normalizing Conversation.participating_user_ids, using the most recent participant as active user context, and loading that user’s global commands accordingly (with added debug logging).

Expanded context profile loading to include memories for all participating users and all corresponding organization_member rows, while still using the most recent participant for active structured job/global context fields.

Ensured newly created conversations consistently seed participating_user_ids across web chat, websocket chat creation, SMS conversations, workflow route creation, worker-created workflow conversations, and orchestrator auto-created conversations so participant memory scope is always available from conversation data.

Added unit tests for participant merge/recency behavior used by orchestrator context resolution.