### PR TITLE
Add compatibility Alembic revision to restore migration graph

### DIFF
--- a/backend/db/migrations/versions/070_merge_drop_agent_global_cmd.py
+++ b/backend/db/migrations/versions/070_merge_drop_agent_global_cmd.py
@@ -1,0 +1,26 @@
+"""Compatibility merge revision for global command column drop.
+
+Revision ID: 070_merge_drop_agent_global_cmd
+Revises: 069_conv_participants
+Create Date: 2026-02-18 16:10:00
+"""
+
+from typing import Sequence, Union
+
+
+# revision identifiers, used by Alembic.
+revision: str = "070_merge_drop_agent_global_cmd"
+down_revision: Union[str, None] = "069_conv_participants"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Intentionally empty. This revision exists to support environments
+    # that already recorded this historical revision ID.
+    pass
+
+
+def downgrade() -> None:
+    # Intentionally empty.
+    pass

--- a/backend/db/migrations/versions/58726d896351_merge_multiple_heads.py
+++ b/backend/db/migrations/versions/58726d896351_merge_multiple_heads.py
@@ -1,7 +1,7 @@
 """Merge multiple heads
 
 Revision ID: 58726d896351
-Revises: 066_add_home_app_id, 067_add_home_app_id, 070_drop_user_cmd_col
+Revises: 066_add_home_app_id, 067_add_home_app_id, 070_drop_user_cmd_col, 070_merge_drop_agent_global_cmd
 Create Date: 2026-02-18 15:53:41.261288
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = '58726d896351'
-down_revision: Union[str, None] = ('066_add_home_app_id', '067_add_home_app_id', '070_drop_user_cmd_col')
+down_revision: Union[str, None] = ('066_add_home_app_id', '067_add_home_app_id', '070_drop_user_cmd_col', '070_merge_drop_agent_global_cmd')
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
### Motivation
- Alembic failed to load the migration graph because the historical revision ID `070_merge_drop_agent_global_cmd` was referenced by some environments but missing from the repository, causing `Can't locate revision identified by '070_merge_drop_agent_global_cmd'` during `alembic upgrade`.
- Provide a compatibility no-op migration and include it in the existing merge node so both historical branchings converge to the current head without changing runtime schema behavior.

### Description
- Added a no-op compatibility migration file `backend/db/migrations/versions/070_merge_drop_agent_global_cmd.py` that defines `revision = "070_merge_drop_agent_global_cmd"` and a no-op `upgrade()`/`downgrade()` to satisfy stamped databases.
- Updated `backend/db/migrations/versions/58726d896351_merge_multiple_heads.py` to include `'070_merge_drop_agent_global_cmd'` in its `down_revision` tuple so the merge head accepts either lineage.
- Ensured all affected migration `revision` and `down_revision` identifiers remain within the required length limits and adhered to the project's Alembic naming constraints.

### Testing
- Ran a Python preflight script that loads the two changed migration files and asserted `len(revision) <= 32` and `len(down_revision) <= 32`, which passed.
- Executed `alembic heads` and `alembic history` to verify the migration graph now shows the compatibility node and the merge topology, which succeeded.
- Attempted `alembic upgrade head` in this environment but it failed due to the local Postgres server not running on `localhost:5432`, so full apply to a DB could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699627079a888321a30639c2fa00d5ba)