### PR TITLE
Fix duplicate-column failure in home_app_id Alembic migration

### DIFF
--- a/backend/db/migrations/versions/067_add_home_app_id_to_organizations.py
+++ b/backend/db/migrations/versions/067_add_home_app_id_to_organizations.py
@@ -1,13 +1,11 @@
 """Add home_app_id to organizations for customizable Home tab.
 
-Revision ID: 066_add_home_app_id
-Revises: 065_create_apps_table
+Revision ID: 067_add_home_app_id
+Revises: 066_embeddings_to_pgvector
 Create Date: 2026-02-17
 """
 
 from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import UUID
 
 revision = "067_add_home_app_id"
 down_revision = "066_embeddings_to_pgvector"
@@ -16,16 +14,15 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "organizations",
-        sa.Column(
-            "home_app_id",
-            UUID(as_uuid=True),
-            sa.ForeignKey("apps.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
+    # Compatibility-safe for environments that already applied
+    # 066_add_home_app_id_to_organizations.
+    op.execute(
+        """
+        ALTER TABLE organizations
+        ADD COLUMN IF NOT EXISTS home_app_id UUID REFERENCES apps(id) ON DELETE SET NULL
+        """
     )
 
 
 def downgrade() -> None:
-    op.drop_column("organizations", "home_app_id")
+    op.execute("ALTER TABLE organizations DROP COLUMN IF EXISTS home_app_id")


### PR DESCRIPTION
### Motivation
- The 067 migration attempted to add `organizations.home_app_id` even when an earlier revision had already created the column, causing `psycopg2.errors.DuplicateColumn` during upgrade.

### Description
- Updated `backend/db/migrations/versions/067_add_home_app_id_to_organizations.py` to use raw SQL with `ADD COLUMN IF NOT EXISTS` to make the upgrade idempotent.
- Made the downgrade resilient by using `DROP COLUMN IF EXISTS` to avoid errors when the column is absent.
- Corrected the migration header metadata to match the actual revision chain (`Revision ID: 067_add_home_app_id`, `Revises: 066_embeddings_to_pgvector`) and removed unused imports.

### Testing
- Ran a Python preflight check that imports the migration module and asserts `len(revision) <= 32` (and `len(down_revision) <= 32`), and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996286287388321a3864c3731e0c979)