### PR TITLE
Fix stale current-user context by honoring source identity each turn

### DIFF
--- a/backend/tests/test_orchestrator_identity.py
+++ b/backend/tests/test_orchestrator_identity.py
@@ -1,0 +1,33 @@
+from agents.orchestrator import ChatOrchestrator
+
+
+def test_resolve_current_user_uuid_returns_user_uuid_when_valid():
+    orchestrator = ChatOrchestrator(
+        user_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        organization_id="11111111-1111-1111-1111-111111111111",
+        source="slack_thread",
+        source_user_id="U123",
+    )
+
+    resolved = orchestrator._resolve_current_user_uuid()
+
+    assert resolved is not None
+    assert str(resolved) == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+
+def test_resolve_current_user_uuid_returns_none_when_missing_or_invalid():
+    missing_orchestrator = ChatOrchestrator(
+        user_id=None,
+        organization_id="11111111-1111-1111-1111-111111111111",
+        source="slack_thread",
+        source_user_id="U123",
+    )
+    assert missing_orchestrator._resolve_current_user_uuid() is None
+
+    invalid_orchestrator = ChatOrchestrator(
+        user_id="not-a-uuid",
+        organization_id="11111111-1111-1111-1111-111111111111",
+        source="slack_thread",
+        source_user_id="U123",
+    )
+    assert invalid_orchestrator._resolve_current_user_uuid() is None


### PR DESCRIPTION
### Motivation
- Prevent agents from retaining a stale RevTops user context when Slack speaker identity changes by making the per-turn resolved user the single source of truth. 
- Users reported that Penny sometimes kept the wrong user ID across speaker handoffs; this change ensures `source_user_id` drives current-user resolution for the turn.

### Description
- Added `ChatOrchestrator._resolve_current_user_uuid()` to treat the orchestrator's `user_id` (derived from the current source identity) as the authoritative current user, with defensive logging for invalid UUIDs. 
- Updated context/profile loading to use the per-turn resolved user UUID (`_resolve_current_user_uuid()`) instead of falling back to historical `participating_user_ids[-1]`, avoiding stale carryover. 
- Injected an explicit note into the system prompt that `source_user_id` is the source-of-truth speaker identity for the current turn. 
- Added unit tests (`backend/tests/test_orchestrator_identity.py`) that validate valid, missing, and invalid `user_id` behaviors.

### Testing
- Ran `pytest backend/tests/test_orchestrator_identity.py backend/tests/test_slack_user_resolution.py` and observed all tests passing (`14 passed`).
- The new unit tests exercise `_resolve_current_user_uuid()` for valid, missing, and malformed `user_id` cases and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699793f3af748321a994cf2b47f30aed)