### PR TITLE
Prefer Source User ID in Current User prompt context

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1086,12 +1086,16 @@ class ChatOrchestrator:
         # Add user context so the agent knows who "me" is
         if self.user_email and self.user_id:
             user_context = "\n\n## Current User\n"
+            if self.source_user_id:
+                user_context += f"- Source User ID: {self.source_user_id}\n"
             if self.user_name:
                 user_context += f"- Name: {self.user_name}\n"
             user_context += f"- Email: {self.user_email}\n"
             user_context += f"- User ID: {self.user_id}\n"
             if self.organization_name:
                 user_context += f"- Organization: {self.organization_name}\n"
+            if self.source_user_id:
+                user_context += "\nIf both Source User ID and Current User details are present, prioritize Source User ID as the authoritative identity for this turn.\n"
             user_context += "\nWhen the user asks about 'my' data, use this email to filter queries. "
             user_context += "For example, to find the user's company, join the users table (filter by email) to the organizations table."
             system_prompt += user_context


### PR DESCRIPTION
### Motivation
- Ensure the assistant is given a clear, authoritative speaker identity for the current turn by preferring an external `Source User ID` (e.g. Slack user ID) when it is available alongside the resolved current user fields. 

### Description
- Updated prompt assembly in `backend/agents/orchestrator.py` to include `Source User ID` inside the `## Current User` block when present and to add an explicit sentence instructing that `Source User ID` should be treated as the authoritative identity for the turn. 

### Testing
- Ran `python -m compileall backend/agents/orchestrator.py` and the module compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997a140fbe88321ba8b3f0e5e115c9f)