### PR TITLE
Import Memory in orchestrator to fix user-context NameError

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -25,6 +25,7 @@ from config import settings
 from models.chat_message import ChatMessage
 from models.conversation import Conversation
 from models.database import get_session
+from models.memory import Memory
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Motivation
- Resolve intermittent `NameError: name 'Memory' is not defined` raised during user context resolution and context profile loading when calling `select(Memory.content)` or `select(Memory)`.

### Description
- Add `from models.memory import Memory` to `backend/agents/orchestrator.py` so DB queries referencing `Memory` resolve correctly.

### Testing
- Ran `python -m py_compile /workspace/revtops/backend/agents/orchestrator.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997a158a91c83218ad09a8183117922)