### PR TITLE
Link Slack UI and email mappings together during admin manual linking

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -26,7 +26,7 @@ from fastapi.responses import RedirectResponse
 
 from api.auth_middleware import AuthContext, get_current_auth
 from pydantic import BaseModel, Field
-from sqlalchemy import select, text
+from sqlalchemy import func, or_, select, text
 
 from config import settings, get_nango_integration_id, get_provider_scope
 from models.database import get_admin_session, get_session
@@ -967,10 +967,60 @@ async def link_identity(
         if not mapping or mapping.organization_id != org_uuid:
             raise HTTPException(status_code=404, detail="Identity mapping not found")
 
+        logger.info(
+            "Linking identity mapping id=%s org=%s target_user=%s source=%s external_userid=%s external_email=%s",
+            mapping_uuid,
+            org_uuid,
+            target_uuid,
+            mapping.source,
+            mapping.external_userid,
+            mapping.external_email,
+        )
+
         # Set user_id on the mapping
         mapping.user_id = target_uuid
         mapping.revtops_email = target_user.email
+        if mapping.source == "slack" and not mapping.external_email and target_user.email:
+            mapping.external_email = target_user.email
         mapping.match_source = "admin_manual_link"
+
+        # Slack identities can appear as separate rows (Slack user id vs email-derived).
+        # Link related unmapped rows as well so both Slack UI and email views stay in sync.
+        if mapping.source == "slack":
+            related_filters = []
+            if mapping.external_userid:
+                related_filters.append(SlackUserMapping.external_userid == mapping.external_userid)
+            if mapping.external_email:
+                related_filters.append(func.lower(SlackUserMapping.external_email) == mapping.external_email.lower())
+            if target_user.email:
+                related_filters.append(func.lower(SlackUserMapping.external_email) == target_user.email.lower())
+
+            if related_filters:
+                related_result = await session.execute(
+                    select(SlackUserMapping)
+                    .where(SlackUserMapping.organization_id == org_uuid)
+                    .where(SlackUserMapping.source == "slack")
+                    .where(SlackUserMapping.id != mapping_uuid)
+                    .where(SlackUserMapping.user_id.is_(None))
+                    .where(or_(*related_filters))
+                )
+                related_mappings: list[SlackUserMapping] = list(related_result.scalars().all())
+                for related_mapping in related_mappings:
+                    related_mapping.user_id = target_uuid
+                    related_mapping.revtops_email = target_user.email
+                    if not related_mapping.external_email and target_user.email:
+                        related_mapping.external_email = target_user.email
+                    related_mapping.match_source = "admin_manual_link"
+
+                if related_mappings:
+                    logger.info(
+                        "Linked %d additional Slack mappings org=%s target_user=%s seed_mapping=%s",
+                        len(related_mappings),
+                        org_uuid,
+                        target_uuid,
+                        mapping_uuid,
+                    )
+
         await session.commit()
 
     return {"status": "linked"}

--- a/backend/tests/test_link_identity_slack.py
+++ b/backend/tests/test_link_identity_slack.py
@@ -1,0 +1,150 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID
+
+from api.routes import auth
+
+
+class _FakeScalars:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeExecuteResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return _FakeScalars(self._rows)
+
+
+class _FakeSession:
+    def __init__(self, target_user, mapping, related_rows):
+        self.target_user = target_user
+        self.mapping = mapping
+        self.related_rows = related_rows
+        self.execute_calls = 0
+        self.committed = False
+
+    async def get(self, _model, model_id):
+        if model_id == self.target_user.id:
+            return self.target_user
+        if model_id == self.mapping.id:
+            return self.mapping
+        return None
+
+    async def execute(self, _query):
+        self.execute_calls += 1
+        return _FakeExecuteResult(self.related_rows)
+
+    async def commit(self):
+        self.committed = True
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_link_identity_links_related_slack_mappings(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    requester_id = UUID("22222222-2222-2222-2222-222222222222")
+    target_user_id = UUID("33333333-3333-3333-3333-333333333333")
+    selected_mapping_id = UUID("44444444-4444-4444-4444-444444444444")
+    related_mapping_id = UUID("55555555-5555-5555-5555-555555555555")
+
+    target_user = SimpleNamespace(id=target_user_id, organization_id=org_id, email="owner@acme.com")
+    selected_mapping = SimpleNamespace(
+        id=selected_mapping_id,
+        organization_id=org_id,
+        source="slack",
+        external_userid="U123",
+        external_email=None,
+        user_id=None,
+        revtops_email=None,
+        match_source="unmatched",
+    )
+    related_mapping = SimpleNamespace(
+        id=related_mapping_id,
+        organization_id=org_id,
+        source="slack",
+        external_userid=None,
+        external_email="owner@acme.com",
+        user_id=None,
+        revtops_email=None,
+        match_source="unmatched",
+    )
+
+    fake_session = _FakeSession(target_user, selected_mapping, [related_mapping])
+    monkeypatch.setattr(auth, "get_session", lambda: _FakeSessionContext(fake_session))
+
+    result = asyncio.run(
+        auth.link_identity(
+            org_id=str(org_id),
+            request=auth.LinkIdentityRequest(
+                target_user_id=str(target_user_id),
+                mapping_id=str(selected_mapping_id),
+            ),
+            user_id=str(requester_id),
+        )
+    )
+
+    assert result == {"status": "linked"}
+    assert selected_mapping.user_id == target_user_id
+    assert selected_mapping.external_email == "owner@acme.com"
+    assert selected_mapping.revtops_email == "owner@acme.com"
+    assert selected_mapping.match_source == "admin_manual_link"
+
+    assert related_mapping.user_id == target_user_id
+    assert related_mapping.revtops_email == "owner@acme.com"
+    assert related_mapping.match_source == "admin_manual_link"
+    assert fake_session.execute_calls == 1
+    assert fake_session.committed
+
+
+def test_link_identity_non_slack_does_not_attempt_related_linking(monkeypatch):
+    org_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    requester_id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    target_user_id = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+    selected_mapping_id = UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+
+    target_user = SimpleNamespace(id=target_user_id, organization_id=org_id, email="owner@acme.com")
+    selected_mapping = SimpleNamespace(
+        id=selected_mapping_id,
+        organization_id=org_id,
+        source="hubspot",
+        external_userid="HS-1",
+        external_email=None,
+        user_id=None,
+        revtops_email=None,
+        match_source="unmatched",
+    )
+
+    fake_session = _FakeSession(target_user, selected_mapping, [])
+    monkeypatch.setattr(auth, "get_session", lambda: _FakeSessionContext(fake_session))
+
+    result = asyncio.run(
+        auth.link_identity(
+            org_id=str(org_id),
+            request=auth.LinkIdentityRequest(
+                target_user_id=str(target_user_id),
+                mapping_id=str(selected_mapping_id),
+            ),
+            user_id=str(requester_id),
+        )
+    )
+
+    assert result == {"status": "linked"}
+    assert selected_mapping.user_id == target_user_id
+    assert selected_mapping.match_source == "admin_manual_link"
+    assert fake_session.execute_calls == 0
+    assert fake_session.committed


### PR DESCRIPTION
### Motivation
- Admins linking a Slack identity could leave sibling Slack mapping rows (Slack user-id vs email-derived) unmapped, causing inconsistent Slack UI and email views.

### Description
- Updated `POST /auth/organizations/{org_id}/members/link-identity` in `backend/api/routes/auth.py` to log manual link actions and backfill `external_email` from the target user when linking Slack mappings.
- When linking a Slack mapping, search for related unmapped Slack rows (matched by `external_userid` or lower-cased `external_email`) and assign them the same `user_id`/`revtops_email` and `match_source` so both Slack UI and email-derived mappings are linked together.
- Added `or_` / `func` imports and structured the related-row lookup to only affect unmapped rows in the same organization and source.
- Added unit tests `backend/tests/test_link_identity_slack.py` that verify Slack sibling mappings are linked and that non-Slack mappings do not trigger related-link behavior.

### Testing
- Ran the new test file with `pytest -q backend/tests/test_link_identity_slack.py`, which reported `2 passed, 1 warning` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998d0ea5d0c832199f86d210e0463a1)