### PR TITLE
Handle Slack org lookup DB failures gracefully

### DIFF
--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -127,7 +127,11 @@ async def find_organization_by_slack_team(team_id: str) -> str | None:
                 attempt,
             )
             if attempt == 2:
-                raise
+                logger.error(
+                    "[slack_conversations] Exhausted Slack integration lookup retries for team=%s; returning no organization",
+                    team_id,
+                )
+                return None
             await asyncio.sleep(0.2)
 
     # --- Fast path: match on stored team_id in extra_data ---


### PR DESCRIPTION
### Motivation
- Prevent the Slack DM processing path from raising when the admin DB lookup for Slack integrations repeatedly fails, allowing the event flow to fail gracefully instead of crashing.

### Description
- In `find_organization_by_slack_team` changed the retry-exhaustion behavior to log a terminal error and `return None` instead of re-raising when admin-session `execute` fails after retries.
- Added test scaffolding `class _RaisingSession` and `class _RaisingAdminSessionContext` and a new test `test_find_organization_by_slack_team_returns_none_when_lookup_fails` to assert the function returns `None` on persistent lookup failure.
- Kept existing behavior for the fast/slow lookup paths unchanged; only the terminal error path was altered.

### Testing
- Ran `pytest -q tests/test_slack_user_resolution.py::test_find_organization_by_slack_team_returns_none_when_lookup_fails tests/test_slack_user_resolution.py::test_resolve_revtops_user_falls_back_to_connected_slack_name_match` and both tests passed.
- Ran `pytest -q tests/test_slack_events_thread_locking.py tests/test_slack_user_resolution.py` and the suite completed successfully (`16 passed, 3 warnings`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999505278408321bd092f0716736a9c)