### PR TITLE
Fix password reset and invite email delivery reliability

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -16,6 +16,7 @@ Endpoints:
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import httpx
 import json
 import logging
 from typing import Any, Optional
@@ -156,6 +157,68 @@ def _log_slack_nango_connection(connection: dict[str, Any], connection_id: str) 
 # =============================================================================
 # Response Models
 # =============================================================================
+
+
+class PasswordResetRequest(BaseModel):
+    """Request model for initiating password reset emails."""
+
+    email: str
+
+
+class PasswordResetResponse(BaseModel):
+    """Response model for password reset requests."""
+
+    success: bool
+    message: str
+
+
+@router.post("/password-reset/request", response_model=PasswordResetResponse)
+async def request_password_reset(request: PasswordResetRequest) -> PasswordResetResponse:
+    """Request a password reset email through Supabase Auth with server-side logging."""
+    email: str = request.email.strip().lower()
+    if not email or "@" not in email:
+        raise HTTPException(status_code=400, detail="Invalid email address")
+
+    if not settings.SUPABASE_URL or not settings.SUPABASE_ANON_KEY:
+        logger.error("Password reset unavailable due to missing Supabase config")
+        raise HTTPException(status_code=500, detail="Password reset is temporarily unavailable")
+
+    redirect_to = f"{settings.FRONTEND_URL.rstrip('/')}/auth"
+    payload = {"email": email, "redirect_to": redirect_to}
+    headers = {
+        "apikey": settings.SUPABASE_ANON_KEY,
+        "Authorization": f"Bearer {settings.SUPABASE_ANON_KEY}",
+        "Content-Type": "application/json",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(
+                f"{settings.SUPABASE_URL.rstrip('/')}/auth/v1/recover",
+                headers=headers,
+                json=payload,
+            )
+
+        if not (200 <= response.status_code < 300):
+            logger.error(
+                "Supabase password reset request failed email=%s status=%s body=%s",
+                email,
+                response.status_code,
+                response.text,
+            )
+            raise HTTPException(status_code=502, detail="Failed to send password reset email")
+
+        logger.info("Password reset email requested successfully for email=%s", email)
+        return PasswordResetResponse(
+            success=True,
+            message="If your account exists, check your email for a password reset link.",
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Unexpected password reset failure for email=%s", email)
+        raise HTTPException(status_code=500, detail="Failed to request password reset") from exc
+
 
 
 class UserResponse(BaseModel):

--- a/backend/config.py
+++ b/backend/config.py
@@ -88,6 +88,8 @@ class Settings(BaseSettings):
     SUPABASE_URL: Optional[str] = None
     # JWT Secret: Legacy HS256 secret (optional if using ES256)
     SUPABASE_JWT_SECRET: Optional[str] = None
+    # Public anon key for browser-safe auth operations (password recovery, etc.)
+    SUPABASE_ANON_KEY: Optional[str] = None
     
     # Admin
     ADMIN_KEY: Optional[str] = None  # Simple admin auth for MVP
@@ -157,6 +159,7 @@ EXPECTED_ENV_VARS: tuple[str, ...] = (
     "FRONTEND_URL",
     "SUPABASE_URL",
     "SUPABASE_JWT_SECRET",
+    "SUPABASE_ANON_KEY",
     "ADMIN_KEY",
     "RESEND_API_KEY",
     "EMAIL_FROM",

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -12,6 +12,11 @@ import httpx
 from config import settings
 
 
+def _resend_request_succeeded(status_code: int) -> bool:
+    """Return whether a Resend API response should be considered successful."""
+    return 200 <= status_code < 300
+
+
 async def send_email(
     to: str | list[str],
     subject: str,
@@ -76,7 +81,7 @@ async def send_email(
                 timeout=10.0,
             )
             
-            if response.status_code == 200:
+            if _resend_request_succeeded(response.status_code):
                 print(f"[Email] Sent to {to_list}")
                 return True
             else:
@@ -180,7 +185,7 @@ Needs: {needs or "—"}
                 timeout=10.0,
             )
             
-            if response.status_code == 200:
+            if _resend_request_succeeded(response.status_code):
                 print(f"[Email] Waitlist notification sent for {applicant_email}")
                 return True
             else:
@@ -268,7 +273,7 @@ We'll be in touch soon with next steps.
                 timeout=10.0,
             )
             
-            if response.status_code == 200:
+            if _resend_request_succeeded(response.status_code):
                 print(f"[Email] Waitlist confirmation sent to {to_email}")
                 return True
             else:
@@ -363,7 +368,7 @@ Questions? Just reply to this email.
                 timeout=10.0,
             )
             
-            if response.status_code == 200:
+            if _resend_request_succeeded(response.status_code):
                 print(f"[Email] Invitation sent to {to_email}")
                 return True
             else:
@@ -471,7 +476,7 @@ Questions? Just reply to this email.
                 timeout=10.0,
             )
 
-            if response.status_code == 200:
+            if _resend_request_succeeded(response.status_code):
                 print(f"[Email] Org invitation sent to {to_email} for org {org_name}")
                 return True
             else:

--- a/backend/tests/test_auth_password_reset.py
+++ b/backend/tests/test_auth_password_reset.py
@@ -1,0 +1,62 @@
+from fastapi.testclient import TestClient
+
+from api.main import app
+from config import settings
+
+
+class _MockResponse:
+    def __init__(self, status_code: int, text: str = "") -> None:
+        self.status_code = status_code
+        self.text = text
+
+
+class _MockAsyncClient:
+    def __init__(self, *args, **kwargs):
+        self.response = kwargs.pop("_response")
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, *args, **kwargs):
+        return self.response
+
+
+def test_password_reset_request_success(monkeypatch):
+    monkeypatch.setattr(settings, "SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setattr(settings, "SUPABASE_ANON_KEY", "anon-key")
+
+    import api.routes.auth as auth_routes
+
+    monkeypatch.setattr(
+        auth_routes.httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: _MockAsyncClient(_response=_MockResponse(200)),
+    )
+
+    client = TestClient(app)
+    response = client.post("/api/auth/password-reset/request", json={"email": "user@company.com"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+
+
+def test_password_reset_request_upstream_failure(monkeypatch):
+    monkeypatch.setattr(settings, "SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setattr(settings, "SUPABASE_ANON_KEY", "anon-key")
+
+    import api.routes.auth as auth_routes
+
+    monkeypatch.setattr(
+        auth_routes.httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: _MockAsyncClient(_response=_MockResponse(500, "boom")),
+    )
+
+    client = TestClient(app)
+    response = client.post("/api/auth/password-reset/request", json={"email": "user@company.com"})
+
+    assert response.status_code == 502

--- a/backend/tests/test_email_status_codes.py
+++ b/backend/tests/test_email_status_codes.py
@@ -1,0 +1,13 @@
+from services.email import _resend_request_succeeded
+
+
+def test_resend_success_accepts_all_2xx() -> None:
+    assert _resend_request_succeeded(200)
+    assert _resend_request_succeeded(202)
+    assert _resend_request_succeeded(204)
+
+
+def test_resend_success_rejects_non_2xx() -> None:
+    assert not _resend_request_succeeded(199)
+    assert not _resend_request_succeeded(400)
+    assert not _resend_request_succeeded(500)

--- a/frontend/src/components/Auth.tsx
+++ b/frontend/src/components/Auth.tsx
@@ -9,6 +9,7 @@ import { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
 import { isPersonalEmail } from '../lib/email';
 import { validateGoodPassword } from '../lib/password';
+import { API_BASE } from '../lib/api';
 
 interface AuthProps {
   onBack: () => void;
@@ -67,10 +68,18 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
         if (error) throw error;
         setMessage('Check your email to confirm your account!');
       } else if (mode === 'forgot') {
-        const { error } = await supabase.auth.resetPasswordForEmail(email, {
-          redirectTo: `${window.location.origin}/auth`,
+        const response = await fetch(`${API_BASE}/auth/password-reset/request`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email }),
         });
-        if (error) throw error;
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          const detail = typeof errorData.detail === 'string' ? errorData.detail : 'Failed to send reset email';
+          throw new Error(detail);
+        }
+
         setMessage('Check your email for a password reset link!');
       } else if (mode === 'reset') {
         if (newPassword !== confirmPassword) {


### PR DESCRIPTION
### Motivation
- Password-reset and invite flows were unreliable because the frontend called Supabase directly and email success was only detected for HTTP 200 from Resend. 
- The codebase needs server-side observability and robust handling for upstream email/recovery endpoints to surface failures and improve delivery reliability. 

### Description
- Added a backend endpoint `POST /api/auth/password-reset/request` that validates input, calls Supabase `/auth/v1/recover` with the anon key, logs failures, and returns structured errors (`backend/api/routes/auth.py`).
- Updated the frontend forgot-password flow to call the new backend endpoint instead of invoking Supabase directly from the browser (`frontend/src/components/Auth.tsx`).
- Exposed `SUPABASE_ANON_KEY` in backend settings and added it to expected env var checks so the API can authenticate password-recovery requests (`backend/config.py`).
- Made Resend email handling treat any `2xx` response as success (not only `200`) and factored a helper `_resend_request_succeeded`, improving invite and transactional email reliability (`backend/services/email.py`).
- Added unit tests for the password-reset endpoint success/failure paths and for Resend status-code handling (`backend/tests/test_auth_password_reset.py`, `backend/tests/test_email_status_codes.py`).

### Testing
- Ran `cd backend && pytest -q tests/test_auth_password_reset.py tests/test_email_status_codes.py` and observed all tests passed (4 passed).
- Tests simulate Supabase and Resend responses via monkeypatching and assert correct HTTP mappings for success and upstream failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ba9f481e08321a2fda2eb6ac05c39)