### PR TITLE
Improve org invitation email template styling

### DIFF
--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -396,43 +396,68 @@ async def send_org_invitation_email(
         return False
 
     inviter_line: str = (
-        f"<p>{invited_by_name} has invited you to join <strong>{org_name}</strong> on Revtops.</p>"
+        f"{invited_by_name} has invited you to join <strong>{org_name}</strong> on Revtops."
         if invited_by_name
-        else f"<p>You've been invited to join <strong>{org_name}</strong> on Revtops.</p>"
+        else f"You've been invited to join <strong>{org_name}</strong> on Revtops."
     )
 
     html_content: str = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    </head>
-    <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-        <div style="text-align: center; margin-bottom: 30px;">
-            <div style="display: inline-block; width: 48px; height: 48px; background: linear-gradient(135deg, #6366f1, #4f46e5); border-radius: 12px; margin-bottom: 16px;"></div>
-            <h1 style="margin: 0; font-size: 24px; color: #111;">You're Invited!</h1>
-        </div>
-
-        {inviter_line}
-
-        <p>Revtops connects your CRM, Slack, email, and calendar so you can chat with your revenue data and build automations that save your team hours every week.</p>
-
-        <div style="text-align: center; margin: 30px 0;">
-            <a href="{settings.FRONTEND_URL}" style="display: inline-block; background: linear-gradient(135deg, #6366f1, #4f46e5); color: white; text-decoration: none; padding: 14px 28px; border-radius: 8px; font-weight: 600;">Accept Invitation</a>
-        </div>
-
-        <p>Questions? Just reply to this email.</p>
-
-        <p>— The Revtops Team</p>
-
-        <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
-
-        <p style="font-size: 12px; color: #666;">
-            You received this email because someone invited you to {org_name} on Revtops.
-        </p>
-    </body>
-    </html>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>You're invited to Revtops</title>
+</head>
+<body style="margin:0;padding:0;background:#0b0f1a;color:#e5e7eb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#0b0f1a;padding:24px 12px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:640px;background:linear-gradient(160deg,#111827,#0f172a);border:1px solid #1f2937;border-radius:20px;overflow:hidden;">
+          <tr>
+            <td style="padding:36px 32px 12px;text-align:center;">
+              <img
+                src="https://app.revtops.com/logo.svg"
+                alt="Revtops"
+                width="52"
+                height="52"
+                style="display:inline-block;height:52px;width:52px;border-radius:14px;"
+              />
+              <h1 style="margin:18px 0 8px;font-size:30px;line-height:1.2;color:#f8fafc;font-weight:700;">You're invited</h1>
+              <p style="margin:0;color:#94a3b8;font-size:15px;line-height:1.6;">{inviter_line}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:20px 32px 0;">
+              <div style="background:#0b1222;border:1px solid #1e293b;border-radius:14px;padding:18px;">
+                <p style="margin:0 0 8px;color:#cbd5e1;font-size:14px;line-height:1.5;">Invitation sent to:</p>
+                <p style="margin:0;color:#f8fafc;font-size:16px;line-height:1.5;font-weight:600;">{to_email}</p>
+                <p style="margin:10px 0 0;color:#94a3b8;font-size:13px;line-height:1.6;">Organization: <strong style="color:#f8fafc;">{org_name}</strong></p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:28px 32px 8px;text-align:center;">
+              <a href="{settings.FRONTEND_URL}" style="display:inline-block;background:linear-gradient(135deg,#6366f1,#4f46e5);color:#ffffff;text-decoration:none;font-size:16px;font-weight:700;padding:14px 28px;border-radius:12px;">Accept invitation</a>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:8px 32px 30px;text-align:center;">
+              <p style="margin:0;color:#64748b;font-size:13px;line-height:1.6;">If the button doesn&apos;t work, copy and paste this link into your browser:</p>
+              <p style="margin:8px 0 0;color:#94a3b8;font-size:12px;line-height:1.6;word-break:break-all;">{settings.FRONTEND_URL}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:20px 32px;border-top:1px solid #1f2937;background:#0b1222;">
+              <p style="margin:0;color:#64748b;font-size:12px;line-height:1.6;">You received this email because someone invited you to {org_name} on Revtops. If this wasn&apos;t expected, you can safely ignore this message.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
     """
 
     inviter_text: str = (


### PR DESCRIPTION
### Motivation
- Refresh the organization invitation email to a modern, branded design that matches the provided reference and improves clarity and CTA prominence.

### Description
- Replaced the previous minimal HTML with a dark-themed card layout and stronger visual hierarchy in `backend/services/email.py` (new hero, logo, recipient/org info block, CTA, and fallback link).
- Adjusted the invite intro generation to inject inviter/org context cleanly into the hero copy and removed extra `<p>` wrappers for consistent rendering.
- Included `to_email` and `org_name` values in the HTML info block so recipients see invitation context in the message body.
- Preserved existing send flow, subject and plaintext fallback behavior so delivery and non-HTML clients remain unchanged.

### Testing
- Ran `python -m py_compile backend/services/email.py` to validate syntax, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bbab69fb88321a2d2fc2ce8d1df1d)