### PR TITLE
frontend: bump @stripe/stripe-js to ^2.4.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@codesandbox/sandpack-react": "^2.20.0",
         "@nangohq/frontend": "^0.69.36",
         "@stripe/react-stripe-js": "^2.4.0",
-        "@stripe/stripe-js": "^2.2.0",
+        "@stripe/stripe-js": "^2.4.0",
         "@supabase/supabase-js": "^2.39.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,10 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@stripe/react-stripe-js": "^2.4.0",
-    "@stripe/stripe-js": "^2.2.0",
     "@codesandbox/sandpack-react": "^2.20.0",
     "@nangohq/frontend": "^0.69.36",
+    "@stripe/react-stripe-js": "^2.4.0",
+    "@stripe/stripe-js": "^2.4.0",
     "@supabase/supabase-js": "^2.39.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.90.20",


### PR DESCRIPTION
### Motivation
- Ensure `npm install` pulls a compatible, up-to-date `@stripe/stripe-js` that aligns with `@stripe/react-stripe-js` and resolves deterministically.

### Description
- Updated `frontend/package.json` to set `@stripe/stripe-js` to `^2.4.0`.
- Updated `frontend/package-lock.json` to reflect the new locked version and ensure deterministic installs.
- Committed the updated files so installs and CI will use the bumped Stripe JS version.

### Testing
- Ran `npm install @stripe/stripe-js` in `frontend/` and the install completed successfully.
- Ran `npm ls @stripe/stripe-js` and verified `@stripe/stripe-js@2.4.0` is present.
- Ran `npm run build` in `frontend/` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ca12c4c0483219027a055a5479da0)