### PR TITLE
Fix chat message ordering for equal timestamps

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -141,6 +141,9 @@ export function Chat({
   // Always sort by timestamp to guard against race conditions where WebSocket
   // chunks (assistant message) arrive before the pending user message is moved
   // into the conversation state, which would otherwise cause out-of-order display.
+  // If two messages share the same timestamp (common when backend timestamps have
+  // coarse resolution), keep user questions before assistant responses so grouped
+  // responses always appear after the asking question.
   const messages = useMemo(() => {
     const conversationMessages = conversationState?.messages ?? [];
     const combined: ChatMessage[] = pendingMessages.length > 0
@@ -156,9 +159,21 @@ export function Chat({
         break;
       }
     }
-    return needsSort
-      ? [...combined].sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime())
-      : combined;
+    if (!needsSort) return combined;
+
+    return combined
+      .map((message, index) => ({ message, index }))
+      .sort((a, b) => {
+        const timeDiff = a.message.timestamp.getTime() - b.message.timestamp.getTime();
+        if (timeDiff !== 0) return timeDiff;
+
+        if (a.message.role !== b.message.role) {
+          return a.message.role === 'user' ? -1 : 1;
+        }
+
+        return a.index - b.index;
+      })
+      .map(({ message }) => message);
   }, [pendingMessages, conversationState?.messages]);
   const isThinking = pendingThinking || conversationThinking;
 


### PR DESCRIPTION
### Motivation
- Prevent non-deterministic ordering when multiple messages share the same timestamp so user questions consistently appear before assistant responses.

### Description
- Update `frontend/src/components/Chat.tsx` to sort the combined message list by timestamp and, when timestamps tie, place `role === 'user'` messages before assistant messages and fall back to the original index for stable ordering.

### Testing
- Built the frontend with `npm --prefix frontend run build` which completed successfully (Vite emitted non-fatal warnings about chunk size/dynamic imports).
- Launched the dev server with `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173` and captured a UI screenshot `artifacts/chat-ordering.png` to validate ordering visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c9cd231408321b707eeac4035e3bb)