### PR TITLE
Improve Linear assignee resolution and add unit tests

### DIFF
--- a/backend/connectors/linear.py
+++ b/backend/connectors/linear.py
@@ -895,24 +895,84 @@ class LinearConnector(BaseConnector):
                 return state
         return None
 
-    async def resolve_assignee_by_name(self, name: str) -> dict[str, Any] | None:
-        """Find a user by display name (case-insensitive)."""
-        data: dict[str, Any] = await self._gql("""
-        query {
-            users {
+    async def list_users(self) -> list[dict[str, Any]]:
+        """List users in the Linear workspace (paginated)."""
+        query: str = """
+        query Users($after: String) {
+            users(first: 100, after: $after) {
                 nodes {
                     id
                     name
                     email
                 }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
             }
         }
-        """)
-        users: list[dict[str, Any]] = data.get("users", {}).get("nodes", [])
-        name_lower: str = name.lower().strip()
+        """
+        users: list[dict[str, Any]] = await self._gql_paginated(query, ["users"])
+        logger.debug("Loaded %d Linear users for assignee resolution", len(users))
+        return users
+
+    async def resolve_assignee_by_name(self, name: str) -> dict[str, Any] | None:
+        """Find a Linear user by email or display name.
+
+        Historically this accepted only exact display-name matches, which was brittle
+        and caused assignment failures for common inputs (email, partial name).
+        """
+        needle: str = name.strip()
+        if not needle:
+            return None
+
+        users: list[dict[str, Any]] = await self.list_users()
+        needle_lower: str = needle.lower()
+
+        # 1) Exact email match (most stable identifier)
         for user in users:
-            if user["name"].lower() == name_lower:
+            email: str = (user.get("email") or "").strip().lower()
+            if email and email == needle_lower:
+                logger.info("Resolved Linear assignee '%s' by exact email", name)
                 return user
+
+        # 2) Exact display-name match
+        for user in users:
+            user_name: str = (user.get("name") or "").strip().lower()
+            if user_name and user_name == needle_lower:
+                logger.info("Resolved Linear assignee '%s' by exact name", name)
+                return user
+
+        # 3) Unique prefix match (e.g. "alex" -> "Alex Kim")
+        prefix_matches: list[dict[str, Any]] = [
+            user
+            for user in users
+            if (user.get("name") or "").strip().lower().startswith(needle_lower)
+        ]
+        if len(prefix_matches) == 1:
+            logger.info("Resolved Linear assignee '%s' by unique name prefix", name)
+            return prefix_matches[0]
+
+        # 4) Unique contains match as a final fallback
+        contains_matches: list[dict[str, Any]] = [
+            user
+            for user in users
+            if needle_lower in (user.get("name") or "").strip().lower()
+        ]
+        if len(contains_matches) == 1:
+            logger.info("Resolved Linear assignee '%s' by unique contains match", name)
+            return contains_matches[0]
+
+        if len(prefix_matches) > 1 or len(contains_matches) > 1:
+            logger.warning(
+                "Linear assignee lookup for '%s' is ambiguous (prefix=%d contains=%d)",
+                name,
+                len(prefix_matches),
+                len(contains_matches),
+            )
+        else:
+            logger.warning("Linear assignee '%s' not found", name)
+
         return None
 
     async def resolve_labels_by_names(self, label_names: list[str]) -> list[str]:

--- a/backend/tests/test_linear_connector_assignment.py
+++ b/backend/tests/test_linear_connector_assignment.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from connectors.linear import LinearConnector
+
+
+@pytest.mark.asyncio
+async def test_resolve_assignee_by_name_matches_email(monkeypatch: pytest.MonkeyPatch) -> None:
+    connector = LinearConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    async def _fake_list_users() -> list[dict[str, Any]]:
+        return [
+            {"id": "u1", "name": "Alex Kim", "email": "alex@example.com"},
+            {"id": "u2", "name": "Sam Lee", "email": "sam@example.com"},
+        ]
+
+    monkeypatch.setattr(connector, "list_users", _fake_list_users)
+
+    user = await connector.resolve_assignee_by_name("sam@example.com")
+
+    assert user is not None
+    assert user["id"] == "u2"
+
+
+@pytest.mark.asyncio
+async def test_resolve_assignee_by_name_matches_unique_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    connector = LinearConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    async def _fake_list_users() -> list[dict[str, Any]]:
+        return [
+            {"id": "u1", "name": "Alex Kim", "email": "alex@example.com"},
+            {"id": "u2", "name": "Sam Lee", "email": "sam@example.com"},
+        ]
+
+    monkeypatch.setattr(connector, "list_users", _fake_list_users)
+
+    user = await connector.resolve_assignee_by_name("alex")
+
+    assert user is not None
+    assert user["id"] == "u1"
+
+
+@pytest.mark.asyncio
+async def test_resolve_assignee_by_name_does_not_pick_ambiguous_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connector = LinearConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    async def _fake_list_users() -> list[dict[str, Any]]:
+        return [
+            {"id": "u1", "name": "Alex Kim", "email": "alex@example.com"},
+            {"id": "u2", "name": "Alex Chen", "email": "alex.chen@example.com"},
+        ]
+
+    monkeypatch.setattr(connector, "list_users", _fake_list_users)
+
+    user = await connector.resolve_assignee_by_name("alex")
+
+    assert user is None


### PR DESCRIPTION
### Motivation
- Linear issue assignment was failing when callers provided emails or partial names because assignee resolution required exact display-name matches and used a single-page users query.
- This caused issues to be created unassigned or assigned incorrectly for common inputs, so resolution needed to be more robust and observable.

### Description
- Add a paginated `list_users()` helper that queries `users(first: 100, after: $after)` and returns the full workspace user list for reliable lookups.
- Replace the brittle resolver with `resolve_assignee_by_name()` that tries exact email, exact display-name, unique name-prefix, then unique contains matches, and avoids ambiguous assignments while emitting informative `logger` messages.
- Add unit tests in `backend/tests/test_linear_connector_assignment.py` covering email resolution, unique-prefix resolution, and ambiguous-name handling.
- No database migrations were required for this change.

### Testing
- Ran the focused unit tests with `cd backend && pytest -q tests/test_linear_connector_assignment.py` which executed the new tests.
- Result: `3 passed` (with unrelated warnings) and no test failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cc115c5308321ba9cae299109f16d)