### PR TITLE
Fix: prefer active integration when multiple exist for org-scoped provider

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -2248,7 +2248,10 @@ async def list_integrations(
                     user_scoped_integrations[i.provider] = []
                 user_scoped_integrations[i.provider].append(i)
             else:
-                org_scoped_integrations[i.provider] = i
+                # For org-scoped, prefer active integration if multiple exist
+                existing = org_scoped_integrations.get(i.provider)
+                if existing is None or (i.is_active and not existing.is_active):
+                    org_scoped_integrations[i.provider] = i
 
         # Get team members for validating user IDs and building response
         team_result = await db_session.execute(


### PR DESCRIPTION
## Summary
- Fixes bug where `list_integrations` would arbitrarily return one of multiple org-scoped integrations for the same provider
- Now prefers the active integration over inactive ones
- Resolves issue where Linear wasn't appearing in UI because an old inactive integration was being returned instead of the new active one

## Test plan
- [x] Verified locally that Linear now appears correctly in the Connectors UI
- [x] Read-only endpoint change, no data mutations

Made with [Cursor](https://cursor.com)