### PR TITLE
Enable Penny-initiated Slack DMs and improve DM/thread handling

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -3,7 +3,7 @@ Slack Events API webhook endpoint.
 
 Handles incoming events from Slack, including:
 - URL verification challenge (when setting up the webhook)
-- message.im events (DMs to the bot)
+- message.im/message.mpim events (1:1 and multi-person DMs to the bot)
 - app_mention events (@mentions in channels)
 - message events in threads where the bot is already participating
 
@@ -317,21 +317,32 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
                 )
             )
 
-        if channel_type == "im":
+        is_direct_message = channel_type in {"im", "mpim"}
+        if is_direct_message:
             channel_id = event.get("channel", "")
             user_id = event.get("user", "")
             text = event.get("text", "")
             message_ts = event.get("ts") or event.get("event_ts", "")
+            thread_ts = event.get("thread_ts")
             files: list[dict[str, Any]] = event.get("files", [])
             if not text.strip() and not files:
                 return
-            logger.info("[slack_events] Processing DM from %s in %s: %s (files=%d)", user_id, channel_id, text[:50], len(files))
+            logger.info(
+                "[slack_events] Processing direct message type=%s from %s in %s thread=%s: %s (files=%d)",
+                channel_type,
+                user_id,
+                channel_id,
+                thread_ts,
+                text[:50],
+                len(files),
+            )
             await process_slack_dm(
                 team_id=team_id,
                 channel_id=channel_id,
                 user_id=user_id,
                 message_text=text,
                 event_ts=message_ts,
+                thread_ts=thread_ts,
                 files=files,
             )
             return

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -85,11 +85,12 @@ class SlackConnector(BaseConnector):
         actions=[
             ConnectorAction(
                 name="send_message",
-                description="Send a message to a Slack channel or user. Uses Slack mrkdwn: *bold*, _italic_, ~strike~.",
+                description="Send a message to Slack. Provide `channel` for channels/DM IDs, or `user_id` to open a DM and send directly to that user. Uses Slack mrkdwn: *bold*, _italic_, ~strike~.",
                 parameters=[
-                    {"name": "channel", "type": "string", "required": True, "description": "Channel name (e.g. '#sales-alerts') or channel ID"},
-                    {"name": "message", "type": "string", "required": True, "description": "Message text in Slack mrkdwn format"},
-                    {"name": "thread_ts", "type": "string", "required": False, "description": "Thread timestamp to reply in thread"},
+                    {"name": "channel", "type": "string", "required": False, "description": "Channel/DM/MPIM ID (e.g. 'C123', 'D123', 'G123') or channel name"},
+                    {"name": "user_id", "type": "string", "required": False, "description": "Slack user ID (e.g. 'U123'). If provided without channel, Penny opens a DM to this user and sends the message."},
+                    {"name": "text", "type": "string", "required": True, "description": "Message text in Slack mrkdwn format"},
+                    {"name": "thread_ts", "type": "string", "required": False, "description": "Thread timestamp to reply in-thread (when channel is provided)"},
                 ],
             ),
         ],
@@ -757,13 +758,15 @@ class SlackConnector(BaseConnector):
         if action == "send_message":
             channel: str | None = params.get("channel")
             user_id: str | None = params.get("user_id")
-            text: str = params.get("text", "")
+            text: str = params.get("text") or params.get("message") or ""
             thread_ts: str | None = params.get("thread_ts")
+            if not str(text).strip():
+                raise ValueError("send_message requires non-empty text")
             if user_id and not channel:
                 return await self.send_direct_message(user_id, text)
             if channel:
                 return await self.post_message(channel, text, thread_ts=thread_ts)
-            raise ValueError("send_message requires 'channel' or 'user_id'")
+            raise ValueError("send_message requires 'channel' or 'user_id' and non-empty text")
         raise ValueError(f"Unknown action: {action}")
 
     async def post_message(

--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -1784,15 +1784,17 @@ async def process_slack_dm(
     user_id: str,
     message_text: str,
     event_ts: str,
+    thread_ts: str | None = None,
     files: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """
     Process an incoming Slack DM and generate a response.
     """
     logger.info(
-        "[slack_conversations] Processing DM from user %s in channel %s: %s",
+        "[slack_conversations] Processing direct message from user %s in channel %s thread=%s: %s",
         user_id,
         channel_id,
+        thread_ts,
         message_text[:100],
     )
 
@@ -1823,9 +1825,10 @@ async def process_slack_dm(
             organization_id,
         )
 
+    conversation_key = f"{channel_id}:{thread_ts}" if thread_ts else channel_id
     conversation = await find_or_create_conversation(
         organization_id=organization_id,
-        slack_channel_id=channel_id,
+        slack_channel_id=conversation_key,
         slack_user_id=user_id,
         revtops_user_id=str(linked_user.id) if linked_user else None,
         slack_user_name=slack_user_name,
@@ -1863,6 +1866,7 @@ async def process_slack_dm(
             connector=connector,
             message_text=message_text or "(see attached files)",
             channel=channel_id,
+            thread_ts=thread_ts,
             attachment_ids=attachment_ids or None,
         )
     )
@@ -1890,7 +1894,7 @@ async def process_slack_dm(
         channel_id,
         user_id,
     )
-    await connector.post_message(channel=channel_id, text=SLOW_REPLY_MESSAGE)
+    await connector.post_message(channel=channel_id, text=SLOW_REPLY_MESSAGE, thread_ts=thread_ts)
 
     async def _finish_slow_dm_response() -> None:
         try:

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -1,0 +1,48 @@
+import asyncio
+
+from connectors.slack import SlackConnector
+
+
+def test_execute_action_send_message_can_initiate_dm_with_user_id(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+    captured: dict[str, str] = {}
+
+    async def _fake_send_direct_message(slack_user_id: str, text: str):
+        captured["slack_user_id"] = slack_user_id
+        captured["text"] = text
+        return {"ok": True}
+
+    monkeypatch.setattr(connector, "send_direct_message", _fake_send_direct_message)
+
+    result = asyncio.run(
+        connector.execute_action(
+            "send_message",
+            {"user_id": "U123", "text": "Hi from Penny"},
+        )
+    )
+
+    assert result == {"ok": True}
+    assert captured == {"slack_user_id": "U123", "text": "Hi from Penny"}
+
+
+def test_execute_action_send_message_accepts_legacy_message_param(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+    captured: dict[str, str] = {}
+
+    async def _fake_post_message(channel: str, text: str, thread_ts: str | None = None):
+        captured["channel"] = channel
+        captured["text"] = text
+        captured["thread_ts"] = thread_ts or ""
+        return {"ok": True}
+
+    monkeypatch.setattr(connector, "post_message", _fake_post_message)
+
+    result = asyncio.run(
+        connector.execute_action(
+            "send_message",
+            {"channel": "C123", "message": "Legacy text", "thread_ts": "111.222"},
+        )
+    )
+
+    assert result == {"ok": True}
+    assert captured == {"channel": "C123", "text": "Legacy text", "thread_ts": "111.222"}

--- a/backend/tests/test_slack_dm_threading.py
+++ b/backend/tests/test_slack_dm_threading.py
@@ -1,0 +1,71 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID
+
+from services import slack_conversations
+
+
+def test_process_slack_dm_posts_reply_in_same_thread(monkeypatch) -> None:
+    captured: dict[str, str | None] = {}
+
+    class _FakeConnector:
+        def __init__(self, organization_id: str) -> None:
+            self.organization_id = organization_id
+
+        async def add_reaction(self, channel: str, timestamp: str) -> None:
+            captured["add_reaction_timestamp"] = timestamp
+
+        async def remove_reaction(self, channel: str, timestamp: str) -> None:
+            captured["remove_reaction_timestamp"] = timestamp
+
+        async def post_message(self, channel: str, text: str, thread_ts: str | None = None) -> None:
+            captured["slow_reply_thread_ts"] = thread_ts
+
+    class _FakeOrchestrator:
+        def __init__(self, **kwargs) -> None:
+            captured["conversation_id"] = kwargs["conversation_id"]
+
+    async def _fake_find_org(_team_id: str) -> str:
+        return "org-1"
+
+    async def _fake_resolve_user(**_kwargs):
+        return SimpleNamespace(id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), email="user@example.com")
+
+    async def _fake_find_or_create_conversation(**kwargs):
+        captured["slack_channel_id"] = kwargs["slack_channel_id"]
+        return SimpleNamespace(id=UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+
+    async def _fake_stream_and_post_responses(**kwargs) -> int:
+        captured["thread_ts"] = kwargs["thread_ts"]
+        return 42
+
+    monkeypatch.setattr(slack_conversations, "find_organization_by_slack_team", _fake_find_org)
+    monkeypatch.setattr(slack_conversations, "SlackConnector", _FakeConnector)
+    
+    async def _fake_fetch_user_info(**_kwargs):
+        return {}
+
+    async def _fake_can_use_credits(_organization_id: str) -> bool:
+        return True
+
+    monkeypatch.setattr(slack_conversations, "_fetch_slack_user_info", _fake_fetch_user_info)
+    monkeypatch.setattr(slack_conversations, "resolve_revtops_user_for_slack_actor", _fake_resolve_user)
+    monkeypatch.setattr(slack_conversations, "find_or_create_conversation", _fake_find_or_create_conversation)
+    monkeypatch.setattr(slack_conversations, "can_use_credits", _fake_can_use_credits)
+    monkeypatch.setattr(slack_conversations, "ChatOrchestrator", _FakeOrchestrator)
+    monkeypatch.setattr(slack_conversations, "_stream_and_post_responses", _fake_stream_and_post_responses)
+
+    result = asyncio.run(
+        slack_conversations.process_slack_dm(
+            team_id="T1",
+            channel_id="D1",
+            user_id="U1",
+            message_text="hello",
+            event_ts="100.1",
+            thread_ts="100.0",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert captured["thread_ts"] == "100.0"
+    assert captured["slack_channel_id"] == "D1:100.0"

--- a/backend/tests/test_slack_events_direct_messages.py
+++ b/backend/tests/test_slack_events_direct_messages.py
@@ -1,0 +1,82 @@
+import asyncio
+
+from api.routes import slack_events
+
+
+def test_process_event_callback_routes_mpim_messages_to_direct_message_handler(monkeypatch) -> None:
+    captured: dict[str, str | None] = {}
+
+    async def _fake_is_duplicate_event(_event_id: str) -> bool:
+        return False
+
+    async def _fake_process_slack_dm(**kwargs):
+        captured["team_id"] = kwargs["team_id"]
+        captured["channel_id"] = kwargs["channel_id"]
+        captured["user_id"] = kwargs["user_id"]
+        captured["message_text"] = kwargs["message_text"]
+        captured["event_ts"] = kwargs["event_ts"]
+        captured["thread_ts"] = kwargs["thread_ts"]
+
+    monkeypatch.setattr(slack_events, "is_duplicate_event", _fake_is_duplicate_event)
+    monkeypatch.setattr(slack_events, "process_slack_dm", _fake_process_slack_dm)
+
+    payload = {
+        "type": "event_callback",
+        "event_id": "EvMPIM1",
+        "team_id": "T123",
+        "event": {
+            "type": "message",
+            "channel_type": "mpim",
+            "channel": "G123",
+            "user": "U123",
+            "text": "hey penny",
+            "ts": "1700000000.001",
+        },
+    }
+
+    asyncio.run(slack_events._process_event_callback_impl(payload))
+
+    assert captured == {
+        "team_id": "T123",
+        "channel_id": "G123",
+        "user_id": "U123",
+        "message_text": "hey penny",
+        "event_ts": "1700000000.001",
+        "thread_ts": None,
+    }
+
+
+def test_process_event_callback_passes_thread_ts_for_direct_message_thread(monkeypatch) -> None:
+    captured: dict[str, str | None] = {}
+
+    async def _fake_is_duplicate_event(_event_id: str) -> bool:
+        return False
+
+    async def _fake_process_slack_dm(**kwargs):
+        captured["thread_ts"] = kwargs["thread_ts"]
+        captured["event_ts"] = kwargs["event_ts"]
+
+    monkeypatch.setattr(slack_events, "is_duplicate_event", _fake_is_duplicate_event)
+    monkeypatch.setattr(slack_events, "process_slack_dm", _fake_process_slack_dm)
+
+    payload = {
+        "type": "event_callback",
+        "event_id": "EvIMThread1",
+        "team_id": "T123",
+        "event": {
+            "type": "message",
+            "channel_type": "im",
+            "channel": "D123",
+            "user": "U123",
+            "text": "follow up",
+            "thread_ts": "1700000000.001",
+            "ts": "1700000000.002",
+        },
+    }
+
+    asyncio.run(slack_events._process_event_callback_impl(payload))
+
+    assert captured == {
+        "thread_ts": "1700000000.001",
+        "event_ts": "1700000000.002",
+    }


### PR DESCRIPTION
### Motivation
- Penny must be able to initiate direct messages to a Slack user (open a DM and send) in addition to responding to incoming DMs and DM threads. 
- Maintain thread context for DMs so threaded responses and slow-reply fallbacks post into the correct thread. 
- Preserve backward compatibility for existing callers that send `message` instead of `text`.

### Description
- Updated the Slack connector `send_message` action metadata to allow `user_id` (to open a DM) and `channel`, and standardized the canonical text field to `text`. (`backend/connectors/slack.py`) 
- Improved `SlackConnector.execute_action("send_message", ...)` to accept `text` or legacy `message`, reject empty text, and route `user_id` sends through `send_direct_message` (which calls `conversations.open` + `chat.postMessage`). (`backend/connectors/slack.py`) 
- Propagated `thread_ts` from Slack event routing into the DM processor and keyed threaded DM conversations as `"{channel_id}:{thread_ts}"`, and ensured the slow-reply fallback posts into the originating thread when `thread_ts` is present. (`backend/api/routes/slack_events.py`, `backend/services/slack_conversations.py`) 
- Added unit tests covering DM initiation via `user_id`, legacy `message` parameter compatibility, MPIM routing, and threaded DM conversation keying/response behavior (`backend/tests/test_slack_connector_actions.py`, `backend/tests/test_slack_events_direct_messages.py`, `backend/tests/test_slack_dm_threading.py`).

### Testing
- Ran `cd backend && pytest -q tests/test_slack_events_direct_messages.py tests/test_slack_dm_threading.py tests/test_slack_connector_actions.py` and all tests passed. 
- The new tests exercise DM initiation (via `user_id`), legacy `message` handling, MPIM routing, and threaded-DM conversation keying/response behavior and succeeded with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e026fb1188321a187a704a8e714ae)