### PR TITLE
Cache Slack team->org resolution to reduce Slack event latency

### DIFF
--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -46,6 +46,9 @@ _SLACK_USER_INFO_CACHE_TTL_NOT_FOUND_SECONDS: int = 120  # 2 min for not-found/e
 _SLACK_USER_INFO_CACHE_MAX_ENTRIES: int = 5000  # cap to avoid unbounded growth in long-lived processes
 _slack_user_info_cache: dict[tuple[str, str], tuple[dict[str, Any] | None, float]] = {}
 _slack_user_info_cache_lock: asyncio.Lock = asyncio.Lock()
+_SLACK_TEAM_ORG_CACHE_TTL_SECONDS: int = 300  # 5 min for workspace -> org lookups
+_slack_team_org_cache: dict[str, tuple[str | None, float]] = {}
+_slack_team_org_cache_lock: asyncio.Lock = asyncio.Lock()
 
 
 def _slack_user_info_cache_evict_expired(now: float) -> None:
@@ -130,6 +133,28 @@ async def find_organization_by_slack_team(team_id: str) -> str | None:
     Returns:
         Organization ID string or None if not found
     """
+    normalized_team_id = (team_id or "").strip()
+    if not normalized_team_id:
+        logger.warning("[slack_conversations] Missing team_id on Slack event")
+        return None
+
+    now = time.monotonic()
+    async with _slack_team_org_cache_lock:
+        cached = _slack_team_org_cache.get(normalized_team_id)
+        if cached and cached[1] > now:
+            logger.debug(
+                "[slack_conversations] team_id cache hit for %s -> %s",
+                normalized_team_id,
+                cached[0],
+            )
+            return cached[0]
+        if cached:
+            _slack_team_org_cache.pop(normalized_team_id, None)
+
+    def _cache_team_lookup(organization_id: str | None) -> None:
+        expiry = time.monotonic() + _SLACK_TEAM_ORG_CACHE_TTL_SECONDS
+        _slack_team_org_cache[normalized_team_id] = (organization_id, expiry)
+
     integrations: list[Integration] = []
     query = (
         select(Integration)
@@ -151,29 +176,37 @@ async def find_organization_by_slack_team(team_id: str) -> str | None:
             if attempt == 2:
                 logger.error(
                     "[slack_conversations] Exhausted Slack integration lookup retries for team=%s; returning no organization",
-                    team_id,
+                    normalized_team_id,
                 )
+                async with _slack_team_org_cache_lock:
+                    _cache_team_lookup(None)
                 return None
             await asyncio.sleep(0.2)
 
     # --- Fast path: match on stored team_id in extra_data ---
     for integration in integrations:
         extra_data: dict[str, Any] = integration.extra_data or {}
-        if extra_data.get("team_id") == team_id:
+        if extra_data.get("team_id") == normalized_team_id:
             logger.info(
                 "[slack_conversations] Matched Slack team %s to org %s via integration metadata",
-                team_id,
+                normalized_team_id,
                 integration.organization_id,
             )
-            return str(integration.organization_id)
+            organization_id = str(integration.organization_id)
+            async with _slack_team_org_cache_lock:
+                _cache_team_lookup(organization_id)
+            return organization_id
 
     if len(integrations) == 1:
         logger.warning(
             "[slack_conversations] No team_id metadata match; using the only active Slack integration org=%s for team=%s",
             integrations[0].organization_id,
-            team_id,
+            normalized_team_id,
         )
-        return str(integrations[0].organization_id)
+        organization_id = str(integrations[0].organization_id)
+        async with _slack_team_org_cache_lock:
+            _cache_team_lookup(organization_id)
+        return organization_id
 
     # --- Slow path: resolve team_id via auth.test for integrations missing it ---
     integrations_missing_team_id: list[Integration] = [
@@ -198,15 +231,20 @@ async def find_organization_by_slack_team(team_id: str) -> str | None:
                 integration.id,
                 integration.organization_id,
             )
-            if resolved_team_id == team_id:
+            if resolved_team_id == normalized_team_id:
                 logger.info(
                     "[slack_conversations] Matched Slack team %s to org %s via auth.test",
-                    team_id,
+                    normalized_team_id,
                     integration.organization_id,
                 )
-                return str(integration.organization_id)
+                organization_id = str(integration.organization_id)
+                async with _slack_team_org_cache_lock:
+                    _cache_team_lookup(organization_id)
+                return organization_id
 
-    logger.warning("[slack_conversations] No Slack integration found for team=%s", team_id)
+    logger.warning("[slack_conversations] No Slack integration found for team=%s", normalized_team_id)
+    async with _slack_team_org_cache_lock:
+        _cache_team_lookup(None)
     return None
 
 

--- a/backend/tests/test_slack_user_resolution.py
+++ b/backend/tests/test_slack_user_resolution.py
@@ -1,8 +1,18 @@
 import asyncio
+
+import pytest
 from types import SimpleNamespace
 from uuid import UUID
 
 from services import slack_conversations
+
+
+@pytest.fixture(autouse=True)
+def _clear_slack_team_cache():
+    slack_conversations._slack_team_org_cache.clear()
+    yield
+    slack_conversations._slack_team_org_cache.clear()
+
 
 
 class _FakeScalarResult:
@@ -107,6 +117,31 @@ def test_resolve_revtops_user_falls_back_to_connected_slack_name_match(monkeypat
     assert resolved is not None
     assert resolved.id == jane_id
 
+
+
+
+def test_find_organization_by_slack_team_uses_cache(monkeypatch):
+    org_id = "11111111-1111-1111-1111-111111111111"
+    integration = SimpleNamespace(
+        provider="slack",
+        is_active=True,
+        organization_id=org_id,
+        extra_data={"team_id": "T123"},
+    )
+    calls = {"count": 0}
+
+    def _fake_admin_session():
+        calls["count"] += 1
+        return _FakeAdminSessionContext([[integration]])
+
+    monkeypatch.setattr(slack_conversations, "get_admin_session", _fake_admin_session)
+
+    first = asyncio.run(slack_conversations.find_organization_by_slack_team("T123"))
+    second = asyncio.run(slack_conversations.find_organization_by_slack_team("T123"))
+
+    assert first == org_id
+    assert second == org_id
+    assert calls["count"] == 1
 
 def test_find_organization_by_slack_team_returns_none_when_lookup_fails(monkeypatch):
     monkeypatch.setattr(


### PR DESCRIPTION
### Motivation
- Repeated database lookups for Slack `team_id` → organization resolution are on the hot path for incoming Slack events and can increase response latency under load.  
- Caching successful and negative lookups reduces DB/HTTP work and avoids repeated retries during transient failures.

### Description
- Added a small in-memory TTL cache for workspace/team-to-organization resolution with lock protection and a 5-minute TTL: `_SLACK_TEAM_ORG_CACHE_TTL_SECONDS`, `_slack_team_org_cache`, and `_slack_team_org_cache_lock` in `backend/services/slack_conversations.py`.  
- Normalized `team_id` input and short-circuited when missing or empty values are provided, with additional debug/log messages on cache hits and misses.  
- Cached both positive matches and negative results (None) to avoid repeated expensive lookups during outages, and backfilled cache on successful `auth.test` resolution.  
- Added an autouse pytest fixture to clear cache state and a focused test `test_find_organization_by_slack_team_uses_cache` to verify the caching behavior in `backend/tests/test_slack_user_resolution.py`.

### Testing
- Ran the focused test set with: `cd backend && pytest -q tests/test_slack_user_resolution.py::test_find_organization_by_slack_team_uses_cache tests/test_slack_user_resolution.py::test_find_organization_by_slack_team_returns_none_when_lookup_fails tests/test_slack_events_thread_locking.py`.  
- Result: all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0470bb108321afbabab87da482e9)