### PR TITLE
Add scheduled dependency health monitoring with PagerDuty incidents

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings
 
 
@@ -118,6 +119,14 @@ class Settings(BaseSettings):
     STRIPE_WEBHOOK_SECRET: Optional[str] = None
     STRIPE_PUBLISHABLE_KEY: Optional[str] = None
 
+    # PagerDuty incident API
+    PAGERDUTY_FROM_EMAIL: Optional[str] = None
+    PAGERDUTY_KEY: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("PAGERDUTY_KEY", "PagerDuty_Key"),
+    )
+    PAGERDUTY_SERVICE_ID: Optional[str] = None
+
     @property
     def sandbox_database_url(self) -> str:
         """Sync Postgres URL for E2B sandbox (strips SQLAlchemy asyncpg prefix)."""
@@ -163,6 +172,10 @@ EXPECTED_ENV_VARS: tuple[str, ...] = (
     "ADMIN_KEY",
     "RESEND_API_KEY",
     "EMAIL_FROM",
+    "PAGERDUTY_FROM_EMAIL",
+    "PAGERDUTY_KEY",
+    "PagerDuty_Key",
+    "PAGERDUTY_SERVICE_ID",
 )
 
 

--- a/backend/tests/test_health_monitoring.py
+++ b/backend/tests/test_health_monitoring.py
@@ -1,0 +1,71 @@
+import asyncio
+
+from workers.tasks import health_monitor
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def get(self, key: str):
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        self.store[key] = value
+
+    async def delete(self, key: str) -> None:
+        self.store.pop(key, None)
+
+    async def ping(self) -> bool:
+        return True
+
+    async def aclose(self) -> None:
+        return None
+
+
+class DummyAsyncClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_normalized_url_uses_base_url() -> None:
+    url = health_monitor._normalized_url("https://example.com/", "/health")
+    assert url == "https://example.com/health"
+
+
+def test_dependency_monitor_creates_and_suppresses_duplicate_incidents(monkeypatch) -> None:
+    fake_redis = FakeRedis()
+    created: list[str] = []
+
+    async def fake_check_http(client, url: str, label: str):
+        if "nango" in label.lower():
+            return False, f"{label} unreachable"
+        return True, f"{label} ok"
+
+    async def fake_check_redis_health():
+        return True, "Redis ok"
+
+    async def fake_create_incident(summary: str, details: str) -> bool:
+        created.append(summary)
+        return True
+
+    monkeypatch.setattr(health_monitor.redis, "from_url", lambda *args, **kwargs: fake_redis)
+    monkeypatch.setattr(health_monitor.httpx, "AsyncClient", lambda *args, **kwargs: DummyAsyncClient())
+    monkeypatch.setattr(health_monitor, "_check_http", fake_check_http)
+    monkeypatch.setattr(health_monitor, "_check_redis_health", fake_check_redis_health)
+    monkeypatch.setattr(health_monitor, "_create_pagerduty_incident", fake_create_incident)
+
+    first = asyncio.run(health_monitor.run_dependency_health_checks())
+    second = asyncio.run(health_monitor.run_dependency_health_checks())
+
+    assert first["nango"] == "down_incident_created"
+    assert second["nango"] == "down_existing_incident"
+    assert len(created) == 1
+
+
+def test_settings_accept_pagerduty_alias() -> None:
+    config = health_monitor.settings.__class__(PagerDuty_Key="alias-key")
+    assert config.PAGERDUTY_KEY == "alias-key"

--- a/backend/workers/celery_app.py
+++ b/backend/workers/celery_app.py
@@ -42,6 +42,7 @@ celery_app = Celery(
         "workers.tasks.sync",
         "workers.tasks.workflows",
         "workers.tasks.bulk_operations",
+        "workers.tasks.health_monitor",
     ],
 )
 
@@ -98,6 +99,12 @@ celery_app.conf.beat_schedule = {
     "process-workflow-events": {
         "task": "workers.tasks.workflows.process_pending_events",
         "schedule": timedelta(seconds=10),
+    },
+
+    # Monitor external dependencies every 15 minutes and page on outages
+    "check-dependency-health": {
+        "task": "workers.tasks.health_monitor.check_dependencies",
+        "schedule": timedelta(minutes=15),
     },
 }
 

--- a/backend/workers/tasks/health_monitor.py
+++ b/backend/workers/tasks/health_monitor.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+
+import httpx
+import redis.asyncio as redis
+
+from config import get_redis_connection_kwargs, settings
+from workers.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DependencyCheck:
+    key: str
+    label: str
+    check_type: str
+    target: str
+
+
+DEPENDENCY_CHECKS: tuple[DependencyCheck, ...] = (
+    DependencyCheck(
+        key="supabase",
+        label="Supabase",
+        check_type="http",
+        target="/auth/v1/health",
+    ),
+    DependencyCheck(
+        key="nango",
+        label="Nango",
+        check_type="http",
+        target="/health",
+    ),
+    DependencyCheck(
+        key="redis",
+        label="Redis",
+        check_type="redis",
+        target="redis://",
+    ),
+    DependencyCheck(
+        key="www_revtops",
+        label="www.revtops.com",
+        check_type="http",
+        target="https://www.revtops.com",
+    ),
+    DependencyCheck(
+        key="api_revtops",
+        label="api.revtops.com",
+        check_type="http",
+        target="https://api.revtops.com/health",
+    ),
+)
+
+
+def _normalized_url(base_url: str | None, fallback_path: str) -> str | None:
+    if not base_url:
+        return None
+    normalized_base = base_url.rstrip("/")
+    if fallback_path.startswith("http"):
+        return fallback_path
+    return f"{normalized_base}{fallback_path}"
+
+
+async def _check_http(client: httpx.AsyncClient, url: str, label: str) -> tuple[bool, str]:
+    try:
+        response = await client.get(url)
+        if response.status_code >= 500:
+            return False, f"{label} returned HTTP {response.status_code}"
+        return True, f"{label} reachable (HTTP {response.status_code})"
+    except Exception as exc:
+        return False, f"{label} unreachable: {exc}"
+
+
+async def _check_redis_health() -> tuple[bool, str]:
+    redis_client = redis.from_url(
+        settings.REDIS_URL,
+        **get_redis_connection_kwargs(decode_responses=True),
+    )
+    try:
+        ping_result = await redis_client.ping()
+        if ping_result is True:
+            return True, "Redis reachable (PING ok)"
+        return False, "Redis ping returned unexpected response"
+    except Exception as exc:
+        return False, f"Redis unreachable: {exc}"
+    finally:
+        await redis_client.aclose()
+
+
+async def _create_pagerduty_incident(summary: str, details: str) -> bool:
+    if not settings.PAGERDUTY_KEY:
+        logger.warning("Skipping PagerDuty incident creation: PAGERDUTY_KEY/PagerDuty_Key not configured")
+        return False
+    if not settings.PAGERDUTY_FROM_EMAIL or not settings.PAGERDUTY_SERVICE_ID:
+        logger.warning("Skipping PagerDuty incident creation: missing PAGERDUTY_FROM_EMAIL or PAGERDUTY_SERVICE_ID")
+        return False
+
+    payload = {
+        "incident": {
+            "type": "incident",
+            "title": summary,
+            "service": {
+                "id": settings.PAGERDUTY_SERVICE_ID,
+                "type": "service_reference",
+            },
+            "urgency": "high",
+            "body": {
+                "type": "incident_body",
+                "details": details,
+            },
+        }
+    }
+    headers = {
+        "Authorization": f"Token token={settings.PAGERDUTY_KEY}",
+        "Accept": "application/vnd.pagerduty+json;version=2",
+        "Content-Type": "application/json",
+        "From": settings.PAGERDUTY_FROM_EMAIL,
+    }
+
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await client.post(
+            "https://api.pagerduty.com/incidents",
+            headers=headers,
+            json=payload,
+        )
+        response.raise_for_status()
+        return True
+
+
+async def _redis_delete_safe(redis_state: redis.Redis, key: str) -> None:
+    try:
+        await redis_state.delete(key)
+    except Exception as exc:
+        logger.warning("Failed to clear incident state key", extra={"key": key, "error": str(exc)})
+
+
+async def _redis_get_safe(redis_state: redis.Redis, key: str) -> str | None:
+    try:
+        return await redis_state.get(key)
+    except Exception as exc:
+        logger.warning("Failed to read incident state key", extra={"key": key, "error": str(exc)})
+        return None
+
+
+async def _redis_set_safe(redis_state: redis.Redis, key: str, value: str, ex: int) -> None:
+    try:
+        await redis_state.set(key, value, ex=ex)
+    except Exception as exc:
+        logger.warning("Failed to set incident state key", extra={"key": key, "error": str(exc)})
+
+
+async def run_dependency_health_checks() -> dict[str, str]:
+    results: dict[str, str] = {}
+    redis_state = redis.from_url(
+        settings.REDIS_URL,
+        **get_redis_connection_kwargs(decode_responses=True),
+    )
+
+    async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+        for check in DEPENDENCY_CHECKS:
+            if check.key == "supabase":
+                url = _normalized_url(settings.SUPABASE_URL, check.target)
+                if not url:
+                    logger.info("Skipping Supabase health check: SUPABASE_URL not configured")
+                    continue
+                is_healthy, message = await _check_http(client, url, check.label)
+            elif check.key == "nango":
+                url = _normalized_url(settings.NANGO_HOST, check.target)
+                is_healthy, message = await _check_http(client, url, check.label)
+            elif check.check_type == "redis":
+                is_healthy, message = await _check_redis_health()
+            else:
+                is_healthy, message = await _check_http(client, check.target, check.label)
+
+            state_key = f"health_monitor:incident_open:{check.key}"
+            logger.info("Dependency check result", extra={"dependency": check.key, "healthy": is_healthy, "message": message})
+
+            if is_healthy:
+                await _redis_delete_safe(redis_state, state_key)
+                results[check.key] = "healthy"
+                continue
+
+            incident_open = await _redis_get_safe(redis_state, state_key)
+            if incident_open:
+                logger.warning("Dependency still down; incident already open", extra={"dependency": check.key})
+                results[check.key] = "down_existing_incident"
+                continue
+
+            summary = f"[Revtops] {check.label} is down"
+            details = f"Automated dependency monitor detected an outage for {check.label}.\n\nDetails: {message}"
+            try:
+                created = await _create_pagerduty_incident(summary, details)
+                if created:
+                    await _redis_set_safe(redis_state, state_key, "1", ex=60 * 60 * 12)
+                    logger.error("Created PagerDuty incident", extra={"dependency": check.key, "details": message})
+                    results[check.key] = "down_incident_created"
+                else:
+                    results[check.key] = "down_no_pagerduty_config"
+            except Exception as exc:
+                logger.exception("Failed to create PagerDuty incident", extra={"dependency": check.key, "error": str(exc)})
+                results[check.key] = "down_incident_failed"
+
+    await redis_state.aclose()
+    return results
+
+
+def run_dependency_health_checks_sync() -> dict[str, str]:
+    return asyncio.run(run_dependency_health_checks())
+
+
+@celery_app.task(name="workers.tasks.health_monitor.check_dependencies")
+def check_dependencies() -> dict[str, str]:
+    """Celery task wrapper for dependency monitoring."""
+    return run_dependency_health_checks_sync()

--- a/env.example
+++ b/env.example
@@ -67,3 +67,9 @@ VITE_SUPABASE_URL=your_supabase_project_url
 # Get this from your Railway project variables.
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 VITE_NANGO_PUBLIC_KEY=your_nango_public_key
+
+# PagerDuty (incident creation for dependency outages)
+PAGERDUTY_FROM_EMAIL=alerts@revtops.com
+# Preferred convention: PAGERDUTY_KEY (alias PagerDuty_Key also supported)
+PAGERDUTY_KEY=your_pagerduty_api_key
+PAGERDUTY_SERVICE_ID=your_pagerduty_service_id


### PR DESCRIPTION
### Motivation
- Detect and alert on outages of external dependencies (Supabase, Nango, Redis, www.revtops.com, api.revtops.com) and avoid silent failures. 
- Create PagerDuty incidents automatically for outages so on-call responders are notified. 
- Run checks on a regular schedule and suppress duplicate incidents while an outage persists.

### Description
- Add a new Celery task module `backend/workers/tasks/health_monitor.py` that checks Supabase, Nango, Redis, `www.revtops.com`, and `api.revtops.com`, creates a PagerDuty incident via the v2 Incidents API when appropriate, and uses Redis keys to deduplicate incidents. 
- Register the new task in Celery and schedule it to run every 15 minutes in `backend/workers/celery_app.py`. 
- Add PagerDuty settings to configuration with modern env-var handling and alias support so `PAGERDUTY_KEY` or `PagerDuty_Key` are accepted, and add `PAGERDUTY_FROM_EMAIL` and `PAGERDUTY_SERVICE_ID` to `backend/config.py` and `env.example`. 
- Add unit tests `backend/tests/test_health_monitoring.py` covering URL normalization, deduplicated incident creation, and the PagerDuty env alias behavior. 

### Testing
- Ran `pytest backend/tests/test_health_monitoring.py backend/tests/test_health.py` and all tests passed. 
- Ran `pytest backend/tests/test_health_monitoring.py -q` and tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0b909eb083218bc0e58e65752ba2)