### PR TITLE
Enable connecting new connectors from mobile in DataSources modal

### DIFF
--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -1647,12 +1647,10 @@ export function DataSources(): JSX.Element {
                     <li key={integration.provider}>
                       <button
                         onClick={() => {
-                          if (!isMobile) {
-                            setShowConnectModal(false);
-                            void handleConnect(integration.provider);
-                          }
+                          setShowConnectModal(false);
+                          void handleConnect(integration.provider);
                         }}
-                        disabled={isMobile || isConnecting}
+                        disabled={isConnecting}
                         className="w-full flex items-center gap-4 px-4 py-3 rounded-xl hover:bg-surface-800 transition-colors text-left group disabled:opacity-50"
                       >
                         <div className={`${getColorClass(integration.color)} p-2 rounded-lg text-white flex-shrink-0`}>
@@ -1707,10 +1705,10 @@ export function DataSources(): JSX.Element {
               <HiDeviceMobile className="w-5 h-5 text-primary-400" />
             </div>
             <div>
-              <h3 className="font-medium text-surface-100">Connect from your computer</h3>
+              <h3 className="font-medium text-surface-100">Using mobile?</h3>
               <p className="text-sm text-surface-400 mt-1">
-                For the best experience connecting connectors, please visit this page from a desktop or laptop computer. 
-                OAuth sign-in works more reliably on larger screens.
+                You can connect new connectors from mobile now. If any OAuth popup is blocked or interrupted,
+                retry from a desktop or laptop for the most reliable setup flow.
               </p>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- The mobile UI previously blocked selecting connectors from the Connect Source modal, preventing users from starting the OAuth/connect flow on mobile.
- The intent is to make the mobile experience consistent with desktop and allow initiating `handleConnect(...)` from the modal while still warning about OAuth popup edge cases.

### Description
- Removed the mobile-only guard in the modal connector list so the button now closes the modal and calls `handleConnect(integration.provider)` even on mobile. (changed click handler and `disabled` logic).
- Replaced `disabled={isMobile || isConnecting}` with `disabled={isConnecting}` so mobile selections are allowed while still preventing duplicate connects.
- Updated the mobile helper banner copy to `Using mobile?` and clarified that mobile connections are supported while suggesting desktop as a fallback if OAuth popups are blocked.
- Modified file: `frontend/src/components/DataSources.tsx`.

### Testing
- Built the frontend with `npm run build` in `frontend/`, which completed successfully. 
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the app served correctly. 
- Captured a mobile viewport screenshot via Playwright to validate the modal on a phone-sized viewport; the run completed successfully. 
- No unit tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e6c93593483219d5726f6f6a5720e)