### PR TITLE
Add PagerDuty-backed dependency outage monitoring every 15 minutes

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings
 
 
@@ -118,6 +119,14 @@ class Settings(BaseSettings):
     STRIPE_WEBHOOK_SECRET: Optional[str] = None
     STRIPE_PUBLISHABLE_KEY: Optional[str] = None
 
+    # PagerDuty (outbound incident creation)
+    PAGERDUTY_FROM_EMAIL: Optional[str] = None
+    PAGERDUTY_KEY: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("PAGERDUTY_KEY", "PagerDuty_Key"),
+    )
+    PAGERDUTY_SERVICE_ID: Optional[str] = None
+
     @property
     def sandbox_database_url(self) -> str:
         """Sync Postgres URL for E2B sandbox (strips SQLAlchemy asyncpg prefix)."""
@@ -163,6 +172,9 @@ EXPECTED_ENV_VARS: tuple[str, ...] = (
     "ADMIN_KEY",
     "RESEND_API_KEY",
     "EMAIL_FROM",
+    "PAGERDUTY_FROM_EMAIL",
+    "PagerDuty_Key",
+    "PAGERDUTY_SERVICE_ID",
 )
 
 

--- a/backend/tests/test_monitoring_task.py
+++ b/backend/tests/test_monitoring_task.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any
+
+from config import EXPECTED_ENV_VARS, settings
+from workers.tasks import monitoring
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 201, text: str = "ok") -> None:
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeAsyncClient:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+    async def post(self, url: str, json: dict[str, Any], headers: dict[str, str]) -> _FakeResponse:
+        _FakeAsyncClient.last_call = {
+            "url": url,
+            "json": json,
+            "headers": headers,
+        }
+        return _FakeResponse()
+
+
+def test_expected_env_vars_include_pagerduty() -> None:
+    assert "PAGERDUTY_FROM_EMAIL" in EXPECTED_ENV_VARS
+    assert "PagerDuty_Key" in EXPECTED_ENV_VARS
+    assert "PAGERDUTY_SERVICE_ID" in EXPECTED_ENV_VARS
+
+
+def test_pagerduty_incident_request_shape(monkeypatch: Any) -> None:
+    monkeypatch.setattr(monitoring.httpx, "AsyncClient", _FakeAsyncClient)
+
+    import asyncio
+
+    asyncio.run(
+        monitoring._create_pagerduty_incident(
+            from_email="alerts@revtops.com",
+            api_key="pd_test_key",
+            service_id="svc_123",
+            check_result=monitoring.CheckResult(
+                name="Redis",
+                healthy=False,
+                details="timeout",
+            ),
+        )
+    )
+
+    last_call = _FakeAsyncClient.last_call
+    assert last_call["url"] == "https://api.pagerduty.com/incidents"
+    assert last_call["headers"]["From"] == "alerts@revtops.com"
+    assert last_call["headers"]["Authorization"] == "Token token=pd_test_key"
+    assert last_call["json"]["incident"]["service"]["id"] == "svc_123"
+    assert last_call["json"]["incident"]["title"] == "Redis is down"
+
+
+def test_pagerduty_alias_var_is_loaded(monkeypatch: Any) -> None:
+    monkeypatch.setenv("PagerDuty_Key", "alias_value")
+    fresh_settings = settings.__class__()
+    assert fresh_settings.PAGERDUTY_KEY == "alias_value"

--- a/backend/workers/celery_app.py
+++ b/backend/workers/celery_app.py
@@ -42,6 +42,7 @@ celery_app = Celery(
         "workers.tasks.sync",
         "workers.tasks.workflows",
         "workers.tasks.bulk_operations",
+        "workers.tasks.monitoring",
     ],
 )
 
@@ -98,6 +99,12 @@ celery_app.conf.beat_schedule = {
     "process-workflow-events": {
         "task": "workers.tasks.workflows.process_pending_events",
         "schedule": timedelta(seconds=10),
+    },
+
+    # Check critical infrastructure and create PagerDuty incidents when down
+    "monitor-critical-dependencies": {
+        "task": "workers.tasks.monitoring.monitor_dependencies",
+        "schedule": timedelta(minutes=15),
     },
 }
 

--- a/backend/workers/tasks/monitoring.py
+++ b/backend/workers/tasks/monitoring.py
@@ -1,0 +1,188 @@
+"""Infrastructure reachability monitoring and PagerDuty alerting tasks."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from config import get_redis_connection_kwargs, settings
+from workers.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Represents reachability status for a monitored dependency."""
+
+    name: str
+    healthy: bool
+    details: str
+
+
+def _require_pagerduty_config() -> tuple[str, str, str] | None:
+    """Return PagerDuty settings if complete, else log and skip."""
+    from_email = settings.PAGERDUTY_FROM_EMAIL
+    api_key = settings.PAGERDUTY_KEY
+    service_id = settings.PAGERDUTY_SERVICE_ID
+
+    if not from_email or not api_key or not service_id:
+        logger.warning(
+            "Skipping dependency monitoring alerting: missing PagerDuty configuration "
+            "(PAGERDUTY_FROM_EMAIL=%s, PagerDuty_Key=%s, PAGERDUTY_SERVICE_ID=%s)",
+            bool(from_email),
+            bool(api_key),
+            bool(service_id),
+        )
+        return None
+    return from_email, api_key, service_id
+
+
+async def _check_http_endpoint(name: str, url: str, timeout_s: float = 10.0) -> CheckResult:
+    """Check if an HTTP endpoint is reachable and returns a non-5xx response."""
+    logger.info("Checking endpoint %s (%s)", name, url)
+    try:
+        async with httpx.AsyncClient(timeout=timeout_s, follow_redirects=True) as client:
+            response = await client.get(url)
+        if response.status_code >= 500:
+            return CheckResult(name=name, healthy=False, details=f"HTTP {response.status_code} from {url}")
+        return CheckResult(name=name, healthy=True, details=f"HTTP {response.status_code} from {url}")
+    except Exception as exc:
+        logger.exception("Endpoint check failed for %s (%s)", name, url)
+        return CheckResult(name=name, healthy=False, details=f"Request failed for {url}: {exc}")
+
+
+async def _check_redis(timeout_s: float = 10.0) -> CheckResult:
+    """Check if Redis is reachable via PING."""
+    import redis.asyncio as aioredis
+
+    redis_url = settings.REDIS_URL
+    logger.info("Checking Redis reachability via %s", redis_url)
+    redis_client = aioredis.from_url(
+        redis_url,
+        **get_redis_connection_kwargs(),
+    )
+
+    try:
+        async with redis_client:
+            is_ok = await redis_client.ping()
+        if is_ok:
+            return CheckResult(name="Redis", healthy=True, details="PING returned true")
+        return CheckResult(name="Redis", healthy=False, details="PING returned false")
+    except Exception as exc:
+        logger.exception("Redis health check failed")
+        return CheckResult(name="Redis", healthy=False, details=f"Redis ping failed: {exc}")
+
+
+async def _create_pagerduty_incident(
+    *,
+    from_email: str,
+    api_key: str,
+    service_id: str,
+    check_result: CheckResult,
+) -> None:
+    """Create an incident in PagerDuty v2 REST API."""
+    title = f"{check_result.name} is down"
+    payload: dict[str, Any] = {
+        "incident": {
+            "type": "incident",
+            "title": title,
+            "service": {
+                "id": service_id,
+                "type": "service_reference",
+            },
+            "urgency": "high",
+            "body": {
+                "type": "incident_body",
+                "details": (
+                    "Automated Revtops dependency monitor detected an outage. "
+                    f"Dependency: {check_result.name}. Details: {check_result.details}"
+                ),
+            },
+        }
+    }
+
+    headers = {
+        "Accept": "application/vnd.pagerduty+json;version=2",
+        "Content-Type": "application/json",
+        "Authorization": f"Token token={api_key}",
+        "From": from_email,
+    }
+
+    logger.warning("Creating PagerDuty incident for %s", check_result.name)
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await client.post(
+            "https://api.pagerduty.com/incidents",
+            json=payload,
+            headers=headers,
+        )
+    if response.status_code >= 300:
+        logger.error(
+            "PagerDuty incident creation failed for %s: HTTP %s - %s",
+            check_result.name,
+            response.status_code,
+            response.text,
+        )
+        return
+
+    logger.info(
+        "PagerDuty incident created for %s with status %s",
+        check_result.name,
+        response.status_code,
+    )
+
+
+async def _run_dependency_checks() -> list[CheckResult]:
+    """Run all dependency checks and return results."""
+    checks = [
+        _check_http_endpoint("Supabase", settings.SUPABASE_URL or "https://supabase.com"),
+        _check_http_endpoint("Nango", settings.NANGO_HOST),
+        _check_redis(),
+        _check_http_endpoint("www.revtops.com", "https://www.revtops.com"),
+        _check_http_endpoint("api.revtops.com", "https://api.revtops.com/health"),
+    ]
+
+    return [await check for check in checks]
+
+
+@celery_app.task(bind=True, name="workers.tasks.monitoring.monitor_dependencies")
+def monitor_dependencies(self: Any) -> dict[str, Any]:
+    """Periodic task: monitor key dependencies and open PagerDuty incidents if down."""
+    import asyncio
+
+    logger.info("Task %s: Starting dependency monitoring run", self.request.id)
+    pagerduty_config = _require_pagerduty_config()
+    if pagerduty_config is None:
+        return {
+            "status": "skipped",
+            "reason": "missing_pagerduty_config",
+        }
+
+    from_email, api_key, service_id = pagerduty_config
+
+    async def _run() -> dict[str, Any]:
+        results = await _run_dependency_checks()
+        down = [result for result in results if not result.healthy]
+
+        for result in results:
+            level = logging.INFO if result.healthy else logging.WARNING
+            logger.log(level, "Dependency check: %s healthy=%s (%s)", result.name, result.healthy, result.details)
+
+        for result in down:
+            await _create_pagerduty_incident(
+                from_email=from_email,
+                api_key=api_key,
+                service_id=service_id,
+                check_result=result,
+            )
+
+        return {
+            "status": "ok",
+            "total_checks": len(results),
+            "down_count": len(down),
+            "down_services": [result.name for result in down],
+        }
+
+    return asyncio.run(_run())

--- a/env.example
+++ b/env.example
@@ -61,6 +61,12 @@ SCRAPINGBEE_API_KEY=your_scrapingbee_api_key
 # Get your API key from https://e2b.dev/dashboard
 E2B_API_KEY=your_e2b_api_key
 
+# PagerDuty (dependency outage incident creation)
+PAGERDUTY_FROM_EMAIL=alerts@yourdomain.com
+# API key env var supports both PAGERDUTY_KEY and PagerDuty_Key; prefer PagerDuty_Key for current deployment compatibility
+PagerDuty_Key=your_pagerduty_api_key
+PAGERDUTY_SERVICE_ID=your_pagerduty_service_id
+
 # Frontend (Vite) - prefix with VITE_ so they're exposed to the client
 VITE_API_URL=http://localhost:8000
 VITE_SUPABASE_URL=your_supabase_project_url


### PR DESCRIPTION
### Motivation
- Add automated, outbound incident creation to PagerDuty when core infrastructure (Supabase, Nango, Redis, or public app endpoints) becomes unreachable so on-call can be notified immediately.
- Run these checks on a regular interval (every 15 minutes) from the existing Celery beat runner to keep monitoring lightweight and centralized.
- Read PagerDuty configuration from environment variables and follow repository env var conventions while supporting the requested `PagerDuty_Key` alias.

### Description
- Added a new Celery task module `workers.tasks.monitoring` that checks Supabase, Nango, Redis, `www.revtops.com`, and `api.revtops.com` reachability and creates incidents via the PagerDuty v2 API (`POST https://api.pagerduty.com/incidents`) when a check fails.
- Wired the task into Celery by including `workers.tasks.monitoring` and adding a beat schedule entry `monitor-critical-dependencies` that runs `workers.tasks.monitoring.monitor_dependencies` every 15 minutes in `backend/workers/celery_app.py`.
- Added PagerDuty settings to config: `PAGERDUTY_FROM_EMAIL`, `PAGERDUTY_SERVICE_ID`, and `PAGERDUTY_KEY` (with alias support for `PagerDuty_Key`) in `backend/config.py`, and included these variables in `EXPECTED_ENV_VARS` and the environment example `env.example`.
- Implemented robust logging around checks and PagerDuty API responses, and made the monitoring task skip incident creation with a clear warning if required PagerDuty env vars are missing.
- Added unit tests `backend/tests/test_monitoring_task.py` to validate expected env vars, alias loading for `PagerDuty_Key`, and the outgoing PagerDuty request shape.

### Testing
- Ran `pytest backend/tests/test_monitoring_task.py -q`, which passed (3 tests passed).
- Ran `pytest backend/tests/test_health.py -q`, which passed (3 tests passed, output contained unrelated deprecation warnings).
- The new monitoring task was exercised in tests by monkeypatching `httpx.AsyncClient` to validate payloads and headers; all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e6f1fbf608321aacd82b708fa91a8)