### PR TITLE
Fix ambiguous Slack integration lookup when user_id is absent

### DIFF
--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -58,15 +58,7 @@ class BaseConnector(ABC):
     async def ensure_sync_active(self, stage: str) -> None:
         """Stop in-flight syncs when integration has been disconnected or pending config."""
         async with get_session(organization_id=self.organization_id) as session:
-            conditions = [
-                Integration.organization_id == UUID(self.organization_id),
-                Integration.provider == self.source_system,
-            ]
-            if self.user_id:
-                conditions.append(Integration.user_id == UUID(self.user_id))
-
-            result = await session.execute(select(Integration).where(*conditions))
-            integration = result.scalar_one_or_none()
+            integration = await self._select_integration(session)
 
         if not integration:
             logger.info(
@@ -154,15 +146,47 @@ class BaseConnector(ABC):
     async def _load_integration(self) -> None:
         """Load integration record from database."""
         async with get_session(organization_id=self.organization_id) as session:
-            conditions = [
-                Integration.organization_id == UUID(self.organization_id),
-                Integration.provider == self.source_system,
-            ]
-            if self.user_id:
-                conditions.append(Integration.user_id == UUID(self.user_id))
+            self._integration = await self._select_integration(session)
 
-            result = await session.execute(select(Integration).where(*conditions))
-            self._integration = result.scalar_one_or_none()
+    async def _select_integration(
+        self,
+        session: Any,
+        *,
+        require_active: bool = False,
+    ) -> Integration | None:
+        """Return the best matching integration row for this connector context.
+
+        When ``user_id`` is omitted, an org can have multiple user-scoped rows for a
+        provider. In that case, prefer the most recently updated connection and log a
+        warning to aid cleanup of ambiguous call sites.
+        """
+        conditions = [
+            Integration.organization_id == UUID(self.organization_id),
+            Integration.provider == self.source_system,
+        ]
+        if require_active:
+            conditions.append(Integration.is_active == True)  # noqa: E712
+        if self.user_id:
+            conditions.append(Integration.user_id == UUID(self.user_id))
+
+        result = await session.execute(
+            select(Integration)
+            .where(*conditions)
+            .order_by(
+                Integration.updated_at.desc().nullslast(),
+                Integration.created_at.desc().nullslast(),
+            )
+            .limit(2)
+        )
+        candidates = result.scalars().all()
+        if len(candidates) > 1 and not self.user_id:
+            logger.warning(
+                "Multiple active %s integrations found for org=%s with no user_id; using integration=%s",
+                self.source_system,
+                self.organization_id,
+                candidates[0].id,
+            )
+        return candidates[0] if candidates else None
 
     @abstractmethod
     async def sync_deals(self) -> int:
@@ -264,19 +288,7 @@ class BaseConnector(ABC):
 
         # Verify we have an active integration for this user
         async with get_session(organization_id=self.organization_id) as session:
-            conditions = [
-                Integration.organization_id == UUID(self.organization_id),
-                Integration.provider == self.source_system,
-                Integration.is_active == True,  # noqa: E712
-            ]
-            # All integrations are user-scoped
-            if self.user_id:
-                conditions.append(Integration.user_id == UUID(self.user_id))
-
-            result = await session.execute(
-                select(Integration).where(*conditions)
-            )
-            integration = result.scalar_one_or_none()
+            integration = await self._select_integration(session, require_active=True)
 
             if not integration:
                 user_msg = f" for user {self.user_id}" if self.user_id else ""
@@ -351,13 +363,7 @@ class BaseConnector(ABC):
         if not self._integration:
             # Try to load integration
             async with get_session(organization_id=self.organization_id) as session:
-                result = await session.execute(
-                    select(Integration).where(
-                        Integration.organization_id == UUID(self.organization_id),
-                        Integration.provider == self.source_system,
-                    )
-                )
-                self._integration = result.scalar_one_or_none()
+                self._integration = await self._select_integration(session)
 
         if not self._integration:
             print(f"[Sync] WARNING: No integration found for {self.source_system} in org {self.organization_id}")

--- a/backend/tests/test_base_connector_integration_selection.py
+++ b/backend/tests/test_base_connector_integration_selection.py
@@ -1,0 +1,88 @@
+import asyncio
+from types import SimpleNamespace
+
+from connectors.base import BaseConnector
+
+
+class _DummyConnector(BaseConnector):
+    source_system = "slack"
+
+    async def sync_deals(self) -> int:
+        return 0
+
+    async def sync_accounts(self) -> int:
+        return 0
+
+    async def sync_contacts(self) -> int:
+        return 0
+
+    async def sync_activities(self) -> int:
+        return 0
+
+    async def fetch_deal(self, deal_id: str) -> dict:
+        return {"id": deal_id}
+
+
+class _FakeScalarCollection:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeExecuteResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return _FakeScalarCollection(self._rows)
+
+
+class _FakeSession:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def execute(self, _query):
+        return _FakeExecuteResult(self._rows)
+
+
+class _FakeSessionContext:
+    def __init__(self, rows):
+        self._session = _FakeSession(rows)
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeNango:
+    def __init__(self):
+        self.calls = []
+
+    async def get_token(self, integration_id, connection_id):
+        self.calls.append((integration_id, connection_id))
+        return "token-123"
+
+
+def test_get_oauth_token_handles_multiple_integrations_without_user_id(monkeypatch):
+    first = SimpleNamespace(id="int-new", nango_connection_id="conn-new")
+    second = SimpleNamespace(id="int-old", nango_connection_id="conn-old")
+
+    monkeypatch.setattr(
+        "connectors.base.get_session",
+        lambda organization_id: _FakeSessionContext([first, second]),
+    )
+
+    fake_nango = _FakeNango()
+    monkeypatch.setattr("connectors.base.get_nango_client", lambda: fake_nango)
+    monkeypatch.setattr("connectors.base.get_nango_integration_id", lambda _source: "nango-slack")
+
+    connector = _DummyConnector(organization_id="11111111-1111-1111-1111-111111111111")
+    token, instance = asyncio.run(connector.get_oauth_token())
+
+    assert token == "token-123"
+    assert instance == ""
+    assert fake_nango.calls == [("nango-slack", "conn-new")]


### PR DESCRIPTION
### Motivation
- Slack-related code paths sometimes instantiate a connector with only `organization_id` (no `user_id`), and orgs with multiple user-scoped integrations caused a `Multiple rows were found when one or none was required` error during lookups. 
- The change makes integration selection deterministic and robust in the absence of `user_id`, preventing failures during `users.info` lookups and other connector flows.

### Description
- Added a shared helper `BaseConnector._select_integration(...)` that applies org/provider filters, optionally requires active integrations, orders candidates by `updated_at`/`created_at` and returns the top candidate. 
- When multiple integrations exist and `user_id` is not supplied, the helper logs a warning and selects the most-recently-updated integration instead of relying on `scalar_one_or_none()`. 
- Updated `ensure_sync_active`, `_load_integration`, `get_oauth_token`, and `update_last_sync` to use `._select_integration(...)` for consistent behavior. 
- Added `backend/tests/test_base_connector_integration_selection.py` to cover multi-integration selection behavior for `get_oauth_token()`.

### Testing
- Ran the new unit test and related Slack resolution suite via `pytest -q backend/tests/test_base_connector_integration_selection.py backend/tests/test_slack_user_resolution.py -q`, and the tests completed successfully (all tests passed with only unrelated warnings). 
- The new test asserts that when multiple integrations exist without `user_id`, the connector requests a token for the top-ranked (most recently updated) integration and returns the expected token.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e76b595c48321bba19820de2df40b)