### PR TITLE
Prevent duplicate Slack identity inserts and grant mapping read access

### DIFF
--- a/backend/db/migrations/versions/077_usermap_read_grant.py
+++ b/backend/db/migrations/versions/077_usermap_read_grant.py
@@ -1,0 +1,50 @@
+"""Grant read access to identity user mappings for app role.
+
+Revision ID: 077_usermap_read_grant
+Revises: 076_user_scoped_connectors
+Create Date: 2026-02-25
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "077_usermap_read_grant"
+down_revision: Union[str, None] = "076_user_scoped_connectors"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        text(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'revtops_app') THEN
+                    GRANT SELECT ON TABLE user_mappings_for_identity TO revtops_app;
+                END IF;
+            END
+            $$;
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        text(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'revtops_app') THEN
+                    REVOKE SELECT ON TABLE user_mappings_for_identity FROM revtops_app;
+                END IF;
+            END
+            $$;
+            """
+        )
+    )

--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -865,7 +865,7 @@ async def _upsert_slack_user_mapping(
                     .where(SlackUserMapping.organization_id == UUID(organization_id))
                     .where(_slack_mapping_source_clause())
                     .where(SlackUserMapping.external_userid == normalized_slack_user_id)
-                    .where(SlackUserMapping.user_id.is_(None))
+                    .order_by(SlackUserMapping.updated_at.desc())
                     .limit(1)
                 )
                 existing_mapping = existing_result.scalar_one_or_none()
@@ -878,7 +878,33 @@ async def _upsert_slack_user_mapping(
                             user_id,
                         )
                         return
-                    existing_mapping.user_id = user_id
+                    if existing_mapping.user_id is None:
+                        existing_mapping.user_id = user_id
+                        existing_mapping.revtops_email = resolved_revtops_email
+                        existing_mapping.external_email = slack_email
+                        existing_mapping.source = "slack"
+                        existing_mapping.match_source = match_source
+                        existing_mapping.updated_at = now
+                        await session.commit()
+                        logger.info(
+                            "[slack_conversations] Promoted Slack user mapping org=%s slack_user=%s to user=%s source=%s",
+                            organization_id,
+                            slack_user_id,
+                            user_id,
+                            match_source,
+                        )
+                        return
+
+                    if existing_mapping.user_id != user_id:
+                        logger.info(
+                            "[slack_conversations] Skipping Slack user mapping insert because Slack user already mapped org=%s slack_user=%s existing_user=%s requested_user=%s",
+                            organization_id,
+                            normalized_slack_user_id,
+                            existing_mapping.user_id,
+                            user_id,
+                        )
+                        return
+
                     existing_mapping.revtops_email = resolved_revtops_email
                     existing_mapping.external_email = slack_email
                     existing_mapping.source = "slack"
@@ -886,10 +912,10 @@ async def _upsert_slack_user_mapping(
                     existing_mapping.updated_at = now
                     await session.commit()
                     logger.info(
-                        "[slack_conversations] Promoted Slack user mapping org=%s slack_user=%s to user=%s source=%s",
+                        "[slack_conversations] Refreshed existing Slack user mapping org=%s user=%s slack_user=%s source=%s",
                         organization_id,
-                        slack_user_id,
                         user_id,
+                        normalized_slack_user_id,
                         match_source,
                     )
                     return


### PR DESCRIPTION
### Motivation
- Prevent the Slack connector from creating duplicate rows in the identity mapping table when a Slack user is already mapped to an internal user. 
- Ensure the application role used by runtime sessions (`revtops_app`) can read `user_mappings_for_identity` so connectors/tools operating under the app role can look up identity mappings safely.

### Description
- Updated `_upsert_slack_user_mapping` in `backend/services/slack_conversations.py` to first look up the latest `SlackUserMapping` for `organization_id + source + external_userid` (ordered by `updated_at`).
- Preserve promotion behavior for unmapped rows (where `user_id IS NULL`) and explicitly `return` when a mapping is already mapped to a different internal user, preventing a duplicate insert.
- When the mapping exists and is already mapped to the same user, refresh email/source/match details and update `updated_at` instead of inserting a duplicate, and added clearer informational logs.
- Added Alembic migration `backend/db/migrations/versions/077_usermap_read_grant.py` (`revision = "077_usermap_read_grant"`) that conditionally `GRANT SELECT ON TABLE user_mappings_for_identity TO revtops_app` in `upgrade()` and conditionally `REVOKE` in `downgrade()`.

### Testing
- Ran a migration preflight check that loads the migration file and asserts `len(revision) <= 32` and `len(down_revision) <= 32`, and it passed.
- Executed `pytest -q tests/test_slack_connector_actions.py`, which passed (2 tests passed, no failures).
- Verified the modified code paths with added logging to observe promotion, skip, and refresh behavior during mapping upserts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e76b7e75883219eb1fb95c06212f3)