### PR TITLE
Disambiguate SlackConnector by team_id to fix reactions across multiple Slack connectors

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -65,6 +65,7 @@ from connectors.registry import (
 )
 from models.activity import Activity
 from models.database import get_session
+from models.integration import Integration
 from models.user import User
 
 SLACK_API_BASE = "https://slack.com/api"
@@ -97,6 +98,80 @@ class SlackConnector(BaseConnector):
         nango_integration_id="slack",
         description="Slack workspace – messages, channels, and real-time events",
     )
+
+    def __init__(
+        self,
+        organization_id: str,
+        user_id: str | None = None,
+        team_id: str | None = None,
+    ) -> None:
+        """Initialize Slack connector.
+
+        Args:
+            organization_id: Organization UUID.
+            user_id: Optional owner user UUID.
+            team_id: Optional Slack team/workspace ID used to disambiguate
+                between multiple Slack integrations in the same org.
+        """
+        super().__init__(organization_id=organization_id, user_id=user_id)
+        self.team_id = (team_id or "").strip() or None
+
+    async def _select_integration(
+        self,
+        session: Any,
+        *,
+        require_active: bool = False,
+    ) -> Integration | None:
+        """Select the matching Slack integration.
+
+        When team_id is provided, prefer an integration with matching
+        ``extra_data.team_id`` to avoid cross-workspace token mix-ups.
+        """
+        if not self.team_id:
+            return await super()._select_integration(
+                session,
+                require_active=require_active,
+            )
+
+        conditions = [
+            Integration.organization_id == uuid.UUID(self.organization_id),
+            Integration.provider == self.source_system,
+            Integration.extra_data["team_id"].astext == self.team_id,
+        ]
+        if require_active:
+            conditions.append(Integration.is_active == True)  # noqa: E712
+        if self.user_id:
+            conditions.append(Integration.user_id == uuid.UUID(self.user_id))
+
+        result = await session.execute(
+            select(Integration)
+            .where(*conditions)
+            .order_by(
+                Integration.updated_at.desc().nullslast(),
+                Integration.created_at.desc().nullslast(),
+            )
+            .limit(2)
+        )
+        candidates = result.scalars().all()
+        if len(candidates) > 1 and not self.user_id:
+            logger.warning(
+                "Multiple Slack integrations matched org=%s team=%s with no user_id; using integration=%s",
+                self.organization_id,
+                self.team_id,
+                candidates[0].id,
+            )
+        if candidates:
+            return candidates[0]
+
+        logger.warning(
+            "No Slack integration matched org=%s team=%s; falling back to default connector selection",
+            self.organization_id,
+            self.team_id,
+        )
+        return await super()._select_integration(
+            session,
+            require_active=require_active,
+        )
 
     async def _get_headers(self) -> dict[str, str]:
         """Get authorization headers for Slack API."""

--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -113,7 +113,7 @@ async def post_slow_processing_notice(
         )
         return
 
-    connector = SlackConnector(organization_id=organization_id)
+    connector = SlackConnector(organization_id=organization_id, team_id=team_id)
     await connector.post_message(channel=channel_id, text=SLOW_REPLY_MESSAGE, thread_ts=thread_ts)
     if reaction_ts:
         await connector.remove_reaction(channel=channel_id, timestamp=reaction_ts)
@@ -1867,7 +1867,7 @@ async def process_slack_dm(
         logger.error("[slack_conversations] No organization found for team %s", team_id)
         return {"status": "error", "error": f"No organization found for Slack team {team_id}"}
 
-    connector = SlackConnector(organization_id=organization_id)
+    connector = SlackConnector(organization_id=organization_id, team_id=team_id)
     await connector.add_reaction(channel=channel_id, timestamp=event_ts)
 
     slack_user = await _fetch_slack_user_info(
@@ -2015,7 +2015,7 @@ async def process_slack_mention(
         logger.warning("[slack_conversations] No organization found for team %s", team_id)
         return {"status": "error", "error": f"No organization found for team {team_id}"}
     
-    connector = SlackConnector(organization_id=organization_id)
+    connector = SlackConnector(organization_id=organization_id, team_id=team_id)
 
     # Show a reaction so the user knows the bot is working
     await connector.add_reaction(channel=channel_id, timestamp=thread_ts)
@@ -2231,7 +2231,7 @@ async def process_slack_thread_reply(
     previous_source_user_id: str | None = conversation.source_user_id
     current_source_user_id: str = user_id if speaker_changed else (conversation.source_user_id or user_id)
 
-    connector = SlackConnector(organization_id=organization_id)
+    connector = SlackConnector(organization_id=organization_id, team_id=team_id)
 
     # Show a reaction on the user's reply immediately so they know the bot is working
     await connector.add_reaction(channel=channel_id, timestamp=event_ts)

--- a/backend/tests/test_slack_dm_threading.py
+++ b/backend/tests/test_slack_dm_threading.py
@@ -9,8 +9,9 @@ def test_process_slack_dm_posts_reply_in_same_thread(monkeypatch) -> None:
     captured: dict[str, str | None] = {}
 
     class _FakeConnector:
-        def __init__(self, organization_id: str) -> None:
+        def __init__(self, organization_id: str, team_id: str | None = None) -> None:
             self.organization_id = organization_id
+            captured["team_id"] = team_id
 
         async def add_reaction(self, channel: str, timestamp: str) -> None:
             captured["add_reaction_timestamp"] = timestamp
@@ -69,3 +70,4 @@ def test_process_slack_dm_posts_reply_in_same_thread(monkeypatch) -> None:
     assert result["status"] == "success"
     assert captured["thread_ts"] == "100.0"
     assert captured["slack_channel_id"] == "D1:100.0"
+    assert captured["team_id"] == "T1"

--- a/backend/tests/test_slack_user_resolution.py
+++ b/backend/tests/test_slack_user_resolution.py
@@ -69,7 +69,7 @@ class _RaisingAdminSessionContext:
 
 
 class _FakeSlackConnector:
-    def __init__(self, organization_id: str):
+    def __init__(self, organization_id: str, team_id: str | None = None):
         self.organization_id = organization_id
 
     async def get_user_info(self, slack_user_id: str):
@@ -180,7 +180,7 @@ def test_resolve_revtops_user_matches_slack_metadata(monkeypatch):
     )
 
     class _NoSlackConnector:
-        def __init__(self, organization_id: str):
+        def __init__(self, organization_id: str, team_id: str | None = None):
             raise AssertionError("SlackConnector should not be called when metadata matches")
 
     monkeypatch.setattr(slack_conversations, "SlackConnector", _NoSlackConnector)
@@ -222,7 +222,7 @@ def test_resolve_revtops_user_uses_legacy_mapping_source_and_normalizes_id(monke
     )
 
     class _NoSlackConnector:
-        def __init__(self, organization_id: str):
+        def __init__(self, organization_id: str, team_id: str | None = None):
             raise AssertionError("SlackConnector should not be called when legacy mapping exists")
 
     monkeypatch.setattr(slack_conversations, "SlackConnector", _NoSlackConnector)
@@ -257,7 +257,7 @@ def test_resolve_revtops_user_uses_existing_mapping(monkeypatch):
     )
 
     class _NoSlackConnector:
-        def __init__(self, organization_id: str):
+        def __init__(self, organization_id: str, team_id: str | None = None):
             raise AssertionError("SlackConnector should not be called when mapping exists")
 
     monkeypatch.setattr(slack_conversations, "SlackConnector", _NoSlackConnector)
@@ -394,7 +394,7 @@ def test_process_slack_thread_reply_applies_speaker_and_global_handoff_before_ot
     )
 
     class _FakeSlackConnectorForThread:
-        def __init__(self, organization_id: str):
+        def __init__(self, organization_id: str, team_id: str | None = None):
             self.organization_id = organization_id
 
         async def add_reaction(self, channel: str, timestamp: str):
@@ -479,7 +479,7 @@ def test_process_slack_mention_clears_active_user_on_unresolved_speaker_handoff(
     )
 
     class _FakeSlackConnectorForMention:
-        def __init__(self, organization_id: str):
+        def __init__(self, organization_id: str, team_id: str | None = None):
             self.organization_id = organization_id
 
         async def add_reaction(self, channel: str, timestamp: str):


### PR DESCRIPTION
### Motivation
- Slack event handlers were instantiating `SlackConnector` without scoping to the incoming workspace, causing API calls to use the wrong workspace token when an org had multiple Slack integrations and resulting in `channel_not_found` errors for reactions.
- The intent is to ensure reactions and message posts for an incoming Slack event use the correct Slack integration for that workspace.

### Description
- Added an optional `team_id` parameter to `SlackConnector` and stored it on the connector instance to enable workspace-scoped selection.
- Overrode `SlackConnector._select_integration` to prefer an `Integration` whose `extra_data.team_id` matches the connector `team_id`, falling back to the previous selection behavior with a warning when no exact match exists.
- Updated Slack event handling paths to pass `team_id` when constructing connectors in `post_slow_processing_notice`, `process_slack_dm`, `process_slack_mention`, and `process_slack_thread_reply` so `add_reaction`/`post_message` operate against the correct workspace token.
- Updated affected tests to accept the new connector constructor signature and added an assertion that `team_id` is propagated in the DM flow.

### Testing
- Ran targeted tests with `pytest -q backend/tests/test_slack_dm_threading.py backend/tests/test_slack_user_resolution.py backend/tests/test_slack_connector_actions.py` and all tests passed (`18 passed`).
- Ran the same test selection after making constructor and handler updates to validate the `team_id` propagation and integration selection logic, with no failures reported.
- No database migrations were introduced or required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e7a88aadc83218378a8c2a6d3c626)