### PR TITLE
Improve Penny Slack responsiveness with soft credit gate and incremental streaming flush

### DIFF
--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -38,6 +38,10 @@ logger = logging.getLogger(__name__)
 EMAIL_PATTERN = re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}", re.IGNORECASE)
 SLACK_MENTION_PATTERN = re.compile(r"<@[A-Z0-9]+>\s*")
 SLOW_REPLY_TIMEOUT_SECONDS = 30
+SLACK_STREAM_FLUSH_CHAR_THRESHOLD = 240
+SLACK_STREAM_FLUSH_INTERVAL_SECONDS = 0.7
+SLACK_CREDITS_CHECK_SOFT_TIMEOUT_SECONDS = 0.5
+_SLACK_CREDITS_GATE_CACHE_TTL_SECONDS = 2.0
 
 # In-memory cache for Slack users.info to avoid repeated API calls within a request.
 # Key: (organization_id, slack_user_id). Value: (user_dict or None, expires_at monotonic).
@@ -49,6 +53,8 @@ _slack_user_info_cache_lock: asyncio.Lock = asyncio.Lock()
 _SLACK_TEAM_ORG_CACHE_TTL_SECONDS: int = 300  # 5 min for workspace -> org lookups
 _slack_team_org_cache: dict[str, tuple[str | None, float]] = {}
 _slack_team_org_cache_lock: asyncio.Lock = asyncio.Lock()
+_slack_credits_gate_cache: dict[str, tuple[bool, float]] = {}
+_slack_credits_gate_cache_lock: asyncio.Lock = asyncio.Lock()
 
 
 def _slack_user_info_cache_evict_expired(now: float) -> None:
@@ -94,6 +100,99 @@ async def _post_cannot_action_response(
         text=_cannot_action_message(),
         thread_ts=thread_ts,
     )
+
+
+async def _get_cached_can_use_credits(organization_id: str) -> bool | None:
+    """Return cached credit-gate result if fresh."""
+    now = time.monotonic()
+    async with _slack_credits_gate_cache_lock:
+        cached = _slack_credits_gate_cache.get(organization_id)
+        if not cached:
+            return None
+        cached_value, expires_at = cached
+        if expires_at <= now:
+            _slack_credits_gate_cache.pop(organization_id, None)
+            return None
+        logger.debug(
+            "[slack_conversations] Credits gate cache hit org=%s allowed=%s",
+            organization_id,
+            cached_value,
+        )
+        return cached_value
+
+
+async def _cache_can_use_credits(organization_id: str, allowed: bool) -> None:
+    """Cache credit-gate result briefly to reduce repeated DB checks."""
+    expires_at = time.monotonic() + _SLACK_CREDITS_GATE_CACHE_TTL_SECONDS
+    async with _slack_credits_gate_cache_lock:
+        _slack_credits_gate_cache[organization_id] = (allowed, expires_at)
+
+
+async def _monitor_late_credits_check(
+    credits_task: asyncio.Task[bool],
+    *,
+    organization_id: str,
+    context: str,
+) -> None:
+    """Observe soft-timed-out credit checks so task exceptions are handled."""
+    try:
+        allowed = await credits_task
+        await _cache_can_use_credits(organization_id, allowed)
+        logger.info(
+            "[slack_conversations] Late credits check completed org=%s context=%s allowed=%s",
+            organization_id,
+            context,
+            allowed,
+        )
+    except Exception:
+        logger.exception(
+            "[slack_conversations] Late credits check failed org=%s context=%s",
+            organization_id,
+            context,
+        )
+
+
+async def _allow_response_with_credit_grace(
+    organization_id: str,
+    *,
+    context: str,
+) -> bool:
+    """Allow a response if credits are valid or credits check exceeds soft timeout."""
+    cached = await _get_cached_can_use_credits(organization_id)
+    if cached is not None:
+        return cached
+
+    credits_task: asyncio.Task[bool] = asyncio.create_task(can_use_credits(organization_id))
+    started_at = time.monotonic()
+    try:
+        allowed = await asyncio.wait_for(
+            asyncio.shield(credits_task),
+            timeout=SLACK_CREDITS_CHECK_SOFT_TIMEOUT_SECONDS,
+        )
+        await _cache_can_use_credits(organization_id, allowed)
+        logger.info(
+            "[slack_conversations] Credits check completed quickly org=%s context=%s allowed=%s elapsed_ms=%.1f",
+            organization_id,
+            context,
+            allowed,
+            (time.monotonic() - started_at) * 1000,
+        )
+        return allowed
+    except asyncio.TimeoutError:
+        logger.warning(
+            "[slack_conversations] Credits check exceeded %.0fms org=%s context=%s; allowing initial response with soft-grace",
+            SLACK_CREDITS_CHECK_SOFT_TIMEOUT_SECONDS * 1000,
+            organization_id,
+            context,
+        )
+        asyncio.create_task(
+            _monitor_late_credits_check(
+                credits_task,
+                organization_id=organization_id,
+                context=context,
+            )
+        )
+        return True
 
 
 
@@ -1789,9 +1888,12 @@ async def _stream_and_post_responses(
     attachment_ids: list[str] | None = None,
 ) -> int:
     """
-    Stream orchestrator output and post each text segment to Slack
-    incrementally — flushing whenever a tool-call boundary (JSON chunk)
-    is encountered so the user sees early messages immediately.
+    Stream orchestrator output and post text segments to Slack incrementally.
+
+    Flushes happen when:
+    - a tool-call boundary arrives (JSON chunk),
+    - buffered output reaches ``SLACK_STREAM_FLUSH_CHAR_THRESHOLD``, or
+    - ``SLACK_STREAM_FLUSH_INTERVAL_SECONDS`` elapsed since last flush.
 
     Args:
         orchestrator: Initialised ChatOrchestrator
@@ -1807,23 +1909,45 @@ async def _stream_and_post_responses(
     current_text: str = ""
     total_length: int = 0
     cleaned_message = _strip_slack_mentions(message_text)
+    last_flush_at = time.monotonic()
+
+    async def _flush_current_text(*, reason: str) -> None:
+        nonlocal current_text, total_length, last_flush_at
+        text_to_send = current_text.strip()
+        if not text_to_send:
+            current_text = ""
+            return
+
+        await connector.post_message(
+            channel=channel,
+            text=text_to_send,
+            thread_ts=thread_ts,
+        )
+        total_length += len(text_to_send)
+        logger.info(
+            "[slack_conversations] Flushed Slack stream chunk reason=%s channel=%s thread_ts=%s chars=%d",
+            reason,
+            channel,
+            thread_ts,
+            len(text_to_send),
+        )
+        current_text = ""
+        last_flush_at = time.monotonic()
 
     try:
         async for chunk in orchestrator.process_message(
             cleaned_message, attachment_ids=attachment_ids,
         ):
             if chunk.startswith("{"):
-                # Tool-call boundary — send whatever text we have so far
-                if current_text.strip():
-                    await connector.post_message(
-                        channel=channel,
-                        text=current_text.strip(),
-                        thread_ts=thread_ts,
-                    )
-                    total_length += len(current_text)
-                    current_text = ""
+                await _flush_current_text(reason="tool_boundary")
             else:
                 current_text += chunk
+                should_flush_for_size = len(current_text) >= SLACK_STREAM_FLUSH_CHAR_THRESHOLD
+                should_flush_for_time = (time.monotonic() - last_flush_at) >= SLACK_STREAM_FLUSH_INTERVAL_SECONDS
+                if should_flush_for_size or should_flush_for_time:
+                    await _flush_current_text(
+                        reason="buffer_size" if should_flush_for_size else "flush_interval",
+                    )
     except Exception as e:
         logger.error(
             "[slack_conversations] Error during streaming: %s", e, exc_info=True,
@@ -1831,13 +1955,7 @@ async def _stream_and_post_responses(
         current_text += f"\n{_cannot_action_message()}"
 
     # Post any remaining text after the stream ends
-    if current_text.strip():
-        await connector.post_message(
-            channel=channel,
-            text=current_text.strip(),
-            thread_ts=thread_ts,
-        )
-        total_length += len(current_text)
+    await _flush_current_text(reason="stream_end")
 
     return total_length
 
@@ -1902,7 +2020,10 @@ async def process_slack_dm(
     if files:
         attachment_ids = await _download_and_store_slack_files(connector, files)
 
-    if not await can_use_credits(organization_id):
+    if not await _allow_response_with_credit_grace(
+        organization_id,
+        context=f"slack_dm:{channel_id}:{thread_ts or event_ts}",
+    ):
         await connector.post_message(
             channel=channel_id,
             text="You're out of credits or don't have an active subscription. Please add a payment method in Revtops to continue.",
@@ -2091,7 +2212,10 @@ async def process_slack_mention(
     if files:
         attachment_ids = await _download_and_store_slack_files(connector, files)
 
-    if not await can_use_credits(organization_id):
+    if not await _allow_response_with_credit_grace(
+        organization_id,
+        context=f"slack_mention:{channel_id}:{thread_ts}",
+    ):
         await connector.post_message(
             channel=channel_id,
             text="You're out of credits or don't have an active subscription. Please add a payment method in Revtops to continue.",
@@ -2296,7 +2420,10 @@ async def process_slack_thread_reply(
     if files:
         attachment_ids = await _download_and_store_slack_files(connector, files)
 
-    if not await can_use_credits(organization_id):
+    if not await _allow_response_with_credit_grace(
+        organization_id,
+        context=f"slack_thread:{channel_id}:{thread_ts}",
+    ):
         await connector.post_message(
             channel=channel_id,
             text="You're out of credits or don't have an active subscription. Please add a payment method in Revtops to continue.",

--- a/backend/tests/test_slack_dm_threading.py
+++ b/backend/tests/test_slack_dm_threading.py
@@ -71,3 +71,99 @@ def test_process_slack_dm_posts_reply_in_same_thread(monkeypatch) -> None:
     assert captured["thread_ts"] == "100.0"
     assert captured["slack_channel_id"] == "D1:100.0"
     assert captured["team_id"] == "T1"
+
+
+def test_streaming_flushes_on_buffer_threshold(monkeypatch) -> None:
+    posted: list[str] = []
+
+    class _FakeConnector:
+        async def post_message(self, channel: str, text: str, thread_ts: str | None = None) -> None:
+            posted.append(text)
+
+    class _FakeOrchestrator:
+        async def process_message(self, _message_text: str, attachment_ids=None):
+            yield "x" * slack_conversations.SLACK_STREAM_FLUSH_CHAR_THRESHOLD
+            yield "tail"
+
+    total = asyncio.run(
+        slack_conversations._stream_and_post_responses(
+            orchestrator=_FakeOrchestrator(),
+            connector=_FakeConnector(),
+            message_text="hello",
+            channel="C123",
+            thread_ts="T123",
+        )
+    )
+
+    assert len(posted) == 2
+    assert posted[0] == "x" * slack_conversations.SLACK_STREAM_FLUSH_CHAR_THRESHOLD
+    assert posted[1] == "tail"
+    assert total == len(posted[0]) + len(posted[1])
+
+
+def test_process_slack_dm_allows_initial_response_when_credits_check_is_slow(monkeypatch) -> None:
+    events: list[str] = []
+
+    class _FakeConnector:
+        def __init__(self, organization_id: str, team_id: str | None = None) -> None:
+            self.organization_id = organization_id
+
+        async def add_reaction(self, channel: str, timestamp: str) -> None:
+            events.append("add_reaction")
+
+        async def remove_reaction(self, channel: str, timestamp: str) -> None:
+            events.append("remove_reaction")
+
+        async def post_message(self, channel: str, text: str, thread_ts: str | None = None) -> None:
+            events.append(f"post:{text}")
+
+    class _FakeOrchestrator:
+        def __init__(self, **kwargs) -> None:
+            self.user_id = kwargs.get("user_id")
+
+    async def _fake_find_org(_team_id: str) -> str:
+        return "org-slow-credits"
+
+    async def _fake_fetch_user_info(**_kwargs):
+        return {}
+
+    async def _fake_resolve_user(**_kwargs):
+        return SimpleNamespace(id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), email="user@example.com")
+
+    async def _fake_find_or_create_conversation(**_kwargs):
+        return SimpleNamespace(id=UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+
+    async def _fake_stream_and_post_responses(**_kwargs) -> int:
+        events.append("stream")
+        await asyncio.sleep(0.03)
+        return 8
+
+    async def _fake_can_use_credits(_organization_id: str) -> bool:
+        await asyncio.sleep(0.02)
+        return False
+
+    slack_conversations._slack_credits_gate_cache.clear()
+    monkeypatch.setattr(slack_conversations, "SLACK_CREDITS_CHECK_SOFT_TIMEOUT_SECONDS", 0.005)
+    monkeypatch.setattr(slack_conversations, "find_organization_by_slack_team", _fake_find_org)
+    monkeypatch.setattr(slack_conversations, "SlackConnector", _FakeConnector)
+    monkeypatch.setattr(slack_conversations, "_fetch_slack_user_info", _fake_fetch_user_info)
+    monkeypatch.setattr(slack_conversations, "resolve_revtops_user_for_slack_actor", _fake_resolve_user)
+    monkeypatch.setattr(slack_conversations, "find_or_create_conversation", _fake_find_or_create_conversation)
+    monkeypatch.setattr(slack_conversations, "can_use_credits", _fake_can_use_credits)
+    monkeypatch.setattr(slack_conversations, "ChatOrchestrator", _FakeOrchestrator)
+    monkeypatch.setattr(slack_conversations, "_stream_and_post_responses", _fake_stream_and_post_responses)
+
+    result = asyncio.run(
+        slack_conversations.process_slack_dm(
+            team_id="T1",
+            channel_id="D1",
+            user_id="U1",
+            message_text="hello",
+            event_ts="100.1",
+            thread_ts="100.0",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert "stream" in events
+    assert not any("out of credits" in e for e in events if e.startswith("post:"))


### PR DESCRIPTION
### Motivation
- Reduce Slack time-to-first-message by allowing the bot to start replying when slow external checks would otherwise block the initial reply.  
- Avoid user-visible delays caused by awaiting `can_use_credits` for every incoming Slack event.  
- Improve perceived responsiveness by flushing partial assistant output earlier (not only at tool-boundaries/end-of-stream).  
- Reduce load/latency from repetitive credit checks during bursty Slack traffic via a short-lived cache.

### Description
- Added soft credit-gate helpers: `
_get_cached_can_use_credits`, `
_cache_can_use_credits`, `
_monitor_late_credits_check`, and `
_allow_response_with_credit_grace` to perform a credits check with a soft timeout and brief in-memory caching.  
- New configurable constants: `SLACK_CREDITS_CHECK_SOFT_TIMEOUT_SECONDS`, `SLACK_STREAM_FLUSH_CHAR_THRESHOLD`, and `SLACK_STREAM_FLUSH_INTERVAL_SECONDS` to tune grace and flush behaviour.  
- Applied the soft-credit gate (`_allow_response_with_credit_grace`) to Slack DM, @mention, and thread-reply paths so an initial response proceeds if the credits check is slow, while quick denials still block responses.  
- Enhanced `_stream_and_post_responses` to flush incremental Slack messages on tool-boundary, buffer-size threshold, or elapsed interval; added logging for flush events and kept the final stream-end flush.  
- Added unit tests covering buffer-threshold flush behaviour and the slow credits-check soft-grace DM flow, and small supportive logging/debug messages.

### Testing
- Ran `pytest -q tests/test_slack_dm_threading.py tests/test_slack_user_resolution.py::test_process_slack_thread_reply_applies_speaker_and_global_handoff_before_other_processing tests/test_slack_user_resolution.py::test_process_slack_mention_clears_active_user_on_unresolved_speaker_handoff` and all tests passed (`5 passed`).  
- Ran `pytest -q tests/test_slack_events_direct_messages.py` and it passed (`2 passed`).  
- New tests were added/updated in `backend/tests/test_slack_dm_threading.py` and exercised the new flush and soft-credit behaviours, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e8e510d0c83219af571ceca49523a)