### PR TITLE
Enforce sentence-boundary flushing for Slack streamed assistant output

### DIFF
--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -55,6 +55,7 @@ _slack_team_org_cache: dict[str, tuple[str | None, float]] = {}
 _slack_team_org_cache_lock: asyncio.Lock = asyncio.Lock()
 _slack_credits_gate_cache: dict[str, tuple[bool, float]] = {}
 _slack_credits_gate_cache_lock: asyncio.Lock = asyncio.Lock()
+_SENTENCE_BOUNDARY_PATTERN = re.compile(r"(?s)^(.+?[.!?](?:[\"'\)\]\u201d\u2019]+)?)(?:\s+|$)")
 
 
 def _slack_user_info_cache_evict_expired(now: float) -> None:
@@ -1911,11 +1912,34 @@ async def _stream_and_post_responses(
     cleaned_message = _strip_slack_mentions(message_text)
     last_flush_at = time.monotonic()
 
-    async def _flush_current_text(*, reason: str) -> None:
+    def _split_flushable_sentences(text: str) -> tuple[str, str]:
+        """Split text into a flushable sentence prefix and remaining suffix."""
+        idx = 0
+        while idx < len(text):
+            match = _SENTENCE_BOUNDARY_PATTERN.match(text[idx:])
+            if not match:
+                break
+            idx += len(match.group(0))
+        if idx == 0:
+            return "", text
+        return text[:idx], text[idx:]
+
+    async def _flush_current_text(*, reason: str, force: bool = False) -> None:
         nonlocal current_text, total_length, last_flush_at
-        text_to_send = current_text.strip()
-        if not text_to_send:
+        if force:
+            text_to_send = current_text.strip()
             current_text = ""
+        else:
+            flushable_text, remaining_text = _split_flushable_sentences(current_text)
+            text_to_send = flushable_text.strip()
+            current_text = remaining_text
+
+        if not text_to_send:
+            logger.debug(
+                "[slack_conversations] Skipped flush reason=%s force=%s; waiting for sentence boundary",
+                reason,
+                force,
+            )
             return
 
         await connector.post_message(
@@ -1931,7 +1955,6 @@ async def _stream_and_post_responses(
             thread_ts,
             len(text_to_send),
         )
-        current_text = ""
         last_flush_at = time.monotonic()
 
     try:
@@ -1939,7 +1962,7 @@ async def _stream_and_post_responses(
             cleaned_message, attachment_ids=attachment_ids,
         ):
             if chunk.startswith("{"):
-                await _flush_current_text(reason="tool_boundary")
+                await _flush_current_text(reason="tool_boundary", force=True)
             else:
                 current_text += chunk
                 should_flush_for_size = len(current_text) >= SLACK_STREAM_FLUSH_CHAR_THRESHOLD
@@ -1955,7 +1978,7 @@ async def _stream_and_post_responses(
         current_text += f"\n{_cannot_action_message()}"
 
     # Post any remaining text after the stream ends
-    await _flush_current_text(reason="stream_end")
+    await _flush_current_text(reason="stream_end", force=True)
 
     return total_length
 

--- a/backend/tests/test_slack_dm_threading.py
+++ b/backend/tests/test_slack_dm_threading.py
@@ -73,7 +73,7 @@ def test_process_slack_dm_posts_reply_in_same_thread(monkeypatch) -> None:
     assert captured["team_id"] == "T1"
 
 
-def test_streaming_flushes_on_buffer_threshold(monkeypatch) -> None:
+def test_streaming_waits_for_sentence_boundary_when_threshold_reached(monkeypatch) -> None:
     posted: list[str] = []
 
     class _FakeConnector:
@@ -95,10 +95,39 @@ def test_streaming_flushes_on_buffer_threshold(monkeypatch) -> None:
         )
     )
 
-    assert len(posted) == 2
-    assert posted[0] == "x" * slack_conversations.SLACK_STREAM_FLUSH_CHAR_THRESHOLD
-    assert posted[1] == "tail"
-    assert total == len(posted[0]) + len(posted[1])
+    assert len(posted) == 1
+    assert posted[0] == ("x" * slack_conversations.SLACK_STREAM_FLUSH_CHAR_THRESHOLD) + "tail"
+    assert total == len(posted[0])
+
+
+def test_streaming_flushes_completed_sentences_before_stream_end(monkeypatch) -> None:
+    posted: list[str] = []
+
+    class _FakeConnector:
+        async def post_message(self, channel: str, text: str, thread_ts: str | None = None) -> None:
+            posted.append(text)
+
+    class _FakeOrchestrator:
+        async def process_message(self, _message_text: str, attachment_ids=None):
+            yield "Hello world."
+            yield " Another sentence"
+            yield " without punctuation"
+            yield "!"
+
+    monkeypatch.setattr(slack_conversations, "SLACK_STREAM_FLUSH_CHAR_THRESHOLD", 1)
+
+    total = asyncio.run(
+        slack_conversations._stream_and_post_responses(
+            orchestrator=_FakeOrchestrator(),
+            connector=_FakeConnector(),
+            message_text="hello",
+            channel="C123",
+            thread_ts="T123",
+        )
+    )
+
+    assert posted == ["Hello world.", "Another sentence without punctuation!"]
+    assert total == sum(len(chunk) for chunk in posted)
 
 
 def test_process_slack_dm_allows_initial_response_when_credits_check_is_slow(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Prevent mid-sentence partial messages from being posted to Slack when streaming assistant output by only emitting text at sentence boundaries or explicit tool/end boundaries.
- Preserve incremental streaming behavior and responsiveness for tool boundaries and end-of-stream events while reducing confusing partial fragments.
- Add observability for skipped flushes so debugging streaming behavior is easier.

### Description
- Add `_SENTENCE_BOUNDARY_PATTERN` and a helper ` _split_flushable_sentences` to extract complete-sentence prefixes from the stream buffer.
- Change `_flush_current_text` to accept a `force` flag and, when not forced, flush only complete sentences while retaining the remainder in `current_text`.
- Force immediate flushes on tool-call boundaries (`chunk.startswith("{")`) and at end-of-stream to ensure required boundaries still emit promptly.
- Add a debug log when a size/time-triggered flush is skipped due to missing sentence boundary, and update related tests in `backend/tests/test_slack_dm_threading.py` to validate the new behavior.

### Testing
- Ran `pytest -q backend/tests/test_slack_dm_threading.py` which completed successfully (`4 passed`).
- New/updated tests cover threshold-triggered flush waiting for sentence completion and incremental flushing of completed sentences (`test_streaming_waits_for_sentence_boundary_when_threshold_reached`, `test_streaming_flushes_completed_sentences_before_stream_end`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e8ff9565483219d423753f06a7129)