### PR TITLE
Allow Penny to receive and process Slack DM bot messages

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -300,7 +300,17 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
 
     if inner_type == "message":
         channel_type = event.get("channel_type")
-        if event.get("bot_id") or event.get("subtype") == "bot_message":
+        is_direct_message = channel_type in {"im", "mpim"}
+        event_bot_id = (event.get("bot_id") or "").strip()
+        is_bot_message = bool(event_bot_id or event.get("subtype") == "bot_message")
+        if is_bot_message and not is_direct_message:
+            logger.debug(
+                "[slack_events] Ignoring non-DM bot message team=%s channel=%s subtype=%s bot_id=%s",
+                team_id,
+                event.get("channel"),
+                event.get("subtype"),
+                event_bot_id,
+            )
             return
         if event.get("subtype") in ("message_changed", "message_deleted"):
             return
@@ -317,20 +327,30 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
                 )
             )
 
-        is_direct_message = channel_type in {"im", "mpim"}
         if is_direct_message:
             channel_id = event.get("channel", "")
             user_id = event.get("user", "")
+            actor_id = user_id or event_bot_id
             text = event.get("text", "")
             message_ts = event.get("ts") or event.get("event_ts", "")
             thread_ts = event.get("thread_ts")
             files: list[dict[str, Any]] = event.get("files", [])
+            if not actor_id:
+                logger.warning(
+                    "[slack_events] Skipping DM without actor id team=%s channel=%s ts=%s",
+                    team_id,
+                    channel_id,
+                    message_ts,
+                )
+                return
             if not text.strip() and not files:
                 return
             logger.info(
-                "[slack_events] Processing direct message type=%s from %s in %s thread=%s: %s (files=%d)",
+                "[slack_events] Processing direct message type=%s actor=%s user=%s bot=%s in %s thread=%s: %s (files=%d)",
                 channel_type,
+                actor_id,
                 user_id,
+                event_bot_id,
                 channel_id,
                 thread_ts,
                 text[:50],
@@ -339,7 +359,8 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
             await process_slack_dm(
                 team_id=team_id,
                 channel_id=channel_id,
-                user_id=user_id,
+                user_id=actor_id,
+                bot_id=event_bot_id or None,
                 message_text=text,
                 event_ts=message_ts,
                 thread_ts=thread_ts,

--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -1964,6 +1964,7 @@ async def process_slack_dm(
     team_id: str,
     channel_id: str,
     user_id: str,
+    bot_id: str | None,
     message_text: str,
     event_ts: str,
     thread_ts: str | None = None,
@@ -1973,8 +1974,10 @@ async def process_slack_dm(
     Process an incoming Slack DM and generate a response.
     """
     logger.info(
-        "[slack_conversations] Processing direct message from user %s in channel %s thread=%s: %s",
+        "[slack_conversations] Processing direct message actor=%s user=%s bot=%s channel=%s thread=%s: %s",
         user_id,
+        user_id,
+        bot_id,
         channel_id,
         thread_ts,
         message_text[:100],
@@ -1988,23 +1991,38 @@ async def process_slack_dm(
     connector = SlackConnector(organization_id=organization_id, team_id=team_id)
     await connector.add_reaction(channel=channel_id, timestamp=event_ts)
 
-    slack_user = await _fetch_slack_user_info(
-        organization_id=organization_id,
-        slack_user_id=user_id,
-    )
-    linked_user = await resolve_revtops_user_for_slack_actor(
-        organization_id=organization_id,
-        slack_user_id=user_id,
-        slack_user=slack_user,
-    )
-    slack_user_name: str | None = _extract_slack_display_name(slack_user)
-    slack_user_email: str | None = _extract_slack_email(slack_user)
-    slack_user_tz: str | None = _extract_slack_timezone(slack_user)
+    is_bot_actor = bool(bot_id and bot_id == user_id)
+    slack_user: dict[str, Any] | None = None
+    linked_user: User | None = None
+    slack_user_name: str | None = None
+    slack_user_email: str | None = None
+    slack_user_tz: str | None = None
+    if is_bot_actor:
+        slack_user_name = f"Slack bot {bot_id}"
+        logger.info(
+            "[slack_conversations] DM actor is Slack bot bot_id=%s org=%s",
+            bot_id,
+            organization_id,
+        )
+    else:
+        slack_user = await _fetch_slack_user_info(
+            organization_id=organization_id,
+            slack_user_id=user_id,
+        )
+        linked_user = await resolve_revtops_user_for_slack_actor(
+            organization_id=organization_id,
+            slack_user_id=user_id,
+            slack_user=slack_user,
+        )
+        slack_user_name = _extract_slack_display_name(slack_user)
+        slack_user_email = _extract_slack_email(slack_user)
+        slack_user_tz = _extract_slack_timezone(slack_user)
     if not linked_user:
         logger.info(
-            "[slack_conversations] No linked RevTops user for Slack actor=%s org=%s; proceeding without user context",
+            "[slack_conversations] No linked RevTops user for Slack actor=%s org=%s is_bot_actor=%s; proceeding without user context",
             user_id,
             organization_id,
+            is_bot_actor,
         )
 
     conversation_key = f"{channel_id}:{thread_ts}" if thread_ts else channel_id

--- a/backend/tests/test_slack_dm_threading.py
+++ b/backend/tests/test_slack_dm_threading.py
@@ -61,6 +61,7 @@ def test_process_slack_dm_posts_reply_in_same_thread(monkeypatch) -> None:
             team_id="T1",
             channel_id="D1",
             user_id="U1",
+            bot_id=None,
             message_text="hello",
             event_ts="100.1",
             thread_ts="100.0",
@@ -158,6 +159,7 @@ def test_process_slack_dm_allows_initial_response_when_credits_check_is_slow(mon
             team_id="T1",
             channel_id="D1",
             user_id="U1",
+            bot_id=None,
             message_text="hello",
             event_ts="100.1",
             thread_ts="100.0",
@@ -167,3 +169,60 @@ def test_process_slack_dm_allows_initial_response_when_credits_check_is_slow(mon
     assert result["status"] == "success"
     assert "stream" in events
     assert not any("out of credits" in e for e in events if e.startswith("post:"))
+
+
+def test_process_slack_dm_passes_bot_actor_id_to_orchestrator(monkeypatch) -> None:
+    captured: dict[str, str | None] = {}
+
+    class _FakeConnector:
+        def __init__(self, organization_id: str, team_id: str | None = None) -> None:
+            self.organization_id = organization_id
+
+        async def add_reaction(self, channel: str, timestamp: str) -> None:
+            return None
+
+        async def remove_reaction(self, channel: str, timestamp: str) -> None:
+            return None
+
+        async def post_message(self, channel: str, text: str, thread_ts: str | None = None) -> None:
+            return None
+
+    class _FakeOrchestrator:
+        def __init__(self, **kwargs) -> None:
+            captured["source_user_id"] = kwargs.get("source_user_id")
+            captured["source_user_email"] = kwargs.get("source_user_email")
+
+    async def _fake_find_org(_team_id: str) -> str:
+        return "org-1"
+
+    async def _fake_find_or_create_conversation(**_kwargs):
+        return SimpleNamespace(id=UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+
+    async def _fake_stream_and_post_responses(**_kwargs) -> int:
+        return 11
+
+    async def _fake_can_use_credits(_organization_id: str) -> bool:
+        return True
+
+    monkeypatch.setattr(slack_conversations, "find_organization_by_slack_team", _fake_find_org)
+    monkeypatch.setattr(slack_conversations, "SlackConnector", _FakeConnector)
+    monkeypatch.setattr(slack_conversations, "find_or_create_conversation", _fake_find_or_create_conversation)
+    monkeypatch.setattr(slack_conversations, "can_use_credits", _fake_can_use_credits)
+    monkeypatch.setattr(slack_conversations, "ChatOrchestrator", _FakeOrchestrator)
+    monkeypatch.setattr(slack_conversations, "_stream_and_post_responses", _fake_stream_and_post_responses)
+
+    result = asyncio.run(
+        slack_conversations.process_slack_dm(
+            team_id="T1",
+            channel_id="D1",
+            user_id="B1",
+            bot_id="B1",
+            message_text="bot hello",
+            event_ts="100.1",
+            thread_ts=None,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert captured["source_user_id"] == "B1"
+    assert captured["source_user_email"] is None

--- a/backend/tests/test_slack_events_direct_messages.py
+++ b/backend/tests/test_slack_events_direct_messages.py
@@ -15,6 +15,7 @@ def test_process_event_callback_routes_mpim_messages_to_direct_message_handler(m
         captured["user_id"] = kwargs["user_id"]
         captured["message_text"] = kwargs["message_text"]
         captured["event_ts"] = kwargs["event_ts"]
+        captured["bot_id"] = kwargs["bot_id"]
         captured["thread_ts"] = kwargs["thread_ts"]
 
     monkeypatch.setattr(slack_events, "is_duplicate_event", _fake_is_duplicate_event)
@@ -43,6 +44,7 @@ def test_process_event_callback_routes_mpim_messages_to_direct_message_handler(m
         "message_text": "hey penny",
         "event_ts": "1700000000.001",
         "thread_ts": None,
+        "bot_id": None,
     }
 
 
@@ -55,6 +57,7 @@ def test_process_event_callback_passes_thread_ts_for_direct_message_thread(monke
     async def _fake_process_slack_dm(**kwargs):
         captured["thread_ts"] = kwargs["thread_ts"]
         captured["event_ts"] = kwargs["event_ts"]
+        captured["bot_id"] = kwargs["bot_id"]
 
     monkeypatch.setattr(slack_events, "is_duplicate_event", _fake_is_duplicate_event)
     monkeypatch.setattr(slack_events, "process_slack_dm", _fake_process_slack_dm)
@@ -79,4 +82,43 @@ def test_process_event_callback_passes_thread_ts_for_direct_message_thread(monke
     assert captured == {
         "thread_ts": "1700000000.001",
         "event_ts": "1700000000.002",
+        "bot_id": None,
+    }
+
+
+def test_process_event_callback_routes_dm_bot_messages_to_direct_message_handler(monkeypatch) -> None:
+    captured: dict[str, str | None] = {}
+
+    async def _fake_is_duplicate_event(_event_id: str) -> bool:
+        return False
+
+    async def _fake_process_slack_dm(**kwargs):
+        captured["user_id"] = kwargs["user_id"]
+        captured["bot_id"] = kwargs["bot_id"]
+        captured["channel_id"] = kwargs["channel_id"]
+
+    monkeypatch.setattr(slack_events, "is_duplicate_event", _fake_is_duplicate_event)
+    monkeypatch.setattr(slack_events, "process_slack_dm", _fake_process_slack_dm)
+
+    payload = {
+        "type": "event_callback",
+        "event_id": "EvIMBot1",
+        "team_id": "T123",
+        "event": {
+            "type": "message",
+            "channel_type": "im",
+            "channel": "D123",
+            "bot_id": "B222",
+            "subtype": "bot_message",
+            "text": "hey from bot",
+            "ts": "1700000000.003",
+        },
+    }
+
+    asyncio.run(slack_events._process_event_callback_impl(payload))
+
+    assert captured == {
+        "user_id": "B222",
+        "bot_id": "B222",
+        "channel_id": "D123",
     }


### PR DESCRIPTION
### Motivation
- Penny should be able to converse with bot actors in Slack DMs, so bot IDs must be propagated into Penny and Penny must be able to DM bots. 
- Previously bot messages were broadly filtered out, preventing DM/MPIM bot actors from reaching Penny while still ignoring non-DM channel bot noise. 

### Description
- Update `api/routes/slack_events.py` to only drop bot messages for non-DM channels and to compute an `actor_id` fallback (`user_id or bot_id`), logging actor context and passing `bot_id` into the DM handler via `process_slack_dm(..., bot_id=...)`. 
- Extend `services/slack_conversations.py` `process_slack_dm` signature to accept `bot_id`, detect `is_bot_actor`, short-circuit human profile/mapping lookups for bot actors, log bot context, and retain the actor ID in the conversation/orchestrator context. 
- Add and update tests to assert DM routing includes `bot_id`, that DM bot messages are routed to `process_slack_dm`, and that bot actor IDs are forwarded into the orchestrator context. 

### Testing
- Ran the targeted test suite with `pytest -q backend/tests/test_slack_events_direct_messages.py backend/tests/test_slack_dm_threading.py` and all tests passed. 
- The run showed `7 passed` (with unrelated warnings) validating DM routing, bot actor handling, and orchestrator propagation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e902fde448321a9ce671fcb230e31)