### PR TITLE
Avoid Slack stream flush splitting wrapped email domains

### DIFF
--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -55,7 +55,8 @@ _slack_team_org_cache: dict[str, tuple[str | None, float]] = {}
 _slack_team_org_cache_lock: asyncio.Lock = asyncio.Lock()
 _slack_credits_gate_cache: dict[str, tuple[bool, float]] = {}
 _slack_credits_gate_cache_lock: asyncio.Lock = asyncio.Lock()
-_SENTENCE_BOUNDARY_PATTERN = re.compile(r"(?s)^(.+?[.!?](?:[\"'\)\]\u201d\u2019]+)?)(?:\s+|$)")
+_SENTENCE_BOUNDARY_PATTERN = re.compile(r"[.!?](?:[\"'\)\]\u201d\u2019]+)?(?=\s+|$)")
+_NEXT_WORD_PATTERN = re.compile(r"\s+([a-z]{2,24})(?=\b)")
 
 
 def _slack_user_info_cache_evict_expired(now: float) -> None:
@@ -1914,15 +1915,29 @@ async def _stream_and_post_responses(
 
     def _split_flushable_sentences(text: str) -> tuple[str, str]:
         """Split text into a flushable sentence prefix and remaining suffix."""
-        idx = 0
-        while idx < len(text):
-            match = _SENTENCE_BOUNDARY_PATTERN.match(text[idx:])
-            if not match:
-                break
-            idx += len(match.group(0))
-        if idx == 0:
+        last_boundary_end = 0
+
+        for match in _SENTENCE_BOUNDARY_PATTERN.finditer(text):
+            punct_index = match.start()
+            boundary_end = match.end()
+
+            # Avoid flushing at `.` boundaries that are likely mid-email/domain
+            # line wraps, e.g. `vincent@basebase.\ncom`.
+            if text[punct_index] == "." and punct_index > 0 and text[punct_index - 1].isalnum():
+                remainder = text[boundary_end:]
+                next_word_match = _NEXT_WORD_PATTERN.match(remainder)
+                token_start = punct_index
+                while token_start > 0 and not text[token_start - 1].isspace():
+                    token_start -= 1
+                token = text[token_start:punct_index]
+                if ("@" in token or "." in token) and (next_word_match or not remainder.strip()):
+                    continue
+
+            last_boundary_end = boundary_end
+
+        if last_boundary_end == 0:
             return "", text
-        return text[:idx], text[idx:]
+        return text[:last_boundary_end], text[last_boundary_end:]
 
     async def _flush_current_text(*, reason: str, force: bool = False) -> None:
         nonlocal current_text, total_length, last_flush_at

--- a/backend/tests/test_slack_dm_threading.py
+++ b/backend/tests/test_slack_dm_threading.py
@@ -130,6 +130,37 @@ def test_streaming_flushes_completed_sentences_before_stream_end(monkeypatch) ->
     assert total == sum(len(chunk) for chunk in posted)
 
 
+def test_streaming_does_not_flush_mid_email_domain_wrap(monkeypatch) -> None:
+    posted: list[str] = []
+
+    class _FakeConnector:
+        async def post_message(self, channel: str, text: str, thread_ts: str | None = None) -> None:
+            posted.append(text)
+
+    class _FakeOrchestrator:
+        async def process_message(self, _message_text: str, attachment_ids=None):
+            yield "- Email: vincent@basebase.\n"
+            yield "com\n"
+            yield "- Title: Head of \"No, that's Breach\""
+
+    monkeypatch.setattr(slack_conversations, "SLACK_STREAM_FLUSH_CHAR_THRESHOLD", 1)
+
+    total = asyncio.run(
+        slack_conversations._stream_and_post_responses(
+            orchestrator=_FakeOrchestrator(),
+            connector=_FakeConnector(),
+            message_text="hello",
+            channel="C123",
+            thread_ts="T123",
+        )
+    )
+
+    assert posted == [
+        "- Email: vincent@basebase.\ncom\n- Title: Head of \"No, that's Breach\"",
+    ]
+    assert total == len(posted[0])
+
+
 def test_process_slack_dm_allows_initial_response_when_credits_check_is_slow(monkeypatch) -> None:
     events: list[str] = []
 


### PR DESCRIPTION
### Motivation
- Prevent the Slack streaming flush from breaking sentences at `.` when the dot is part of an email/domain that was wrapped across a newline (e.g. `vincent@basebase.\ncom`) which caused premature short posts.

### Description
- Replace the previous sentence-boundary approach with a punctuation-focused regex and add a `_NEXT_WORD_PATTERN` heuristic to detect likely continuation tokens after a punctuation boundary.
- Update `_split_flushable_sentences` to skip flush boundaries when the `.` appears inside an email/domain-like token and the following segment looks like a continuation, preserving the full address in the buffer.
- Add a regression test `test_streaming_does_not_flush_mid_email_domain_wrap` in `backend/tests/test_slack_dm_threading.py` that verifies wrapped email domains are not flushed into separate Slack posts.
- Files changed: `backend/services/slack_conversations.py` and `backend/tests/test_slack_dm_threading.py`.

### Testing
- Ran `pytest -q backend/tests/test_slack_dm_threading.py` which passed all tests (`5 passed`).
- The added regression test confirms the streamed Slack output is posted as a single combined chunk for wrapped email domains.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e939932b88321a794994380c7c9ab)