### PR TITLE
Log PagerDuty health check outcomes in monitoring task

### DIFF
--- a/backend/tests/test_monitoring_task.py
+++ b/backend/tests/test_monitoring_task.py
@@ -67,3 +67,32 @@ def test_pagerduty_alias_var_is_loaded(monkeypatch: Any) -> None:
     monkeypatch.setenv("PagerDuty_Key", "alias_value")
     fresh_settings = settings.__class__()
     assert fresh_settings.PAGERDUTY_KEY == "alias_value"
+
+
+def test_monitor_dependencies_logs_health_check_outcome(monkeypatch: Any, caplog: Any) -> None:
+    async def _fake_run_dependency_checks() -> list[monitoring.CheckResult]:
+        return [
+            monitoring.CheckResult(name="Supabase", healthy=True, details="ok"),
+            monitoring.CheckResult(name="Redis", healthy=False, details="timeout"),
+        ]
+
+    monkeypatch.setattr(monitoring, "_run_dependency_checks", _fake_run_dependency_checks)
+
+    created_incidents: list[str] = []
+
+    async def _fake_create_pagerduty_incident(**kwargs: Any) -> None:
+        created_incidents.append(kwargs["check_result"].name)
+
+    monkeypatch.setattr(monitoring, "_create_pagerduty_incident", _fake_create_pagerduty_incident)
+    monkeypatch.setenv("PAGERDUTY_FROM_EMAIL", "alerts@revtops.com")
+    monkeypatch.setenv("PagerDuty_Key", "pd_test_key")
+    monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
+    monkeypatch.setattr(monitoring, "settings", settings.__class__())
+
+    caplog.set_level("INFO")
+    result = monitoring.monitor_dependencies.__wrapped__()
+
+    assert result["down_services"] == ["Redis"]
+    assert created_incidents == ["Redis"]
+    assert "PagerDuty health check succeeded for Supabase; incident creation skipped" in caplog.text
+    assert "PagerDuty health check failed for Redis; incident will be created" in caplog.text

--- a/backend/workers/tasks/monitoring.py
+++ b/backend/workers/tasks/monitoring.py
@@ -170,6 +170,17 @@ def monitor_dependencies(self: Any) -> dict[str, Any]:
             level = logging.INFO if result.healthy else logging.WARNING
             logger.log(level, "Dependency check: %s healthy=%s (%s)", result.name, result.healthy, result.details)
 
+            if result.healthy:
+                logger.info(
+                    "PagerDuty health check succeeded for %s; incident creation skipped",
+                    result.name,
+                )
+            else:
+                logger.warning(
+                    "PagerDuty health check failed for %s; incident will be created",
+                    result.name,
+                )
+
         for result in down:
             await _create_pagerduty_incident(
                 from_email=from_email,


### PR DESCRIPTION
### Motivation
- Make dependency-monitoring runs more observable by recording whether each PagerDuty-related health check succeeded or failed in server logs.

### Description
- Add explicit `INFO` log when a check is healthy and `WARNING` log when a check fails immediately before PagerDuty incident creation logic in `backend/workers/tasks/monitoring.py`.
- Add a unit test `test_monitor_dependencies_logs_health_check_outcome` in `backend/tests/test_monitoring_task.py` that stubs `_run_dependency_checks` and `_create_pagerduty_incident`, verifies only failed checks trigger incident creation, and asserts the new success/failure log messages are emitted.
- The test invokes the underlying task implementation via the Celery proxy `__wrapped__` to run synchronously in tests and monkeypatches `settings` and PagerDuty env vars for isolation.

### Testing
- Ran `pytest backend/tests/test_monitoring_task.py -q`, which completed successfully with all tests passing (4 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f240056008321928a4a3a947953f3)