### PR TITLE
Fix Slack stream flush for list markers

### DIFF
--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -57,6 +57,7 @@ _slack_credits_gate_cache: dict[str, tuple[bool, float]] = {}
 _slack_credits_gate_cache_lock: asyncio.Lock = asyncio.Lock()
 _SENTENCE_BOUNDARY_PATTERN = re.compile(r"[.!?](?:[\"'\)\]\u201d\u2019]+)?(?=\s+|$)")
 _NEXT_WORD_PATTERN = re.compile(r"\s+([a-z]{2,24})(?=\b)")
+_LIST_MARKER_BREAK_PATTERN = re.compile(r"(^|\n)(\s*(?:\d+[.)]|[-*+])\s*)\n+(?=\S)")
 
 
 def _slack_user_info_cache_evict_expired(now: float) -> None:
@@ -69,6 +70,13 @@ def _slack_user_info_cache_evict_expired(now: float) -> None:
 def _strip_slack_mentions(text: str) -> str:
     """Remove Slack user mentions like <@U09HDFN8DO8> from text."""
     return SLACK_MENTION_PATTERN.sub("", text).strip()
+
+
+def _collapse_list_marker_breaks(text: str) -> str:
+    """Collapse accidental line breaks after list markers to avoid split list items."""
+    return _LIST_MARKER_BREAK_PATTERN.sub(lambda m: f"{m.group(1)}{m.group(2).rstrip()} ", text)
+
+
 SLOW_REPLY_MESSAGE = "Still working on this..."
 
 
@@ -1938,6 +1946,10 @@ async def _stream_and_post_responses(
             # Avoid flushing at `.` boundaries that are likely mid-email/domain
             # line wraps, e.g. `vincent@basebase.\ncom`.
             if text[punct_index] == "." and punct_index > 0 and text[punct_index - 1].isalnum():
+                line_start = text.rfind("\n", 0, punct_index) + 1
+                if re.fullmatch(r"\s*\d+", text[line_start:punct_index]):
+                    continue
+
                 remainder = text[boundary_end:]
                 next_word_match = _NEXT_WORD_PATTERN.match(remainder)
                 token_start = punct_index
@@ -1970,6 +1982,8 @@ async def _stream_and_post_responses(
                 force,
             )
             return
+
+        text_to_send = _collapse_list_marker_breaks(text_to_send)
 
         await connector.post_message(
             channel=channel,

--- a/backend/tests/test_slack_dm_threading.py
+++ b/backend/tests/test_slack_dm_threading.py
@@ -161,6 +161,34 @@ def test_streaming_does_not_flush_mid_email_domain_wrap(monkeypatch) -> None:
     assert total == len(posted[0])
 
 
+def test_streaming_keeps_list_marker_with_following_text(monkeypatch) -> None:
+    posted: list[str] = []
+
+    class _FakeConnector:
+        async def post_message(self, channel: str, text: str, thread_ts: str | None = None) -> None:
+            posted.append(text)
+
+    class _FakeOrchestrator:
+        async def process_message(self, _message_text: str, attachment_ids=None):
+            yield "1.\n"
+            yield "Text"
+
+    monkeypatch.setattr(slack_conversations, "SLACK_STREAM_FLUSH_CHAR_THRESHOLD", 1)
+
+    total = asyncio.run(
+        slack_conversations._stream_and_post_responses(
+            orchestrator=_FakeOrchestrator(),
+            connector=_FakeConnector(),
+            message_text="hello",
+            channel="C123",
+            thread_ts="T123",
+        )
+    )
+
+    assert posted == ["1. Text"]
+    assert total == len(posted[0])
+
+
 def test_process_slack_dm_allows_initial_response_when_credits_check_is_slow(monkeypatch) -> None:
     events: list[str] = []
 


### PR DESCRIPTION
### Motivation
- Prevent streamed Slack responses from splitting numbered/bulleted list markers (e.g. `1.` or `-`) onto their own line when the generator yields a marker and then the item text separately.
- Preserve existing protections for email/domain wraps and sentence-boundary flushing while improving list handling.

### Description
- Add `_LIST_MARKER_BREAK_PATTERN` and helper ` _collapse_list_marker_breaks` to normalize accidental line breaks after list markers in streamed text in `backend/services/slack_conversations.py`.
- Update `_split_flushable_sentences` to treat a `.` at the end of a line that is just a list index (digits only) as non-terminal so it won't trigger a flush.
- Apply `_collapse_list_marker_breaks` to any chunk being flushed so markers and their following text are posted as `1. Text` or `- Text` instead of split lines.
- Add a regression test `test_streaming_keeps_list_marker_with_following_text` in `backend/tests/test_slack_dm_threading.py` that verifies a stream yielding `"1.\n"` then `"Text"` posts as `"1. Text"`.

### Testing
- Ran targeted pytest: `pytest -q tests/test_slack_dm_threading.py::test_streaming_keeps_list_marker_with_following_text tests/test_slack_dm_threading.py::test_streaming_flushes_completed_sentences_before_stream_end tests/test_slack_dm_threading.py::test_streaming_does_not_flush_mid_email_domain_wrap`.
- All targeted tests passed (`3 passed`) with the updated logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f4504cd808321b41ae67c35387fdd)