### PR TITLE
Route in-thread message events that @mention the bot to mention handler

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -291,6 +291,7 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
     event = payload.get("event", {})
     event_id = payload.get("event_id", "")
     team_id = payload.get("team_id", "")
+    bot_user_ids = _extract_bot_user_ids(payload)
 
     if event_id and await is_duplicate_event(event_id):
         logger.info("[slack_events] Skipping duplicate event: %s", event_id)
@@ -357,6 +358,41 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
             if not text.strip() and not files:
                 return
 
+            # When a bot @mention happens inside an existing thread where the bot
+            # has not previously participated, Slack may deliver a message event
+            # before app_mention. In that ordering, treating this as a normal
+            # thread reply can cause the conversation lookup path to ignore the
+            # message before app_mention runs. If the current message explicitly
+            # mentions this bot, route it through mention handling for the same
+            # thread so the bot reliably joins and replies in-thread.
+            if _message_mentions_bot_user(text, bot_user_ids):
+                if message_ts and channel_id and await is_duplicate_message(channel_id, message_ts):
+                    logger.info(
+                        "[slack_events] Skipping duplicate message %s:%s (already claimed by another event type)",
+                        channel_id,
+                        message_ts,
+                    )
+                    return
+
+                normalized_text = _strip_bot_mentions(text, bot_user_ids)
+                logger.info(
+                    "[slack_events] Routing in-thread bot mention from message event to mention handler user=%s channel=%s thread=%s",
+                    user_id,
+                    channel_id,
+                    thread_ts,
+                )
+                lock_key = SlackThreadLockManager.build_lock_key(team_id, channel_id, thread_ts)
+                async with _thread_lock_manager.thread_lock(lock_key):
+                    await process_slack_mention(
+                        team_id=team_id,
+                        channel_id=channel_id,
+                        user_id=user_id,
+                        message_text=normalized_text,
+                        thread_ts=thread_ts,
+                        files=files,
+                    )
+                return
+
             # Cross-event-type dedup: if the same message already triggered
             # an app_mention handler, skip the redundant thread-reply path.
             if message_ts and channel_id and await is_duplicate_message(channel_id, message_ts):
@@ -417,6 +453,43 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
                 thread_ts=lock_thread_ts,
                 files=files,
             )
+
+
+def _extract_bot_user_ids(payload: dict[str, Any]) -> set[str]:
+    """Extract known bot user IDs for this event payload."""
+    user_ids: set[str] = set()
+
+    authed_users = payload.get("authed_users")
+    if isinstance(authed_users, list):
+        for candidate in authed_users:
+            if isinstance(candidate, str) and candidate:
+                user_ids.add(candidate)
+
+    authorizations = payload.get("authorizations")
+    if isinstance(authorizations, list):
+        for authorization in authorizations:
+            if not isinstance(authorization, dict):
+                continue
+            candidate = authorization.get("user_id")
+            if isinstance(candidate, str) and candidate:
+                user_ids.add(candidate)
+
+    return user_ids
+
+
+def _message_mentions_bot_user(text: str, bot_user_ids: set[str]) -> bool:
+    """Return True when message text contains an explicit mention of this bot."""
+    if not text or not bot_user_ids:
+        return False
+    return any(f"<@{bot_user_id}>" in text for bot_user_id in bot_user_ids)
+
+
+def _strip_bot_mentions(text: str, bot_user_ids: set[str]) -> str:
+    """Normalize message text by removing all direct mentions of this bot."""
+    normalized: str = text
+    for bot_user_id in bot_user_ids:
+        normalized = re.sub(rf"<@{re.escape(bot_user_id)}>\s*", "", normalized)
+    return normalized.strip()
 
 
 @router.post("/events", response_model=None)

--- a/backend/tests/test_slack_events_thread_locking.py
+++ b/backend/tests/test_slack_events_thread_locking.py
@@ -75,3 +75,56 @@ def test_process_event_callback_serializes_thread_reply_events(monkeypatch) -> N
     asyncio.run(_run())
 
     assert max_overlap == 1
+
+
+def test_process_event_callback_routes_thread_message_bot_mention_to_mention_handler(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    async def _fake_is_duplicate_event(_event_id: str) -> bool:
+        return False
+
+    async def _fake_is_duplicate_message(_channel_id: str, _message_ts: str) -> bool:
+        return False
+
+    async def _fake_process_slack_mention(**kwargs):
+        captured["thread_ts"] = kwargs["thread_ts"]
+        captured["message_text"] = kwargs["message_text"]
+        captured["channel_id"] = kwargs["channel_id"]
+
+    async def _fake_process_slack_thread_reply(**_kwargs):
+        raise AssertionError("thread reply handler should not be called")
+
+    monkeypatch.setattr(slack_events, "is_duplicate_event", _fake_is_duplicate_event)
+    monkeypatch.setattr(slack_events, "is_duplicate_message", _fake_is_duplicate_message)
+    monkeypatch.setattr(slack_events, "process_slack_mention", _fake_process_slack_mention)
+    monkeypatch.setattr(slack_events, "process_slack_thread_reply", _fake_process_slack_thread_reply)
+
+    payload = {
+        "type": "event_callback",
+        "event_id": "EvThreadMention1",
+        "team_id": "T123",
+        "authed_users": ["UBOT"],
+        "event": {
+            "type": "message",
+            "channel_type": "channel",
+            "channel": "C123",
+            "user": "U123",
+            "thread_ts": "1700000000.001",
+            "ts": "1700000000.002",
+            "text": "<@UBOT> can you help in this thread?",
+        },
+    }
+
+    asyncio.run(slack_events._process_event_callback_impl(payload))
+
+    assert captured == {
+        "thread_ts": "1700000000.001",
+        "message_text": "can you help in this thread?",
+        "channel_id": "C123",
+    }
+
+
+def test_strip_bot_mentions_removes_only_known_bot_mentions() -> None:
+    text = "<@UBOT> hi <@UOTHER> and <@UBOT>"
+    cleaned = slack_events._strip_bot_mentions(text, {"UBOT"})
+    assert cleaned == "hi <@UOTHER> and"


### PR DESCRIPTION
### Motivation
- Slack can deliver a `message` event before the `app_mention` event when a bot is @mentioned inside an existing thread the bot has not previously participated in, causing the message to be ignored by the thread-reply path.
- The change ensures explicit in-thread @mentions reliably result in the bot joining and replying in-thread instead of being dropped by conversation lookup ordering.

### Description
- Extract bot user IDs from event payloads by adding `_extract_bot_user_ids` which reads `authed_users` and `authorizations` to identify the bot's user IDs.
- Detect explicit bot mentions in `message` events and, when present in a thread, route the event to `process_slack_mention` after stripping only the bot mention via `_strip_bot_mentions`, while preserving cross-event dedup and per-thread locking.
- Add `_message_mentions_bot_user` helper to test for mentions and reuse `_thread_lock_manager` to serialize handling identical to `app_mention` processing.
- Add tests in `backend/tests/test_slack_events_thread_locking.py` covering routing of an in-thread message-event bot mention to the mention handler and validating mention stripping behavior; modified `backend/api/routes/slack_events.py` to include the new helpers and routing logic.

### Testing
- Ran `pytest -q backend/tests/test_slack_events_thread_locking.py backend/tests/test_slack_events_direct_messages.py` which succeeded with `6 passed` and no failures.
- Added unit tests that simulate a `message` payload containing `<@UBOT>` and assert it is handled by `process_slack_mention` and that `_strip_bot_mentions` only removes the known bot mention.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f459138d083219945f119bd6664c4)