### PR TITLE
Add configurable grace credits and force out-of-credits turn closeout

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1615,6 +1615,7 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
             
             # === EXECUTE TOOLS: Process each tool and update results ===
             tool_results: list[dict[str, Any]] = []
+            forced_out_of_credits_closeout: bool = False
             
             for tool_use in tool_uses:
                 tool_name = tool_use["name"]
@@ -1658,6 +1659,10 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
                 except Exception as exc:
                     logger.exception("[Orchestrator] Tool %s raised: %s", tool_name, exc)
                     tool_result = {"error": f"Tool execution failed: {exc}"}
+
+                forced_out_of_credits_closeout = forced_out_of_credits_closeout or bool(
+                    tool_result.pop("_out_of_credits_after_turn", False)
+                )
 
                 logger.info(
                     "[Orchestrator] Tool result for %s: %s",
@@ -1729,6 +1734,20 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
                     "content": str(tool_result),
                 })
             
+            if forced_out_of_credits_closeout:
+                out_of_credits_message = (
+                    "You're out of credits. I paused here before finishing your last request. "
+                    "Please add a payment method in Revtops to continue."
+                )
+                logger.info(
+                    "[Orchestrator] Ending turn with out-of-credits closeout org_id=%s conversation_id=%s",
+                    self.organization_id,
+                    self.conversation_id,
+                )
+                content_blocks.append({"type": "text", "text": out_of_credits_message})
+                yield out_of_credits_message
+                break
+
             # Add assistant message with all tool uses, then user message with all results
             # Convert content blocks to plain dicts to avoid Pydantic serialization issues
             assistant_content: list[dict[str, Any]] = []

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -276,10 +276,11 @@ async def execute_tool(
 
     conversation_id: str | None = (context or {}).get("conversation_id")
     # Deduct credits before running the tool (fail fast if insufficient); import here to avoid circular import
-    from services.credits import credits_for_tool, deduct as deduct_credits
+    from services.credits import credits_for_tool, deduct_with_grace
     cost: int = credits_for_tool(tool_name, tool_input or {}, context)
+    used_grace_credits: bool = False
     if cost > 0:
-        ok = await deduct_credits(
+        ok, used_grace_credits = await deduct_with_grace(
             organization_id,
             cost,
             "tool",
@@ -289,7 +290,8 @@ async def execute_tool(
         )
         if not ok:
             return {
-                "error": "Insufficient credits. Please upgrade your plan or wait for your next billing period."
+                "error": "You're out of credits. Please add a payment method in Revtops to continue.",
+                "_out_of_credits_after_turn": True,
             }
 
     # Check if this tool should bypass approval (for auto-approved workflows)
@@ -325,6 +327,13 @@ async def execute_tool(
         return {"error": f"Unknown tool: {tool_name}"}
 
     result = await handler()
+    if used_grace_credits:
+        result["_out_of_credits_after_turn"] = True
+        logger.info(
+            "[Tools] Grace credits used for tool=%s org_id=%s; forcing out-of-credits closeout",
+            tool_name,
+            organization_id,
+        )
     _log_tool_execution_result(tool_name, tool_name, result)
     return result
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -132,6 +132,9 @@ class Settings(BaseSettings):
     )
     PAGERDUTY_SERVICE_ID: Optional[str] = None
 
+    # Credits
+    NUM_GRACE_CREDITS: int = 5
+
     @property
     def sandbox_database_url(self) -> str:
         """Sync Postgres URL for E2B sandbox (strips SQLAlchemy asyncpg prefix)."""

--- a/backend/services/credits.py
+++ b/backend/services/credits.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from models.credit_transaction import CreditTransaction
 from models.database import get_admin_session
 from models.organization import Organization
+from config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +131,83 @@ async def deduct(
         if ok:
             await sess.commit()
         return ok
+
+
+async def deduct_with_grace(
+    organization_id: str,
+    amount: int,
+    reason: str,
+    *,
+    reference_type: str | None = None,
+    reference_id: str | None = None,
+    user_id: str | None = None,
+    session: AsyncSession | None = None,
+) -> tuple[bool, bool]:
+    """
+    Deduct credits and allow temporary overage up to NUM_GRACE_CREDITS.
+
+    Returns (ok, used_grace).
+    """
+    if amount <= 0:
+        return True, False
+
+    max_grace: int = max(0, int(settings.NUM_GRACE_CREDITS))
+
+    async def _run(sess: AsyncSession) -> tuple[bool, bool]:
+        result = await sess.execute(
+            select(Organization).where(Organization.id == UUID(organization_id))
+        )
+        org: Organization | None = result.scalar_one_or_none()
+        if org is None:
+            logger.warning("[Credits] deduct_with_grace: organization %s not found", organization_id)
+            return False, False
+
+        current: int = int(org.credits_balance)
+        new_balance: int = current - amount
+        allowed_floor: int = -max_grace
+        if new_balance < allowed_floor:
+            logger.info(
+                "[Credits] deduct_with_grace: org %s would exceed grace (%d -> %d, floor=%d)",
+                organization_id,
+                current,
+                new_balance,
+                allowed_floor,
+            )
+            return False, False
+
+        await sess.execute(
+            update(Organization)
+            .where(Organization.id == UUID(organization_id))
+            .values(credits_balance=new_balance)
+        )
+        tx = CreditTransaction(
+            organization_id=UUID(organization_id),
+            user_id=UUID(user_id) if user_id else None,
+            amount=-amount,
+            balance_after=new_balance,
+            reason=reason[:64],
+            reference_type=reference_type,
+            reference_id=reference_id,
+        )
+        sess.add(tx)
+        used_grace = new_balance < 0
+        logger.info(
+            "[Credits] deduct_with_grace: org %s deducted %d, new balance %d, used_grace=%s",
+            organization_id,
+            amount,
+            new_balance,
+            used_grace,
+        )
+        return True, used_grace
+
+    if session is not None:
+        return await _run(session)
+
+    async with get_admin_session() as sess:
+        ok, used_grace = await _run(sess)
+        if ok:
+            await sess.commit()
+        return ok, used_grace
 
 
 def credits_for_tool(

--- a/backend/tests/test_tools_credit_grace.py
+++ b/backend/tests/test_tools_credit_grace.py
@@ -1,0 +1,56 @@
+import asyncio
+
+from agents import tools
+from services import credits
+
+
+def test_execute_tool_returns_credit_error_when_grace_exhausted(monkeypatch) -> None:
+    async def _fake_deduct_with_grace(*args, **kwargs):
+        return False, False
+
+    async def _fake_should_skip_approval(*args, **kwargs) -> bool:
+        return True
+
+    monkeypatch.setattr(credits, "deduct_with_grace", _fake_deduct_with_grace)
+    monkeypatch.setattr(tools, "_should_skip_approval", _fake_should_skip_approval)
+
+    result = asyncio.run(
+        tools.execute_tool(
+            tool_name="list_connected_systems",
+            tool_input={},
+            organization_id="00000000-0000-0000-0000-000000000001",
+            user_id="00000000-0000-0000-0000-000000000002",
+            context={},
+        )
+    )
+
+    assert "out of credits" in result.get("error", "").lower()
+    assert result.get("_out_of_credits_after_turn") is True
+
+
+def test_execute_tool_marks_turn_for_credit_closeout_when_grace_used(monkeypatch) -> None:
+    async def _fake_deduct_with_grace(*args, **kwargs):
+        return True, True
+
+    async def _fake_should_skip_approval(*args, **kwargs) -> bool:
+        return True
+
+    async def _fake_list_connected_systems(_organization_id: str):
+        return {"connected_systems": []}
+
+    monkeypatch.setattr(credits, "deduct_with_grace", _fake_deduct_with_grace)
+    monkeypatch.setattr(tools, "_should_skip_approval", _fake_should_skip_approval)
+    monkeypatch.setattr(tools, "_list_connected_systems", _fake_list_connected_systems)
+
+    result = asyncio.run(
+        tools.execute_tool(
+            tool_name="list_connected_systems",
+            tool_input={},
+            organization_id="00000000-0000-0000-0000-000000000001",
+            user_id="00000000-0000-0000-0000-000000000002",
+            context={},
+        )
+    )
+
+    assert result.get("connected_systems") == []
+    assert result.get("_out_of_credits_after_turn") is True

--- a/backend/tests/test_tools_write_to_system_of_record.py
+++ b/backend/tests/test_tools_write_to_system_of_record.py
@@ -32,12 +32,12 @@ def test_write_to_system_routes_to_dispatcher(monkeypatch) -> None:
         called["conversation_id"] = conversation_id
         return {"status": "created", "message": "ok"}
 
-    async def _fake_deduct_credits(*args, **kwargs) -> bool:
-        return True
+    async def _fake_deduct_with_grace(*args, **kwargs):
+        return True, False
 
     monkeypatch.setattr(tools, "_should_skip_approval", _fake_should_skip_approval)
     monkeypatch.setattr(tools, "_write_to_system", _fake_write_to_system)
-    monkeypatch.setattr(credits, "deduct", _fake_deduct_credits)
+    monkeypatch.setattr(credits, "deduct_with_grace", _fake_deduct_with_grace)
 
     result = asyncio.run(
         tools.execute_tool(

--- a/env.example
+++ b/env.example
@@ -82,3 +82,6 @@ VITE_SUPABASE_URL=your_supabase_project_url
 # Get this from your Railway project variables.
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 VITE_NANGO_PUBLIC_KEY=your_nango_public_key
+
+# Credits
+NUM_GRACE_CREDITS=5


### PR DESCRIPTION
### Motivation
- Improve UX when an org runs out of credits mid-turn by allowing a small configurable grace so the agent can finish current work but still surface a clear out-of-credits failure in the conversation.
- Make the grace budget environment-configurable to allow ops to tune behavior without code changes.

### Description
- Added `NUM_GRACE_CREDITS` to application settings and `env.example` to make the grace limit configurable (default 5). (files: `backend/config.py`, `env.example`)
- Implemented `deduct_with_grace(...)` in `backend/services/credits.py` which records transactions and allows balances to dip down to `-NUM_GRACE_CREDITS`; it returns `(ok, used_grace)` to indicate whether grace was consumed. (file: `backend/services/credits.py`)
- Switched tool execution credit gating to call `deduct_with_grace(...)`, return a clear out-of-credits error when deduction would exceed grace, and tag successful results that consumed grace with `_out_of_credits_after_turn`. (file: `backend/agents/tools.py`)
- Updated the orchestrator tool loop to detect the `_out_of_credits_after_turn` tag and inject a deterministic assistant message telling the user the turn was paused for out-of-credits, then end the turn so the UI shows a failure even if the last tool returned successfully. (file: `backend/agents/orchestrator.py`)
- Updated existing unit test to use the new deduction API and added tests covering both the exhausted-grace and used-grace scenarios. (files: `backend/tests/test_tools_write_to_system_of_record.py`, `backend/tests/test_tools_credit_grace.py`)

### Testing
- Ran the targeted test suite: `cd backend && pytest -q tests/test_tools_write_to_system_of_record.py tests/test_tools_credit_grace.py`, which completed with all tests passing (3 passed) and one pydantic deprecation warning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f70d8aff0832191feadba218c0f27)