### PR TITLE
Add configurable spike-mode log compression

### DIFF
--- a/backend/api/logging_config.py
+++ b/backend/api/logging_config.py
@@ -1,0 +1,63 @@
+"""Logging setup helpers for API service."""
+from __future__ import annotations
+
+import gzip
+import logging
+import logging.handlers
+import os
+import shutil
+import sys
+from pathlib import Path
+
+from config import settings
+
+
+class GZipRotatingFileHandler(logging.handlers.RotatingFileHandler):
+    """Rotating file handler that compresses backups as .gz files."""
+
+    def rotator(self, source: str, dest: str) -> None:  # type: ignore[override]
+        with open(source, "rb") as source_stream, gzip.open(f"{dest}.gz", "wb") as dest_stream:
+            shutil.copyfileobj(source_stream, dest_stream)
+        os.remove(source)
+
+
+def _sanitize_level(level_name: str, fallback: int) -> int:
+    value = getattr(logging, level_name.upper(), None)
+    return value if isinstance(value, int) else fallback
+
+
+def configure_logging() -> None:
+    """Configure process-wide logging based on environment settings."""
+    log_format = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+
+    spike_mode = settings.LOGGING_SPIKE_MODE
+    root_level = logging.WARNING if spike_mode else _sanitize_level(settings.LOG_LEVEL, logging.INFO)
+    root_logger.setLevel(root_level)
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(logging.Formatter(log_format))
+    root_logger.addHandler(stream_handler)
+
+    if spike_mode:
+        log_file = Path(settings.LOG_SPIKE_FILE_PATH)
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = GZipRotatingFileHandler(
+            filename=log_file,
+            maxBytes=settings.LOG_SPIKE_MAX_BYTES,
+            backupCount=settings.LOG_SPIKE_BACKUP_COUNT,
+            encoding="utf-8",
+        )
+        file_handler.setFormatter(logging.Formatter(log_format))
+        root_logger.addHandler(file_handler)
+
+    agents_level = logging.INFO if spike_mode else _sanitize_level(settings.AGENTS_LOG_LEVEL, logging.DEBUG)
+    logging.getLogger("agents").setLevel(agents_level)
+
+    logging.getLogger(__name__).info(
+        "Logging configured: spike_mode=%s root_level=%s agents_level=%s",
+        spike_mode,
+        logging.getLevelName(root_level),
+        logging.getLevelName(agents_level),
+    )

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import logging
 import os
-import sys
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -22,15 +21,10 @@ from api.websockets import websocket_endpoint
 from api.routes import apps, artifacts, auth, billing, change_sessions, chat, connectors, data, deals, drive, memories, search, slack_events, slack_user_mappings, sync, tool_settings, twilio_events, waitlist, workflows
 from models.database import init_db, close_db, get_pool_status
 from config import log_missing_env_vars, settings
+from api.logging_config import configure_logging
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-    stream=sys.stdout,
-)
-# Set agents module to DEBUG for detailed tool logging
-logging.getLogger("agents").setLevel(logging.DEBUG)
+configure_logging()
 
 app = FastAPI(title="Revenue Copilot API", version="1.0.0")
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -83,6 +83,14 @@ class Settings(BaseSettings):
     SECRET_KEY: str = "dev-secret-change-in-production"
     ENVIRONMENT: str = "development"
     FRONTEND_URL: str = "http://localhost:5173"
+
+    # Logging
+    LOG_LEVEL: str = "INFO"
+    AGENTS_LOG_LEVEL: str = "DEBUG"
+    LOGGING_SPIKE_MODE: bool = False
+    LOG_SPIKE_FILE_PATH: str = "backend/logs/app.log"
+    LOG_SPIKE_MAX_BYTES: int = 10 * 1024 * 1024
+    LOG_SPIKE_BACKUP_COUNT: int = 5
     
     # Supabase configuration
     # URL: Your Supabase project URL (e.g., https://xyz.supabase.co)

--- a/backend/tests/test_logging_config.py
+++ b/backend/tests/test_logging_config.py
@@ -1,0 +1,51 @@
+import logging
+
+from api.logging_config import GZipRotatingFileHandler, configure_logging
+from config import settings
+
+
+def _set_settings(**kwargs):
+    previous = {key: getattr(settings, key) for key in kwargs}
+    for key, value in kwargs.items():
+        setattr(settings, key, value)
+    return previous
+
+
+def _restore_settings(previous):
+    for key, value in previous.items():
+        setattr(settings, key, value)
+
+
+def test_configure_logging_default_mode_uses_configured_levels() -> None:
+    previous = _set_settings(
+        LOGGING_SPIKE_MODE=False,
+        LOG_LEVEL="ERROR",
+        AGENTS_LOG_LEVEL="WARNING",
+    )
+    try:
+        configure_logging()
+        assert logging.getLogger().level == logging.ERROR
+        assert logging.getLogger("agents").level == logging.WARNING
+        assert all(not isinstance(h, GZipRotatingFileHandler) for h in logging.getLogger().handlers)
+    finally:
+        _restore_settings(previous)
+
+
+def test_configure_logging_spike_mode_reduces_volume_and_enables_compression(tmp_path) -> None:
+    log_file_path = tmp_path / "spike.log"
+    previous = _set_settings(
+        LOGGING_SPIKE_MODE=True,
+        LOG_LEVEL="DEBUG",
+        AGENTS_LOG_LEVEL="DEBUG",
+        LOG_SPIKE_FILE_PATH=str(log_file_path),
+        LOG_SPIKE_MAX_BYTES=1024,
+        LOG_SPIKE_BACKUP_COUNT=2,
+    )
+    try:
+        configure_logging()
+        root_logger = logging.getLogger()
+        assert root_logger.level == logging.WARNING
+        assert logging.getLogger("agents").level == logging.INFO
+        assert any(isinstance(h, GZipRotatingFileHandler) for h in root_logger.handlers)
+    finally:
+        _restore_settings(previous)

--- a/env.example
+++ b/env.example
@@ -38,6 +38,20 @@ SECRET_KEY=your_secret_key_for_sessions_change_this_in_production
 ENVIRONMENT=development
 FRONTEND_URL=http://localhost:5173
 
+# Logging controls
+# Default app log level outside of spike mode (DEBUG/INFO/WARNING/ERROR/CRITICAL)
+LOG_LEVEL=INFO
+# Agent subsystem log level outside of spike mode
+AGENTS_LOG_LEVEL=DEBUG
+# Enable spike mode to reduce normal log volume and write compressed rotating logs
+LOGGING_SPIKE_MODE=false
+# File path for compressed rotating logs when spike mode is enabled
+LOG_SPIKE_FILE_PATH=backend/logs/app.log
+# Rotate log file at this size (bytes) before compressing archive
+LOG_SPIKE_MAX_BYTES=10485760
+# Number of compressed rotated log files to retain
+LOG_SPIKE_BACKUP_COUNT=5
+
 # Supabase configuration (backend)
 # Get these from your Railway project variables.
 # URL: Your Supabase project URL


### PR DESCRIPTION
### Motivation
- Reduce noisy runtime logging during incident "spikes" while preserving searchable compressed archives for post-mortem analysis.
- Make log-volume reduction configurable via environment so operators can toggle behavior without changing code.

### Description
- Add centralized logging bootstrap in `backend/api/logging_config.py` including a `GZipRotatingFileHandler` that compresses rotated logs as `.gz` archives.
- Introduce environment-backed settings in `backend/config.py` (`LOG_LEVEL`, `AGENTS_LOG_LEVEL`, `LOGGING_SPIKE_MODE`, `LOG_SPIKE_FILE_PATH`, `LOG_SPIKE_MAX_BYTES`, `LOG_SPIKE_BACKUP_COUNT`).
- Replace the inline `logging.basicConfig(...)` in `backend/api/main.py` with a call to `configure_logging()` so startup uses the new centralized behavior.
- Document the new environment variables in `env.example` and add `backend/tests/test_logging_config.py` with tests for default and spike-mode behavior.

### Testing
- Ran `cd backend && pytest -q tests/test_logging_config.py`, which executed the two new tests and both passed (2 passed, 1 deprecation warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b31bbb7c8321ace7bdf1df3e0f3a)