### PR TITLE
Add PagerDuty helpers, admin incident controls, and JWKS failure alerting

### DIFF
--- a/backend/api/auth_middleware.py
+++ b/backend/api/auth_middleware.py
@@ -28,6 +28,7 @@ from sqlalchemy import select
 from config import settings
 from models.database import get_session
 from models.user import User
+from services.pagerduty import create_pagerduty_incident
 
 logger = logging.getLogger(__name__)
 
@@ -171,6 +172,13 @@ async def _get_jwks() -> dict:
             return _jwks_cache
 
     logger.error("Failed to fetch JWKS from %s after %d attempts: %s", jwks_url, max_retries, last_error)
+    await create_pagerduty_incident(
+        title="Auth JWKS endpoint unreachable",
+        details=(
+            "Auth middleware failed to fetch JWKS after 3 attempts and has no cache fallback. "
+            f"JWKS URL: {jwks_url}. Last error: {last_error}"
+        ),
+    )
     raise HTTPException(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         detail="Authentication service temporarily unavailable",

--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -83,6 +83,20 @@ class GlobalSyncResponse(BaseModel):
     integration_count: int
 
 
+class AdminQueueTaskResponse(BaseModel):
+    """Response model for queued admin maintenance tasks."""
+
+    status: str
+    task_id: str
+
+
+class AdminFireIncidentResponse(BaseModel):
+    """Response model for manually triggered PagerDuty incidents."""
+
+    status: str
+    title: str
+
+
 class AdminIntegration(BaseModel):
     """Integration info for admin view."""
 
@@ -368,6 +382,40 @@ async def trigger_global_sync(user_id: str) -> GlobalSyncResponse:
         task_id=task.id,
         integration_count=len(integrations),
     )
+
+
+@router.post("/admin/dependency-checks", response_model=AdminQueueTaskResponse)
+async def trigger_dependency_checks(user_id: str) -> AdminQueueTaskResponse:
+    """Trigger dependency checks immediately (global admin only)."""
+    await _require_global_admin(user_id)
+
+    from workers.tasks.monitoring import monitor_dependencies
+
+    task = monitor_dependencies.delay()
+    logger.warning("Admin user %s queued dependency checks task_id=%s", user_id, task.id)
+    return AdminQueueTaskResponse(status="queued", task_id=task.id)
+
+
+@router.post("/admin/fire-incident", response_model=AdminFireIncidentResponse)
+async def admin_fire_incident(user_id: str) -> AdminFireIncidentResponse:
+    """Manually fire a PagerDuty incident to validate alerting (global admin only)."""
+    from services.pagerduty import create_pagerduty_incident
+
+    await _require_global_admin(user_id)
+
+    title = "Admin test incident"
+    created = await create_pagerduty_incident(
+        title=title,
+        details=(
+            "Manual admin-panel trigger to validate PagerDuty wiring and on-call delivery. "
+            f"Triggered by global admin user_id={user_id}."
+        ),
+    )
+    if not created:
+        raise HTTPException(status_code=503, detail="PagerDuty is not configured or request failed")
+
+    logger.warning("Admin user %s fired PagerDuty test incident", user_id)
+    return AdminFireIncidentResponse(status="sent", title=title)
 
 
 @router.get("/admin/jobs", response_model=AdminRunningJobsResponse)

--- a/backend/services/pagerduty.py
+++ b/backend/services/pagerduty.py
@@ -1,0 +1,77 @@
+"""PagerDuty incident helpers shared across API and worker tasks."""
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def get_pagerduty_config() -> tuple[str, str, str] | None:
+    """Return PagerDuty settings if complete, else log and skip."""
+    from_email = settings.PAGERDUTY_FROM_EMAIL
+    api_key = settings.PAGERDUTY_KEY
+    service_id = settings.PAGERDUTY_SERVICE_ID
+
+    if not from_email or not api_key or not service_id:
+        logger.warning(
+            "PagerDuty incident skipped: missing configuration "
+            "(PAGERDUTY_FROM_EMAIL=%s, PagerDuty_Key=%s, PAGERDUTY_SERVICE_ID=%s)",
+            bool(from_email),
+            bool(api_key),
+            bool(service_id),
+        )
+        return None
+    return from_email, api_key, service_id
+
+
+async def create_pagerduty_incident(*, title: str, details: str) -> bool:
+    """Create a PagerDuty incident and return True if request was accepted."""
+    config = get_pagerduty_config()
+    if config is None:
+        return False
+
+    from_email, api_key, service_id = config
+    payload = {
+        "incident": {
+            "type": "incident",
+            "title": title,
+            "service": {
+                "id": service_id,
+                "type": "service_reference",
+            },
+            "urgency": "high",
+            "body": {
+                "type": "incident_body",
+                "details": details,
+            },
+        }
+    }
+    headers = {
+        "Accept": "application/vnd.pagerduty+json;version=2",
+        "Content-Type": "application/json",
+        "Authorization": f"Token token={api_key}",
+        "From": from_email,
+    }
+
+    logger.warning("Creating PagerDuty incident: %s", title)
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await client.post(
+            "https://api.pagerduty.com/incidents",
+            json=payload,
+            headers=headers,
+        )
+    if response.status_code >= 300:
+        logger.error(
+            "PagerDuty incident creation failed for %s: HTTP %s - %s",
+            title,
+            response.status_code,
+            response.text,
+        )
+        return False
+
+    logger.info("PagerDuty incident created for %s with status %s", title, response.status_code)
+    return True

--- a/backend/tests/test_auth_middleware_jwks.py
+++ b/backend/tests/test_auth_middleware_jwks.py
@@ -52,3 +52,25 @@ async def test_get_jwks_raises_503_without_cache_when_refresh_fails(monkeypatch:
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "Authentication service temporarily unavailable"
+
+
+@pytest.mark.asyncio
+async def test_get_jwks_raises_incident_after_final_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(am.settings, "SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setattr(am.httpx, "AsyncClient", _FailingClient)
+
+    calls: list[tuple[str, str]] = []
+
+    async def _fake_create_pagerduty_incident(*, title: str, details: str) -> bool:
+        calls.append((title, details))
+        return True
+
+    monkeypatch.setattr(am, "create_pagerduty_incident", _fake_create_pagerduty_incident)
+    am._jwks_cache = None
+    am._jwks_cache_fetched_at = None
+
+    with pytest.raises(HTTPException):
+        await am._get_jwks()
+
+    assert len(calls) == 1
+    assert calls[0][0] == "Auth JWKS endpoint unreachable"

--- a/backend/tests/test_monitoring_task.py
+++ b/backend/tests/test_monitoring_task.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from config import EXPECTED_ENV_VARS, settings
+from services import pagerduty
 from workers.tasks import monitoring
 
 
@@ -38,15 +39,16 @@ def test_expected_env_vars_include_pagerduty() -> None:
 
 
 def test_pagerduty_incident_request_shape(monkeypatch: Any) -> None:
-    monkeypatch.setattr(monitoring.httpx, "AsyncClient", _FakeAsyncClient)
+    monkeypatch.setattr(pagerduty.httpx, "AsyncClient", _FakeAsyncClient)
+    monkeypatch.setenv("PAGERDUTY_FROM_EMAIL", "alerts@revtops.com")
+    monkeypatch.setenv("PagerDuty_Key", "pd_test_key")
+    monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
+    monkeypatch.setattr(pagerduty, "settings", settings.__class__())
 
     import asyncio
 
     asyncio.run(
         monitoring._create_pagerduty_incident(
-            from_email="alerts@revtops.com",
-            api_key="pd_test_key",
-            service_id="svc_123",
             check_result=monitoring.CheckResult(
                 name="Redis",
                 healthy=False,
@@ -87,7 +89,7 @@ def test_monitor_dependencies_logs_health_check_outcome(monkeypatch: Any, caplog
     monkeypatch.setenv("PAGERDUTY_FROM_EMAIL", "alerts@revtops.com")
     monkeypatch.setenv("PagerDuty_Key", "pd_test_key")
     monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
-    monkeypatch.setattr(monitoring, "settings", settings.__class__())
+    monkeypatch.setattr(pagerduty, "settings", settings.__class__())
 
     caplog.set_level("INFO")
     result = monitoring.monitor_dependencies.__wrapped__()

--- a/backend/workers/tasks/monitoring.py
+++ b/backend/workers/tasks/monitoring.py
@@ -8,6 +8,7 @@ from typing import Any
 import httpx
 
 from config import get_redis_connection_kwargs, settings
+from services.pagerduty import create_pagerduty_incident, get_pagerduty_config
 from workers.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
@@ -20,24 +21,6 @@ class CheckResult:
     name: str
     healthy: bool
     details: str
-
-
-def _require_pagerduty_config() -> tuple[str, str, str] | None:
-    """Return PagerDuty settings if complete, else log and skip."""
-    from_email = settings.PAGERDUTY_FROM_EMAIL
-    api_key = settings.PAGERDUTY_KEY
-    service_id = settings.PAGERDUTY_SERVICE_ID
-
-    if not from_email or not api_key or not service_id:
-        logger.warning(
-            "Skipping dependency monitoring alerting: missing PagerDuty configuration "
-            "(PAGERDUTY_FROM_EMAIL=%s, PagerDuty_Key=%s, PAGERDUTY_SERVICE_ID=%s)",
-            bool(from_email),
-            bool(api_key),
-            bool(service_id),
-        )
-        return None
-    return from_email, api_key, service_id
 
 
 async def _check_http_endpoint(name: str, url: str, timeout_s: float = 10.0) -> CheckResult:
@@ -78,59 +61,15 @@ async def _check_redis(timeout_s: float = 10.0) -> CheckResult:
 
 async def _create_pagerduty_incident(
     *,
-    from_email: str,
-    api_key: str,
-    service_id: str,
     check_result: CheckResult,
 ) -> None:
     """Create an incident in PagerDuty v2 REST API."""
-    title = f"{check_result.name} is down"
-    payload: dict[str, Any] = {
-        "incident": {
-            "type": "incident",
-            "title": title,
-            "service": {
-                "id": service_id,
-                "type": "service_reference",
-            },
-            "urgency": "high",
-            "body": {
-                "type": "incident_body",
-                "details": (
-                    "Automated Revtops dependency monitor detected an outage. "
-                    f"Dependency: {check_result.name}. Details: {check_result.details}"
-                ),
-            },
-        }
-    }
-
-    headers = {
-        "Accept": "application/vnd.pagerduty+json;version=2",
-        "Content-Type": "application/json",
-        "Authorization": f"Token token={api_key}",
-        "From": from_email,
-    }
-
-    logger.warning("Creating PagerDuty incident for %s", check_result.name)
-    async with httpx.AsyncClient(timeout=20.0) as client:
-        response = await client.post(
-            "https://api.pagerduty.com/incidents",
-            json=payload,
-            headers=headers,
-        )
-    if response.status_code >= 300:
-        logger.error(
-            "PagerDuty incident creation failed for %s: HTTP %s - %s",
-            check_result.name,
-            response.status_code,
-            response.text,
-        )
-        return
-
-    logger.info(
-        "PagerDuty incident created for %s with status %s",
-        check_result.name,
-        response.status_code,
+    await create_pagerduty_incident(
+        title=f"{check_result.name} is down",
+        details=(
+            "Automated Revtops dependency monitor detected an outage. "
+            f"Dependency: {check_result.name}. Details: {check_result.details}"
+        ),
     )
 
 
@@ -153,14 +92,12 @@ def monitor_dependencies(self: Any) -> dict[str, Any]:
     import asyncio
 
     logger.info("Task %s: Starting dependency monitoring run", self.request.id)
-    pagerduty_config = _require_pagerduty_config()
+    pagerduty_config = get_pagerduty_config()
     if pagerduty_config is None:
         return {
             "status": "skipped",
             "reason": "missing_pagerduty_config",
         }
-
-    from_email, api_key, service_id = pagerduty_config
 
     async def _run() -> dict[str, Any]:
         results = await _run_dependency_checks()
@@ -183,9 +120,6 @@ def monitor_dependencies(self: Any) -> dict[str, Any]:
 
         for result in down:
             await _create_pagerduty_incident(
-                from_email=from_email,
-                api_key=api_key,
-                service_id=service_id,
                 check_result=result,
             )
 

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -120,6 +120,10 @@ export function AdminPanel(): JSX.Element {
   // Global sync state
   const [syncing, setSyncing] = useState<boolean>(false);
   const [syncResult, setSyncResult] = useState<{ status: string; taskId: string; count: number } | null>(null);
+  const [runningDependencyChecks, setRunningDependencyChecks] = useState<boolean>(false);
+  const [dependencyCheckTaskId, setDependencyCheckTaskId] = useState<string | null>(null);
+  const [firingIncident, setFiringIncident] = useState<boolean>(false);
+  const [incidentResult, setIncidentResult] = useState<string | null>(null);
 
   // Jobs tab state
   const [runningJobs, setRunningJobs] = useState<AdminRunningJob[]>([]);
@@ -466,6 +470,60 @@ export function AdminPanel(): JSX.Element {
       alert('Failed to trigger sync: ' + (err instanceof Error ? err.message : 'Unknown error'));
     } finally {
       setSyncing(false);
+    }
+  };
+
+  const handleRunDependencyChecks = async (): Promise<void> => {
+    if (!user) return;
+
+    setRunningDependencyChecks(true);
+    setDependencyCheckTaskId(null);
+
+    try {
+      const response = await fetch(
+        `${API_BASE}/sync/admin/dependency-checks?user_id=${user.id}`,
+        { method: 'POST' }
+      );
+
+      if (!response.ok) {
+        const data = await response.json() as { detail?: string };
+        throw new Error(data.detail ?? 'Failed to run dependency checks');
+      }
+
+      const data = await response.json() as { status: string; task_id: string };
+      setDependencyCheckTaskId(data.task_id);
+    } catch (err) {
+      console.error('Failed to run dependency checks:', err);
+      alert('Failed to run dependency checks: ' + (err instanceof Error ? err.message : 'Unknown error'));
+    } finally {
+      setRunningDependencyChecks(false);
+    }
+  };
+
+  const handleFireIncident = async (): Promise<void> => {
+    if (!user) return;
+
+    setFiringIncident(true);
+    setIncidentResult(null);
+
+    try {
+      const response = await fetch(
+        `${API_BASE}/sync/admin/fire-incident?user_id=${user.id}`,
+        { method: 'POST' }
+      );
+
+      if (!response.ok) {
+        const data = await response.json() as { detail?: string };
+        throw new Error(data.detail ?? 'Failed to fire PagerDuty incident');
+      }
+
+      const data = await response.json() as { status: string; title: string };
+      setIncidentResult(data.title);
+    } catch (err) {
+      console.error('Failed to fire PagerDuty incident:', err);
+      alert('Failed to fire incident: ' + (err instanceof Error ? err.message : 'Unknown error'));
+    } finally {
+      setFiringIncident(false);
     }
   };
 
@@ -1195,6 +1253,28 @@ export function AdminPanel(): JSX.Element {
               </div>
               <div className="flex gap-2">
                 <button
+                  onClick={() => void handleRunDependencyChecks()}
+                  disabled={runningDependencyChecks}
+                  className="px-4 py-2 rounded-lg bg-blue-500/20 border border-blue-500/30 text-blue-400 hover:bg-blue-500/30 transition-colors disabled:opacity-50 flex items-center gap-2"
+                  title="Run dependency checks immediately"
+                >
+                  <svg className={`w-4 h-4 ${runningDependencyChecks ? 'animate-spin' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6M7 4h10a2 2 0 012 2v12a2 2 0 01-2 2H7a2 2 0 01-2-2V6a2 2 0 012-2z" />
+                  </svg>
+                  {runningDependencyChecks ? 'Checking...' : 'Run Checks'}
+                </button>
+                <button
+                  onClick={() => void handleFireIncident()}
+                  disabled={firingIncident}
+                  className="px-4 py-2 rounded-lg bg-red-500/20 border border-red-500/30 text-red-400 hover:bg-red-500/30 transition-colors disabled:opacity-50 flex items-center gap-2"
+                  title="Fire a test PagerDuty incident"
+                >
+                  <svg className={`w-4 h-4 ${firingIncident ? 'animate-pulse' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4c-.77-1.33-2.69-1.33-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z" />
+                  </svg>
+                  {firingIncident ? 'Firing...' : 'Fire Incident'}
+                </button>
+                <button
                   onClick={() => void handleGlobalSync()}
                   disabled={syncing}
                   className="px-4 py-2 rounded-lg bg-emerald-500/20 border border-emerald-500/30 text-emerald-400 hover:bg-emerald-500/30 transition-colors disabled:opacity-50 flex items-center gap-2"
@@ -1233,6 +1313,40 @@ export function AdminPanel(): JSX.Element {
                 <button
                   onClick={() => setSyncResult(null)}
                   className="text-emerald-400/60 hover:text-emerald-400"
+                >
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            )}
+
+            {dependencyCheckTaskId && (
+              <div className="p-4 rounded-lg bg-blue-500/10 border border-blue-500/20 text-blue-400 flex items-center justify-between">
+                <div>
+                  <span className="font-medium">Dependency checks queued.</span>
+                  <span className="ml-2 text-xs text-blue-400/70">Task ID: {dependencyCheckTaskId.slice(0, 8)}...</span>
+                </div>
+                <button
+                  onClick={() => setDependencyCheckTaskId(null)}
+                  className="text-blue-400/60 hover:text-blue-400"
+                >
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            )}
+
+            {incidentResult && (
+              <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 flex items-center justify-between">
+                <div>
+                  <span className="font-medium">Incident sent:</span>
+                  <span className="ml-2 text-red-300/80">{incidentResult}</span>
+                </div>
+                <button
+                  onClick={() => setIncidentResult(null)}
+                  className="text-red-400/60 hover:text-red-400"
                 >
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />


### PR DESCRIPTION
### Motivation
- Ensure we page on critical auth failures by raising a PagerDuty incident when JWKS cannot be fetched after retries and there's no cache fallback. 
- Give operators a simple way to validate dependency checks and PagerDuty wiring from the Admin UI. 
- Centralize PagerDuty request/config validation to avoid duplicated logic and make tests consistent.

### Description
- Added a shared helper `backend/services/pagerduty.py` implementing `get_pagerduty_config()` and `create_pagerduty_incident()` and switched workers/API code to reuse it. 
- Updated JWT JWKS retrieval in `backend/api/auth_middleware.py` to call `create_pagerduty_incident()` when the final fetch attempt fails and no cached keys exist. 
- Refactored the dependency monitoring task `backend/workers/tasks/monitoring.py` to use the shared PagerDuty helper and keep the existing periodic checks, while preserving the stale-cache behavior. 
- Exposed admin endpoints in `backend/api/routes/sync.py`: `POST /sync/admin/dependency-checks` to queue dependency checks immediately and `POST /sync/admin/fire-incident` to send a manual test PagerDuty incident. 
- Added UI controls in `frontend/src/components/AdminPanel.tsx` (Sources tab) to trigger dependency checks and fire a test incident, plus result banners showing queued task IDs and incident confirmation. 
- Updated and extended backend tests (`tests/test_auth_middleware_jwks.py`, `tests/test_monitoring_task.py`) to validate the new JWKS incident behavior and the shared PagerDuty integration path.

### Testing
- Ran backend unit tests: `cd backend && pytest tests/test_auth_middleware_jwks.py tests/test_monitoring_task.py` and all tests passed (`7 passed`).
- Built the frontend: `cd frontend && npm run build` which completed successfully and produced a production bundle.
- Verified the Admin UI locally via `vite` and captured a screenshot of the Admin Panel to validate the new buttons and banners (artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b41782a083219ae19be73f0d0b57)