### PR TITLE
Add PagerDuty incident on JWKS repeated failures and admin 'Fire Incident' control

### DIFF
--- a/backend/api/auth_middleware.py
+++ b/backend/api/auth_middleware.py
@@ -28,6 +28,7 @@ from sqlalchemy import select
 from config import settings
 from models.database import get_session
 from models.user import User
+from services.pagerduty import create_incident
 
 logger = logging.getLogger(__name__)
 
@@ -155,6 +156,24 @@ async def _get_jwks() -> dict:
                 logger.warning("JWKS fetch attempt %d/%d failed: %s", attempt + 1, max_retries, e)
                 if attempt < max_retries - 1:
                     await asyncio.sleep(0.5 * (attempt + 1))  # Backoff
+
+        logger.error(
+            "JWKS fetch failed after %d attempts; triggering PagerDuty incident. last_error=%s",
+            max_retries,
+            last_error,
+        )
+        incident_created = await create_incident(
+            title="Supabase JWKS fetch failed",
+            details=(
+                "Authentication middleware could not fetch Supabase JWKS after 3 attempts. "
+                f"JWKS URL: {jwks_url}. Last error: {last_error!r}"
+            ),
+            source="auth_jwks_fetch",
+        )
+        logger.info(
+            "JWKS failure PagerDuty incident request completed (created=%s)",
+            incident_created,
+        )
 
         if _jwks_cache is not None:
             # Stale-if-error fallback: continue serving existing keys during transient outages.

--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -26,6 +26,7 @@ from models.organization import Organization
 from models.agent_task import AgentTask
 from models.conversation import Conversation
 from models.workflow import Workflow, WorkflowRun
+from services.pagerduty import create_incident
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -124,6 +125,14 @@ class AdminRunningJobsResponse(BaseModel):
     jobs: list[AdminRunningJob]
     total: int
 
+
+
+
+class AdminPagerDutyTestResponse(BaseModel):
+    """Response model for firing a PagerDuty test incident."""
+
+    status: str
+    incident_created: bool
 
 class AdminCancelJobRequest(BaseModel):
     """Admin request model for cancelling a job."""
@@ -367,6 +376,28 @@ async def trigger_global_sync(user_id: str) -> GlobalSyncResponse:
         status="queued",
         task_id=task.id,
         integration_count=len(integrations),
+    )
+
+
+
+
+@router.post("/admin/pagerduty/test", response_model=AdminPagerDutyTestResponse)
+async def fire_admin_pagerduty_test_incident(user_id: str) -> AdminPagerDutyTestResponse:
+    """Fire a PagerDuty test incident from admin panel (global admin only)."""
+    await _require_global_admin(user_id)
+
+    incident_created = await create_incident(
+        title="Revtops admin PagerDuty test incident",
+        details=(
+            "This is an intentionally triggered test incident from the Revtops admin panel. "
+            "No production outage is implied."
+        ),
+        source="admin_pagerduty_test",
+    )
+
+    return AdminPagerDutyTestResponse(
+        status="ok",
+        incident_created=incident_created,
     )
 
 

--- a/backend/services/pagerduty.py
+++ b/backend/services/pagerduty.py
@@ -1,0 +1,76 @@
+"""PagerDuty incident helpers."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from config import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def create_incident(*, title: str, details: str, source: str) -> bool:
+    """Create an incident in PagerDuty. Returns True when PagerDuty accepts the request."""
+    from_email = settings.PAGERDUTY_FROM_EMAIL
+    api_key = settings.PAGERDUTY_KEY
+    service_id = settings.PAGERDUTY_SERVICE_ID
+
+    if not from_email or not api_key or not service_id:
+        logger.warning(
+            "Skipping PagerDuty incident for source=%s due to missing configuration "
+            "(PAGERDUTY_FROM_EMAIL=%s, PagerDuty_Key=%s, PAGERDUTY_SERVICE_ID=%s)",
+            source,
+            bool(from_email),
+            bool(api_key),
+            bool(service_id),
+        )
+        return False
+
+    payload: dict[str, Any] = {
+        "incident": {
+            "type": "incident",
+            "title": title,
+            "service": {
+                "id": service_id,
+                "type": "service_reference",
+            },
+            "urgency": "high",
+            "body": {
+                "type": "incident_body",
+                "details": details,
+            },
+        }
+    }
+
+    headers = {
+        "Accept": "application/vnd.pagerduty+json;version=2",
+        "Content-Type": "application/json",
+        "Authorization": f"Token token={api_key}",
+        "From": from_email,
+    }
+
+    logger.warning("Creating PagerDuty incident for source=%s title=%s", source, title)
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await client.post(
+            "https://api.pagerduty.com/incidents",
+            json=payload,
+            headers=headers,
+        )
+
+    if response.status_code >= 300:
+        logger.error(
+            "PagerDuty incident creation failed for source=%s: HTTP %s - %s",
+            source,
+            response.status_code,
+            response.text,
+        )
+        return False
+
+    logger.info(
+        "PagerDuty incident created for source=%s with status=%s",
+        source,
+        response.status_code,
+    )
+    return True

--- a/backend/tests/test_auth_middleware_jwks.py
+++ b/backend/tests/test_auth_middleware_jwks.py
@@ -52,3 +52,27 @@ async def test_get_jwks_raises_503_without_cache_when_refresh_fails(monkeypatch:
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "Authentication service temporarily unavailable"
+
+
+@pytest.mark.asyncio
+async def test_get_jwks_raises_incident_after_third_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(am.settings, "SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setattr(am.httpx, "AsyncClient", _FailingClient)
+
+    created_payloads: list[dict[str, str]] = []
+
+    async def _fake_create_incident(*, title: str, details: str, source: str) -> bool:
+        created_payloads.append({"title": title, "details": details, "source": source})
+        return True
+
+    monkeypatch.setattr(am, "create_incident", _fake_create_incident)
+
+    am._jwks_cache = None
+    am._jwks_cache_fetched_at = None
+
+    with pytest.raises(HTTPException):
+        await am._get_jwks()
+
+    assert len(created_payloads) == 1
+    assert created_payloads[0]["source"] == "auth_jwks_fetch"
+    assert created_payloads[0]["title"] == "Supabase JWKS fetch failed"

--- a/backend/tests/test_monitoring_task.py
+++ b/backend/tests/test_monitoring_task.py
@@ -6,31 +6,6 @@ from config import EXPECTED_ENV_VARS, settings
 from workers.tasks import monitoring
 
 
-class _FakeResponse:
-    def __init__(self, status_code: int = 201, text: str = "ok") -> None:
-        self.status_code = status_code
-        self.text = text
-
-
-class _FakeAsyncClient:
-    def __init__(self, **kwargs: Any) -> None:
-        self.kwargs = kwargs
-
-    async def __aenter__(self) -> "_FakeAsyncClient":
-        return self
-
-    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
-        return None
-
-    async def post(self, url: str, json: dict[str, Any], headers: dict[str, str]) -> _FakeResponse:
-        _FakeAsyncClient.last_call = {
-            "url": url,
-            "json": json,
-            "headers": headers,
-        }
-        return _FakeResponse()
-
-
 def test_expected_env_vars_include_pagerduty() -> None:
     assert "PAGERDUTY_FROM_EMAIL" in EXPECTED_ENV_VARS
     assert "PagerDuty_Key" in EXPECTED_ENV_VARS
@@ -38,7 +13,13 @@ def test_expected_env_vars_include_pagerduty() -> None:
 
 
 def test_pagerduty_incident_request_shape(monkeypatch: Any) -> None:
-    monkeypatch.setattr(monitoring.httpx, "AsyncClient", _FakeAsyncClient)
+    called: dict[str, Any] = {}
+
+    async def _fake_create_incident(*, title: str, details: str, source: str) -> bool:
+        called.update({"title": title, "details": details, "source": source})
+        return True
+
+    monkeypatch.setattr(monitoring, "create_incident", _fake_create_incident)
 
     import asyncio
 
@@ -55,12 +36,9 @@ def test_pagerduty_incident_request_shape(monkeypatch: Any) -> None:
         )
     )
 
-    last_call = _FakeAsyncClient.last_call
-    assert last_call["url"] == "https://api.pagerduty.com/incidents"
-    assert last_call["headers"]["From"] == "alerts@revtops.com"
-    assert last_call["headers"]["Authorization"] == "Token token=pd_test_key"
-    assert last_call["json"]["incident"]["service"]["id"] == "svc_123"
-    assert last_call["json"]["incident"]["title"] == "Redis is down"
+    assert called["title"] == "Redis is down"
+    assert called["source"] == "dependency_monitor"
+    assert "Dependency: Redis" in called["details"]
 
 
 def test_pagerduty_alias_var_is_loaded(monkeypatch: Any) -> None:

--- a/backend/workers/tasks/monitoring.py
+++ b/backend/workers/tasks/monitoring.py
@@ -8,6 +8,7 @@ from typing import Any
 import httpx
 
 from config import get_redis_connection_kwargs, settings
+from services.pagerduty import create_incident
 from workers.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
@@ -84,53 +85,14 @@ async def _create_pagerduty_incident(
     check_result: CheckResult,
 ) -> None:
     """Create an incident in PagerDuty v2 REST API."""
-    title = f"{check_result.name} is down"
-    payload: dict[str, Any] = {
-        "incident": {
-            "type": "incident",
-            "title": title,
-            "service": {
-                "id": service_id,
-                "type": "service_reference",
-            },
-            "urgency": "high",
-            "body": {
-                "type": "incident_body",
-                "details": (
-                    "Automated Revtops dependency monitor detected an outage. "
-                    f"Dependency: {check_result.name}. Details: {check_result.details}"
-                ),
-            },
-        }
-    }
-
-    headers = {
-        "Accept": "application/vnd.pagerduty+json;version=2",
-        "Content-Type": "application/json",
-        "Authorization": f"Token token={api_key}",
-        "From": from_email,
-    }
-
-    logger.warning("Creating PagerDuty incident for %s", check_result.name)
-    async with httpx.AsyncClient(timeout=20.0) as client:
-        response = await client.post(
-            "https://api.pagerduty.com/incidents",
-            json=payload,
-            headers=headers,
-        )
-    if response.status_code >= 300:
-        logger.error(
-            "PagerDuty incident creation failed for %s: HTTP %s - %s",
-            check_result.name,
-            response.status_code,
-            response.text,
-        )
-        return
-
-    logger.info(
-        "PagerDuty incident created for %s with status %s",
-        check_result.name,
-        response.status_code,
+    _ = (from_email, api_key, service_id)
+    await create_incident(
+        title=f"{check_result.name} is down",
+        details=(
+            "Automated Revtops dependency monitor detected an outage. "
+            f"Dependency: {check_result.name}. Details: {check_result.details}"
+        ),
+        source="dependency_monitor",
     )
 
 

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -120,6 +120,8 @@ export function AdminPanel(): JSX.Element {
   // Global sync state
   const [syncing, setSyncing] = useState<boolean>(false);
   const [syncResult, setSyncResult] = useState<{ status: string; taskId: string; count: number } | null>(null);
+  const [incidentTesting, setIncidentTesting] = useState<boolean>(false);
+  const [incidentTestResult, setIncidentTestResult] = useState<{ incidentCreated: boolean } | null>(null);
 
   // Jobs tab state
   const [runningJobs, setRunningJobs] = useState<AdminRunningJob[]>([]);
@@ -466,6 +468,32 @@ export function AdminPanel(): JSX.Element {
       alert('Failed to trigger sync: ' + (err instanceof Error ? err.message : 'Unknown error'));
     } finally {
       setSyncing(false);
+    }
+  };
+
+  const handleFirePagerDutyIncident = async (): Promise<void> => {
+    if (!user) return;
+
+    setIncidentTesting(true);
+    setIncidentTestResult(null);
+
+    try {
+      const response = await fetch(`${API_BASE}/sync/admin/pagerduty/test?user_id=${user.id}`, {
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        const data = await response.json() as { detail?: string };
+        throw new Error(data.detail ?? 'Failed to fire PagerDuty incident test');
+      }
+
+      const data = await response.json() as { status: string; incident_created: boolean };
+      setIncidentTestResult({ incidentCreated: data.incident_created });
+    } catch (err) {
+      console.error('Failed to fire PagerDuty incident test:', err);
+      alert('Failed to fire PagerDuty incident test: ' + (err instanceof Error ? err.message : 'Unknown error'));
+    } finally {
+      setIncidentTesting(false);
     }
   };
 
@@ -1206,6 +1234,14 @@ export function AdminPanel(): JSX.Element {
                   {syncing ? 'Syncing...' : 'Sync All'}
                 </button>
                 <button
+                  onClick={() => void handleFirePagerDutyIncident()}
+                  disabled={incidentTesting}
+                  className="px-4 py-2 rounded-lg bg-rose-500/20 border border-rose-500/30 text-rose-400 hover:bg-rose-500/30 transition-colors disabled:opacity-50"
+                  title="Fire a PagerDuty test incident"
+                >
+                  {incidentTesting ? 'Firing Incident...' : 'Fire Incident'}
+                </button>
+                <button
                   onClick={() => void fetchIntegrations()}
                   disabled={integrationsLoading}
                   className="px-4 py-2 rounded-lg bg-surface-800 border border-surface-700 text-surface-300 hover:bg-surface-700 transition-colors disabled:opacity-50 flex items-center gap-2"
@@ -1233,6 +1269,27 @@ export function AdminPanel(): JSX.Element {
                 <button
                   onClick={() => setSyncResult(null)}
                   className="text-emerald-400/60 hover:text-emerald-400"
+                >
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+            )}
+
+            {incidentTestResult && (
+              <div className={`p-4 rounded-lg border flex items-center justify-between ${incidentTestResult.incidentCreated ? 'bg-rose-500/10 border-rose-500/20 text-rose-300' : 'bg-amber-500/10 border-amber-500/20 text-amber-300'}`}>
+                <div>
+                  <span className="font-medium">PagerDuty test request sent.</span>
+                  <span className="ml-2 text-sm opacity-90">
+                    {incidentTestResult.incidentCreated
+                      ? 'Incident accepted by PagerDuty.'
+                      : 'PagerDuty config appears incomplete, so no incident was created.'}
+                  </span>
+                </div>
+                <button
+                  onClick={() => setIncidentTestResult(null)}
+                  className="opacity-70 hover:opacity-100"
                 >
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />


### PR DESCRIPTION
### Motivation
- Ensure on-call is notified when authentication JWKS fetch repeatedly fails so outages are escalated automatically.
- Give global admins a way to validate PagerDuty configuration from the admin UI by firing a test incident.

### Description
- Add a shared PagerDuty helper `backend/services/pagerduty.py` that encapsulates payload construction, config checks, request, and logging via `create_incident`.
- Wire JWKS fetch failure handling in `backend/api/auth_middleware.py` to call `create_incident` after the 3rd unsuccessful JWKS retry while preserving the stale-cache fallback.
- Add a new global-admin API endpoint `POST /sync/admin/pagerduty/test` in `backend/api/routes/sync.py` that triggers a test incident and returns `incident_created`.
- Add a "Fire Incident" button and result banner to the Admin Panel `frontend/src/components/AdminPanel.tsx` that calls the new endpoint, and refactor monitoring task `backend/workers/tasks/monitoring.py` to reuse the shared helper; update tests accordingly.

### Testing
- Ran `pytest backend/tests/test_auth_middleware_jwks.py backend/tests/test_monitoring_task.py` and all tests passed (`7 passed`).
- Built the frontend with `npm run build` in the `frontend` directory and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0b2c79cc8832196f7dd867db6fb9a)