### PR TITLE
Improve PagerDuty incident failure diagnostics

### DIFF
--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -399,20 +399,33 @@ async def trigger_dependency_checks(user_id: str) -> AdminQueueTaskResponse:
 @router.post("/admin/fire-incident", response_model=AdminFireIncidentResponse)
 async def admin_fire_incident(user_id: str) -> AdminFireIncidentResponse:
     """Manually fire a PagerDuty incident to validate alerting (global admin only)."""
-    from services.pagerduty import create_pagerduty_incident
+    from services.pagerduty import create_pagerduty_incident_with_details
 
     await _require_global_admin(user_id)
 
     title = "Admin test incident"
-    created = await create_pagerduty_incident(
+    incident_result = await create_pagerduty_incident_with_details(
         title=title,
         details=(
             "Manual admin-panel trigger to validate PagerDuty wiring and on-call delivery. "
             f"Triggered by global admin user_id={user_id}."
         ),
     )
-    if not created:
-        raise HTTPException(status_code=503, detail="PagerDuty is not configured or request failed")
+    if not incident_result.ok:
+        logger.error(
+            "Admin user %s failed to fire PagerDuty test incident; reason=%s status=%s body=%s",
+            user_id,
+            incident_result.reason,
+            incident_result.status_code,
+            incident_result.response_body,
+        )
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "PagerDuty request failed "
+                f"(reason={incident_result.reason}, status={incident_result.status_code})"
+            ),
+        )
 
     logger.warning("Admin user %s fired PagerDuty test incident", user_id)
     return AdminFireIncidentResponse(status="sent", title=title)

--- a/backend/services/pagerduty.py
+++ b/backend/services/pagerduty.py
@@ -2,12 +2,23 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 
 import httpx
 
 from config import settings
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PagerDutyIncidentResult:
+    """Result metadata for PagerDuty incident creation attempts."""
+
+    ok: bool
+    reason: str
+    status_code: int | None = None
+    response_body: str | None = None
 
 
 def get_pagerduty_config() -> tuple[str, str, str] | None:
@@ -30,9 +41,15 @@ def get_pagerduty_config() -> tuple[str, str, str] | None:
 
 async def create_pagerduty_incident(*, title: str, details: str) -> bool:
     """Create a PagerDuty incident and return True if request was accepted."""
+    result = await create_pagerduty_incident_with_details(title=title, details=details)
+    return result.ok
+
+
+async def create_pagerduty_incident_with_details(*, title: str, details: str) -> PagerDutyIncidentResult:
+    """Create a PagerDuty incident and return structured status details."""
     config = get_pagerduty_config()
     if config is None:
-        return False
+        return PagerDutyIncidentResult(ok=False, reason="missing_config")
 
     from_email, api_key, service_id = config
     payload = {
@@ -58,12 +75,17 @@ async def create_pagerduty_incident(*, title: str, details: str) -> bool:
     }
 
     logger.warning("Creating PagerDuty incident: %s", title)
-    async with httpx.AsyncClient(timeout=20.0) as client:
-        response = await client.post(
-            "https://api.pagerduty.com/incidents",
-            json=payload,
-            headers=headers,
-        )
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            response = await client.post(
+                "https://api.pagerduty.com/incidents",
+                json=payload,
+                headers=headers,
+            )
+    except httpx.HTTPError as exc:
+        logger.exception("PagerDuty incident creation failed for %s: transport error", title)
+        return PagerDutyIncidentResult(ok=False, reason=f"transport_error:{type(exc).__name__}")
+
     if response.status_code >= 300:
         logger.error(
             "PagerDuty incident creation failed for %s: HTTP %s - %s",
@@ -71,7 +93,12 @@ async def create_pagerduty_incident(*, title: str, details: str) -> bool:
             response.status_code,
             response.text,
         )
-        return False
+        return PagerDutyIncidentResult(
+            ok=False,
+            reason="http_error",
+            status_code=response.status_code,
+            response_body=response.text,
+        )
 
     logger.info("PagerDuty incident created for %s with status %s", title, response.status_code)
-    return True
+    return PagerDutyIncidentResult(ok=True, reason="created", status_code=response.status_code)

--- a/backend/tests/test_pagerduty_service.py
+++ b/backend/tests/test_pagerduty_service.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any
+
+from config import settings
+from services import pagerduty
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 201, text: str = "ok") -> None:
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeAsyncClient:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+    async def post(self, url: str, json: dict[str, Any], headers: dict[str, str]) -> _FakeResponse:
+        return _FakeResponse()
+
+
+class _FakeAsyncClient500(_FakeAsyncClient):
+    async def post(self, url: str, json: dict[str, Any], headers: dict[str, str]) -> _FakeResponse:
+        return _FakeResponse(status_code=500, text="upstream error")
+
+
+def test_create_pagerduty_incident_with_details_missing_config(monkeypatch: Any) -> None:
+    monkeypatch.delenv("PAGERDUTY_FROM_EMAIL", raising=False)
+    monkeypatch.delenv("PAGERDUTY_KEY", raising=False)
+    monkeypatch.delenv("PagerDuty_Key", raising=False)
+    monkeypatch.delenv("PAGERDUTY_SERVICE_ID", raising=False)
+    monkeypatch.setattr(pagerduty, "settings", settings.__class__())
+
+    import asyncio
+
+    result = asyncio.run(
+        pagerduty.create_pagerduty_incident_with_details(
+            title="test",
+            details="test",
+        )
+    )
+
+    assert result.ok is False
+    assert result.reason == "missing_config"
+
+
+def test_create_pagerduty_incident_with_details_http_error(monkeypatch: Any) -> None:
+    monkeypatch.setattr(pagerduty.httpx, "AsyncClient", _FakeAsyncClient500)
+    monkeypatch.setenv("PAGERDUTY_FROM_EMAIL", "alerts@revtops.com")
+    monkeypatch.setenv("PagerDuty_Key", "pd_test_key")
+    monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
+    monkeypatch.setattr(pagerduty, "settings", settings.__class__())
+
+    import asyncio
+
+    result = asyncio.run(
+        pagerduty.create_pagerduty_incident_with_details(
+            title="test",
+            details="test",
+        )
+    )
+
+    assert result.ok is False
+    assert result.reason == "http_error"
+    assert result.status_code == 500
+
+
+def test_create_pagerduty_incident_with_details_success(monkeypatch: Any) -> None:
+    monkeypatch.setattr(pagerduty.httpx, "AsyncClient", _FakeAsyncClient)
+    monkeypatch.setenv("PAGERDUTY_FROM_EMAIL", "alerts@revtops.com")
+    monkeypatch.setenv("PagerDuty_Key", "pd_test_key")
+    monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
+    monkeypatch.setattr(pagerduty, "settings", settings.__class__())
+
+    import asyncio
+
+    result = asyncio.run(
+        pagerduty.create_pagerduty_incident_with_details(
+            title="test",
+            details="test",
+        )
+    )
+
+    assert result.ok is True
+    assert result.reason == "created"
+    assert result.status_code == 201


### PR DESCRIPTION
### Motivation
- PagerDuty incidents were failing with a generic "not configured or request failed" response that made root cause analysis difficult.
- The change aims to make failures actionable by distinguishing missing configuration, transport errors, and HTTP errors from the PagerDuty API.

### Description
- Add a frozen dataclass `PagerDutyIncidentResult` to return structured metadata about incident creation attempts.
- Introduce `create_pagerduty_incident_with_details` which returns `PagerDutyIncidentResult` and keep `create_pagerduty_incident` as a boolean-wrapper for backward compatibility.
- Capture transport errors (`httpx.HTTPError`) and HTTP response failures with reason/status/body, and update `/admin/fire-incident` to log and surface the failure reason instead of a generic message.
- Add unit tests `backend/tests/test_pagerduty_service.py` covering missing config, HTTP error, and success cases.

### Testing
- Ran `pytest -q backend/tests/test_pagerduty_service.py backend/tests/test_monitoring_task.py` which completed successfully with all tests passing (7 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f01e76e0832184900a13087e7711)