### PR TITLE
Require explicit org selection for domain-based signups

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ We use [Nango](https://nango.dev) to handle all OAuth complexity:
 | `/api/auth/me`                               | GET    | Get current user                           |
 | `/api/auth/users/sync`                       | POST   | Sync Supabase user to backend              |
 | `/api/auth/organizations`                    | POST   | Create organization                        |
-| `/api/auth/organizations/by-domain/{domain}` | GET    | Get organization by email domain           |
+| `/api/auth/organizations/by-domain/{domain}` | GET    | List organizations by email domain           |
 | `/api/auth/available-integrations`           | GET    | List available integrations                |
 | `/api/auth/connect/{provider}`               | GET    | Get Nango connect URL                      |
 | `/api/auth/connect/{provider}/session`       | GET    | Get Nango session token (for frontend SDK) |

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -446,6 +446,12 @@ class OrganizationResponse(BaseModel):
     logo_url: Optional[str] = None
 
 
+class DomainOrganizationsResponse(BaseModel):
+    """Organizations available for a given email domain."""
+
+    organizations: list[OrganizationResponse]
+
+
 class SyncUserRequest(BaseModel):
     """Request model for syncing a user from Supabase auth."""
 
@@ -669,69 +675,14 @@ async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
             # email lookup, but included for safety.
             pass
 
-        # Check if their email domain has an approved org
-        email_domain = request.email.split("@")[1].lower() if "@" in request.email else None
-        
-        if email_domain:
-            # Check if an organization exists for this domain (means someone from their company is already approved)
-            result = await session.execute(
-                select(Organization).where(Organization.email_domain == email_domain)
-            )
-            existing_org = result.scalar_one_or_none()
-            
-            if existing_org:
-                # Auto-create user as active - they're a colleague of an approved user
-                new_user = User(
-                    id=user_uuid,
-                    email=request.email,
-                    name=request.name,
-                    avatar_url=request.avatar_url,
-                    organization_id=existing_org.id,
-                    status="active",
-                    role="member",
-                    last_login=datetime.utcnow(),
-                )
-                session.add(new_user)
-                await session.flush()
-
-                # Also create membership record
-                new_membership = OrgMember(
-                    user_id=new_user.id,
-                    organization_id=existing_org.id,
-                    role="member",
-                    status="active",
-                    joined_at=datetime.utcnow(),
-                )
-                session.add(new_membership)
-                global_commands = await _set_user_global_commands(session, new_user, request.agent_global_commands)
-                await session.commit()
-                await session.refresh(new_user)
-
-                # Include organization data for new user
-                _sub_ok = (existing_org.subscription_status or "") in ("active", "trialing")
-                org_data = SyncOrganizationData(
-                    id=str(existing_org.id),
-                    name=existing_org.name,
-                    logo_url=existing_org.logo_url,
-                    subscription_required=not _sub_ok,
-                )
-
-                return SyncUserResponse(
-                    id=str(new_user.id),
-                    email=new_user.email,
-                    name=new_user.name,
-                    avatar_url=new_user.avatar_url,
-                    agent_global_commands=global_commands,
-                    phone_number=new_user.phone_number,
-                    job_title=None,
-                    organization_id=str(new_user.organization_id),
-                    organization=org_data,
-                    status=new_user.status,
-                    roles=new_user.roles or [],
-                )
-        
-        # No existing org for their domain - create new user (they'll create org in company setup)
-        # Waitlist is disabled - anyone can sign up directly
+        # New users are no longer auto-joined by domain.
+        # They can explicitly choose an existing org for their domain
+        # or create a new one in the client flow.
+        logger.info(
+            "Creating active user without default org assignment user_id=%s email=%s",
+            user_uuid,
+            request.email,
+        )
         new_user = User(
             id=user_uuid,
             email=request.email,
@@ -762,26 +713,33 @@ async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
         )
 
 
-@router.get("/organizations/by-domain/{email_domain}", response_model=OrganizationResponse)
-async def get_organization_by_domain(email_domain: str) -> OrganizationResponse:
-    """Get organization by email domain.
-    
-    Used to check if an organization exists for a domain when a new user signs up.
-    """
+@router.get("/organizations/by-domain/{email_domain}", response_model=DomainOrganizationsResponse)
+async def get_organizations_by_domain(email_domain: str) -> DomainOrganizationsResponse:
+    """Get all organizations associated with an email domain."""
     async with get_admin_session() as session:
+        normalized_domain = (email_domain or "").strip().lower()
         result = await session.execute(
-            select(Organization).where(Organization.email_domain == email_domain)
+            select(Organization)
+            .where(Organization.email_domain == normalized_domain)
+            .order_by(Organization.created_at.asc())
         )
-        org = result.scalar_one_or_none()
-        
-        if not org:
-            raise HTTPException(status_code=404, detail="Organization not found")
-        
-        return OrganizationResponse(
-            id=str(org.id),
-            name=org.name,
-            email_domain=org.email_domain,
-            logo_url=org.logo_url,
+        orgs = list(result.scalars().all())
+        logger.info(
+            "Found %d organizations for domain=%s",
+            len(orgs),
+            normalized_domain,
+        )
+
+        return DomainOrganizationsResponse(
+            organizations=[
+                OrganizationResponse(
+                    id=str(org.id),
+                    name=org.name,
+                    email_domain=org.email_domain,
+                    logo_url=org.logo_url,
+                )
+                for org in orgs
+            ]
         )
 
 
@@ -796,6 +754,8 @@ async def create_organization(request: CreateOrganizationRequest) -> Organizatio
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid organization ID")
 
+    normalized_domain = (request.email_domain or "").strip().lower()
+
     async with get_admin_session() as session:
         # Check if organization already exists by ID
         existing = await session.get(Organization, org_uuid)
@@ -807,25 +767,12 @@ async def create_organization(request: CreateOrganizationRequest) -> Organizatio
                 logo_url=existing.logo_url,
             )
         
-        # Check if organization exists for this email domain (different browser scenario)
-        result = await session.execute(
-            select(Organization).where(Organization.email_domain == request.email_domain)
-        )
-        existing_by_domain = result.scalar_one_or_none()
-        if existing_by_domain:
-            return OrganizationResponse(
-                id=str(existing_by_domain.id),
-                name=existing_by_domain.name,
-                email_domain=existing_by_domain.email_domain,
-                logo_url=existing_by_domain.logo_url,
-            )
-
         # Create new organization with free tier auto-enrolled
         now = datetime.now(timezone.utc)
         new_org = Organization(
             id=org_uuid,
             name=request.name,
-            email_domain=request.email_domain,
+            email_domain=normalized_domain,
             subscription_tier="free",
             subscription_status="active",
             credits_balance=100,

--- a/backend/db/migrations/versions/079_org_domain_nonunique.py
+++ b/backend/db/migrations/versions/079_org_domain_nonunique.py
@@ -1,0 +1,56 @@
+"""Allow multiple organizations to share an email domain.
+
+Revision ID: 079_org_domain_nonunique
+Revises: 078_slack_bot_installs
+Create Date: 2026-02-28
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "079_org_domain_nonunique"
+down_revision: Union[str, None] = "078_slack_bot_installs"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(
+        text(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                    FROM pg_constraint
+                    WHERE conname = 'organizations_email_domain_key'
+                ) THEN
+                    ALTER TABLE organizations DROP CONSTRAINT organizations_email_domain_key;
+                END IF;
+            END
+            $$;
+            """
+        )
+    )
+
+    op.drop_index("ix_organizations_email_domain", table_name="organizations")
+    op.create_index(
+        "ix_organizations_email_domain",
+        "organizations",
+        ["email_domain"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_organizations_email_domain", table_name="organizations")
+    op.create_index(
+        "ix_organizations_email_domain",
+        "organizations",
+        ["email_domain"],
+        unique=True,
+    )

--- a/backend/models/organization.py
+++ b/backend/models/organization.py
@@ -29,8 +29,8 @@ class Organization(Base):
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     email_domain: Mapped[Optional[str]] = mapped_column(
-        String(255), unique=True, nullable=True, index=True
-    )  # e.g., "acmecorp.com" - used to auto-match new users
+        String(255), nullable=True, index=True
+    )  # e.g., "acmecorp.com" - used to suggest org options on signup
     logo_url: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
     
     # Legacy Salesforce fields (kept for backwards compatibility)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,13 @@ interface StoredCompany {
   name: string;
 }
 
+interface DomainOrganization {
+  id: string;
+  name: string;
+  email_domain: string | null;
+  logo_url: string | null;
+}
+
 function generateUUID(): string {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
     const r = (Math.random() * 16) | 0;
@@ -79,15 +86,11 @@ function storeCompany(domain: string, name: string): StoredCompany {
   return company;
 }
 
-function getCompanyByDomain(domain: string): StoredCompany | null {
-  const companies = getStoredCompanies();
-  return companies[domain] || null;
-}
-
 function App(): JSX.Element {
   const [screen, setScreen] = useState<Screen>('auth');
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [emailDomain, setEmailDomain] = useState<string>('');
+  const [domainOrganizations, setDomainOrganizations] = useState<DomainOrganization[]>([]);
   
   // Zustand store
   const { 
@@ -319,65 +322,21 @@ function App(): JSX.Element {
       return;
     }
 
-    // User is allowed in - now check company/organization
-    let existingCompany = getCompanyByDomain(domain);
-
-    // If not in localStorage, check backend (colleague on different machine scenario)
-    if (!existingCompany) {
-      try {
-        const response = await fetch(`${API_BASE}/auth/organizations/by-domain/${encodeURIComponent(domain)}`);
-        if (response.ok) {
-          const backendOrg: { id: string; name: string; email_domain: string } = await response.json();
-          // Store in localStorage for future use
-          existingCompany = {
-            id: backendOrg.id,
-            name: backendOrg.name,
-          };
-          // Update localStorage
-          const companies = getStoredCompanies();
-          companies[domain] = existingCompany;
-          localStorage.setItem('revtops_companies', JSON.stringify(companies));
-        }
-      } catch (error) {
-        console.error('Failed to check backend for organization:', error);
-      }
-    }
-
-    if (!existingCompany) {
-      setScreen('company-setup');
-      return;
-    }
-
-    // Set organization in store
-    setOrganization({
-      id: existingCompany.id,
-      name: existingCompany.name,
-      logoUrl: null,
-    });
-
-    // Sync user with organization to backend
-    await syncUserToBackend();
-
-    // Ensure organization exists in backend (migration for existing localStorage data)
+    // User is allowed in - fetch org options for their domain.
+    // We no longer auto-join by domain; user can pick one or create new.
     try {
-      await fetch(`${API_BASE}/auth/organizations`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          id: existingCompany.id,
-          name: existingCompany.name,
-          email_domain: domain,
-        }),
-      });
+      const response = await fetch(`${API_BASE}/auth/organizations/by-domain/${encodeURIComponent(domain)}`);
+      if (response.ok) {
+        const data = await response.json() as { organizations: DomainOrganization[] };
+        setDomainOrganizations(data.organizations ?? []);
+      } else {
+        setDomainOrganizations([]);
+      }
     } catch (error) {
-      console.error('Failed to sync organization to backend:', error);
+      console.error('Failed to check backend for organizations:', error);
+      setDomainOrganizations([]);
     }
-
-    // Fetch the user's org list (for multi-org switcher)
-    await fetchUserOrganizations();
-
-    // Go directly to app - orgs are auto-enrolled in free tier
-    setScreen('app');
+    setScreen('company-setup');
   };
 
   const handleCompanySetup = async (companyName: string): Promise<void> => {
@@ -420,6 +379,18 @@ function App(): JSX.Element {
 
     // Show welcome screen for new orgs on free tier
     setScreen('welcome-free-tier');
+  };
+
+  const handleJoinOrganization = async (organization: DomainOrganization): Promise<void> => {
+    setOrganization({
+      id: organization.id,
+      name: organization.name,
+      logoUrl: organization.logo_url,
+    });
+
+    await syncUserToBackend();
+    await fetchUserOrganizations();
+    setScreen('app');
   };
 
   const handleLogout = async (): Promise<void> => {
@@ -590,6 +561,8 @@ Sign out
       return (
         <CompanySetup
           emailDomain={emailDomain}
+          existingOrganizations={domainOrganizations}
+          onJoinOrganization={(org) => void handleJoinOrganization(org)}
           onComplete={(name) => void handleCompanySetup(name)}
           onBack={() => void handleLogout()}
         />

--- a/frontend/src/components/CompanySetup.tsx
+++ b/frontend/src/components/CompanySetup.tsx
@@ -10,13 +10,32 @@ import { APP_NAME } from '../lib/brand';
 
 interface CompanySetupProps {
   emailDomain: string;
+  existingOrganizations?: Array<{
+    id: string;
+    name: string;
+    email_domain: string | null;
+    logo_url: string | null;
+  }>;
+  onJoinOrganization?: (organization: {
+    id: string;
+    name: string;
+    email_domain: string | null;
+    logo_url: string | null;
+  }) => Promise<void> | void;
   onComplete: (companyName: string) => void;
   onBack: () => void;
 }
 
-export function CompanySetup({ emailDomain, onComplete, onBack }: CompanySetupProps): JSX.Element {
+export function CompanySetup({
+  emailDomain,
+  existingOrganizations = [],
+  onJoinOrganization,
+  onComplete,
+  onBack,
+}: CompanySetupProps): JSX.Element {
   const [companyName, setCompanyName] = useState('');
   const [loading, setLoading] = useState(false);
+  const [joiningOrgId, setJoiningOrgId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   // Generate a suggested name from the domain
@@ -47,6 +66,23 @@ export function CompanySetup({ emailDomain, onComplete, onBack }: CompanySetupPr
     }
   };
 
+  const handleJoinOrganization = async (organization: {
+    id: string;
+    name: string;
+    email_domain: string | null;
+    logo_url: string | null;
+  }): Promise<void> => {
+    if (!onJoinOrganization) return;
+    setError(null);
+    setJoiningOrgId(organization.id);
+    try {
+      await onJoinOrganization(organization);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to join organization');
+      setJoiningOrgId(null);
+    }
+  };
+
   return (
     <div className="min-h-screen flex items-center justify-center p-4">
       {/* Background effects */}
@@ -74,14 +110,34 @@ export function CompanySetup({ emailDomain, onComplete, onBack }: CompanySetupPr
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
             </svg>
           </div>
-          <h1 className="text-2xl font-bold text-surface-50">Set up your company</h1>
+          <h1 className="text-2xl font-bold text-surface-50">Set up your organization</h1>
           <p className="text-surface-400 mt-2">
-            You're the first person from <span className="text-primary-400 font-medium">@{emailDomain}</span>
+            We found your work email domain <span className="text-primary-400 font-medium">@{emailDomain}</span>
           </p>
         </div>
 
         {/* Setup Card */}
         <div className="bg-surface-900/80 backdrop-blur-sm border border-surface-800 rounded-2xl p-8">
+          {existingOrganizations.length > 0 && (
+            <div className="mb-6">
+              <p className="text-sm text-surface-300 mb-3">Join an existing organization:</p>
+              <div className="space-y-2">
+                {existingOrganizations.map((org) => (
+                  <button
+                    key={org.id}
+                    type="button"
+                    onClick={() => void handleJoinOrganization(org)}
+                    disabled={loading || joiningOrgId !== null}
+                    className="w-full text-left px-4 py-3 rounded-xl bg-surface-800 border border-surface-700 hover:bg-surface-700 transition-colors disabled:opacity-60"
+                  >
+                    <span className="text-surface-100 font-medium">{org.name}</span>
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-surface-500 mt-3">Or create a new organization below.</p>
+            </div>
+          )}
+
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>
               <label htmlFor="companyName" className="block text-sm font-medium text-surface-300 mb-2">
@@ -123,7 +179,7 @@ export function CompanySetup({ emailDomain, onComplete, onBack }: CompanySetupPr
 
             <button
               type="submit"
-              disabled={loading || !companyName.trim()}
+              disabled={loading || joiningOrgId !== null || !companyName.trim()}
               className="btn-primary w-full py-3.5 text-base disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {loading ? (
@@ -136,10 +192,6 @@ export function CompanySetup({ emailDomain, onComplete, onBack }: CompanySetupPr
               )}
             </button>
           </form>
-
-          <p className="text-center text-surface-500 text-xs mt-6">
-            Your teammates from @{emailDomain} will automatically join this workspace
-          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation

- Prevent silently auto-joining new signups to an organization just because their email domain matches an existing org, and instead let users explicitly choose or create an org during onboarding. 
- Support multiple organizations owning the same email domain (e.g. franchisees, sub-brands) rather than enforcing a unique domain constraint. 
- Keep invited-user behavior intact so users invited to a specific org still become members of that org when they sign in. 
- Make the frontend onboarding flow clearer by offering domain-scoped org options and an explicit create-new path.

### Description

- Backend: removed auto-join-by-domain behavior from `/auth/users/sync` so new work-email users are created active without a default `organization_id` unless invited, and added a log message when creating such users. 
- Backend: replaced `GET /auth/organizations/by-domain/{domain}` to return all matching organizations as `{ organizations: [...] }`, normalizes the lookup domain, and logs results. 
- Backend/model: removed the unique constraint on `Organization.email_domain` in the SQLAlchemy model and added migration `079_org_domain_nonunique` to drop the unique constraint and recreate a non-unique index. 
- Backend: normalize `email_domain` when creating an organization to ensure consistent lookup. 
- Frontend: updated onboarding in `App.tsx` to always show company/org setup for non-personal emails that lack an org, fetch domain org candidates, and allow the user to either join a returned org or create a new one. 
- Frontend: updated `CompanySetup` to surface existing domain organizations as joinable options and changed copy to remove the previous "auto-join teammates" messaging. 
- Docs: updated README API table text to reflect that the by-domain endpoint now lists organizations.

### Testing

- Ran a migration preflight/assertion that verifies `revision` and `down_revision` lengths (both `<= 32`) for `079_org_domain_nonunique`, and the checks passed. 
- Compiled changed Python modules with `python -m compileall backend/api/routes/auth.py backend/models/organization.py backend/db/migrations/versions/079_org_domain_nonunique.py` and it succeeded. 
- Built the frontend with `npm --prefix frontend run build`; the first run surfaced an unused symbol which was fixed and the subsequent build completed successfully. 
- Started the frontend dev server and captured a UI screenshot of the auth/onboarding screen to validate the new flow visually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a247d65ef08321befa573a2aa5a843)