### PR TITLE
Switch org onboarding to invite-driven membership and allow non-unique domains

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -608,6 +608,26 @@ async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
                 if not existing.organization_id:
                     existing.organization_id = pm.organization_id
                     existing.role = pm.role
+
+            if not existing.organization_id:
+                active_membership_result = await session.execute(
+                    select(OrgMember)
+                    .where(
+                        OrgMember.user_id == existing.id,
+                        OrgMember.status == "active",
+                    )
+                    .order_by(OrgMember.joined_at.asc().nulls_last(), OrgMember.created_at.asc())
+                    .limit(1)
+                )
+                active_membership: Optional[OrgMember] = active_membership_result.scalar_one_or_none()
+                if active_membership:
+                    existing.organization_id = active_membership.organization_id
+                    existing.role = active_membership.role
+                    logger.info(
+                        "Bound user=%s to existing active membership org=%s during sync",
+                        existing.id,
+                        active_membership.organization_id,
+                    )
             
             await session.commit()
             await session.refresh(existing)
@@ -647,91 +667,8 @@ async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
                 roles=existing.roles or [],
             )
 
-        from models.org_member import OrgMember
-
-        # User doesn't exist — check for pending invitation first
-        invite_result = await session.execute(
-            select(OrgMember).where(
-                OrgMember.status == "invited",
-            )
-        )
-        # We need to find invitations that match this email, but the membership
-        # points to a stub user. Look up stub users by email to find invites.
-        invite_user_result = await session.execute(
-            select(User).where(User.email == request.email, User.status == "invited")
-        )
-        invited_stub: Optional[User] = invite_user_result.scalar_one_or_none()
-
-        if invited_stub:
-            # There's a stub user from an invitation — this case is already
-            # handled by the "existing user" path above (found by email).
-            # This branch shouldn't normally be reached because of the earlier
-            # email lookup, but included for safety.
-            pass
-
-        # Check if their email domain has an approved org
-        email_domain = request.email.split("@")[1].lower() if "@" in request.email else None
-        
-        if email_domain:
-            # Check if an organization exists for this domain (means someone from their company is already approved)
-            result = await session.execute(
-                select(Organization).where(Organization.email_domain == email_domain)
-            )
-            existing_org = result.scalar_one_or_none()
-            
-            if existing_org:
-                # Auto-create user as active - they're a colleague of an approved user
-                new_user = User(
-                    id=user_uuid,
-                    email=request.email,
-                    name=request.name,
-                    avatar_url=request.avatar_url,
-                    organization_id=existing_org.id,
-                    status="active",
-                    role="member",
-                    last_login=datetime.utcnow(),
-                )
-                session.add(new_user)
-                await session.flush()
-
-                # Also create membership record
-                new_membership = OrgMember(
-                    user_id=new_user.id,
-                    organization_id=existing_org.id,
-                    role="member",
-                    status="active",
-                    joined_at=datetime.utcnow(),
-                )
-                session.add(new_membership)
-                global_commands = await _set_user_global_commands(session, new_user, request.agent_global_commands)
-                await session.commit()
-                await session.refresh(new_user)
-
-                # Include organization data for new user
-                _sub_ok = (existing_org.subscription_status or "") in ("active", "trialing")
-                org_data = SyncOrganizationData(
-                    id=str(existing_org.id),
-                    name=existing_org.name,
-                    logo_url=existing_org.logo_url,
-                    subscription_required=not _sub_ok,
-                )
-
-                return SyncUserResponse(
-                    id=str(new_user.id),
-                    email=new_user.email,
-                    name=new_user.name,
-                    avatar_url=new_user.avatar_url,
-                    agent_global_commands=global_commands,
-                    phone_number=new_user.phone_number,
-                    job_title=None,
-                    organization_id=str(new_user.organization_id),
-                    organization=org_data,
-                    status=new_user.status,
-                    roles=new_user.roles or [],
-                )
-        
-        # No existing org for their domain - create new user (they'll create org in company setup)
-        # Waitlist is disabled - anyone can sign up directly
+        # Create a new active user with no org. Organization assignment is now
+        # invite/membership-driven and no longer inferred from email domain.
         new_user = User(
             id=user_uuid,
             email=request.email,
@@ -770,10 +707,13 @@ async def get_organization_by_domain(email_domain: str) -> OrganizationResponse:
     """
     async with get_admin_session() as session:
         result = await session.execute(
-            select(Organization).where(Organization.email_domain == email_domain)
+            select(Organization)
+            .where(Organization.email_domain == email_domain)
+            .order_by(Organization.created_at.desc().nulls_last(), Organization.id.desc())
+            .limit(1)
         )
         org = result.scalar_one_or_none()
-        
+
         if not org:
             raise HTTPException(status_code=404, detail="Organization not found")
         
@@ -807,19 +747,6 @@ async def create_organization(request: CreateOrganizationRequest) -> Organizatio
                 logo_url=existing.logo_url,
             )
         
-        # Check if organization exists for this email domain (different browser scenario)
-        result = await session.execute(
-            select(Organization).where(Organization.email_domain == request.email_domain)
-        )
-        existing_by_domain = result.scalar_one_or_none()
-        if existing_by_domain:
-            return OrganizationResponse(
-                id=str(existing_by_domain.id),
-                name=existing_by_domain.name,
-                email_domain=existing_by_domain.email_domain,
-                logo_url=existing_by_domain.logo_url,
-            )
-
         # Create new organization with free tier auto-enrolled
         now = datetime.now(timezone.utc)
         new_org = Organization(

--- a/backend/db/migrations/versions/079_org_domain_nonunique.py
+++ b/backend/db/migrations/versions/079_org_domain_nonunique.py
@@ -1,0 +1,44 @@
+"""Make organizations.email_domain non-unique.
+
+Revision ID: 079_org_domain_nonunique
+Revises: 078_slack_bot_installs
+Create Date: 2026-02-28
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "079_org_domain_nonunique"
+down_revision: Union[str, None] = "078_slack_bot_installs"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'organizations_email_domain_key'
+                  AND conrelid = 'organizations'::regclass
+            ) THEN
+                ALTER TABLE organizations
+                DROP CONSTRAINT organizations_email_domain_key;
+            END IF;
+        END
+        $$;
+        """
+    )
+
+    op.drop_index("ix_organizations_email_domain", table_name="organizations", if_exists=True)
+    op.create_index("ix_organizations_email_domain", "organizations", ["email_domain"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_organizations_email_domain", table_name="organizations", if_exists=True)
+    op.create_index("ix_organizations_email_domain", "organizations", ["email_domain"], unique=True)

--- a/backend/models/organization.py
+++ b/backend/models/organization.py
@@ -29,7 +29,7 @@ class Organization(Base):
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     email_domain: Mapped[Optional[str]] = mapped_column(
-        String(255), unique=True, nullable=True, index=True
+        String(255), nullable=True, index=True
     )  # e.g., "acmecorp.com" - used to auto-match new users
     logo_url: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
     

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,6 @@
  *
  * Handles:
  * - Authentication flow (auth → app)
- * - Work email validation
  * - Company setup for new organizations
  * - Main app layout routing
  * 
@@ -12,7 +11,7 @@
 
 import { useEffect, useState } from 'react';
 import { supabase } from './lib/supabase';
-import { getEmailDomain, isPersonalEmail } from './lib/email';
+import { getEmailDomain } from './lib/email';
 import { API_BASE } from './lib/api';
 import { useAppStore } from './store';
 import { Auth } from './components/Auth';
@@ -79,10 +78,6 @@ function storeCompany(domain: string, name: string): StoredCompany {
   return company;
 }
 
-function getCompanyByDomain(domain: string): StoredCompany | null {
-  const companies = getStoredCompanies();
-  return companies[domain] || null;
-}
 
 function App(): JSX.Element {
   const [screen, setScreen] = useState<Screen>('auth');
@@ -254,16 +249,6 @@ function App(): JSX.Element {
         }),
       });
 
-      if (syncResponse.status === 403) {
-        // User not registered — block personal emails only
-        if (isPersonalEmail(email)) {
-          setScreen('blocked-email');
-          return;
-        }
-        // Work email - this shouldn't happen anymore since waitlist is disabled
-        // but handle gracefully by proceeding to company setup
-        console.warn('Unexpected 403 for work email, proceeding to company setup');
-      }
 
       if (syncResponse.ok) {
         const userData = await syncResponse.json() as { 
@@ -313,71 +298,25 @@ function App(): JSX.Element {
       console.error('Failed to check user status:', error);
     }
 
-    // Block personal emails for org creation (not for invited users who already passed sync)
-    if (isPersonalEmail(email)) {
-      setScreen('blocked-email');
-      return;
-    }
-
-    // User is allowed in - now check company/organization
-    let existingCompany = getCompanyByDomain(domain);
-
-    // If not in localStorage, check backend (colleague on different machine scenario)
-    if (!existingCompany) {
-      try {
-        const response = await fetch(`${API_BASE}/auth/organizations/by-domain/${encodeURIComponent(domain)}`);
-        if (response.ok) {
-          const backendOrg: { id: string; name: string; email_domain: string } = await response.json();
-          // Store in localStorage for future use
-          existingCompany = {
-            id: backendOrg.id,
-            name: backendOrg.name,
-          };
-          // Update localStorage
-          const companies = getStoredCompanies();
-          companies[domain] = existingCompany;
-          localStorage.setItem('revtops_companies', JSON.stringify(companies));
-        }
-      } catch (error) {
-        console.error('Failed to check backend for organization:', error);
-      }
-    }
-
-    if (!existingCompany) {
-      setScreen('company-setup');
-      return;
-    }
-
-    // Set organization in store
-    setOrganization({
-      id: existingCompany.id,
-      name: existingCompany.name,
-      logoUrl: null,
-    });
-
-    // Sync user with organization to backend
-    await syncUserToBackend();
-
-    // Ensure organization exists in backend (migration for existing localStorage data)
-    try {
-      await fetch(`${API_BASE}/auth/organizations`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          id: existingCompany.id,
-          name: existingCompany.name,
-          email_domain: domain,
-        }),
-      });
-    } catch (error) {
-      console.error('Failed to sync organization to backend:', error);
-    }
-
-    // Fetch the user's org list (for multi-org switcher)
+    // Check if the user already has active org memberships but no active org returned from sync.
     await fetchUserOrganizations();
+    const organizations = useAppStore.getState().organizations;
+    if (organizations.length > 0) {
+      const activeOrg = organizations.find((o) => o.isActive) ?? organizations[0];
+      if (activeOrg) {
+        setOrganization({
+          id: activeOrg.id,
+          name: activeOrg.name,
+          logoUrl: activeOrg.logoUrl ?? null,
+        });
+      }
+      setScreen('app');
+      return;
+    }
 
-    // Go directly to app - orgs are auto-enrolled in free tier
-    setScreen('app');
+    // No memberships yet: continue to create-org onboarding.
+    setScreen('company-setup');
+    return;
   };
 
   const handleCompanySetup = async (companyName: string): Promise<void> => {

--- a/frontend/src/components/Auth.tsx
+++ b/frontend/src/components/Auth.tsx
@@ -2,12 +2,10 @@
  * Authentication component.
  * 
  * Handles sign up and sign in using Supabase Auth.
- * Requires work email (blocks personal email domains).
  */
 
 import { useState, useEffect } from 'react';
 import { supabase } from '../lib/supabase';
-import { isPersonalEmail } from '../lib/email';
 import { validateGoodPassword } from '../lib/password';
 import { API_BASE } from '../lib/api';
 import { APP_NAME, LOGO_PATH } from '../lib/brand';
@@ -42,13 +40,6 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
     setLoading(true);
     setError(null);
     setMessage(null);
-
-    // Validate work email (except for password reset which doesn't need email)
-    if (mode !== 'reset' && isPersonalEmail(email)) {
-      setError('Please use your work email address. Personal email domains like Gmail and Hotmail are not allowed.');
-      setLoading(false);
-      return;
-    }
 
     try {
       if (mode === 'signup') {

--- a/frontend/src/lib/email.ts
+++ b/frontend/src/lib/email.ts
@@ -1,46 +1,9 @@
 /**
- * Email validation utilities.
- * 
- * Used to enforce work email requirement and extract company domain.
+ * Email helpers.
  */
-
-// Blocked personal email domains
-export const BLOCKED_EMAIL_DOMAINS = [
-  'gmail.com',
-  'googlemail.com',
-  'hotmail.com',
-  'hotmail.co.uk',
-  'outlook.com',
-  'outlook.co.uk',
-  'live.com',
-  'msn.com',
-  'yahoo.com',
-  'yahoo.co.uk',
-  'yahoo.fr',
-  'ymail.com',
-  'aol.com',
-  'icloud.com',
-  'me.com',
-  'mac.com',
-  'protonmail.com',
-  'proton.me',
-  'zoho.com',
-  'mail.com',
-  'gmx.com',
-  'gmx.net',
-  'yandex.com',
-  'fastmail.com',
-  'tutanota.com',
-  'hey.com',
-];
 
 export function getEmailDomain(email: string): string {
   return email.split('@')[1]?.toLowerCase() || '';
-}
-
-export function isPersonalEmail(email: string): boolean {
-  const domain = getEmailDomain(email);
-  return BLOCKED_EMAIL_DOMAINS.includes(domain);
 }
 
 export function suggestCompanyName(domain: string): string {


### PR DESCRIPTION
### Motivation

- Remove domain-based restrictions and "gmail-like" blocking so all email domains can join without client-side blocking.
- Make organization assignment invitation/membership-driven rather than inferred from email domain to avoid accidental domain-based auto-joins.
- Allow multiple organizations to share the same email domain by removing the unique constraint on `organizations.email_domain`.

### Description

- Stop auto-assigning new users to an org by email domain in `POST /auth/users/sync`; new users are now created active with `organization_id=None` unless an invite/membership applies. (backend: `backend/api/routes/auth.py`)
- Auto-activate pending invited memberships on login and, when a user has active memberships but no `organization_id`, bind them to one active membership so they enter the app without extra dialogs. (backend: `backend/api/routes/auth.py`)
- Change the `GET /auth/organizations/by-domain/{email_domain}` lookup to return the most-recent org match (no uniqueness assumption), and stop short-circuiting org creation on domain collisions. (backend: `backend/api/routes/auth.py`)
- Add Alembic migration `079_org_domain_nonunique` to safely drop any legacy unique constraint and recreate the domain index as non-unique, with a safe downgrade that restores uniqueness. (migration: `backend/db/migrations/versions/079_org_domain_nonunique.py`)
- Update SQLAlchemy metadata so `Organization.email_domain` is non-unique to match the migration and product behavior. (model: `backend/models/organization.py`)
- Remove frontend personal-email blocking and the local domain auto-join flow; after sync the frontend now fetches the user's org memberships and either sets an active org and proceeds to the app, or shows the company creation dialog when no memberships exist. (frontend: `frontend/src/App.tsx`, `frontend/src/components/Auth.tsx`, `frontend/src/lib/email.ts`)

### Testing

- Ran a migration preflight check verifying `revision`/`down_revision` length for `079_org_domain_nonunique` and the check passed.
- Type/byte-compile checks with `python -m py_compile backend/api/routes/auth.py backend/models/organization.py backend/db/migrations/versions/079_org_domain_nonunique.py` completed successfully.
- Built the frontend with `npm --prefix frontend run build`, which succeeded; Vite reported existing non-blocking bundle/chunk-size warnings but the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a256f00ae48321b22f38b8a3cb735a)