### PR TITLE
Update invited email header image to GitHub avatar

### DIFF
--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -422,7 +422,7 @@ async def send_org_invitation_email(
           <tr>
             <td style="padding:36px 32px 12px;text-align:center;">
               <img
-                src="{settings.FRONTEND_URL.rstrip("/")}/logo.svg"
+                src="https://avatars.githubusercontent.com/u/223328573?s=48&v=4"
                 alt="Basebase"
                 width="52"
                 height="52"


### PR DESCRIPTION
### Motivation
- Replace the default header logo in the "You're invited" organization email with the provided GitHub avatar URL to match the requested image.

### Description
- Changed the `<img>` `src` in `send_org_invitation_email` HTML template to `https://avatars.githubusercontent.com/u/223328573?s=48&v=4` while keeping the existing sizing and styling intact.

### Testing
- Ran `python -m py_compile backend/services/email.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a32b8b26488321922b83fed2bae28c)