### PR TITLE
Use basebase_logo-256.png in invitation email header

### DIFF
--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -422,7 +422,7 @@ async def send_org_invitation_email(
           <tr>
             <td style="padding:36px 32px 12px;text-align:center;">
               <img
-                src="{settings.FRONTEND_URL.rstrip("/")}/logo.svg"
+                src="{settings.FRONTEND_URL.rstrip("/")}/basebase_logo-256.png"
                 alt="Basebase"
                 width="52"
                 height="52"


### PR DESCRIPTION
### Motivation
- Swap the header image in the "You're invited" email to the provided PNG so the invite uses the requested `basebase_logo-256.png` asset instead of the default `logo.svg`.

### Description
- Changed the image `src` in `backend/services/email.py` from `{settings.FRONTEND_URL.rstrip("/")}/logo.svg` to `{settings.FRONTEND_URL.rstrip("/")}/basebase_logo-256.png` on the invite template line.

### Testing
- Verified the code change with `git diff -- backend/services/email.py` and committed the update; attempted `curl -I https://app.basebase.com/basebase_logo-256.png` and `curl -I http://app.basebase.com/basebase_logo-256.png`, both of which returned `403 Forbidden` from the upstream proxy so external URL reachability could not be fully validated from this runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a32e5eec48832196c3c429a7b8b69e)