### PR TITLE
Normalize Slack `team_id` during org lookup and improve diagnostics

### DIFF
--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -100,6 +100,11 @@ def _normalize_slack_user_id(slack_user_id: str | None) -> str:
     return (slack_user_id or "").strip().upper()
 
 
+def _normalize_slack_team_id(team_id: str | None) -> str:
+    """Normalize a Slack workspace/team ID for consistent lookups."""
+    return (team_id or "").strip().upper()
+
+
 async def _post_cannot_action_response(
     connector: SlackConnector,
     channel: str,
@@ -242,7 +247,7 @@ async def find_organization_by_slack_team(team_id: str) -> str | None:
     Returns:
         Organization ID string or None if not found
     """
-    normalized_team_id = (team_id or "").strip()
+    normalized_team_id = _normalize_slack_team_id(team_id)
     if not normalized_team_id:
         logger.warning("[slack_conversations] Missing team_id on Slack event")
         return None
@@ -293,13 +298,22 @@ async def find_organization_by_slack_team(team_id: str) -> str | None:
             await asyncio.sleep(0.2)
 
     # --- Fast path: match on stored team_id in extra_data ---
+    available_team_ids: set[str] = set()
     for integration in integrations:
         extra_data: dict[str, Any] = integration.extra_data or {}
-        if extra_data.get("team_id") == normalized_team_id:
+        raw_team_id = extra_data.get("team_id")
+        normalized_integration_team_id = _normalize_slack_team_id(
+            raw_team_id if isinstance(raw_team_id, str) else None
+        )
+        if normalized_integration_team_id:
+            available_team_ids.add(normalized_integration_team_id)
+
+        if normalized_integration_team_id == normalized_team_id:
             logger.info(
-                "[slack_conversations] Matched Slack team %s to org %s via integration metadata",
+                "[slack_conversations] Matched Slack team %s to org %s via integration metadata (raw_team_id=%r)",
                 normalized_team_id,
                 integration.organization_id,
+                raw_team_id,
             )
             organization_id = str(integration.organization_id)
             async with _slack_team_org_cache_lock:
@@ -365,7 +379,11 @@ async def find_organization_by_slack_team(team_id: str) -> str | None:
             _cache_team_lookup(bot_install_org_id)
         return bot_install_org_id
 
-    logger.warning("[slack_conversations] No Slack integration found for team=%s", normalized_team_id)
+    logger.warning(
+        "[slack_conversations] No Slack integration found for team=%s (active integration team_ids=%s)",
+        normalized_team_id,
+        sorted(available_team_ids),
+    )
     async with _slack_team_org_cache_lock:
         _cache_team_lookup(None)
     return None

--- a/backend/tests/test_slack_user_resolution.py
+++ b/backend/tests/test_slack_user_resolution.py
@@ -143,6 +143,28 @@ def test_find_organization_by_slack_team_uses_cache(monkeypatch):
     assert second == org_id
     assert calls["count"] == 1
 
+
+def test_find_organization_by_slack_team_normalizes_whitespace_and_case(monkeypatch):
+    org_id = "11111111-1111-1111-1111-111111111111"
+    integration = SimpleNamespace(
+        provider="slack",
+        is_active=True,
+        organization_id=org_id,
+        extra_data={"team_id": " t123 "},
+    )
+
+    monkeypatch.setattr(
+        slack_conversations,
+        "get_admin_session",
+        lambda: _FakeAdminSessionContext([[integration]]),
+    )
+
+    resolved = asyncio.run(
+        slack_conversations.find_organization_by_slack_team("T123")
+    )
+
+    assert resolved == org_id
+
 def test_find_organization_by_slack_team_returns_none_when_lookup_fails(monkeypatch):
     monkeypatch.setattr(
         slack_conversations,


### PR DESCRIPTION
### Motivation
- Slack org resolution can fail when incoming `team_id` values differ in whitespace or case from stored `integration.extra_data["team_id"]` even though the integration exists. 
- Improve reliability of workspace→organization mapping so events for the same Slack workspace always resolve to the correct org. 
- Make debugging easier by adding more diagnostic information when lookups do not match.

### Description
- Added `_normalize_slack_team_id()` and use it to normalize incoming `team_id` values before cache and lookup comparisons by trimming whitespace and uppercasing the ID. 
- Normalize each integration's stored `extra_data["team_id"]` before matching and collect normalized IDs into `available_team_ids` for diagnostics. 
- Include the raw stored `team_id` value in the match log on success to aid investigation of formatting mismatches. 
- When lookup fails, log the set of normalized `team_id` values present on active Slack integrations to make failure reasons clearer, and added a regression test `test_find_organization_by_slack_team_normalizes_whitespace_and_case` that asserts matching succeeds with mixed-case and surrounding whitespace metadata.

### Testing
- Ran `pytest -q backend/tests/test_slack_user_resolution.py` and all tests in that file passed (`16 passed`).
- The change is covered by the new unit test that verifies normalization of stored `team_id` values with whitespace/case differences.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a337a7c018832183bd80975a662287)