### PR TITLE
Add TCP keepalive configuration for DB asyncpg connections

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -44,6 +44,9 @@ class Settings(BaseSettings):
     DB_POOL_RECYCLE_SECONDS: int = 45
     DB_CONNECT_TIMEOUT_SECONDS: float = 10.0
     DB_COMMAND_TIMEOUT_SECONDS: float = 30.0
+    DB_TCP_KEEPALIVES_IDLE_SECONDS: int = 60
+    DB_TCP_KEEPALIVES_INTERVAL_SECONDS: int = 30
+    DB_TCP_KEEPALIVES_COUNT: int = 5
 
     # Redis
     REDIS_URL: str = "redis://localhost:6379"

--- a/backend/models/database.py
+++ b/backend/models/database.py
@@ -56,7 +56,19 @@ def _make_pgbouncer_safe_connect_args() -> dict[str, Any]:
         "timeout": settings.DB_CONNECT_TIMEOUT_SECONDS,
         "command_timeout": settings.DB_COMMAND_TIMEOUT_SECONDS,
         "statement_cache_size": 0,
+        "server_settings": {
+            "tcp_keepalives_idle": str(settings.DB_TCP_KEEPALIVES_IDLE_SECONDS),
+            "tcp_keepalives_interval": str(settings.DB_TCP_KEEPALIVES_INTERVAL_SECONDS),
+            "tcp_keepalives_count": str(settings.DB_TCP_KEEPALIVES_COUNT),
+        },
     }
+
+    logger.debug(
+        "DB connect args configured with TCP keepalives (idle=%ss interval=%ss count=%s)",
+        settings.DB_TCP_KEEPALIVES_IDLE_SECONDS,
+        settings.DB_TCP_KEEPALIVES_INTERVAL_SECONDS,
+        settings.DB_TCP_KEEPALIVES_COUNT,
+    )
 
     try:
         from asyncpg import Connection

--- a/backend/tests/test_database_tcp_keepalives.py
+++ b/backend/tests/test_database_tcp_keepalives.py
@@ -1,0 +1,16 @@
+from config import settings
+from models.database import _make_pgbouncer_safe_connect_args
+
+
+def test_make_connect_args_includes_tcp_keepalives(monkeypatch):
+    monkeypatch.setattr(settings, "DB_TCP_KEEPALIVES_IDLE_SECONDS", 75)
+    monkeypatch.setattr(settings, "DB_TCP_KEEPALIVES_INTERVAL_SECONDS", 20)
+    monkeypatch.setattr(settings, "DB_TCP_KEEPALIVES_COUNT", 4)
+
+    connect_args = _make_pgbouncer_safe_connect_args()
+
+    assert connect_args["server_settings"] == {
+        "tcp_keepalives_idle": "75",
+        "tcp_keepalives_interval": "20",
+        "tcp_keepalives_count": "4",
+    }

--- a/env.example
+++ b/env.example
@@ -1,5 +1,8 @@
 # Database
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/revenue_copilot
+DB_TCP_KEEPALIVES_IDLE_SECONDS=60
+DB_TCP_KEEPALIVES_INTERVAL_SECONDS=30
+DB_TCP_KEEPALIVES_COUNT=5
 
 # Redis
 REDIS_URL=redis://localhost:6379


### PR DESCRIPTION
### Motivation

- Prevent long-lived connections from being dropped by cloud/network middleboxes or poolers by enabling TCP keepalives on asyncpg connections. 
- Make keepalive behavior configurable per deployment so timeouts can be tuned for different infrastructure (Supabase, Railway, etc.).

### Description

- Added three new settings to `Settings`: `DB_TCP_KEEPALIVES_IDLE_SECONDS`, `DB_TCP_KEEPALIVES_INTERVAL_SECONDS`, and `DB_TCP_KEEPALIVES_COUNT` so values are configurable via environment variables. 
- Updated `_make_pgbouncer_safe_connect_args()` to include PostgreSQL `server_settings` (`tcp_keepalives_idle`, `tcp_keepalives_interval`, `tcp_keepalives_count`) passed to asyncpg and to log the applied keepalive values. 
- Documented the new environment variables in `env.example`. 
- Added a unit test `backend/tests/test_database_tcp_keepalives.py` to assert `_make_pgbouncer_safe_connect_args()` includes the expected `server_settings` values.

### Testing

- Ran `pytest -q backend/tests/test_database_tcp_keepalives.py`, which succeeded (`1 passed`) with one Pydantic deprecation warning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a499d3d44c8321801d85994adac73a)