### PR TITLE
Handle Supabase 522 pool outage in monitoring checks

### DIFF
--- a/backend/tests/test_monitoring_task.py
+++ b/backend/tests/test_monitoring_task.py
@@ -12,6 +12,9 @@ class _FakeResponse:
         self.status_code = status_code
         self.text = text
 
+    def json(self) -> dict[str, Any]:
+        return {}
+
 
 class _FakeAsyncClient:
     def __init__(self, **kwargs: Any) -> None:
@@ -163,3 +166,56 @@ def test_api_healthcheck_url_uses_backend_public_url(monkeypatch: Any) -> None:
     monkeypatch.setattr(monitoring, "settings", settings.__class__())
 
     assert monitoring._api_healthcheck_url() == "https://revtops.example.com/health"
+
+
+def test_check_http_endpoint_marks_supabase_522_as_connection_pool_outage(monkeypatch: Any) -> None:
+    class _FakeHttpClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+        async def __aenter__(self) -> "_FakeHttpClient":
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        async def get(self, url: str) -> _FakeResponse:
+            return _FakeResponse(status_code=522)
+
+    monkeypatch.setattr(monitoring.httpx, "AsyncClient", _FakeHttpClient)
+
+    import asyncio
+
+    result = asyncio.run(monitoring._check_http_endpoint("Supabase", "https://example.supabase.co"))
+
+    assert result.name == "Supabase"
+    assert result.healthy is False
+    assert result.details == "HTTP 522 from https://example.supabase.co (possible Supabase connection pool outage)"
+
+
+def test_monitor_dependencies_raises_incident_for_supabase_522(monkeypatch: Any) -> None:
+    async def _fake_run_dependency_checks() -> list[monitoring.CheckResult]:
+        return [
+            monitoring.CheckResult(
+                name="Supabase",
+                healthy=False,
+                details="HTTP 522 from https://example.supabase.co (possible Supabase connection pool outage)",
+            ),
+        ]
+
+    async def _fake_record_check_heartbeat() -> None:
+        return None
+
+    created_incidents: list[str] = []
+
+    async def _fake_create_pagerduty_incident(**kwargs: Any) -> None:
+        created_incidents.append(kwargs["check_result"].name)
+
+    monkeypatch.setattr(monitoring, "_run_dependency_checks", _fake_run_dependency_checks)
+    monkeypatch.setattr(monitoring, "_record_check_heartbeat", _fake_record_check_heartbeat)
+    monkeypatch.setattr(monitoring, "_create_pagerduty_incident", _fake_create_pagerduty_incident)
+
+    result = monitoring.monitor_dependencies.__wrapped__()
+
+    assert result["down_services"] == ["Supabase"]
+    assert created_incidents == ["Supabase"]

--- a/backend/workers/tasks/monitoring.py
+++ b/backend/workers/tasks/monitoring.py
@@ -39,6 +39,14 @@ async def _check_http_endpoint(name: str, url: str, timeout_s: float = 10.0) -> 
     try:
         async with httpx.AsyncClient(timeout=timeout_s, follow_redirects=True) as client:
             response = await client.get(url)
+        if name == "Supabase" and response.status_code == 522:
+            return CheckResult(
+                name=name,
+                healthy=False,
+                details=(
+                    f"HTTP 522 from {url} (possible Supabase connection pool outage)"
+                ),
+            )
         if response.status_code >= 500:
             return CheckResult(name=name, healthy=False, details=f"HTTP {response.status_code} from {url}")
         return CheckResult(name=name, healthy=True, details=f"HTTP {response.status_code} from {url}")


### PR DESCRIPTION
### Motivation

- The 15-minute dependency monitor must classify Supabase `522` responses (Cloudflare/Gateway timeouts often produced when the Supabase connection pool is exhausted) as an outage so PagerDuty incidents are raised when the DB pooler goes down.

### Description

- Added a Supabase-specific `522` check in `workers.tasks.monitoring._check_http_endpoint` that returns an unhealthy `CheckResult` with details indicating a possible connection pool outage.
- Updated `backend/tests/test_monitoring_task.py` to provide a `.json()` shim on the fake response and added `test_check_http_endpoint_marks_supabase_522_as_connection_pool_outage` to validate `522` handling and `test_monitor_dependencies_raises_incident_for_supabase_522` to ensure the monitor task triggers incident creation for that condition.
- Modified files: `backend/workers/tasks/monitoring.py` and `backend/tests/test_monitoring_task.py`.

### Testing

- Ran `pytest -q backend/tests/test_monitoring_task.py` and all tests passed (`10 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49e8ec2548321824835fb7f2e38a7)