### PR TITLE
Show (admin) pill for organization admins in team panel

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -902,7 +902,7 @@ async def get_organization_members(
                     id=str(u.id),
                     name=u.name,
                     email=u.email,
-                    role=u.role,
+                    role=membership.role if membership else u.role,
                     avatar_url=u.avatar_url,
                     job_title=membership.title if membership else None,
                     status=u.status,

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -395,7 +395,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                   <div className="space-y-2">
                     {members.map((member) => {
                       const displayName: string = member.name ?? member.email.split('@')[0] ?? 'Unknown';
-                      const isAdmin: boolean = member.role === 'admin' || member.id === currentUser.id;
+                      const isAdmin: boolean = member.role === 'admin';
                       const isExpanded: boolean = expandedMemberId === member.id;
                       const identities: IdentityMapping[] = [...member.identities].sort((a, b) => {
                         const sourceCompare = sourceLabel(a.source).localeCompare(sourceLabel(b.source));
@@ -421,7 +421,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                                 </span>
                                 {isAdmin && (
                                   <span className="px-2 py-0.5 text-xs font-medium bg-primary-500/20 text-primary-400 rounded-full">
-                                    Admin
+                                    (admin)
                                   </span>
                                 )}
                               </div>


### PR DESCRIPTION
### Motivation
- Team list should indicate which users can sign in as admin for the current organization using the org-specific membership role rather than a possibly stale global `user.role`.
- The right-hand Organization panel UI should display the requested `(admin)` pill for those org admins so site admins are obvious in the team panel.

### Description
- Adjusted the API `GET /auth/organizations/{org_id}/members` serializer to return the organization membership role when present (`role=membership.role if membership else u.role`) so the client receives the org-specific role. (edited in `backend/api/routes/auth.py`).
- Updated the Organization panel team list to compute admin status strictly from `member.role === 'admin'` and changed the badge text to `(admin)` to match the requested UI. (edited in `frontend/src/components/OrganizationPanel.tsx`).

### Testing
- Built the frontend with `npm --prefix frontend run build`, which completed successfully. 
- Started the frontend dev server with `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173` and verified the UI by capturing a screenshot via a Playwright script, all of which succeeded. 
- No automated unit tests were added; changes are covered by the build and manual visual verification described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4cb4d2ac0832191b1a6cf90384761)