### PR TITLE
Revert PR #428 changes in orchestrator and app tools

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1636,8 +1636,6 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
                     tool_context.update(self.workflow_context)
                 if self.conversation_id:
                     tool_context["conversation_id"] = self.conversation_id
-                if self.source_user_id:
-                    tool_context["source_user_id"] = self.source_user_id
                 tool_context["tool_id"] = tool_id
 
                 # Execute tool with hard timeout so we always yield a result and the UI can stop "Running"

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -5338,54 +5338,18 @@ async def _write_app_create(
 
     message_id: str | None = context.get("message_id") if context else None
     conversation_id: str | None = (context or {}).get("conversation_id")
-    source_user_id: str | None = (context or {}).get("source_user_id")
 
     user_uuid: UUID | None = UUID(user_id) if user_id else None
     if not user_uuid and conversation_id:
         async with get_session(organization_id=organization_id) as session:
             row = await session.execute(
-                select(
-                    Conversation.user_id,
-                    Conversation.source_user_id,
-                    Conversation.participating_user_ids,
-                ).where(
+                select(Conversation.user_id).where(
                     Conversation.id == UUID(conversation_id),
                 )
             )
-            conv_row = row.one_or_none()
-            if conv_row is not None:
-                if conv_row.user_id is not None:
-                    user_uuid = conv_row.user_id
-                elif not source_user_id and conv_row.source_user_id:
-                    source_user_id = conv_row.source_user_id
-
-                # Fallback: use a known participant from this conversation
-                if not user_uuid and conv_row.participating_user_ids:
-                    user_uuid = conv_row.participating_user_ids[0]
-
-    # Fallback: resolve Slack source_user_id to a RevTops user
-    if not user_uuid and source_user_id:
-        try:
-            from services.slack_conversations import resolve_revtops_user_for_slack_actor
-
-            resolved_user = await resolve_revtops_user_for_slack_actor(
-                organization_id=organization_id,
-                slack_user_id=source_user_id,
-            )
-            if resolved_user:
-                user_uuid = resolved_user.id
-                logger.info(
-                    "[Tools._write_app] Resolved source_user_id=%s to user=%s for app creation",
-                    source_user_id,
-                    user_uuid,
-                )
-        except Exception as exc:
-            logger.warning(
-                "[Tools._write_app] Failed to resolve source_user_id=%s: %s",
-                source_user_id,
-                exc,
-            )
-
+            conv_user_id: UUID | None = row.scalar_one_or_none()
+            if conv_user_id is not None:
+                user_uuid = conv_user_id
     if not user_uuid:
         return {
             "error": "App creation requires a user context. This can happen in some automated flows; try creating the app from a normal chat message.",
@@ -5417,7 +5381,6 @@ async def _write_app_create(
             list(queries.keys()),
         )
 
-    app_url = f"{settings.FRONTEND_URL.rstrip('/')}/apps/{app_id_str}"
     return {
         "status": "success",
         "app_id": app_id_str,
@@ -5427,8 +5390,7 @@ async def _write_app_create(
             "description": description,
             "frontendCode": frontend_code,
         },
-        "url": app_url,
-        "message": f"Created interactive app: {title}. View it at {app_url}",
+        "message": f"Created interactive app: {title}",
     }
 
 
@@ -5493,12 +5455,10 @@ async def _write_app_update(
             app.title,
         )
 
-    app_url = f"{settings.FRONTEND_URL.rstrip('/')}/apps/{app_id}"
     return {
         "status": "success",
         "app_id": app_id,
-        "url": app_url,
-        "message": f"Updated app: {app.title}. View it at {app_url}",
+        "message": f"Updated app: {app.title}",
         "updated_fields": [
             f for f in ["queries", "frontend_code", "title", "description"]
             if params.get(f) is not None


### PR DESCRIPTION
### Motivation
- Undo the changes that exposed Slack `source_user_id` into tool execution context and altered app creation ownership resolution, which introduced unexpected identity fallbacks and surfaced app URLs in tool responses. 
- Restore the pre-change semantics so tools receive only the intended user context and app creation uses a deterministic RevTops user lookup.

### Description
- Removed injecting `source_user_id` into the tool context in `backend/agents/orchestrator.py` when building `tool_context` for tool execution. 
- Reverted `backend/agents/tools.py` `write_app` create flow to resolve ownership from the supplied `user_id` or from `Conversation.user_id` only, removing the `Conversation.source_user_id` and `participating_user_ids` fallbacks and the Slack resolution path. 
- Removed construction and inclusion of `app_url` from the `write_app` create/update responses and restored the original concise success `message` fields. 
- Kept code formatting and ensured the changed code paths use `scalar_one_or_none()` to read `Conversation.user_id` consistently.

### Testing
- Ran `python -m py_compile backend/agents/orchestrator.py backend/agents/tools.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4cf74081483218c273a043f3bd508)