### PR TITLE
Revert identity fallbacks for app creation in orchestrator/tools

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1636,8 +1636,6 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
                     tool_context.update(self.workflow_context)
                 if self.conversation_id:
                     tool_context["conversation_id"] = self.conversation_id
-                if self.source_user_id:
-                    tool_context["source_user_id"] = self.source_user_id
                 tool_context["tool_id"] = tool_id
 
                 # Execute tool with hard timeout so we always yield a result and the UI can stop "Running"

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -5338,53 +5338,17 @@ async def _write_app_create(
 
     message_id: str | None = context.get("message_id") if context else None
     conversation_id: str | None = (context or {}).get("conversation_id")
-    source_user_id: str | None = (context or {}).get("source_user_id")
-
     user_uuid: UUID | None = UUID(user_id) if user_id else None
     if not user_uuid and conversation_id:
         async with get_session(organization_id=organization_id) as session:
             row = await session.execute(
-                select(
-                    Conversation.user_id,
-                    Conversation.source_user_id,
-                    Conversation.participating_user_ids,
-                ).where(
+                select(Conversation.user_id).where(
                     Conversation.id == UUID(conversation_id),
                 )
             )
-            conv_row = row.one_or_none()
-            if conv_row is not None:
-                if conv_row.user_id is not None:
-                    user_uuid = conv_row.user_id
-                elif not source_user_id and conv_row.source_user_id:
-                    source_user_id = conv_row.source_user_id
-
-                # Fallback: use a known participant from this conversation
-                if not user_uuid and conv_row.participating_user_ids:
-                    user_uuid = conv_row.participating_user_ids[0]
-
-    # Fallback: resolve Slack source_user_id to a RevTops user
-    if not user_uuid and source_user_id:
-        try:
-            from services.slack_conversations import resolve_revtops_user_for_slack_actor
-
-            resolved_user = await resolve_revtops_user_for_slack_actor(
-                organization_id=organization_id,
-                slack_user_id=source_user_id,
-            )
-            if resolved_user:
-                user_uuid = resolved_user.id
-                logger.info(
-                    "[Tools._write_app] Resolved source_user_id=%s to user=%s for app creation",
-                    source_user_id,
-                    user_uuid,
-                )
-        except Exception as exc:
-            logger.warning(
-                "[Tools._write_app] Failed to resolve source_user_id=%s: %s",
-                source_user_id,
-                exc,
-            )
+            conv_user_id: UUID | None = row.scalar_one_or_none()
+            if conv_user_id is not None:
+                user_uuid = conv_user_id
 
     if not user_uuid:
         return {


### PR DESCRIPTION
### Motivation
- Undo recent identity propagation and Slack-based fallbacks so app creation uses the same explicit user context as before.
- Avoid resolving app ownership from transient `source_user_id` or conversation participants to prevent misattribution of created apps.

### Description
- Removed `source_user_id` propagation from the tool context in `backend/agents/orchestrator.py` so tools no longer receive `source_user_id` implicitly.
- Reverted `_write_app_create` in `backend/agents/tools.py` to only resolve the app owner from an explicit `user_id` or `Conversation.user_id`, removing conversation participant fallback and Slack actor resolution logic.
- Restored the simpler `select(Conversation.user_id)` query path and usage of `row.scalar_one_or_none()` for determining the user context.

### Testing
- Ran `python -m py_compile backend/agents/orchestrator.py backend/agents/tools.py` and the files compiled successfully with no syntax errors.
- No automated unit tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d04a9a1083218f8599854f919b7d)