### PR TITLE
Shorten app name display width in Apps gallery

### DIFF
--- a/frontend/src/components/apps/AppsGallery.tsx
+++ b/frontend/src/components/apps/AppsGallery.tsx
@@ -197,7 +197,7 @@ export function AppsGallery(): JSX.Element {
                   </svg>
                 </div>
                 <div className="min-w-0 flex-1">
-                  <h3 className="text-sm font-medium text-surface-100 group-hover:text-primary-300 transition-colors truncate">
+                  <h3 className="text-sm font-medium text-surface-100 group-hover:text-primary-300 transition-colors truncate max-w-[35ch]">
                     {app.title ?? "Untitled App"}
                   </h3>
                   {app.description && (
@@ -298,7 +298,7 @@ export function AppsGallery(): JSX.Element {
                         </svg>
                       </div>
                       <div className="min-w-0 flex-1">
-                        <h3 className="text-sm font-medium text-surface-300 group-hover:text-surface-100 transition-colors truncate">
+                        <h3 className="text-sm font-medium text-surface-300 group-hover:text-surface-100 transition-colors truncate max-w-[35ch]">
                           {app.title ?? "Untitled App"}
                         </h3>
                         {app.description && (


### PR DESCRIPTION
### Motivation
- Make long app titles ellipsize slightly sooner (roughly ~5 characters earlier) in the Apps gallery so names don't run as long visually while preserving layout.

### Description
- Constrain the title element in both active and archived app cards by adding `max-w-[35ch]` to the truncated `<h3>` in `frontend/src/components/apps/AppsGallery.tsx` so the ellipsis appears earlier.

### Testing
- Ran lint via `cd frontend && npm run lint`, which completed successfully.
- Ran an automated Playwright script to load the local Vite app and capture a screenshot of the gallery, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4dcb9d4f483218ca9508426c8adaf)