### PR TITLE
Fix archived apps not moving to Archived section in Apps gallery

### DIFF
--- a/frontend/src/components/apps/AppsGallery.tsx
+++ b/frontend/src/components/apps/AppsGallery.tsx
@@ -72,22 +72,45 @@ export function AppsGallery(): JSX.Element {
 
   const handleArchive = async (appId: string): Promise<void> => {
     const resp = await apiRequest<{ status: string }>(`/apps/${appId}/archive`, { method: "POST" });
-    if (!resp.error) {
-      setApps((prev) => prev.filter((a) => a.id !== appId));
-      // Reset archived cache so next expand re-fetches
-      setArchivedFetched(false);
-      if (showArchived) {
-        void fetchArchivedApps();
+    if (resp.error) {
+      setError(resp.error);
+      return;
+    }
+
+    let archivedApp: AppItem | null = null;
+    setApps((prev) => {
+      const match = prev.find((a) => a.id === appId) ?? null;
+      if (match) {
+        archivedApp = {
+          ...match,
+          archived_at: new Date().toISOString(),
+        };
       }
+      return prev.filter((a) => a.id !== appId);
+    });
+
+    if (archivedApp) {
+      setArchivedApps((prev) => [archivedApp as AppItem, ...prev.filter((a) => a.id !== appId)]);
+      setArchivedFetched(true);
+    } else {
+      // Fallback when app was not in local state
+      setArchivedFetched(false);
+    }
+
+    if (showArchived) {
+      void fetchArchivedApps();
     }
   };
 
   const handleUnarchive = async (appId: string): Promise<void> => {
     const resp = await apiRequest<{ status: string }>(`/apps/${appId}/unarchive`, { method: "POST" });
-    if (!resp.error) {
-      setArchivedApps((prev) => prev.filter((a) => a.id !== appId));
-      void fetchApps();
+    if (resp.error) {
+      setError(resp.error);
+      return;
     }
+
+    setArchivedApps((prev) => prev.filter((a) => a.id !== appId));
+    void fetchApps();
   };
 
   const toggleArchived = (): void => {


### PR DESCRIPTION
### Motivation
- Clicking **Archive** did not reliably move an app into the archived section of the gallery and API errors were silently ignored. 
- The archived cache could become stale because the UI did not consistently update local `archivedApps` state after an archive action.

### Description
- Update `handleArchive` in `frontend/src/components/apps/AppsGallery.tsx` to surface API errors via `setError` and return early when the archive request fails. 
- Implement optimistic UI update: remove the app from the active `apps` list, build a local `archivedApp` with `archived_at` set, and prepend it into `archivedApps` when available; otherwise fall back to triggering a refetch. 
- Update `handleUnarchive` to surface API errors and remove the unarchived app from `archivedApps` then refetch active apps. 
- Preserve existing behavior for refreshing archived items when the archived section is open by calling `fetchArchivedApps()` where appropriate.

### Testing
- Ran `npm --prefix frontend run build` and TypeScript/Vite build completed successfully. (success)
- Launched the frontend dev server with `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173` for visual verification. (success)
- Captured a Playwright screenshot for validation (`artifacts/apps-gallery-fix.png`). (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4dd08d4e48321a1a73253b2e25913)