### PR TITLE
Fix app archive/unarchive timestamp timezone mismatch

### DIFF
--- a/backend/api/routes/apps.py
+++ b/backend/api/routes/apps.py
@@ -374,7 +374,10 @@ async def archive_app(
         app: App | None = result.scalar_one_or_none()
         if app is None:
             raise HTTPException(status_code=404, detail="App not found")
-        app.archived_at = datetime.now(timezone.utc)
+        # apps.archived_at is stored as a timestamp without timezone in Postgres.
+        # Persist a naive UTC datetime to avoid asyncpg offset-aware/naive errors.
+        app.archived_at = datetime.utcnow()
+        logger.info("Archived app %s at %s", app_id, app.archived_at.isoformat())
         await session.commit()
 
     return {"status": "ok"}
@@ -398,6 +401,7 @@ async def unarchive_app(
         if app is None:
             raise HTTPException(status_code=404, detail="App not found")
         app.archived_at = None
+        logger.info("Unarchived app %s", app_id)
         await session.commit()
 
     return {"status": "ok"}


### PR DESCRIPTION
### Motivation
- Avoid asyncpg `offset-naive`/`offset-aware` datetime errors when writing to the `apps.archived_at` column (which is a `timestamp without time zone`) so archive/unarchive flows no longer fail.

### Description
- Replace `datetime.now(timezone.utc)` with `datetime.utcnow()` in `backend/api/routes/apps.py` and add a brief comment explaining the naive-UTC requirement plus info logs for both archive and unarchive operations.

### Testing
- Ran `cd backend && pytest -q tests/test_health.py` and the test suite completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4dec5d3948321974a8365943c44f8)