### PR TITLE
Adjust Google Drive sync cadence and add login-triggered sync

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -42,6 +42,46 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
+_DRIVE_LOGIN_SYNC_MIN_INTERVAL = timedelta(minutes=5)
+
+
+def _should_trigger_drive_sync_on_login(last_sync_at: Optional[datetime]) -> bool:
+    """Throttle login-triggered Drive syncs to at most once every 5 minutes."""
+    if last_sync_at is None:
+        return True
+    return (datetime.utcnow() - last_sync_at) >= _DRIVE_LOGIN_SYNC_MIN_INTERVAL
+
+
+def _enqueue_google_drive_login_sync(organization_id: UUID, user_id: UUID, integration: Integration) -> None:
+    """Queue a Google Drive sync for the logging-in user when throttling allows."""
+    if not _should_trigger_drive_sync_on_login(integration.last_sync_at):
+        logger.info(
+            "Skipping login-triggered Google Drive sync org=%s user=%s last_sync_at=%s",
+            organization_id,
+            user_id,
+            integration.last_sync_at.isoformat() if integration.last_sync_at else None,
+        )
+        return
+
+    try:
+        from workers.tasks.sync import sync_integration
+
+        task = sync_integration.delay(str(organization_id), "google_drive", str(user_id))
+        logger.info(
+            "Queued login-triggered Google Drive sync org=%s user=%s task_id=%s",
+            organization_id,
+            user_id,
+            task.id,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to queue login-triggered Google Drive sync org=%s user=%s error=%s",
+            organization_id,
+            user_id,
+            exc,
+        )
+
+
 _AGENT_GLOBAL_COMMANDS_CATEGORY = "global_commands"
 
 
@@ -631,7 +671,25 @@ async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
             
             await session.commit()
             await session.refresh(existing)
-            
+
+            # Trigger a user-scoped Google Drive sync on login (throttled to >=5 min).
+            if existing.organization_id:
+                drive_integration_result = await session.execute(
+                    select(Integration).where(
+                        Integration.organization_id == existing.organization_id,
+                        Integration.provider == "google_drive",
+                        Integration.user_id == existing.id,
+                        Integration.is_active == True,
+                    )
+                )
+                drive_integration = drive_integration_result.scalar_one_or_none()
+                if drive_integration:
+                    _enqueue_google_drive_login_sync(
+                        existing.organization_id,
+                        existing.id,
+                        drive_integration,
+                    )
+
             # Load organization data and job title if user has an org
             org_data: Optional[SyncOrganizationData] = None
             sync_job_title: Optional[str] = None

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -16,13 +16,20 @@ if str(_backend_dir) not in sys.path:
 
 import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID
 
 from workers.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
+
+# Provider-specific sync cadence for periodic global sync runs.
+# Default cadence remains hourly unless explicitly overridden.
+PROVIDER_SYNC_INTERVALS: dict[str, timedelta] = {
+    "google_drive": timedelta(minutes=30),
+}
+DEFAULT_SYNC_INTERVAL: timedelta = timedelta(hours=1)
 
 
 def run_async(coro: Any) -> Any:
@@ -188,9 +195,51 @@ async def _get_all_active_integrations() -> list[dict[str, str | None]]:
                 "organization_id": str(i.organization_id),
                 "provider": i.provider,
                 "user_id": str(i.user_id) if i.user_id else None,
+                "last_sync_at": i.last_sync_at.isoformat() if i.last_sync_at else None,
             }
             for i in integrations
         ]
+
+
+def _should_sync_in_periodic_run(integration: dict[str, str | None], now: datetime) -> bool:
+    """Return whether an integration is due for sync in the periodic global run."""
+    provider: str = integration["provider"]  # type: ignore[assignment]
+    cadence: timedelta = PROVIDER_SYNC_INTERVALS.get(provider, DEFAULT_SYNC_INTERVAL)
+    raw_last_sync_at: str | None = integration.get("last_sync_at")
+
+    if not raw_last_sync_at:
+        logger.info(
+            "Periodic sync due provider=%s org=%s user=%s reason=never_synced",
+            provider,
+            integration.get("organization_id"),
+            integration.get("user_id"),
+        )
+        return True
+
+    try:
+        last_sync_at = datetime.fromisoformat(raw_last_sync_at)
+    except ValueError:
+        logger.warning(
+            "Periodic sync forced provider=%s org=%s user=%s reason=invalid_last_sync_at value=%s",
+            provider,
+            integration.get("organization_id"),
+            integration.get("user_id"),
+            raw_last_sync_at,
+        )
+        return True
+
+    elapsed: timedelta = now - last_sync_at
+    due: bool = elapsed >= cadence
+    if not due:
+        logger.info(
+            "Skipping periodic sync provider=%s org=%s user=%s elapsed_seconds=%s min_interval_seconds=%s",
+            provider,
+            integration.get("organization_id"),
+            integration.get("user_id"),
+            int(elapsed.total_seconds()),
+            int(cadence.total_seconds()),
+        )
+    return due
 
 
 async def _get_org_integrations(organization_id: str) -> list[dict[str, str | None]]:
@@ -284,6 +333,7 @@ def sync_all_organizations(self: Any) -> dict[str, Any]:
     logger.info(f"Task {self.request.id}: Starting hourly sync for all organizations")
     
     async def _sync_all() -> dict[str, Any]:
+        now = datetime.utcnow()
         all_integrations: list[dict[str, str | None]] = await _get_all_active_integrations()
         
         # Group by organization
@@ -301,6 +351,8 @@ def sync_all_organizations(self: Any) -> dict[str, Any]:
         for org_id, entries in orgs.items():
             results[org_id] = {}
             for entry in entries:
+                if not _should_sync_in_periodic_run(entry, now):
+                    continue
                 provider: str = entry["provider"]  # type: ignore[assignment]
                 uid: str | None = entry["user_id"]
                 key: str = f"{provider}:{uid}" if uid else provider


### PR DESCRIPTION
### Motivation
- Google Drive Docs/Sheets/Slides should be kept fresher than the default hourly cadence while avoiding excessive API calls and worker load. 
- Also queue a user-scoped Drive sync when a user logs in, but throttle it so a given integration is not triggered too frequently.

### Description
- Added provider-specific periodic sync cadence in `backend/workers/tasks/sync.py` with `google_drive` set to 30 minutes and a `DEFAULT_SYNC_INTERVAL` for others. 
- Included `last_sync_at` in the payload returned by `_get_all_active_integrations` and implemented `_should_sync_in_periodic_run(...)` to skip non-due integrations during the global periodic run with explicit logging. 
- On user sync/login flow in `backend/api/routes/auth.py` added a throttled login-triggered enqueue path that finds an active per-user `google_drive` `Integration` and queues `sync_integration` when allowed, with a 5-minute minimum interval. 
- Added logging for queued, skipped, and enqueue-failure cases and kept behavior backward-compatible without DB schema changes.

### Testing
- Ran `python -m compileall backend/workers/tasks/sync.py backend/api/routes/auth.py` to ensure the modified modules compile successfully, and the step completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ddde23a483218fb3aef836aa0f3a)