### PR TITLE
Show Admin pill for global admin-capable users in team panel

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -794,6 +794,7 @@ class TeamMemberResponse(BaseModel):
     avatar_url: Optional[str]
     job_title: Optional[str] = None
     status: Optional[str] = None  # 'active', 'crm_only', etc.
+    can_login_as_admin: bool = False
     identities: list[IdentityMappingResponse] = []
 
 
@@ -906,6 +907,7 @@ async def get_organization_members(
                     avatar_url=u.avatar_url,
                     job_title=membership.title if membership else None,
                     status=u.status,
+                    can_login_as_admin=u.role == "admin",
                     identities=identities,
                 )
             )

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -395,7 +395,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                   <div className="space-y-2">
                     {members.map((member) => {
                       const displayName: string = member.name ?? member.email.split('@')[0] ?? 'Unknown';
-                      const isAdmin: boolean = member.role === 'admin';
+                      const isAdmin: boolean = member.role === 'admin' || member.canLoginAsAdmin;
                       const isExpanded: boolean = expandedMemberId === member.id;
                       const identities: IdentityMapping[] = [...member.identities].sort((a, b) => {
                         const sourceCompare = sourceLabel(a.source).localeCompare(sourceLabel(b.source));
@@ -421,7 +421,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                                 </span>
                                 {isAdmin && (
                                   <span className="px-2 py-0.5 text-xs font-medium bg-primary-500/20 text-primary-400 rounded-full">
-                                    (admin)
+                                    Admin
                                   </span>
                                 )}
                               </div>

--- a/frontend/src/hooks/useOrganization.ts
+++ b/frontend/src/hooks/useOrganization.ts
@@ -33,6 +33,7 @@ export interface TeamMember {
   avatarUrl: string | null;
   jobTitle: string | null;
   status: string | null;
+  canLoginAsAdmin: boolean;
   identities: IdentityMapping[];
 }
 
@@ -61,6 +62,7 @@ interface TeamMembersApiResponse {
     avatar_url: string | null;
     job_title: string | null;
     status: string | null;
+    can_login_as_admin?: boolean;
     identities: IdentityMappingApiResponse[];
   }>;
   unmapped_identities: IdentityMappingApiResponse[];
@@ -113,6 +115,7 @@ async function fetchTeamMembers(orgId: string, userId: string): Promise<TeamMemb
       avatarUrl: m.avatar_url,
       jobTitle: m.job_title ?? null,
       status: m.status ?? null,
+      canLoginAsAdmin: Boolean(m.can_login_as_admin),
       identities: (m.identities ?? []).map(mapIdentity),
     })),
     unmappedIdentities: (data.unmapped_identities ?? []).map(mapIdentity),


### PR DESCRIPTION
### Motivation
- The team panel should surface which users can log in as a global admin even when their org membership role is not `admin`, and the pill text should read `Admin` (not `(admin)`).

### Description
- Backend: extend the organization members response model with `can_login_as_admin` so the API exposes global-admin capability for each user (`TeamMemberResponse.can_login_as_admin`).
- Frontend types/mapping: add `canLoginAsAdmin` to the `TeamMember` interface and map the backend `can_login_as_admin` field in `useOrganization.fetchTeamMembers`.
- UI: update the Organization team list to treat a member as admin when `member.role === 'admin' || member.canLoginAsAdmin` and change the pill label from `(admin)` to `Admin` in `OrganizationPanel.tsx`.

### Testing
- Ran a production build with `cd frontend && npm run build`, which completed successfully (Vite reported non-blocking bundle warnings about large chunks).
- Launched the dev server with `npm run dev` and executed a Playwright script to capture a screenshot of the organization panel to validate the pill rendering, which ran successfully and produced an artifact image.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4df0a72d88321b83ee2134da99711)