### PR TITLE
Add archive/unarchive support for workflows with active-run guardrails

### DIFF
--- a/backend/api/routes/workflows.py
+++ b/backend/api/routes/workflows.py
@@ -6,13 +6,13 @@ Provides CRUD operations for user-defined workflow automations.
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import select, and_, func
+from sqlalchemy import select, and_, func, or_
 
 from models.database import get_session
 from models.workflow import Workflow, WorkflowRun
@@ -104,6 +104,7 @@ class WorkflowResponse(BaseModel):
     output_schema: Optional[dict[str, Any]]  # JSON Schema for typed outputs
     child_workflows: list[str]  # IDs of workflows this can call
     output_config: Optional[dict[str, Any]]
+    archived_at: Optional[str]
     is_enabled: bool
     last_run_at: Optional[str]
     last_error: Optional[str]
@@ -151,6 +152,7 @@ class TriggerWorkflowResponse(BaseModel):
 async def list_workflows(
     organization_id: str,
     enabled_only: bool = False,
+    archived: bool = False,
 ) -> WorkflowListResponse:
     """List all workflows for an organization."""
     try:
@@ -160,6 +162,10 @@ async def list_workflows(
 
     async with get_session(organization_id=organization_id) as session:
         query = select(Workflow).where(Workflow.organization_id == org_uuid)
+        if archived:
+            query = query.where(Workflow.archived_at.isnot(None))
+        else:
+            query = query.where(Workflow.archived_at.is_(None))
         if enabled_only:
             query = query.where(Workflow.is_enabled == True)
         query = query.order_by(Workflow.created_at.desc())
@@ -230,6 +236,90 @@ async def get_workflow(organization_id: str, workflow_id: str) -> WorkflowRespon
             raise HTTPException(status_code=404, detail="Workflow not found")
 
         return WorkflowResponse(**workflow.to_dict())
+
+
+@router.post("/{organization_id}/{workflow_id}/archive")
+async def archive_workflow(organization_id: str, workflow_id: str) -> dict[str, str]:
+    """Archive a workflow (hide from default list)."""
+    try:
+        org_uuid = UUID(organization_id)
+        wf_uuid = UUID(workflow_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    async with get_session(organization_id=organization_id) as session:
+        result = await session.execute(
+            select(Workflow).where(
+                and_(
+                    Workflow.id == wf_uuid,
+                    Workflow.organization_id == org_uuid,
+                )
+            )
+        )
+        workflow = result.scalar_one_or_none()
+
+        if not workflow:
+            raise HTTPException(status_code=404, detail="Workflow not found")
+
+        has_active_schedule = workflow.is_enabled and workflow.trigger_type == "schedule"
+        active_run_result = await session.execute(
+            select(WorkflowRun.id)
+            .where(
+                and_(
+                    WorkflowRun.workflow_id == workflow.id,
+                    WorkflowRun.organization_id == org_uuid,
+                    WorkflowRun.status.in_(["pending", "running"]),
+                    or_(
+                        WorkflowRun.triggered_by == "schedule",
+                        WorkflowRun.triggered_by == "manual",
+                    ),
+                )
+            )
+            .limit(1)
+        )
+        has_active_run = active_run_result.scalar_one_or_none() is not None
+
+        if has_active_schedule or has_active_run:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot archive an active scheduled workflow or a workflow with running/pending scheduled/manual runs",
+            )
+
+        workflow.archived_at = datetime.now(timezone.utc)
+        workflow.updated_at = datetime.utcnow()
+        await session.commit()
+
+    return {"status": "ok"}
+
+
+@router.post("/{organization_id}/{workflow_id}/unarchive")
+async def unarchive_workflow(organization_id: str, workflow_id: str) -> dict[str, str]:
+    """Unarchive a workflow."""
+    try:
+        org_uuid = UUID(organization_id)
+        wf_uuid = UUID(workflow_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    async with get_session(organization_id=organization_id) as session:
+        result = await session.execute(
+            select(Workflow).where(
+                and_(
+                    Workflow.id == wf_uuid,
+                    Workflow.organization_id == org_uuid,
+                )
+            )
+        )
+        workflow = result.scalar_one_or_none()
+
+        if not workflow:
+            raise HTTPException(status_code=404, detail="Workflow not found")
+
+        workflow.archived_at = None
+        workflow.updated_at = datetime.utcnow()
+        await session.commit()
+
+    return {"status": "ok"}
 
 
 @router.post("/{organization_id}", response_model=WorkflowResponse)
@@ -423,6 +513,9 @@ async def trigger_workflow(
 
         if not workflow:
             raise HTTPException(status_code=404, detail="Workflow not found")
+
+        if workflow.archived_at is not None:
+            raise HTTPException(status_code=400, detail="Archived workflows cannot be triggered")
 
         if not workflow.is_enabled:
             raise HTTPException(status_code=400, detail="Workflow is disabled")

--- a/backend/db/migrations/versions/081_workflow_archive.py
+++ b/backend/db/migrations/versions/081_workflow_archive.py
@@ -1,0 +1,25 @@
+"""Add archived_at to workflows.
+
+Revision ID: 081_workflow_archive
+Revises: 080_app_archived_at
+Create Date: 2026-03-02
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "081_workflow_archive"
+down_revision: Union[str, None] = "080_app_archived_at"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("workflows", sa.Column("archived_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("workflows", "archived_at")

--- a/backend/models/workflow.py
+++ b/backend/models/workflow.py
@@ -116,6 +116,7 @@ class Workflow(Base):
     )
 
     # Status
+    archived_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     is_enabled: Mapped[bool] = mapped_column(default=True, nullable=False)
     last_run_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     last_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
@@ -154,6 +155,7 @@ class Workflow(Base):
             "output_schema": self.output_schema,
             "child_workflows": self.child_workflows,
             "output_config": self.output_config,
+            "archived_at": f"{self.archived_at.isoformat()}Z" if self.archived_at else None,
             "is_enabled": self.is_enabled,
             "last_run_at": f"{self.last_run_at.isoformat()}Z" if self.last_run_at else None,
             "last_error": self.last_error,

--- a/frontend/src/components/Workflows.tsx
+++ b/frontend/src/components/Workflows.tsx
@@ -39,6 +39,7 @@ interface Workflow {
   input_schema: Record<string, unknown> | null;  // JSON Schema for typed inputs
   output_schema: Record<string, unknown> | null;  // JSON Schema for typed outputs
   child_workflows: string[];  // IDs of workflows this can call
+  archived_at: string | null;
   is_enabled: boolean;
   last_run_at: string | null;
   last_error: string | null;
@@ -74,9 +75,9 @@ interface WorkflowListResponse {
 }
 
 // Fetch workflows for the organization
-async function fetchWorkflows(orgId: string): Promise<Workflow[]> {
-  console.debug('[Workflows] Fetching workflows', { orgId });
-  const { data, error } = await apiRequest<WorkflowListResponse>(`/workflows/${orgId}`);
+async function fetchWorkflows(orgId: string, archived = false): Promise<Workflow[]> {
+  console.debug('[Workflows] Fetching workflows', { orgId, archived });
+  const { data, error } = await apiRequest<WorkflowListResponse>(`/workflows/${orgId}?archived=${archived}`);
   if (error || !data) throw new Error(error ?? 'Failed to fetch workflows');
   return data.workflows;
 }
@@ -101,6 +102,21 @@ async function triggerWorkflow(orgId: string, workflowId: string): Promise<Trigg
   });
   if (error || !data) throw new Error(error ?? 'Failed to trigger workflow');
   return data;
+}
+
+
+async function archiveWorkflow(orgId: string, workflowId: string): Promise<void> {
+  const { error } = await apiRequest<{ status: string }>(`/workflows/${orgId}/${workflowId}/archive`, {
+    method: 'POST',
+  });
+  if (error) throw new Error(error);
+}
+
+async function unarchiveWorkflow(orgId: string, workflowId: string): Promise<void> {
+  const { error } = await apiRequest<{ status: string }>(`/workflows/${orgId}/${workflowId}/unarchive`, {
+    method: 'POST',
+  });
+  if (error) throw new Error(error);
 }
 
 // Delete a workflow
@@ -304,6 +320,7 @@ function WorkflowDetail({
   onDelete,
   onToggle,
   onEdit,
+  onArchive,
   isToggling,
   isTriggering,
 }: {
@@ -313,6 +330,7 @@ function WorkflowDetail({
   onDelete: () => void;
   onToggle: (enabled: boolean) => void;
   onEdit: () => void;
+  onArchive: () => void;
   isToggling: boolean;
   isTriggering: boolean;
 }): JSX.Element {
@@ -598,12 +616,20 @@ function WorkflowDetail({
                 </button>
               </div>
             ) : (
-              <button
-                onClick={() => setShowDeleteConfirm(true)}
-                className="text-sm text-red-400 hover:text-red-300"
-              >
-                Delete workflow
-              </button>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={onArchive}
+                  className="text-sm text-surface-300 hover:text-surface-100"
+                >
+                  Archive workflow
+                </button>
+                <button
+                  onClick={() => setShowDeleteConfirm(true)}
+                  className="text-sm text-red-400 hover:text-red-300"
+                >
+                  Delete workflow
+                </button>
+              </div>
             )}
           </div>
           <div className="flex items-center gap-2">
@@ -712,7 +738,7 @@ function WorkflowModal({
   // Get all workflows for child workflow selection (exclude current workflow)
   const { data: allWorkflows = [] } = useQuery({
     queryKey: ['workflows', organization?.id],
-    queryFn: () => fetchWorkflows(organization?.id ?? ''),
+    queryFn: () => fetchWorkflows(organization?.id ?? '', false),
     enabled: !!organization?.id,
   });
   
@@ -1090,7 +1116,7 @@ export function Workflows(): JSX.Element {
   // Fetch workflows — poll every 5s when any workflow is running/pending
   const { data: workflows = [], isLoading, error, refetch } = useQuery({
     queryKey: ['workflows', organization?.id],
-    queryFn: () => fetchWorkflows(organization?.id ?? ''),
+    queryFn: () => fetchWorkflows(organization?.id ?? '', false),
     enabled: !!organization?.id,
     refetchInterval: (query) => {
       const wfs = query.state.data;
@@ -1099,6 +1125,13 @@ export function Workflows(): JSX.Element {
       );
       return hasActive ? 5000 : false;
     },
+  });
+
+  const [showArchived, setShowArchived] = useState(false);
+  const { data: archivedWorkflows = [] } = useQuery({
+    queryKey: ['workflows', organization?.id, 'archived'],
+    queryFn: () => fetchWorkflows(organization?.id ?? '', true),
+    enabled: !!organization?.id && showArchived,
   });
 
   const { data: teamMembersData } = useTeamMembers(organization?.id ?? null, user?.id ?? null);
@@ -1155,6 +1188,26 @@ export function Workflows(): JSX.Element {
       deleteWorkflow(organization?.id ?? '', workflowId),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['workflows'] });
+    },
+  });
+
+
+  const archiveMutation = useMutation({
+    mutationFn: ({ workflowId }: { workflowId: string }) =>
+      archiveWorkflow(organization?.id ?? '', workflowId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['workflows'] });
+      void queryClient.invalidateQueries({ queryKey: ['workflows', organization?.id, 'archived'] });
+      setSelectedWorkflow(null);
+    },
+  });
+
+  const unarchiveMutation = useMutation({
+    mutationFn: ({ workflowId }: { workflowId: string }) =>
+      unarchiveWorkflow(organization?.id ?? '', workflowId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['workflows'] });
+      void queryClient.invalidateQueries({ queryKey: ['workflows', organization?.id, 'archived'] });
     },
   });
 
@@ -1264,7 +1317,7 @@ export function Workflows(): JSX.Element {
 
       {/* Content */}
       <div className="flex-1 overflow-y-auto p-6">
-        {workflows.length === 0 ? (
+        {workflows.length === 0 && archivedWorkflows.length === 0 ? (
           <div className="text-center py-12">
             <div className="w-16 h-16 rounded-full bg-surface-800 flex items-center justify-center mx-auto mb-4">
               <svg className="w-8 h-8 text-surface-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -1321,6 +1374,32 @@ export function Workflows(): JSX.Element {
                 </div>
               </div>
             )}
+
+            <div>
+              <button
+                onClick={() => setShowArchived((prev) => !prev)}
+                className="text-sm text-surface-400 hover:text-surface-200"
+              >
+                {showArchived ? 'Hide' : 'Show'} archived workflows {showArchived ? `(${archivedWorkflows.length})` : ''}
+              </button>
+              {showArchived && (
+                <div className="mt-4 space-y-2">
+                  {archivedWorkflows.length === 0 ? (
+                    <p className="text-sm text-surface-500">No archived workflows</p>
+                  ) : archivedWorkflows.map((workflow) => (
+                    <div key={workflow.id} className="flex items-center justify-between rounded-lg border border-surface-800 px-3 py-2">
+                      <span className="text-sm text-surface-300">{workflow.name}</span>
+                      <button
+                        onClick={() => unarchiveMutation.mutate({ workflowId: workflow.id })}
+                        className="text-xs px-2 py-1 rounded bg-surface-700 hover:bg-surface-600 text-surface-200"
+                      >
+                        Unarchive
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
         )}
       </div>
@@ -1338,6 +1417,7 @@ export function Workflows(): JSX.Element {
             toggleMutation.mutate({ workflowId: selectedWorkflow.id, enabled });
           }}
           onEdit={() => openEditModal(selectedWorkflow)}
+          onArchive={() => archiveMutation.mutate({ workflowId: selectedWorkflow.id })}
           isToggling={toggleMutation.isPending}
           isTriggering={triggerMutation.isPending}
         />


### PR DESCRIPTION
### Motivation
- Provide parity with apps by allowing workflows to be soft-archived and restored and to hide archived workflows from default lists. 
- Prevent users from archiving workflows that are actively scheduled or have in-flight `pending`/`running` scheduled/manual runs to avoid interrupting executions.

### Description
- Add `archived_at` column to the `Workflow` model and include it in `to_dict()` so APIs return `archived_at` (backend change in `backend/models/workflow.py`).
- Add Alembic migration `081_workflow_archive` which creates/drops the `workflows.archived_at` column and respects the repo revision naming/length constraints.
- Extend the Workflows API (`backend/api/routes/workflows.py`) to support `?archived=true|false` filtering and to expose `POST /api/workflows/{org_id}/{workflow_id}/archive` and `POST /api/workflows/{org_id}/{workflow_id}/unarchive` endpoints, and block archiving when the workflow is an active schedule or has running/pending scheduled/manual runs using a safe DB query.
- Prevent manual triggers for archived workflows and update the frontend (`frontend/src/components/Workflows.tsx`) to add archive/unarchive API calls, an archived workflows view, UI actions to archive/unarchive, and query/mutation wiring with cache invalidation.

### Testing
- Ran `python -m compileall backend/api/routes/workflows.py backend/models/workflow.py backend/db/migrations/versions/081_workflow_archive.py` and compilation succeeded. 
- Ran migration preflight checks to assert `revision`/`down_revision` length constraints for `081_workflow_archive` and the assertions passed. 
- Executed backend test suite with `cd backend && pytest -q` and all tests passed (`106 passed`).
- Built the frontend with `cd frontend && npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4de3558c08321afe6cb2278755fe5)