### PR TITLE
Improve archive/unarchive UI responsiveness for apps and workflows

### DIFF
--- a/frontend/src/components/Workflows.tsx
+++ b/frontend/src/components/Workflows.tsx
@@ -1195,9 +1195,25 @@ export function Workflows(): JSX.Element {
   const archiveMutation = useMutation({
     mutationFn: ({ workflowId }: { workflowId: string }) =>
       archiveWorkflow(organization?.id ?? '', workflowId),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['workflows'] });
-      void queryClient.invalidateQueries({ queryKey: ['workflows', organization?.id, 'archived'] });
+    onSuccess: (_data, { workflowId }) => {
+      const now = new Date().toISOString();
+      let archivedWorkflow: Workflow | null = null;
+
+      queryClient.setQueryData<Workflow[]>(['workflows', organization?.id], (prev = []) => {
+        const match = prev.find((workflow) => workflow.id === workflowId) ?? null;
+        if (match) {
+          archivedWorkflow = { ...match, archived_at: now };
+        }
+        return prev.filter((workflow) => workflow.id !== workflowId);
+      });
+
+      if (archivedWorkflow) {
+        queryClient.setQueryData<Workflow[]>(['workflows', organization?.id, 'archived'], (prev = []) => [
+          archivedWorkflow as Workflow,
+          ...prev.filter((workflow) => workflow.id !== workflowId),
+        ]);
+      }
+
       setSelectedWorkflow(null);
     },
   });
@@ -1205,9 +1221,23 @@ export function Workflows(): JSX.Element {
   const unarchiveMutation = useMutation({
     mutationFn: ({ workflowId }: { workflowId: string }) =>
       unarchiveWorkflow(organization?.id ?? '', workflowId),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['workflows'] });
-      void queryClient.invalidateQueries({ queryKey: ['workflows', organization?.id, 'archived'] });
+    onSuccess: (_data, { workflowId }) => {
+      let restoredWorkflow: Workflow | null = null;
+
+      queryClient.setQueryData<Workflow[]>(['workflows', organization?.id, 'archived'], (prev = []) => {
+        const match = prev.find((workflow) => workflow.id === workflowId) ?? null;
+        if (match) {
+          restoredWorkflow = { ...match, archived_at: null };
+        }
+        return prev.filter((workflow) => workflow.id !== workflowId);
+      });
+
+      if (restoredWorkflow) {
+        queryClient.setQueryData<Workflow[]>(['workflows', organization?.id], (prev = []) => [
+          restoredWorkflow as Workflow,
+          ...prev.filter((workflow) => workflow.id !== workflowId),
+        ]);
+      }
     },
   });
 

--- a/frontend/src/components/apps/AppsGallery.tsx
+++ b/frontend/src/components/apps/AppsGallery.tsx
@@ -97,9 +97,6 @@ export function AppsGallery(): JSX.Element {
       setArchivedFetched(false);
     }
 
-    if (showArchived) {
-      void fetchArchivedApps();
-    }
   };
 
   const handleUnarchive = async (appId: string): Promise<void> => {
@@ -109,8 +106,21 @@ export function AppsGallery(): JSX.Element {
       return;
     }
 
-    setArchivedApps((prev) => prev.filter((a) => a.id !== appId));
-    void fetchApps();
+    let restoredApp: AppItem | null = null;
+    setArchivedApps((prev) => {
+      const match = prev.find((a) => a.id === appId) ?? null;
+      if (match) {
+        restoredApp = {
+          ...match,
+          archived_at: null,
+        };
+      }
+      return prev.filter((a) => a.id !== appId);
+    });
+
+    if (restoredApp) {
+      setApps((prev) => [restoredApp as AppItem, ...prev.filter((a) => a.id !== appId)]);
+    }
   };
 
   const toggleArchived = (): void => {


### PR DESCRIPTION
### Motivation
- The UI felt slow when archiving/unarchiving because it relied on refetching lists from the backend, causing unnecessary roundtrips and visible flicker.
- Improve perceived responsiveness by updating local state/caches immediately after archive/unarchive operations.
- Keep existing UX behavior (e.g. closing the selected workflow modal on archive) while removing the dependency on a full backend requery for UI correction.

### Description
- Update `AppsGallery` to optimistically move an app between `apps` and `archivedApps` local state on `handleArchive` / `handleUnarchive` instead of refetching the whole list (changes in `frontend/src/components/apps/AppsGallery.tsx`).
- Remove the extra `fetchArchivedApps()` call after archiving and make `handleUnarchive` restore the app into the active list immediately by setting `archived_at: null` when moving it back.
- Update `Workflows` archive/unarchive mutations to directly mutate React Query caches via `queryClient.setQueryData` for `['workflows', orgId]` and `['workflows', orgId, 'archived']`, moving items between those caches and setting/clearing `archived_at` for instant UI updates (changes in `frontend/src/components/Workflows.tsx`).
- Preserve existing behaviors such as clearing `selectedWorkflow` on archive while avoiding a backend requery for the UI to reflect the change.

### Testing
- Ran linter with `npm --prefix frontend run lint`, which completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e08812d083219fbd4df6980ee477)