### PR TITLE
Close workflow detail popover immediately when archiving

### DIFF
--- a/frontend/src/components/Workflows.tsx
+++ b/frontend/src/components/Workflows.tsx
@@ -1198,7 +1198,6 @@ export function Workflows(): JSX.Element {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['workflows'] });
       void queryClient.invalidateQueries({ queryKey: ['workflows', organization?.id, 'archived'] });
-      setSelectedWorkflow(null);
     },
   });
 
@@ -1417,7 +1416,11 @@ export function Workflows(): JSX.Element {
             toggleMutation.mutate({ workflowId: selectedWorkflow.id, enabled });
           }}
           onEdit={() => openEditModal(selectedWorkflow)}
-          onArchive={() => archiveMutation.mutate({ workflowId: selectedWorkflow.id })}
+          onArchive={() => {
+            const workflowId = selectedWorkflow.id;
+            setSelectedWorkflow(null);
+            archiveMutation.mutate({ workflowId });
+          }}
           isToggling={toggleMutation.isPending}
           isTriggering={triggerMutation.isPending}
         />


### PR DESCRIPTION
### Motivation
- Archiving a workflow should immediately close the workflow detail popover so the UI reflects the action instantly and avoids leaving a stale detail view open.

### Description
- Updated the `onArchive` handler passed to `WorkflowDetail` to call `setSelectedWorkflow(null)` immediately before invoking the archive mutation. 
- Removed the now-redundant `setSelectedWorkflow(null)` from the `archiveMutation` `onSuccess` handler. 
- Kept cache invalidation for both active and archived workflow queries to ensure lists refresh after the archive completes; changes are in `frontend/src/components/Workflows.tsx`.

### Testing
- Ran linting with `npm --prefix frontend run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e0dc083c8321b560d36c6e167cc9)