### PR TITLE
Close workflow popover immediately when archiving

### DIFF
--- a/frontend/src/components/Workflows.tsx
+++ b/frontend/src/components/Workflows.tsx
@@ -1447,7 +1447,11 @@ export function Workflows(): JSX.Element {
             toggleMutation.mutate({ workflowId: selectedWorkflow.id, enabled });
           }}
           onEdit={() => openEditModal(selectedWorkflow)}
-          onArchive={() => archiveMutation.mutate({ workflowId: selectedWorkflow.id })}
+          onArchive={() => {
+            const workflowId = selectedWorkflow.id;
+            setSelectedWorkflow(null);
+            archiveMutation.mutate({ workflowId });
+          }}
           isToggling={toggleMutation.isPending}
           isTriggering={triggerMutation.isPending}
         />


### PR DESCRIPTION
### Motivation
- Improve UX by dismissing the workflow detail popover immediately when the user archives a workflow instead of waiting for the archive mutation/network round-trip.

### Description
- Update the `onArchive` handler in `frontend/src/components/Workflows.tsx` to capture the current workflow id, call `setSelectedWorkflow(null)` to close the popover, and then invoke `archiveMutation.mutate({ workflowId })`.

### Testing
- Ran the frontend linter with `npm --prefix frontend run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e176cba88321b600408ab6431a91)