### PR TITLE
Use explicit kwargs when enqueueing workflow tasks (fix Run Now)

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -5025,14 +5025,14 @@ async def _run_workflow(
             # Fire and forget - queue via Celery
             from workers.tasks.workflows import execute_workflow
             task = execute_workflow.delay(
-                workflow_id,
-                "run_workflow",
-                {
+                workflow_id=workflow_id,
+                triggered_by="run_workflow",
+                trigger_data={
                     **input_data,
                     "_parent_context": parent_context,
                 },
-                None,
-                organization_id
+                conversation_id=None,
+                organization_id=organization_id,
             )
             
             return {

--- a/backend/api/routes/workflows.py
+++ b/backend/api/routes/workflows.py
@@ -545,7 +545,21 @@ async def trigger_workflow(
 
     # Queue execution via Celery
     from workers.tasks.workflows import execute_workflow
-    task = execute_workflow.delay(workflow_id, "manual", None, conversation_id, organization_id)
+    logger.info(
+        "[Workflows API] Queueing manual workflow run",
+        extra={
+            "workflow_id": workflow_id,
+            "organization_id": organization_id,
+            "has_conversation": bool(conversation_id),
+        },
+    )
+    task = execute_workflow.delay(
+        workflow_id=workflow_id,
+        triggered_by="manual",
+        trigger_data=None,
+        conversation_id=conversation_id,
+        organization_id=organization_id,
+    )
 
     return TriggerWorkflowResponseV2(
         status="queued",

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -543,11 +543,11 @@ async def _check_scheduled_workflows() -> dict[str, Any]:
                 if next_run <= now:
                     # Queue workflow for execution
                     execute_workflow.delay(
-                        str(workflow.id), 
-                        "schedule", 
-                        None, 
-                        None, 
-                        str(workflow.organization_id)
+                        workflow_id=str(workflow.id),
+                        triggered_by="schedule",
+                        trigger_data=None,
+                        conversation_id=None,
+                        organization_id=str(workflow.organization_id),
                     )
                     triggered.append(str(workflow.id))
                     
@@ -604,11 +604,11 @@ async def _process_pending_events() -> dict[str, Any]:
                 if trigger_event == event_type:
                     # Queue workflow for execution with event data
                     execute_workflow.delay(
-                        str(workflow.id),
-                        f"event:{event_type}",
-                        event["data"],
-                        None,  # conversation_id
-                        org_id,  # organization_id for RLS
+                        workflow_id=str(workflow.id),
+                        triggered_by=f"event:{event_type}",
+                        trigger_data=event["data"],
+                        conversation_id=None,
+                        organization_id=org_id,
                     )
                     triggered.append({
                         "workflow_id": str(workflow.id),


### PR DESCRIPTION
### Motivation
- The "Run Now" manual trigger sometimes failed to start workflows because `execute_workflow.delay(...)` was being called with positional arguments which is brittle when task signatures change.
- Make task dispatch explicit and debuggable so manual, scheduled and event-driven triggers always map the correct payload to the Celery task.

### Description
- Updated the manual trigger endpoint `trigger_workflow` to log when a manual run is queued and call `execute_workflow.delay(...)` with named keyword arguments (`workflow_id`, `triggered_by`, `trigger_data`, `conversation_id`, `organization_id`).
- Converted scheduled and event enqueueing in `backend/workers/tasks/workflows.py` to use the same explicit keyword-argument pattern when calling `execute_workflow.delay(...)`.
- Updated the agent `run_workflow` fire-and-forget path in `backend/agents/tools.py` to enqueue the task with named arguments and `conversation_id=None` for consistency.
- Consistently used `triggered_by` and `trigger_data` parameter names to ensure the event payload and trigger type are passed correctly to the worker.

### Testing
- Ran Python bytecode compilation with `python -m compileall backend/api/routes/workflows.py backend/workers/tasks/workflows.py backend/agents/tools.py` which completed successfully.
- Verified affected modules compile without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4fb0f0c948321863186582361bc54)