### PR TITLE
Fix misleading Slack error message

### DIFF
--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -80,10 +80,18 @@ def _collapse_list_marker_breaks(text: str) -> str:
 SLOW_REPLY_MESSAGE = "Still working on this..."
 
 
-def _cannot_action_message() -> str:
+def _error_message(error: Exception | None = None) -> str:
+    detail = ""
+    if error:
+        brief = str(error)
+        # Keep it short — truncate long tracebacks
+        if len(brief) > 200:
+            brief = brief[:200] + "…"
+        detail = f"\n> `{brief}`"
     return (
-        "I'm sorry, I can't help with that right now. "
-        "Try connecting Slack to RevTops for your account."
+        "Sorry, something went wrong while processing your request. "
+        "Please try again — if this keeps happening, let the team know."
+        f"{detail}"
     )
 
 
@@ -105,14 +113,15 @@ def _normalize_slack_team_id(team_id: str | None) -> str:
     return (team_id or "").strip().upper()
 
 
-async def _post_cannot_action_response(
+async def _post_error_response(
     connector: SlackConnector,
     channel: str,
     thread_ts: str | None = None,
+    error: Exception | None = None,
 ) -> None:
     await connector.post_message(
         channel=channel,
-        text=_cannot_action_message(),
+        text=_error_message(error),
         thread_ts=thread_ts,
     )
 
@@ -2078,7 +2087,7 @@ async def _stream_and_post_responses(
         logger.error(
             "[slack_conversations] Error during streaming: %s", e, exc_info=True,
         )
-        current_text += f"\n{_cannot_action_message()}"
+        current_text += f"\n{_error_message(e)}"
 
     # Post any remaining text after the stream ends
     await _flush_current_text(reason="stream_end", force=True)


### PR DESCRIPTION
## Summary
- Replace the generic "I can't help with that, try connecting Slack" error with an honest message that shows what actually went wrong
- Error detail is truncated to 200 chars and shown in a Slack code block so users (and us) can debug faster
- Also renamed the dead `_post_cannot_action_response` helper to `_post_error_response` with the same pattern

**Before:** "I'm sorry, I can't help with that right now. Try connecting Slack to RevTops for your account."

**After:** "Sorry, something went wrong while processing your request. Please try again — if this keeps happening, let the team know."
> `<actual error detail>`

## Test plan
- [ ] Trigger a streaming error in Slack (e.g. tool timeout) and verify the new message appears with error detail
- [ ] Verify normal Slack conversations still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)