### PR TITLE
Fix SQLAlchemy CreditTransaction mapper initialization failure

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -24,6 +24,7 @@ from models.shared_file import SharedFile
 from models.memory import Memory
 from models.org_member import OrgMember
 from models.goal import Goal
+from models.credit_transaction import CreditTransaction
 from models.tracker_team import TrackerTeam
 from models.tracker_project import TrackerProject
 from models.tracker_issue import TrackerIssue
@@ -59,6 +60,7 @@ __all__ = [
     "Memory",
     "OrgMember",
     "Goal",
+    "CreditTransaction",
     "TrackerTeam",
     "TrackerProject",
     "TrackerIssue",

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -74,7 +74,7 @@ class User(Base):
         "ChangeSession", back_populates="user", foreign_keys="ChangeSession.user_id"
     )
     credit_transactions: Mapped[list["CreditTransaction"]] = relationship(
-        "CreditTransaction", back_populates="user", foreign_keys="CreditTransaction.user_id"
+        "CreditTransaction", back_populates="user"
     )
 
     def to_dict(self) -> dict[str, Any]:


### PR DESCRIPTION
### Motivation
- Address a startup failure where SQLAlchemy mapper initialization raises `InvalidRequestError` because the string-based `foreign_keys` expression `CreditTransaction.user_id` could not be resolved during import order variations.

### Description
- Remove the string `foreign_keys="CreditTransaction.user_id"` from `User.credit_transactions` and let SQLAlchemy infer the foreign key from the model definition.
- Ensure `CreditTransaction` is imported and exported from the central `models` package by adding it to `backend/models/__init__.py` so the mapper is registered consistently during package import.

### Testing
- Ran mapper configuration via `python - <<'PY'\nfrom sqlalchemy.orm import configure_mappers\nimport models  # noqa\nconfigure_mappers()\nprint('mappers configured')\nPY` which printed `mappers configured` and returned successfully.
- Ran `pytest -q tests/test_tools_credit_grace.py` which completed successfully with `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4fc6455b0832190956552f6902048)