### PR TITLE
Fix manual workflow trigger Celery argument order

### DIFF
--- a/backend/api/routes/workflows.py
+++ b/backend/api/routes/workflows.py
@@ -561,7 +561,7 @@ async def trigger_workflow(
         trigger_data=None,
         conversation_id=conversation_id,
         organization_id=organization_id,
-        str(trigger_user_uuid) if trigger_user_uuid else None,
+        triggered_by_user_id=str(trigger_user_uuid) if trigger_user_uuid else None,
     )
 
     return TriggerWorkflowResponseV2(


### PR DESCRIPTION
### Motivation
- The manual trigger route passed `str(trigger_user_uuid)` as a positional argument after keyword args to `execute_workflow.delay(...)`, causing `SyntaxError: positional argument follows keyword argument` during import/startup.

### Description
- Convert the trailing positional argument to a keyword by using `triggered_by_user_id=str(trigger_user_uuid) if trigger_user_uuid else None` in `backend/api/routes/workflows.py` so the call matches the Celery task signature.

### Testing
- Ran `python -m py_compile backend/api/routes/workflows.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4fddeed20832182b50c86d414b8a5)