### PR TITLE
Fix workflow Slack posting connector initialization

### DIFF
--- a/backend/tests/test_workflow_send_slack_action.py
+++ b/backend/tests/test_workflow_send_slack_action.py
@@ -1,0 +1,60 @@
+import asyncio
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+from workers.tasks import workflows
+
+
+class _FakeExecuteResult:
+    def __init__(self, integration: object) -> None:
+        self._integration = integration
+
+    def scalar_one_or_none(self) -> object:
+        return self._integration
+
+
+class _FakeSession:
+    def __init__(self, integration: object) -> None:
+        self._integration = integration
+
+    async def execute(self, _query: object) -> _FakeExecuteResult:
+        return _FakeExecuteResult(self._integration)
+
+
+class _FakeSlackConnector:
+    init_kwargs: dict[str, object] | None = None
+
+    def __init__(self, **kwargs: object) -> None:
+        _FakeSlackConnector.init_kwargs = kwargs
+
+    async def post_message(self, channel: str, text: str, thread_ts: str | None = None) -> dict[str, str]:
+        return {"channel": channel, "ts": "123.456", "text": text, "thread_ts": thread_ts or ""}
+
+
+def test_action_send_slack_posts_with_team_id(monkeypatch) -> None:
+    integration = SimpleNamespace(
+        nango_connection_id="conn_123",
+        extra_data={"team_id": "T123"},
+    )
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args: object, **_kwargs: object):
+        yield _FakeSession(integration)
+
+    monkeypatch.setattr("models.database.get_session", _fake_get_session)
+    monkeypatch.setattr("connectors.slack.SlackConnector", _FakeSlackConnector)
+
+    async def _run() -> dict[str, object]:
+        return await workflows._action_send_slack(
+            params={"channel": "#alerts", "message": "hello"},
+            context={"organization_id": "00000000-0000-0000-0000-000000000001"},
+            workflow=None,
+        )
+
+    result = asyncio.run(_run())
+
+    assert result["status"] == "completed"
+    assert _FakeSlackConnector.init_kwargs == {
+        "organization_id": "00000000-0000-0000-0000-000000000001",
+        "team_id": "T123",
+    }

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -1400,10 +1400,18 @@ async def _action_send_slack(
                     "error": "No active Slack integration found for organization",
                 }
         
+        slack_team_id = (integration.extra_data or {}).get("team_id")
+        logger.info(
+            "[workflow.send_slack] Posting message org_id=%s channel=%s team_id=%s",
+            org_id,
+            channel,
+            slack_team_id,
+        )
+
         # Create connector and post message
         connector = SlackConnector(
             organization_id=org_id,
-            nango_connection_id=integration.nango_connection_id,
+            team_id=slack_team_id,
         )
         
         result = await connector.post_message(


### PR DESCRIPTION
### Motivation
- Workflows failed to post messages to Slack because the workflow action passed an unsupported connector kwarg and did not select the correct Slack workspace token.
- The integration’s `team_id` should be used to disambiguate workspace installs when constructing the connector.

### Description
- Derive `team_id` from `integration.extra_data` and log org/channel/team context before posting in `_action_send_slack` in `backend/workers/tasks/workflows.py`.
- Instantiate `SlackConnector` with `organization_id` and `team_id` instead of passing `nango_connection_id`.
- Add a regression test `backend/tests/test_workflow_send_slack_action.py` that mocks the DB session and `SlackConnector` to assert the connector is created with `team_id` and that the action completes.

### Testing
- Ran `cd backend && pytest -q tests/test_workflow_send_slack_action.py tests/test_workflow_permissions.py` and observed all tests passed with warnings: `7 passed, 2 warnings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a50291655c832181d8f39632cc0f5b)