### PR TITLE
Normalize Celery time_start for admin running jobs

### DIFF
--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -8,7 +8,7 @@ Endpoints:
 """
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 import ast
 import logging
 from typing import Any, Optional
@@ -244,6 +244,35 @@ def _is_trackable_admin_task(task_name: str) -> bool:
     if ".tasks.sync." in task_name or task_name.startswith("workers.tasks.sync"):
         return True
     return _is_workflow_task(task_name)
+
+
+def _normalize_task_started_at(raw_started_at: Any, task_id: str) -> str | None:
+    """Normalize Celery active-task ``time_start`` into an ISO8601 string."""
+    if raw_started_at is None:
+        return None
+
+    if isinstance(raw_started_at, datetime):
+        return raw_started_at.isoformat()
+
+    if isinstance(raw_started_at, (int, float)):
+        return datetime.fromtimestamp(raw_started_at, tz=timezone.utc).isoformat()
+
+    if isinstance(raw_started_at, str):
+        normalized_value = raw_started_at.strip()
+        if not normalized_value:
+            return None
+        try:
+            parsed_epoch = float(normalized_value)
+        except ValueError:
+            return normalized_value
+        return datetime.fromtimestamp(parsed_epoch, tz=timezone.utc).isoformat()
+
+    logger.debug(
+        "Unable to normalize Celery task started_at for task %s (type=%s)",
+        task_id,
+        type(raw_started_at).__name__,
+    )
+    return None
 
 
 def _extract_workflow_task_org_id(args: list[Any], kwargs: dict[str, Any]) -> str | None:
@@ -544,7 +573,7 @@ async def list_admin_running_jobs(user_id: str) -> AdminRunningJobsResponse:
                     status="running",
                     organization_id=org_id,
                     organization_name=org_name,
-                    started_at=task.get("time_start"),
+                    started_at=_normalize_task_started_at(task.get("time_start"), task_id),
                     title=title,
                     description=description,
                     metadata={

--- a/backend/tests/test_admin_jobs_task_parsing.py
+++ b/backend/tests/test_admin_jobs_task_parsing.py
@@ -5,6 +5,7 @@ from api.routes.sync import (
     _extract_workflow_task_org_id,
     _is_active_workflow_run_status,
     _is_trackable_admin_task,
+    _normalize_task_started_at,
     _parse_celery_kwargs,
 )
 
@@ -37,6 +38,15 @@ def test_get_celery_task_args_supports_argsrepr_fallback() -> None:
 def test_get_celery_task_kwargs_supports_kwargsrepr_fallback() -> None:
     task = {"kwargs": "", "kwargsrepr": "{'organization_id': 'org-2', 'trigger': 'manual'}"}
     assert _get_celery_task_kwargs(task) == {"organization_id": "org-2", "trigger": "manual"}
+
+
+def test_normalize_task_started_at_supports_epoch_numeric_values() -> None:
+    assert _normalize_task_started_at(1772421597.0613391, "task-1") == "2026-03-02T03:19:57.061339+00:00"
+    assert _normalize_task_started_at("1772421597.0613391", "task-2") == "2026-03-02T03:19:57.061339+00:00"
+
+
+def test_normalize_task_started_at_preserves_non_numeric_strings() -> None:
+    assert _normalize_task_started_at("2026-03-02T03:23:14Z", "task-3") == "2026-03-02T03:23:14Z"
 
 
 def test_is_active_workflow_run_status_only_matches_in_progress_statuses() -> None:


### PR DESCRIPTION
### Motivation

- Prevent Pydantic validation errors when Celery `time_start` appears as a numeric epoch (float/int) or numeric string in the admin running-jobs endpoint.

### Description

- Add `_normalize_task_started_at` to `backend/api/routes/sync.py` to normalize `time_start` into an ISO-8601 string for `AdminRunningJob` creation and log unsupported types.
- Use `datetime.fromtimestamp(..., tz=timezone.utc).isoformat()` for numeric epoch values and parse numeric strings into epoch values when possible, while preserving non-numeric strings and `datetime` objects.
- Replace direct use of `task.get("time_start")` with the normalized value when constructing `AdminRunningJob` entries.
- Add unit tests in `backend/tests/test_admin_jobs_task_parsing.py` to cover epoch numeric values and preservation of non-numeric strings.

### Testing

- Ran `pytest -q backend/tests/test_admin_jobs_task_parsing.py` and all tests passed: `9 passed, 2 warnings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a502df6dfc83218a16ec142479e46c)