### PR TITLE
ci: run full backend tests and conditional frontend tests on PRs

### DIFF
--- a/.github/workflows/conformance-tests.yml
+++ b/.github/workflows/conformance-tests.yml
@@ -31,8 +31,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run backend tests
-        run: pytest -q
+      - name: Run all backend tests
+        run: pytest -q tests
 
   frontend-tests:
     name: Frontend conformance
@@ -53,6 +53,14 @@ jobs:
 
       - name: Install frontend dependencies
         run: npm ci
+
+      - name: Run frontend tests (if configured)
+        run: |
+          if npm run | rg -q "^\s*test\b"; then
+            npm test
+          else
+            echo "No frontend test script configured; skipping frontend unit tests."
+          fi
 
       - name: Lint frontend
         run: npm run lint


### PR DESCRIPTION
### Motivation
- Ensure pull requests run the repository's full test coverage on GitHub Actions by explicitly exercising backend unit tests and enabling frontend unit tests when present.

### Description
- Update `.github/workflows/conformance-tests.yml` to run `pytest -q tests` in the backend job so the entire `backend/tests` suite is executed during PRs.
- Add a frontend job step that conditionally runs `npm test` when a `test` script exists and otherwise logs a clear skip message while keeping existing `lint` and `build` steps intact.

### Testing
- Ran a local sanity check script that verified the workflow contains the `pull_request` trigger and the `pytest -q tests` command, and it passed.
- Attempted to lint the workflow with `yamllint`, but the command is not available in this environment so that check was skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5033419548321a9031fd567655410)