### PR TITLE
Infer Slack bot token when team_id missing to fix missing_scope on send_message

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -191,6 +191,34 @@ class SlackConnector(BaseConnector):
                 self._token = bot_token
                 return self._token, ""
 
+        # If team_id was not provided at initialization, infer it from the
+        # selected integration so action calls can still use Add-to-Slack
+        # bot tokens that include chat:write scope.
+        if not self.team_id:
+            if not self._integration:
+                await self._load_integration()
+            inferred_team_id = (
+                (self._integration.extra_data or {}).get("team_id")
+                if self._integration
+                else None
+            )
+            inferred_team_id = str(inferred_team_id or "").strip() or None
+            if inferred_team_id:
+                from services.slack_bot_install import get_slack_bot_token
+
+                bot_token = await get_slack_bot_token(
+                    self.organization_id,
+                    inferred_team_id,
+                )
+                if bot_token:
+                    logger.info(
+                        "[SlackConnector] Using bot-install token inferred from integration team_id=%s",
+                        inferred_team_id,
+                    )
+                    self.team_id = inferred_team_id
+                    self._token = bot_token
+                    return self._token, ""
+
         return await super().get_oauth_token()
 
     async def _get_headers(self) -> dict[str, str]:

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -1,4 +1,5 @@
 import asyncio
+from types import SimpleNamespace
 
 from connectors.slack import SlackConnector
 
@@ -46,3 +47,27 @@ def test_execute_action_send_message_accepts_legacy_message_param(monkeypatch) -
 
     assert result == {"ok": True}
     assert captured == {"channel": "C123", "text": "Legacy text", "thread_ts": "111.222"}
+
+
+def test_get_oauth_token_uses_inferred_team_bot_install(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    async def _fake_load_integration() -> None:
+        connector._integration = SimpleNamespace(extra_data={"team_id": "T999"})
+
+    async def _fake_get_slack_bot_token(organization_id: str, team_id: str) -> str | None:
+        assert organization_id == "00000000-0000-0000-0000-000000000001"
+        assert team_id == "T999"
+        return "xoxb-bot-token"
+
+    async def _fake_base_get_oauth_token() -> tuple[str, str]:
+        raise AssertionError("base token fallback should not be used when bot token exists")
+
+    monkeypatch.setattr(connector, "_load_integration", _fake_load_integration)
+    monkeypatch.setattr("services.slack_bot_install.get_slack_bot_token", _fake_get_slack_bot_token)
+    monkeypatch.setattr("connectors.base.BaseConnector.get_oauth_token", _fake_base_get_oauth_token)
+
+    token, _ = asyncio.run(connector.get_oauth_token())
+
+    assert token == "xoxb-bot-token"
+    assert connector.team_id == "T999"


### PR DESCRIPTION
### Motivation
- Workflows creating a `SlackConnector` without `team_id` previously skipped bot-install token lookup and used the Nango token, which can lack `chat:write` scope and produce `Slack API error: missing_scope` for `send_message` actions.
- The change aims to prefer Add-to-Slack (bot-install) tokens when available even if `team_id` wasn't provided at construction time so action flows use a token with the required scopes.

### Description
- Updated `SlackConnector.get_oauth_token()` to infer `team_id` from the selected integration (`_integration.extra_data['team_id']`) when `team_id` is not provided, then attempt `get_slack_bot_token(...)` using that inferred id before falling back to the base OAuth flow. (modified `backend/connectors/slack.py`)
- When an inferred-team bot token is selected the connector logs an informational message indicating the inferred `team_id`. (modified `backend/connectors/slack.py`)
- Added a regression test `test_get_oauth_token_uses_inferred_team_bot_install` to validate that an inferred team bot token is used and that the base token fallback is not invoked when a bot token exists. (modified `backend/tests/test_slack_connector_actions.py`)

### Testing
- Ran the focused test suite with: `cd /workspace/revtops/backend && pytest -q tests/test_slack_connector_actions.py tests/test_workflow_send_slack_action.py`.
- Result: `4 passed` (tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a504f381ec832184e94cf271e3f118)