### PR TITLE
Improve Slack send_message resiliency for missing_scope and #channel names

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -911,6 +911,8 @@ class SlackConnector(BaseConnector):
         Returns:
             Response with channel, ts (timestamp), and message details
         """
+        channel = await self._resolve_channel_for_post(channel)
+
         # Auto-convert any Markdown to Slack mrkdwn format
         formatted_text = markdown_to_mrkdwn(text)
         
@@ -933,6 +935,43 @@ class SlackConnector(BaseConnector):
             "ts": data.get("ts"),
             "message": data.get("message"),
         }
+
+    async def _resolve_channel_for_post(self, channel: str) -> str:
+        """Resolve a human channel name (e.g. #general) to a channel ID when possible."""
+        normalized_channel = str(channel).strip()
+        if not normalized_channel.startswith("#"):
+            return normalized_channel
+
+        target_name = normalized_channel[1:]
+        try:
+            channels = await self.get_channels()
+        except Exception as exc:
+            logger.warning(
+                "[SlackConnector] Could not resolve channel name=%s before posting: %s",
+                normalized_channel,
+                exc,
+            )
+            return normalized_channel
+
+        for candidate in channels:
+            candidate_names = {
+                str(candidate.get("name") or ""),
+                str(candidate.get("name_normalized") or ""),
+            }
+            if target_name in candidate_names and candidate.get("id"):
+                resolved = str(candidate["id"])
+                logger.info(
+                    "[SlackConnector] Resolved channel name=%s to channel_id=%s",
+                    normalized_channel,
+                    resolved,
+                )
+                return resolved
+
+        logger.warning(
+            "[SlackConnector] Could not resolve channel name=%s to an ID; posting as-is",
+            normalized_channel,
+        )
+        return normalized_channel
 
     async def download_file(self, url_private: str) -> bytes:
         """
@@ -974,11 +1013,22 @@ class SlackConnector(BaseConnector):
     ) -> dict[str, Any]:
         """Open a DM channel and send a direct message."""
         logger.info("[SlackConnector] Opening DM for slack_user_id=%s", slack_user_id)
-        open_data = await self._make_request(
-            "POST",
-            "conversations.open",
-            json_data={"users": slack_user_id},
-        )
+        try:
+            open_data = await self._make_request(
+                "POST",
+                "conversations.open",
+                json_data={"users": slack_user_id},
+            )
+        except ValueError as exc:
+            if "missing_scope" not in str(exc):
+                raise
+            logger.warning(
+                "[SlackConnector] conversations.open missing_scope for slack_user_id=%s; "
+                "falling back to chat.postMessage(channel=user_id)",
+                slack_user_id,
+            )
+            return await self.post_message(channel=slack_user_id, text=text)
+
         channel_id = (open_data.get("channel") or {}).get("id")
         if not channel_id:
             raise ValueError("Slack API error: missing DM channel id")

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -71,3 +71,53 @@ def test_get_oauth_token_uses_inferred_team_bot_install(monkeypatch) -> None:
 
     assert token == "xoxb-bot-token"
     assert connector.team_id == "T999"
+
+
+def test_send_direct_message_falls_back_to_user_channel_on_missing_scope(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    async def _fake_make_request(method: str, endpoint: str, **_: object):
+        assert method == "POST"
+        assert endpoint == "conversations.open"
+        raise ValueError("Slack API error: missing_scope")
+
+    captured: dict[str, str] = {}
+
+    async def _fake_post_message(channel: str, text: str, thread_ts: str | None = None):
+        captured["channel"] = channel
+        captured["text"] = text
+        captured["thread_ts"] = thread_ts or ""
+        return {"ok": True, "channel": channel}
+
+    monkeypatch.setattr(connector, "_make_request", _fake_make_request)
+    monkeypatch.setattr(connector, "post_message", _fake_post_message)
+
+    result = asyncio.run(connector.send_direct_message("U123", "Fallback DM"))
+
+    assert result == {"ok": True, "channel": "U123"}
+    assert captured == {"channel": "U123", "text": "Fallback DM", "thread_ts": ""}
+
+
+def test_post_message_resolves_hash_channel_name(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    async def _fake_get_channels() -> list[dict[str, str]]:
+        return [{"id": "C999", "name": "random", "name_normalized": "random"}]
+
+    captured: dict[str, object] = {}
+
+    async def _fake_make_request(method: str, endpoint: str, **kwargs: object):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["json_data"] = kwargs.get("json_data")
+        return {"ok": True, "channel": "C999", "ts": "1.2", "message": {"text": "hello"}}
+
+    monkeypatch.setattr(connector, "get_channels", _fake_get_channels)
+    monkeypatch.setattr(connector, "_make_request", _fake_make_request)
+
+    result = asyncio.run(connector.post_message("#random", "hello"))
+
+    assert result["ok"] is True
+    assert captured["method"] == "POST"
+    assert captured["endpoint"] == "chat.postMessage"
+    assert captured["json_data"] == {"channel": "C999", "text": "hello"}


### PR DESCRIPTION
### Motivation
- Workflow executions were failing due to Slack API errors like `missing_scope` from `conversations.open` and `channel_not_found` when callers supplied `#channel` names instead of IDs.
- The goal is to make message sending more tolerant of common Slack app scope/configuration mismatches and user-friendly channel name inputs while providing better logs for debugging.

### Description
- Add channel name resolution in `SlackConnector.post_message` by calling a new helper `async def _resolve_channel_for_post(self, channel: str) -> str` which maps `#name` to a channel ID via `get_channels` when possible, and logs a warning if resolution fails (file: `backend/connectors/slack.py`).
- Add a fallback in `SlackConnector.send_direct_message` to catch a `ValueError` containing `missing_scope` from `conversations.open` and retry by calling `post_message(channel=<user_id>)`, with a warning log for observability (file: `backend/connectors/slack.py`).
- Add unit tests for both behaviors: `test_send_direct_message_falls_back_to_user_channel_on_missing_scope` and `test_post_message_resolves_hash_channel_name` (file: `backend/tests/test_slack_connector_actions.py`).

### Testing
- Ran `pytest -q backend/tests/test_slack_connector_actions.py` and all tests passed (`5 passed`) with standard pytest warnings shown but no failures.
- The new tests exercise the DM fallback and `#channel` resolution and confirmed the connector calls `chat.postMessage` with the expected payload when resolving succeeds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a507ce32b483219882279b45092de7)