### PR TITLE
Slack: retry post_message across org team tokens when channel_not_found

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -925,7 +925,19 @@ class SlackConnector(BaseConnector):
         if blocks:
             payload["blocks"] = blocks
         
-        data = await self._make_request("POST", "chat.postMessage", json_data=payload)
+        try:
+            data = await self._make_request("POST", "chat.postMessage", json_data=payload)
+        except ValueError as exc:
+            # In orgs with multiple Slack integrations, a connector created without
+            # team_id can select the wrong workspace token. Retry once per known
+            # Slack team when Slack reports channel_not_found.
+            if "channel_not_found" not in str(exc) or self.team_id:
+                raise
+
+            data = await self._retry_post_message_across_teams(
+                payload=payload,
+                original_error=exc,
+            )
         
         return {
             "ok": data.get("ok"),
@@ -933,6 +945,77 @@ class SlackConnector(BaseConnector):
             "ts": data.get("ts"),
             "message": data.get("message"),
         }
+
+    async def _list_org_team_ids(self) -> list[str]:
+        """Return unique Slack team IDs from active org integrations."""
+        async with get_session(organization_id=self.organization_id) as session:
+            result = await session.execute(
+                select(Integration.extra_data).where(
+                    Integration.organization_id == uuid.UUID(self.organization_id),
+                    Integration.provider == self.source_system,
+                    Integration.is_active == True,  # noqa: E712
+                )
+            )
+            rows = result.all()
+
+        team_ids: list[str] = []
+        for row in rows:
+            extra_data = row[0] or {}
+            if not isinstance(extra_data, dict):
+                continue
+            team_id = str(extra_data.get("team_id") or "").strip()
+            if team_id and team_id not in team_ids:
+                team_ids.append(team_id)
+        return team_ids
+
+    async def _retry_post_message_across_teams(
+        self,
+        payload: dict[str, Any],
+        original_error: ValueError,
+    ) -> dict[str, Any]:
+        """Retry posting message using each active Slack team token for this org."""
+        team_ids = await self._list_org_team_ids()
+        if len(team_ids) <= 1:
+            raise original_error
+
+        logger.warning(
+            "[SlackConnector] channel_not_found for channel=%s org=%s; retrying across %d Slack team token(s)",
+            payload.get("channel"),
+            self.organization_id,
+            len(team_ids),
+        )
+
+        last_error: ValueError = original_error
+        original_team_id = self.team_id
+        original_token = self._token
+        original_integration = self._integration
+        for candidate_team_id in team_ids:
+            if candidate_team_id == original_team_id:
+                continue
+
+            try:
+                self.team_id = candidate_team_id
+                self._token = None
+                self._integration = None
+                logger.info(
+                    "[SlackConnector] Retrying chat.postMessage with team_id=%s channel=%s",
+                    candidate_team_id,
+                    payload.get("channel"),
+                )
+                return await self._make_request("POST", "chat.postMessage", json_data=payload)
+            except ValueError as exc:
+                last_error = exc
+                logger.warning(
+                    "[SlackConnector] Retry failed for team_id=%s channel=%s error=%s",
+                    candidate_team_id,
+                    payload.get("channel"),
+                    exc,
+                )
+
+        self.team_id = original_team_id
+        self._token = original_token
+        self._integration = original_integration
+        raise last_error
 
     async def download_file(self, url_private: str) -> bytes:
         """

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -71,3 +71,48 @@ def test_get_oauth_token_uses_inferred_team_bot_install(monkeypatch) -> None:
 
     assert token == "xoxb-bot-token"
     assert connector.team_id == "T999"
+
+
+def test_post_message_retries_across_team_ids_on_channel_not_found(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+    attempts: list[str] = []
+    connector.team_id = None
+
+    async def _fake_list_org_team_ids() -> list[str]:
+        return ["T_WRONG", "T_RIGHT"]
+
+    async def _fake_make_request(_method: str, endpoint: str, *, json_data=None, params=None):
+        assert endpoint == "chat.postMessage"
+        attempts.append(str(connector.team_id))
+        if connector.team_id != "T_RIGHT":
+            raise ValueError("Slack API error: channel_not_found")
+        return {"ok": True, "channel": "C0AEA4J556F", "ts": "123.456", "message": {"text": "ok"}}
+
+    monkeypatch.setattr(connector, "_list_org_team_ids", _fake_list_org_team_ids)
+    monkeypatch.setattr(connector, "_make_request", _fake_make_request)
+
+    result = asyncio.run(connector.post_message("C0AEA4J556F", "hello"))
+
+    assert result["ok"] is True
+    assert result["channel"] == "C0AEA4J556F"
+    assert attempts == ["None", "T_WRONG", "T_RIGHT"]
+    assert connector.team_id == "T_RIGHT"
+
+
+def test_post_message_no_retry_when_team_id_already_set(monkeypatch) -> None:
+    connector = SlackConnector(
+        organization_id="00000000-0000-0000-0000-000000000001",
+        team_id="T123",
+    )
+
+    async def _fake_make_request(_method: str, _endpoint: str, *, json_data=None, params=None):
+        raise ValueError("Slack API error: channel_not_found")
+
+    monkeypatch.setattr(connector, "_make_request", _fake_make_request)
+
+    try:
+        asyncio.run(connector.post_message("C0AEA4J556F", "hello"))
+    except ValueError as exc:
+        assert "channel_not_found" in str(exc)
+    else:
+        raise AssertionError("Expected channel_not_found to be raised")


### PR DESCRIPTION
### Motivation
- Prevent Slack `send_message` actions from failing with `channel_not_found` when the connector picked a token from the wrong workspace in orgs with multiple Slack integrations. 
- Improve observability and robustness when channel IDs belong to a different workspace than the initially-selected integration.

### Description
- Added a defensive retry path in `SlackConnector.post_message` that catches `ValueError` responses containing `channel_not_found` and only triggers when `self.team_id` is not already set. 
- Implemented `async def _list_org_team_ids(self)` to enumerate unique `team_id`s from active Slack `Integration.extra_data` for the organization. 
- Implemented `async def _retry_post_message_across_teams(self, payload, original_error)` to iterate candidate `team_id`s, refresh token/integration context, and retry `chat.postMessage` until one succeeds or all fail, restoring original state on final failure. 
- Added unit tests in `backend/tests/test_slack_connector_actions.py` validating successful retry across team IDs and that no retry occurs when `team_id` is already pinned, and preserved existing behaviors.

### Testing
- Ran `pytest -q backend/tests/test_slack_connector_actions.py` and all tests passed (`5 passed`).
- New tests exercise the retry loop and no-retry branch and succeeded locally.
- Logging added around retry attempts to aid debugging in multi-integration orgs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a50a1718408321963bb1b0cab491fa)