### PR TITLE
Retry Slack verification DMs across multiple mapped identities

### DIFF
--- a/backend/api/routes/slack_user_mappings.py
+++ b/backend/api/routes/slack_user_mappings.py
@@ -183,17 +183,26 @@ async def request_slack_user_mapping_code(
             .where(SlackUserMapping.external_email == email)
             .order_by(SlackUserMapping.updated_at.desc())
         )
-        matched_mapping = result.scalars().first()
+        matched_mappings = result.scalars().all()
+
+    slack_user_candidates: list[str] = []
+    seen_candidates: set[str] = set()
+    for mapping in matched_mappings:
+        candidate = (mapping.external_userid or "").strip()
+        if not candidate or candidate in seen_candidates:
+            continue
+        seen_candidates.add(candidate)
+        slack_user_candidates.append(candidate)
 
     logger.info(
         "[user_mappings_for_identity] Lookup Slack mapping for org=%s user=%s email=%s matched=%s",
         org_uuid,
         user_uuid,
         email,
-        bool(matched_mapping),
+        bool(slack_user_candidates),
     )
 
-    if not matched_mapping or not matched_mapping.external_userid:
+    if not slack_user_candidates:
         logger.warning(
             "[user_mappings_for_identity] No Slack mapping found for org=%s user=%s email=%s",
             org_uuid,
@@ -226,42 +235,81 @@ async def request_slack_user_mapping_code(
             status_code=429,
             detail="Please wait at least one minute before requesting another code.",
         )
-    matched_user = {
-        "id": matched_mapping.external_userid,
-        "email": matched_mapping.external_email or email,
-    }
-
     code = f"{secrets.randbelow(1000000):06d}"
-    payload = json.dumps(
-        {
-            "slack_user_id": matched_user["id"],
-            "email": matched_user["email"],
-            "code": code,
-        }
-    )
-    code_key = f"revtops:slack-email-verify:{org_uuid}:{user_uuid}:{email}"
-    await redis_client.set(code_key, payload, ex=int(_CODE_TTL.total_seconds()))
-
     logger.info(
-        "[user_mappings_for_identity] Sending Slack verification code org=%s user=%s slack_user=%s",
+        "[user_mappings_for_identity] Sending Slack verification code org=%s user=%s candidate_count=%d",
         org_uuid,
         user_uuid,
-        matched_user["id"],
+        len(slack_user_candidates),
     )
     message_text = (
         "Your RevTops verification code is: "
         f"{code}\n\nIf you didn't request this, you can ignore it."
     )
     connector = SlackConnector(organization_id=str(org_uuid))
-    action_response = await connector.send_direct_message(
-        slack_user_id=matched_user["id"],
-        text=message_text,
+
+    last_send_error: Exception | None = None
+    sent_slack_user_id: str | None = None
+    action_response: dict[str, object] | None = None
+    for idx, slack_user_id in enumerate(slack_user_candidates, start=1):
+        try:
+            logger.info(
+                "[user_mappings_for_identity] Attempting Slack verification DM org=%s user=%s slack_user=%s attempt=%d/%d",
+                org_uuid,
+                user_uuid,
+                slack_user_id,
+                idx,
+                len(slack_user_candidates),
+            )
+            action_response = await connector.send_direct_message(
+                slack_user_id=slack_user_id,
+                text=message_text,
+            )
+            sent_slack_user_id = slack_user_id
+            logger.info(
+                "[user_mappings_for_identity] Slack verification DM succeeded org=%s user=%s slack_user=%s attempt=%d/%d",
+                org_uuid,
+                user_uuid,
+                slack_user_id,
+                idx,
+                len(slack_user_candidates),
+            )
+            break
+        except Exception as exc:
+            last_send_error = exc
+            logger.warning(
+                "[user_mappings_for_identity] Slack verification DM failed org=%s user=%s slack_user=%s attempt=%d/%d error=%s",
+                org_uuid,
+                user_uuid,
+                slack_user_id,
+                idx,
+                len(slack_user_candidates),
+                exc,
+                exc_info=True,
+            )
+
+    if not sent_slack_user_id:
+        await redis_client.delete(cooldown_key)
+        raise HTTPException(
+            status_code=502,
+            detail="Unable to deliver verification code via Slack DM. Please try again.",
+        ) from last_send_error
+
+    code_key = f"revtops:slack-email-verify:{org_uuid}:{user_uuid}:{email}"
+    payload = json.dumps(
+        {
+            "slack_user_id": sent_slack_user_id,
+            "email": email,
+            "code": code,
+        }
     )
+    await redis_client.set(code_key, payload, ex=int(_CODE_TTL.total_seconds()))
+
     logger.info(
         "[user_mappings_for_identity] Slack DM send response org=%s user=%s slack_user=%s keys=%s",
         org_uuid,
         user_uuid,
-        matched_user["id"],
+        sent_slack_user_id,
         sorted(action_response.keys()) if isinstance(action_response, dict) else "n/a",
     )
 

--- a/backend/tests/test_slack_user_mapping_request_code.py
+++ b/backend/tests/test_slack_user_mapping_request_code.py
@@ -1,0 +1,143 @@
+import asyncio
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from uuid import UUID
+
+from fastapi import HTTPException
+
+from api.routes import slack_user_mappings
+
+
+class _FakeScalarResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeExecuteResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return _FakeScalarResult(self._rows)
+
+
+class _FakeSession:
+    def __init__(self, mappings):
+        self._mappings = mappings
+        self._execute_calls = 0
+
+    async def execute(self, _query, _params=None):
+        self._execute_calls += 1
+        if self._execute_calls == 1:
+            return _FakeExecuteResult([])
+        return _FakeExecuteResult(self._mappings)
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.cooldown_set = False
+        self.values = {}
+        self.deleted_keys = []
+
+    async def set(self, key, value, nx=False, ex=None):
+        if nx:
+            if self.cooldown_set:
+                return False
+            self.cooldown_set = True
+            self.values[key] = value
+            return True
+        self.values[key] = value
+        return True
+
+    async def delete(self, key):
+        self.deleted_keys.append(key)
+        self.values.pop(key, None)
+
+
+def test_request_code_retries_multiple_slack_identities(monkeypatch):
+    org_uuid = UUID("00000000-0000-0000-0000-000000000001")
+    user_uuid = UUID("00000000-0000-0000-0000-000000000002")
+    mappings = [
+        SimpleNamespace(external_userid="U_FIRST", external_email="user@example.com"),
+        SimpleNamespace(external_userid="U_SECOND", external_email="user@example.com"),
+    ]
+    sent_ids = []
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        yield _FakeSession(mappings)
+
+    class _FakeSlackConnector:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def send_direct_message(self, slack_user_id, text):
+            sent_ids.append(slack_user_id)
+            if slack_user_id == "U_FIRST":
+                raise RuntimeError("first identity failed")
+            return {"ok": True, "channel": "D123", "text": text}
+
+    fake_redis = _FakeRedis()
+    monkeypatch.setattr(slack_user_mappings, "_resolve_org_and_user", lambda *_: asyncio.sleep(0, result=(org_uuid, user_uuid)))
+    monkeypatch.setattr(slack_user_mappings, "_require_slack_integration", lambda *_: asyncio.sleep(0, result=object()))
+    monkeypatch.setattr(slack_user_mappings, "get_session", _fake_get_session)
+    monkeypatch.setattr(slack_user_mappings, "SlackConnector", _FakeSlackConnector)
+    monkeypatch.setattr(slack_user_mappings, "_get_redis", lambda: asyncio.sleep(0, result=fake_redis))
+    monkeypatch.setattr(slack_user_mappings.secrets, "randbelow", lambda _n: 123456)
+
+    response = asyncio.run(
+        slack_user_mappings.request_slack_user_mapping_code(
+            slack_user_mappings.SlackMappingRequest(
+                user_id=str(user_uuid),
+                organization_id=str(org_uuid),
+                email="user@example.com",
+            )
+        )
+    )
+
+    assert response == {"status": "sent"}
+    assert sent_ids == ["U_FIRST", "U_SECOND"]
+
+
+def test_request_code_returns_502_when_all_slack_identities_fail(monkeypatch):
+    org_uuid = UUID("00000000-0000-0000-0000-000000000001")
+    user_uuid = UUID("00000000-0000-0000-0000-000000000002")
+    mappings = [SimpleNamespace(external_userid="U_ONLY", external_email="user@example.com")]
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        yield _FakeSession(mappings)
+
+    class _FakeSlackConnector:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def send_direct_message(self, slack_user_id, text):
+            raise RuntimeError(f"failed for {slack_user_id}:{len(text)}")
+
+    fake_redis = _FakeRedis()
+    monkeypatch.setattr(slack_user_mappings, "_resolve_org_and_user", lambda *_: asyncio.sleep(0, result=(org_uuid, user_uuid)))
+    monkeypatch.setattr(slack_user_mappings, "_require_slack_integration", lambda *_: asyncio.sleep(0, result=object()))
+    monkeypatch.setattr(slack_user_mappings, "get_session", _fake_get_session)
+    monkeypatch.setattr(slack_user_mappings, "SlackConnector", _FakeSlackConnector)
+    monkeypatch.setattr(slack_user_mappings, "_get_redis", lambda: asyncio.sleep(0, result=fake_redis))
+
+    try:
+        asyncio.run(
+            slack_user_mappings.request_slack_user_mapping_code(
+                slack_user_mappings.SlackMappingRequest(
+                    user_id=str(user_uuid),
+                    organization_id=str(org_uuid),
+                    email="user@example.com",
+                )
+            )
+        )
+        raise AssertionError("Expected HTTPException")
+    except HTTPException as exc:
+        assert exc.status_code == 502
+        assert "Unable to deliver verification code" in exc.detail
+
+    assert fake_redis.deleted_keys


### PR DESCRIPTION
### Motivation
- Slack verification DM flow previously only attempted the newest mapping and could fail when a user has multiple Slack identities; we should try other mapped identities before giving up.

### Description
- Gather all Slack mappings for the normalized email, deduplicate candidate Slack user IDs, and attempt `send_direct_message` to each candidate sequentially until one succeeds in `request_slack_user_mapping_code` (`backend/api/routes/slack_user_mappings.py`).
- Add per-attempt logging (attempt index and candidate count) and preserve the Slack user ID that actually received the code in the verification payload stored in Redis.
- If all attempts fail, clear the cooldown key and return HTTP `502` so the user can retry immediately instead of waiting for cooldown expiry.
- Add a focused test module `backend/tests/test_slack_user_mapping_request_code.py` that validates fallback from a failing identity to a succeeding identity and the 502 + cooldown-clear behavior when all identities fail.

### Testing
- Added and ran `pytest -q backend/tests/test_slack_user_mapping_request_code.py`, which passed (2 tests, 0 failures).
- Unit tests exercise both success (first candidate fails, second succeeds) and total-failure behavior (returns 502 and deletes cooldown key).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a50b56e6cc8321ab6fe24304c5f25c)