### PR TITLE
Slack: fallback to org-level credentials when chat.postMessage returns channel_not_found

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -927,7 +927,19 @@ class SlackConnector(BaseConnector):
         if blocks:
             payload["blocks"] = blocks
         
-        data = await self._make_request("POST", "chat.postMessage", json_data=payload)
+        try:
+            data = await self._make_request("POST", "chat.postMessage", json_data=payload)
+        except ValueError as exc:
+            error_message = str(exc)
+            if "channel_not_found" not in error_message:
+                raise
+
+            logger.warning(
+                "[SlackConnector] chat.postMessage returned channel_not_found for channel=%s user_id=%s; retrying with org-level credentials",
+                channel,
+                self.user_id,
+            )
+            data = await self._retry_post_message_with_org_credentials(payload, original_error=exc)
         
         return {
             "ok": data.get("ok"),
@@ -935,6 +947,34 @@ class SlackConnector(BaseConnector):
             "ts": data.get("ts"),
             "message": data.get("message"),
         }
+
+    async def _retry_post_message_with_org_credentials(
+        self,
+        payload: dict[str, Any],
+        *,
+        original_error: ValueError,
+    ) -> dict[str, Any]:
+        """Retry chat.postMessage with non-user-scoped credentials for this org."""
+        original_user_id = self.user_id
+        original_token = self._token
+        original_integration = self._integration
+
+        try:
+            self.user_id = None
+            self._token = None
+            self._integration = None
+            return await self._make_request("POST", "chat.postMessage", json_data=payload)
+        except Exception:
+            logger.warning(
+                "[SlackConnector] Org-level credential retry failed for channel=%s after channel_not_found",
+                payload.get("channel"),
+                exc_info=True,
+            )
+            raise original_error
+        finally:
+            self.user_id = original_user_id
+            self._token = original_token
+            self._integration = original_integration
 
     async def _resolve_channel_for_post(self, channel: str) -> str:
         """Resolve a human channel name (e.g. #general) to a channel ID when possible."""

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -121,3 +121,33 @@ def test_post_message_resolves_hash_channel_name(monkeypatch) -> None:
     assert captured["method"] == "POST"
     assert captured["endpoint"] == "chat.postMessage"
     assert captured["json_data"] == {"channel": "C999", "text": "hello"}
+
+
+def test_post_message_retries_with_org_credentials_on_channel_not_found(monkeypatch) -> None:
+    connector = SlackConnector(
+        organization_id="00000000-0000-0000-0000-000000000001",
+        user_id="11111111-1111-1111-1111-111111111111",
+    )
+
+    calls: list[str | None] = []
+
+    async def _fake_make_request(method: str, endpoint: str, **kwargs: object):
+        assert method == "POST"
+        assert endpoint == "chat.postMessage"
+        calls.append(connector.user_id)
+        if len(calls) == 1:
+            raise ValueError("Slack API error: channel_not_found")
+        return {
+            "ok": True,
+            "channel": str(kwargs.get("json_data", {}).get("channel")),
+            "ts": "2.3",
+            "message": {"text": "hello"},
+        }
+
+    monkeypatch.setattr(connector, "_make_request", _fake_make_request)
+
+    result = asyncio.run(connector.post_message("C0AEA4J556F", "hello"))
+
+    assert result["ok"] is True
+    assert calls == ["11111111-1111-1111-1111-111111111111", None]
+    assert connector.user_id == "11111111-1111-1111-1111-111111111111"


### PR DESCRIPTION
### Motivation
- Some Slack channels (e.g., `C0AEA4J556F`) can exist but be invisible to a user-scoped token, causing `chat.postMessage` to fail with `channel_not_found` even though the channel is valid. 
- Provide a safe automatic fallback that retries the post with org-level (non-user-scoped) credentials before surfacing an error to callers.

### Description
- Updated `SlackConnector.post_message` to catch `ValueError` errors from `_make_request` and, when the error string contains `channel_not_found`, retry the request via an org-level credential path. 
- Added helper `SlackConnector._retry_post_message_with_org_credentials` that temporarily clears `user_id`, `_token`, and `_integration`, retries `chat.postMessage`, and then restores the original connector state in a `finally` block. 
- Added warning logs on both the fallback attempt and if the fallback itself fails to aid debugging. 
- Added unit test `test_post_message_retries_with_org_credentials_on_channel_not_found` in `backend/tests/test_slack_connector_actions.py` to verify the retry switches from user-scoped credentials to org-level credentials and restores connector state afterward.

### Testing
- Ran the Slack connector action tests with `pytest -q backend/tests/test_slack_connector_actions.py`, which completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a50ba7e3c48321997198413a176950)