### PR TITLE
Compress guest users in admin users table and disable guest masquerade

### DIFF
--- a/backend/api/routes/waitlist.py
+++ b/backend/api/routes/waitlist.py
@@ -359,6 +359,7 @@ class AdminUserResponse(BaseModel):
     organization_id: Optional[str]
     organization_name: Optional[str]
     organizations: list[str] = Field(default_factory=list)
+    is_guest: bool = False
 
 
 class AdminUsersListResponse(BaseModel):
@@ -441,6 +442,7 @@ async def list_admin_users(
                     organization_id=str(u.organization_id) if u.organization_id else None,
                     organization_name=org_name,
                     organizations=organizations,
+                    is_guest=bool(u.is_guest),
                 )
             )
 

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -40,6 +40,7 @@ interface AdminUser {
   organization_id: string | null;
   organization_name: string | null;
   organizations: string[];
+  is_guest: boolean;
 }
 
 interface AdminOrganization {
@@ -92,6 +93,7 @@ export function AdminPanel(): JSX.Element {
   const [usersLoading, setUsersLoading] = useState<boolean>(true);
   const [usersError, setUsersError] = useState<string | null>(null);
   const [userSearch, setUserSearch] = useState<string>('');
+  const [showGuestUsers, setShowGuestUsers] = useState<boolean>(false);
 
   // Organizations tab state
   const [adminOrgs, setAdminOrgs] = useState<AdminOrganization[]>([]);
@@ -581,6 +583,9 @@ export function AdminPanel(): JSX.Element {
     );
   });
 
+  const filteredGuestUsers = filteredUsers.filter((u) => u.is_guest);
+  const filteredNonGuestUsers = filteredUsers.filter((u) => !u.is_guest);
+
   // Filter organizations by search term (in-memory)
   const filteredOrgs = adminOrgs.filter((o) => {
     if (!orgSearch.trim()) return true;
@@ -873,7 +878,7 @@ export function AdminPanel(): JSX.Element {
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-surface-800">
-                    {filteredUsers.map((u) => (
+                    {filteredNonGuestUsers.map((u) => (
                       <tr key={u.id} className="hover:bg-surface-800/50">
                         <td className="px-4 py-3">
                           <div>
@@ -909,7 +914,7 @@ export function AdminPanel(): JSX.Element {
                           {formatDate(u.created_at)}
                         </td>
                         <td className="px-4 py-3">
-                          {u.id !== user?.id && u.status === 'active' && (
+                          {u.id !== user?.id && u.status === 'active' && !u.is_guest && (
                             <button
                               onClick={() => void handleMasquerade(u.id)}
                               disabled={masquerading === u.id}
@@ -920,6 +925,36 @@ export function AdminPanel(): JSX.Element {
                             </button>
                           )}
                         </td>
+                      </tr>
+                    ))}
+                    {filteredGuestUsers.length > 0 && (
+                      <tr className="bg-surface-800/30">
+                        <td colSpan={6} className="px-4 py-2.5 text-sm">
+                          <button
+                            onClick={() => setShowGuestUsers((prev) => !prev)}
+                            className="flex items-center gap-2 text-surface-300 hover:text-surface-100 transition-colors"
+                          >
+                            <span className="text-xs text-surface-500">{showGuestUsers ? '▼' : '▶'}</span>
+                            <span>
+                              {filteredGuestUsers.length} guest {filteredGuestUsers.length === 1 ? 'user' : 'users'}
+                            </span>
+                          </button>
+                        </td>
+                      </tr>
+                    )}
+                    {showGuestUsers && filteredGuestUsers.map((u) => (
+                      <tr key={u.id} className="hover:bg-surface-800/40">
+                        <td className="px-4 py-2.5">
+                          <div>
+                            <div className="font-medium text-surface-200">Guest user</div>
+                            <div className="text-xs text-surface-500">{u.email}</div>
+                          </div>
+                        </td>
+                        <td className="px-4 py-2.5 text-xs text-surface-400">{u.organization_name ?? '—'}</td>
+                        <td className="px-4 py-2.5">{getStatusBadge(u.status)}</td>
+                        <td className="px-4 py-2.5 text-xs text-surface-500">{u.last_login ? formatDate(u.last_login) : 'Never'}</td>
+                        <td className="px-4 py-2.5 text-xs text-surface-500">{formatDate(u.created_at)}</td>
+                        <td className="px-4 py-2.5 text-xs text-surface-500">—</td>
                       </tr>
                     ))}
                   </tbody>


### PR DESCRIPTION
### Motivation
- Guest accounts clutter the Users table and should be visually compressed to reduce noise.  
- Guest accounts cannot be masqueraded into, so the masquerade action should not appear for them.  

### Description
- Add `is_guest` to the admin users API response so the frontend can identify guest accounts reliably (`backend/api/routes/waitlist.py`).  
- Extend the `AdminUser` type and add local state in the Admin Panel, splitting the fetched users into guest and non-guest lists (`frontend/src/components/AdminPanel.tsx`).  
- Render non-guest users in the main table and place guest accounts behind a compact expandable row summarizing `N guest users`, with individual guest rows shown only when expanded.  
- Remove/guard the Masquerade button for guest users so the action is not shown for guests.  

### Testing
- Built the frontend with `npm run -s build` and the build completed successfully.  
- Started the dev server and ran an automated headless capture of the Admin Users view to validate the compressed guest UI (screenshot artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5cbcccbec8321a5cf2509404429d1)