### PR TITLE
Enforce single guest per org and add team-level guest toggle

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1637,6 +1637,15 @@ async def update_guest_user(
         if not org.guest_user_id:
             raise HTTPException(status_code=409, detail="Guest user is not configured for this organization")
 
+        guest_user = await session.get(User, org.guest_user_id)
+        if not guest_user or guest_user.organization_id != org_uuid or not guest_user.is_guest:
+            logger.warning(
+                "Refusing to toggle guest user for org=%s because configured guest_user_id=%s is invalid",
+                org_uuid,
+                org.guest_user_id,
+            )
+            raise HTTPException(status_code=409, detail="Guest user configuration is invalid")
+
         org.guest_user_enabled = request.enabled
         await session.commit()
         logger.info("Updated guest user toggle org=%s enabled=%s by_user=%s", org_uuid, request.enabled, user_uuid)

--- a/backend/db/migrations/versions/082_guest_unique.py
+++ b/backend/db/migrations/versions/082_guest_unique.py
@@ -1,0 +1,95 @@
+"""Enforce one guest user per organization.
+
+Revision ID: 082_guest_unique
+Revises: 081_org_guest_user
+Create Date: 2026-03-02
+
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "082_guest_unique"
+down_revision: Union[str, None] = "081_org_guest_user"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    assert len(revision) <= 32
+    assert isinstance(down_revision, str) and len(down_revision) <= 32
+
+    bind = op.get_bind()
+
+    guest_rows = bind.execute(
+        sa.text(
+            """
+            SELECT id, organization_id, created_at
+            FROM users
+            WHERE is_guest = true
+              AND organization_id IS NOT NULL
+            ORDER BY organization_id, created_at NULLS LAST, id
+            """
+        )
+    ).fetchall()
+
+    guests_by_org: dict[str, list[str]] = defaultdict(list)
+    for row in guest_rows:
+        guests_by_org[str(row.organization_id)].append(str(row.id))
+
+    for org_id in sorted(guests_by_org):
+        guest_ids = guests_by_org[org_id]
+        if len(guest_ids) <= 1:
+            continue
+
+        configured_guest_id = bind.execute(
+            sa.text("SELECT guest_user_id FROM organizations WHERE id = :org_id"),
+            {"org_id": org_id},
+        ).scalar_one_or_none()
+        configured_guest = str(configured_guest_id) if configured_guest_id else None
+        canonical_guest = configured_guest if configured_guest in guest_ids else guest_ids[0]
+
+        bind.execute(
+            sa.text("UPDATE organizations SET guest_user_id = :guest_user_id WHERE id = :org_id"),
+            {"guest_user_id": canonical_guest, "org_id": org_id},
+        )
+
+        duplicate_ids = [guest_id for guest_id in guest_ids if guest_id != canonical_guest]
+        if duplicate_ids:
+            bind.execute(
+                sa.text(
+                    """
+                    DELETE FROM org_members
+                    WHERE organization_id = :org_id
+                      AND user_id = ANY(CAST(:user_ids AS uuid[]))
+                    """
+                ),
+                {"org_id": org_id, "user_ids": duplicate_ids},
+            )
+            bind.execute(
+                sa.text(
+                    """
+                    UPDATE users
+                    SET is_guest = false
+                    WHERE id = ANY(CAST(:user_ids AS uuid[]))
+                    """
+                ),
+                {"user_ids": duplicate_ids},
+            )
+
+    op.create_index(
+        "uq_users_one_guest_per_org",
+        "users",
+        ["organization_id"],
+        unique=True,
+        postgresql_where=sa.text("is_guest = true AND organization_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_users_one_guest_per_org", table_name="users")

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -7,7 +7,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, String
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, String, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -25,6 +25,14 @@ class User(Base):
     """User model representing authenticated users."""
 
     __tablename__ = "users"
+    __table_args__ = (
+        Index(
+            "uq_users_one_guest_per_org",
+            "organization_id",
+            unique=True,
+            postgresql_where=text("is_guest = true AND organization_id IS NOT NULL"),
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -418,22 +418,6 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                         Guest users cannot sign in, connect integrations, or be masqueraded as.
                       </p>
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => void handleToggleGuestUser()}
-                      disabled={updateGuestUserMutation.isPending}
-                      className={`px-3 py-1.5 text-xs font-medium rounded transition-colors disabled:opacity-50 ${
-                        guestUserEnabled
-                          ? 'bg-amber-500/20 text-amber-100 hover:bg-amber-500/30'
-                          : 'bg-surface-700/40 text-surface-200 hover:bg-surface-700/60'
-                      }`}
-                    >
-                      {updateGuestUserMutation.isPending
-                        ? 'Saving...'
-                        : guestUserEnabled
-                          ? 'Disable guest user'
-                          : 'Enable guest user'}
-                    </button>
                   </div>
                 </div>
               )}
@@ -493,7 +477,28 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                               <p className="text-sm text-surface-400 truncate">{member.email}</p>
                             </div>
                             {/* Identity count badges */}
-                            <div className="flex items-center gap-1">
+                            <div className="flex items-center gap-2">
+                              {isGuest && (
+                                <button
+                                  type="button"
+                                  onClick={(event) => {
+                                    event.stopPropagation();
+                                    void handleToggleGuestUser();
+                                  }}
+                                  disabled={updateGuestUserMutation.isPending}
+                                  className={`px-2 py-1 text-[10px] font-medium rounded transition-colors disabled:opacity-50 ${
+                                    guestUserEnabled
+                                      ? 'bg-amber-500/20 text-amber-100 hover:bg-amber-500/30'
+                                      : 'bg-surface-700/40 text-surface-200 hover:bg-surface-700/60'
+                                  }`}
+                                >
+                                  {updateGuestUserMutation.isPending
+                                    ? 'Saving...'
+                                    : guestUserEnabled
+                                      ? 'Enabled'
+                                      : 'Disabled'}
+                                </button>
+                              )}
                               {identities.length > 0 ? (
                                 [...new Set(identities.map((i) => i.source))].map((src) => (
                                   <span


### PR DESCRIPTION
### Motivation
- Ensure there is exactly one guest user per organization at the data layer to avoid ambiguous guest fallbacks and race conditions. 
- Provide a clearer UX by moving the enable/disable control onto the guest user entry in the Team members list so admins can toggle the fallback on the relevant user row.

### Description
- Add a partial unique index to the `users` table for `organization_id` when `is_guest = true` via model-level `__table_args__` and the migration `082_guest_unique` to enforce the invariant and normalize existing duplicates. The migration chooses a canonical guest per org (prefers configured `organizations.guest_user_id`, falls back to earliest) then demotes duplicates and creates the index. 
- Introduce the `082_guest_unique` Alembic migration which performs data cleanup and then creates the partial unique index `uq_users_one_guest_per_org`; the migration includes preflight assertions on `revision`/`down_revision` length. 
- Harden the guest-toggle API (`PATCH /auth/organizations/{org_id}/guest-user`) to validate that `organizations.guest_user_id` points to a valid guest user in the same org, log a warning, and return `409` if the configuration is invalid. 
- Update the Team panel UI (`frontend/src/components/OrganizationPanel.tsx`) to remove the banner-level toggle and add a compact `Enabled`/`Disabled` button directly on the guest user row that reuses the existing mutation and confirmation flow.

### Testing
- Ran backend tests: `cd backend && pytest tests/test_slack_user_resolution.py` which produced one failing test unrelated to these changes (a test double missing `post_message` on `_FakeSlackConnectorForMention`); 15 tests passed and 1 failed. 
- Built the frontend: `cd frontend && npm run build` succeeded (Vite chunk-size warnings only). 
- Migration assertions were added and checked (`assert len(revision) <= 32` etc.) as part of the new migration file `082_guest_unique`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5cc93dd7c8321a393572988f8fbbb)