### PR TITLE
Move guest user warning into member expander

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -138,7 +138,6 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
 
   const members: TeamMember[] = teamData?.members ?? [];
   const unmappedIdentities: IdentityMapping[] = teamData?.unmappedIdentities ?? [];
-  const guestMember: TeamMember | undefined = members.find((member) => member.isGuest);
   const guestUserEnabled: boolean = Boolean(teamData?.guestUserEnabled);
   const canLinkIdentityInOrg: boolean = members.some((member) => member.id === currentUser.id);
 
@@ -406,22 +405,6 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                 </div>
               </div>
 
-              {guestMember && (
-                <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <h3 className="text-sm font-medium text-amber-200">Guest user</h3>
-                      <p className="text-sm text-amber-100 mt-1">
-                        The guest user is the identity anonymous Slack entities run as when they are not linked yet.
-                      </p>
-                      <p className="text-xs text-amber-300/80 mt-2">
-                        Guest users cannot sign in, connect integrations, or be masqueraded as.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              )}
-
               {/* Team List */}
               <div>
                 <h3 className="text-sm font-medium text-surface-200 mb-3">
@@ -560,6 +543,18 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                                 <p className="text-xs text-surface-500 italic">
                                   No external accounts linked yet.
                                 </p>
+                              )}
+
+                              {isGuest && (
+                                <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 mt-3">
+                                  <h4 className="text-xs font-medium text-amber-200">Guest user</h4>
+                                  <p className="text-xs text-amber-100 mt-1">
+                                    The guest user is the identity anonymous Slack entities run as when they are not linked yet.
+                                  </p>
+                                  <p className="text-[11px] text-amber-300/80 mt-2">
+                                    Guest users cannot sign in, connect integrations, or be masqueraded as.
+                                  </p>
+                                </div>
                               )}
 
                               {/* Show unmapped identities that could be linked to this user */}


### PR DESCRIPTION
### Motivation
- The guest user explanatory text currently appears at the top of the Team tab and should instead live within the guest member's expanded details so it is scoped to that user.

### Description
- Remove the top-level guest warning container and the now-unused `guestMember` lookup in `OrganizationPanel.tsx`.
- Add a compact guest-warning block inside the member expander that renders when `isGuest` is true, keeping the original copy but with smaller styling (`rounded-md`, `p-3`, compact text).
- Update related JSX structure in `frontend/src/components/OrganizationPanel.tsx` so the message appears under the expanded guest row.

### Testing
- Ran `npm -C frontend run lint` and the lint step completed successfully.
- Ran `npm -C frontend install` to ensure dependencies were up to date and it completed without error.
- Started the dev server with `npm -C frontend run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready.
- Captured an automated Playwright screenshot of the updated UI which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5cef9c20083219aa9f008aeef6d54)