### PR TITLE
Move guest-user warning into guest member expander

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -138,7 +138,6 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
 
   const members: TeamMember[] = teamData?.members ?? [];
   const unmappedIdentities: IdentityMapping[] = teamData?.unmappedIdentities ?? [];
-  const guestMember: TeamMember | undefined = members.find((member) => member.isGuest);
   const guestUserEnabled: boolean = Boolean(teamData?.guestUserEnabled);
   const canLinkIdentityInOrg: boolean = members.some((member) => member.id === currentUser.id);
 
@@ -406,22 +405,6 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                 </div>
               </div>
 
-              {guestMember && (
-                <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <h3 className="text-sm font-medium text-amber-200">Guest user</h3>
-                      <p className="text-sm text-amber-100 mt-1">
-                        The guest user is the identity anonymous Slack entities run as when they are not linked yet.
-                      </p>
-                      <p className="text-xs text-amber-300/80 mt-2">
-                        Guest users cannot sign in, connect integrations, or be masqueraded as.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              )}
-
               {/* Team List */}
               <div>
                 <h3 className="text-sm font-medium text-surface-200 mb-3">
@@ -525,6 +508,17 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                           {/* Expanded identity details */}
                           {isExpanded && (
                             <div className="px-3 pb-3 pt-1 border-t border-surface-700/50">
+                              {isGuest && (
+                                <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 mb-3">
+                                  <h4 className="text-xs font-medium text-amber-200">Guest user</h4>
+                                  <p className="text-xs text-amber-100 mt-1">
+                                    The guest user is the identity anonymous Slack entities run as when they are not linked yet.
+                                  </p>
+                                  <p className="text-xs text-amber-300/80 mt-1.5">
+                                    Guest users cannot sign in, connect integrations, or be masqueraded as.
+                                  </p>
+                                </div>
+                              )}
                               <p className="text-xs text-surface-500 mb-2">Linked identities</p>
                               {identities.length > 0 ? (
                                 <div className="space-y-1.5">


### PR DESCRIPTION
### Motivation
- The guest-user informational text should appear inside the guest member’s expander in the Team tab rather than as a global banner at the top, to keep context tied to the guest member.

### Description
- Removed the standalone guest-user info card from the top of the Team tab and eliminated its top-level usage in `OrganizationPanel.tsx`.
- Added the same guest-user copy inside the expanded details section for the guest member (`isExpanded && isGuest`) so the message appears under the guest user expander and keeps existing amber styling.
- Changed file: `frontend/src/components/OrganizationPanel.tsx` (small UI-only change, no backend/database modifications).

### Testing
- Ran the frontend production build with `cd frontend && npm run build`, which completed successfully (Vite reported non-blocking chunk-size/dynamic-import warnings). 
- Launched the dev server and captured a UI screenshot to validate the guest message now appears inside the expanded guest member panel.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5cef9c20083219aa9f008aeef6d54)