### PR TITLE
Show guest user first in Organization team list

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -137,6 +137,15 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
   } = useTeamMembers(organization.id, currentUser.id);
 
   const members: TeamMember[] = teamData?.members ?? [];
+  const sortedMembers: TeamMember[] = [...members].sort((a, b) => {
+    if (a.isGuest !== b.isGuest) {
+      return a.isGuest ? -1 : 1;
+    }
+
+    const aName = (a.name ?? a.email).toLowerCase();
+    const bName = (b.name ?? b.email).toLowerCase();
+    return aName.localeCompare(bName);
+  });
   const unmappedIdentities: IdentityMapping[] = teamData?.unmappedIdentities ?? [];
   const guestUserEnabled: boolean = Boolean(teamData?.guestUserEnabled);
   const canLinkIdentityInOrg: boolean = members.some((member) => member.id === currentUser.id);
@@ -416,7 +425,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                   </div>
                 ) : (
                   <div className="space-y-2">
-                    {members.map((member) => {
+                    {sortedMembers.map((member) => {
                       const displayName: string = member.name ?? member.email.split('@')[0] ?? 'Unknown';
                       const isGuest: boolean = member.isGuest;
                       const isAdmin: boolean = member.role === 'admin' || member.canLoginAsAdmin;


### PR DESCRIPTION
### Motivation
- Ensure the guest account consistently appears at the top of the Organization/Team panel so anonymous/guest identities are easily discoverable. 

### Description
- Add a `sortedMembers` array in `frontend/src/components/OrganizationPanel.tsx` that copies and sorts `members` so guest users (`isGuest`) come first and remaining users are deterministically ordered by lowercased `name` or `email`.
- Swap the Team panel rendering loop to iterate over `sortedMembers` instead of `members` so the UI reflects the new ordering.
- Preserve original `members` usage for other logic (e.g. `canLinkIdentityInOrg`) and avoid mutating the source array by sorting a shallow copy with `[...]`.

### Testing
- Ran `npm run lint` in `frontend` and the linter completed successfully.
- Started the frontend dev server with `npm run dev` and Vite reported the server was ready (local/network URLs printed).
- Attempted an automated Playwright screenshot to validate UI, but Chromium crashed in this environment (SIGSEGV) and the capture failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d001333c8321a693189c1b70a6f1)