### PR TITLE
Ensure guest user appears first in organization team member lists

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1001,6 +1001,16 @@ async def get_organization_members(
                 )
             )
 
+        # Keep guest user pinned to the top of team lists, then sort remaining
+        # members alphabetically so all consumers (including sidebar/panels)
+        # get a consistent order without duplicating sort rules in clients.
+        members.sort(
+            key=lambda member: (
+                not member.is_guest,
+                (member.name or member.email).lower(),
+            )
+        )
+
         # Collect unmapped identity rows (user_id is NULL)
         unmapped_mappings: list[SlackUserMapping] = mappings_by_user.get(None, [])
 


### PR DESCRIPTION
### Motivation
- Guarantee the guest user is always shown at the top of organization team lists so UI consumers (sidebar/panels) display the guest first without duplicating client-side sorting logic.

### Description
- Add a deterministic backend-side sort in `backend/api/routes/auth.py` that pins `is_guest` members first and then sorts remaining members alphabetically by `name` (falling back to `email`).

### Testing
- Ran `python -m py_compile backend/api/routes/auth.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d2d4d9c48321a377300dc3a858d4)