### PR TITLE
Harden guest identity protections and block agent writes to users table

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -619,7 +619,7 @@ goes into the `memories` table as free-text.
 **When to use structured fields vs. memories:**
 - Job title → structured column (`org_members.title`)
 - Reporting relationship → structured column (`org_members.reports_to_membership_id`)
-- Phone number → `run_sql_write` to UPDATE users SET phone_number (E.164 format, e.g. +14155551234)
+- Phone number → store as `manage_memory` (never write to `users` table from agent tools)
 - Everything else (preferences, responsibilities, projects, company facts) → `manage_memory`
 
 ### When and what to ask
@@ -641,7 +641,7 @@ Use `manage_memory` with the appropriate `entity_type` to persist what you learn
 (check the Profile Completeness section), ask for it in a natural way — explain it allows you
 to send them urgent SMS alerts when a workflow detects something important. If they decline,
 save a memory with `entity_type="user"`: "User declined to share phone number" so you never ask again.
-Use `run_sql_write` (not `manage_memory`) to store the actual number: `UPDATE users SET phone_number = '+14155551234' WHERE id = '...'`. Always use E.164 format — for US 10-digit numbers, prepend +1.
+Store phone-sharing preferences using `manage_memory`; agent tools must not write to the `users` table. If a user asks to update account profile fields, direct them to profile settings.
 
 **Rules**:
 - Never ask context-gathering questions in group channels, thread replies, or workflow executions.

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -860,15 +860,12 @@ WRITABLE_TABLES: set[str] = {
     "deals",
     "accounts",
     "org_members",
-    "users",
     "temp_data",
 }
 
 # Per-table column restrictions: only these columns may appear in SET clauses.
 # Tables not listed here have no column restrictions.
-WRITABLE_COLUMNS: dict[str, set[str]] = {
-    "users": {"phone_number"},
-}
+WRITABLE_COLUMNS: dict[str, set[str]] = {}
 
 # CRM tables that go through pending operations (review before commit)
 CRM_TABLES: set[str] = {

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1099,11 +1099,20 @@ async def link_identity(
         target_user: User | None = await session.get(User, target_uuid)
         if not target_user or target_user.organization_id != org_uuid:
             raise HTTPException(status_code=404, detail="Target user not found in this organization")
+        if target_user.is_guest:
+            logger.warning(
+                "Refusing manual identity link to guest user org=%s target_user=%s mapping=%s",
+                org_uuid,
+                target_uuid,
+                mapping_uuid,
+            )
+            raise HTTPException(status_code=403, detail="Guest user identities cannot be manually linked")
 
         # Fetch the mapping
         mapping: SlackUserMapping | None = await session.get(SlackUserMapping, mapping_uuid)
         if not mapping or mapping.organization_id != org_uuid:
             raise HTTPException(status_code=404, detail="Identity mapping not found")
+
 
         logger.info(
             "Linking identity mapping id=%s org=%s target_user=%s source=%s external_userid=%s external_email=%s",
@@ -1196,6 +1205,17 @@ async def unlink_identity(
         mapping: SlackUserMapping | None = await session.get(SlackUserMapping, mapping_uuid)
         if not mapping or mapping.organization_id != org_uuid:
             raise HTTPException(status_code=404, detail="Identity mapping not found")
+
+        if mapping.user_id is not None:
+            linked_user: User | None = await session.get(User, mapping.user_id)
+            if linked_user and linked_user.is_guest:
+                logger.warning(
+                    "Refusing manual identity unlink for guest-linked mapping id=%s org=%s by_user=%s",
+                    mapping_uuid,
+                    org_uuid,
+                    requester_uuid,
+                )
+                raise HTTPException(status_code=403, detail="Guest user identities cannot be manually unlinked")
 
         is_unlinking_own_identity = mapping.user_id == requester_uuid
         can_link_identities_in_org = True  # Mirrors current link-identity access for org members.

--- a/backend/tests/test_link_identity_slack.py
+++ b/backend/tests/test_link_identity_slack.py
@@ -62,7 +62,7 @@ def test_link_identity_links_related_slack_mappings(monkeypatch):
     selected_mapping_id = UUID("44444444-4444-4444-4444-444444444444")
     related_mapping_id = UUID("55555555-5555-5555-5555-555555555555")
 
-    target_user = SimpleNamespace(id=target_user_id, organization_id=org_id, email="owner@acme.com")
+    target_user = SimpleNamespace(id=target_user_id, organization_id=org_id, email="owner@acme.com", is_guest=False)
     selected_mapping = SimpleNamespace(
         id=selected_mapping_id,
         organization_id=org_id,
@@ -117,7 +117,7 @@ def test_link_identity_non_slack_does_not_attempt_related_linking(monkeypatch):
     target_user_id = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
     selected_mapping_id = UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
 
-    target_user = SimpleNamespace(id=target_user_id, organization_id=org_id, email="owner@acme.com")
+    target_user = SimpleNamespace(id=target_user_id, organization_id=org_id, email="owner@acme.com", is_guest=False)
     selected_mapping = SimpleNamespace(
         id=selected_mapping_id,
         organization_id=org_id,
@@ -148,3 +148,49 @@ def test_link_identity_non_slack_does_not_attempt_related_linking(monkeypatch):
     assert selected_mapping.match_source == "admin_manual_link"
     assert fake_session.execute_calls == 0
     assert fake_session.committed
+
+
+def test_link_identity_rejects_guest_target_user(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    requester_id = UUID("22222222-2222-2222-2222-222222222222")
+    target_user_id = UUID("33333333-3333-3333-3333-333333333333")
+    selected_mapping_id = UUID("44444444-4444-4444-4444-444444444444")
+
+    target_user = SimpleNamespace(
+        id=target_user_id,
+        organization_id=org_id,
+        email="guest@acme.com",
+        is_guest=True,
+    )
+    selected_mapping = SimpleNamespace(
+        id=selected_mapping_id,
+        organization_id=org_id,
+        source="slack",
+        external_userid="U123",
+        external_email=None,
+        user_id=None,
+        revtops_email=None,
+        match_source="unmatched",
+    )
+
+    fake_session = _FakeSession(target_user, selected_mapping, [])
+    monkeypatch.setattr(auth, "get_session", lambda: _FakeSessionContext(fake_session))
+
+    try:
+        asyncio.run(
+            auth.link_identity(
+                org_id=str(org_id),
+                request=auth.LinkIdentityRequest(
+                    target_user_id=str(target_user_id),
+                    mapping_id=str(selected_mapping_id),
+                ),
+                user_id=str(requester_id),
+            )
+        )
+        raise AssertionError("Expected HTTPException")
+    except auth.HTTPException as exc:
+        assert exc.status_code == 403
+        assert "Guest user identities" in exc.detail
+
+    assert selected_mapping.user_id is None
+    assert fake_session.committed is False

--- a/backend/tests/test_tools_sql_write_users_blocked.py
+++ b/backend/tests/test_tools_sql_write_users_blocked.py
@@ -1,0 +1,17 @@
+import asyncio
+
+from agents import tools
+
+
+def test_run_sql_write_blocks_users_table_updates():
+    result = asyncio.run(
+        tools._run_sql_write(
+            params={"query": "UPDATE users SET phone_number = '+14155551234' WHERE id = 'abc'"},
+            organization_id="00000000-0000-0000-0000-000000000001",
+            user_id="00000000-0000-0000-0000-000000000002",
+            context={"is_workflow": True},
+        )
+    )
+
+    assert "error" in result
+    assert "not in the writable list" in result["error"]

--- a/backend/tests/test_unlink_identity_guest_guard.py
+++ b/backend/tests/test_unlink_identity_guest_guard.py
@@ -1,0 +1,72 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID
+
+from api.routes import auth
+
+
+class _FakeSession:
+    def __init__(self, requester, mapping, linked_user):
+        self.requester = requester
+        self.mapping = mapping
+        self.linked_user = linked_user
+        self.committed = False
+
+    async def get(self, _model, model_id):
+        if model_id == self.requester.id:
+            return self.requester
+        if model_id == self.mapping.id:
+            return self.mapping
+        if self.linked_user and model_id == self.linked_user.id:
+            return self.linked_user
+        return None
+
+    async def commit(self):
+        self.committed = True
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_unlink_identity_rejects_guest_linked_mapping(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    requester_id = UUID("22222222-2222-2222-2222-222222222222")
+    mapping_id = UUID("33333333-3333-3333-3333-333333333333")
+    guest_user_id = UUID("44444444-4444-4444-4444-444444444444")
+
+    requester = SimpleNamespace(id=requester_id, organization_id=org_id)
+    mapping = SimpleNamespace(
+        id=mapping_id,
+        organization_id=org_id,
+        user_id=guest_user_id,
+        revtops_email="guest@acme.com",
+        match_source="admin_manual_link",
+    )
+    linked_user = SimpleNamespace(id=guest_user_id, is_guest=True)
+
+    fake_session = _FakeSession(requester, mapping, linked_user)
+    monkeypatch.setattr(auth, "get_session", lambda: _FakeSessionContext(fake_session))
+
+    try:
+        asyncio.run(
+            auth.unlink_identity(
+                org_id=str(org_id),
+                request=auth.UnlinkIdentityRequest(mapping_id=str(mapping_id)),
+                user_id=str(requester_id),
+            )
+        )
+        raise AssertionError("Expected HTTPException")
+    except auth.HTTPException as exc:
+        assert exc.status_code == 403
+        assert "Guest user identities" in exc.detail
+
+    assert mapping.user_id == guest_user_id
+    assert fake_session.committed is False


### PR DESCRIPTION
### Motivation

- Prevent guest user rows and their linked identities from being modified via manual link/unlink operations to protect guest fallback accounts.
- Disallow agent/actor/workflow code paths from writing to the `users` table (notably phone number writes) to stop automated processes from mutating user profile data.
- Update agent/orchestrator guidance to avoid instructing agents to perform direct `users` table writes.

### Description

- Added a guard in `link_identity` to refuse manual linking when the target `User.is_guest` is true and log a warning, returning HTTP 403 (`api/routes/auth.py`).
- Added a guard in `unlink_identity` to refuse unlinking when the mapping is currently linked to a guest user and log a warning, returning HTTP 403 (`api/routes/auth.py`).
- Removed `users` from `WRITABLE_TABLES` and cleared per-table `WRITABLE_COLUMNS` so `run_sql_write` no longer allows writes to the `users` table (`agents/tools.py`).
- Updated the orchestrator guidance to instruct agents to store phone-sharing preferences with `manage_memory` and not to update `users.phone_number` via SQL (`agents/orchestrator.py`).
- Added focused regression tests: updated `tests/test_link_identity_slack.py`, and added `tests/test_unlink_identity_guest_guard.py` and `tests/test_tools_sql_write_users_blocked.py` to cover guest link/unlink protections and `users` write blocking.

### Testing

- Ran the focused pytest command: `pytest -q tests/test_link_identity_slack.py tests/test_unlink_identity_guest_guard.py tests/test_tools_sql_write_users_blocked.py` and all tests passed (`5 passed`).
- Unit tests verify that manual link attempts against guest targets are rejected, manual unlink of guest-linked mappings is rejected, and `run_sql_write` rejects updates targeting the `users` table.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5db070b4083219c4e4d14be7c6fa5)