### PR TITLE
Harden guest identity protections and prevent agent writes to users table

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -619,7 +619,7 @@ goes into the `memories` table as free-text.
 **When to use structured fields vs. memories:**
 - Job title → structured column (`org_members.title`)
 - Reporting relationship → structured column (`org_members.reports_to_membership_id`)
-- Phone number → `run_sql_write` to UPDATE users SET phone_number (E.164 format, e.g. +14155551234)
+- Phone number → collect it in E.164 format and store it as a user memory via `manage_memory` (do not write to `users` directly)
 - Everything else (preferences, responsibilities, projects, company facts) → `manage_memory`
 
 ### When and what to ask
@@ -641,7 +641,7 @@ Use `manage_memory` with the appropriate `entity_type` to persist what you learn
 (check the Profile Completeness section), ask for it in a natural way — explain it allows you
 to send them urgent SMS alerts when a workflow detects something important. If they decline,
 save a memory with `entity_type="user"`: "User declined to share phone number" so you never ask again.
-Use `run_sql_write` (not `manage_memory`) to store the actual number: `UPDATE users SET phone_number = '+14155551234' WHERE id = '...'`. Always use E.164 format — for US 10-digit numbers, prepend +1.
+Do not use `run_sql_write` against the `users` table for phone updates. Persist the number as memory text and keep E.164 formatting — for US 10-digit numbers, prepend +1.
 
 **Rules**:
 - Never ask context-gathering questions in group channels, thread replies, or workflow executions.

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -860,15 +860,12 @@ WRITABLE_TABLES: set[str] = {
     "deals",
     "accounts",
     "org_members",
-    "users",
     "temp_data",
 }
 
 # Per-table column restrictions: only these columns may appear in SET clauses.
 # Tables not listed here have no column restrictions.
-WRITABLE_COLUMNS: dict[str, set[str]] = {
-    "users": {"phone_number"},
-}
+WRITABLE_COLUMNS: dict[str, set[str]] = {}
 
 # CRM tables that go through pending operations (review before commit)
 CRM_TABLES: set[str] = {

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1099,6 +1099,15 @@ async def link_identity(
         target_user: User | None = await session.get(User, target_uuid)
         if not target_user or target_user.organization_id != org_uuid:
             raise HTTPException(status_code=404, detail="Target user not found in this organization")
+        if getattr(target_user, "is_guest", False):
+            logger.warning(
+                "Blocked manual identity link to guest user org=%s target_user=%s mapping=%s by_user=%s",
+                org_uuid,
+                target_uuid,
+                mapping_uuid,
+                user_id,
+            )
+            raise HTTPException(status_code=403, detail="Guest user identities cannot be manually linked")
 
         # Fetch the mapping
         mapping: SlackUserMapping | None = await session.get(SlackUserMapping, mapping_uuid)
@@ -1196,6 +1205,17 @@ async def unlink_identity(
         mapping: SlackUserMapping | None = await session.get(SlackUserMapping, mapping_uuid)
         if not mapping or mapping.organization_id != org_uuid:
             raise HTTPException(status_code=404, detail="Identity mapping not found")
+
+        if mapping.user_id:
+            linked_user: User | None = await session.get(User, mapping.user_id)
+            if linked_user and getattr(linked_user, "is_guest", False):
+                logger.warning(
+                    "Blocked unlink attempt for guest identity mapping id=%s org=%s by_user=%s",
+                    mapping_uuid,
+                    org_uuid,
+                    requester_uuid,
+                )
+                raise HTTPException(status_code=403, detail="Guest user identities cannot be unlinked")
 
         is_unlinking_own_identity = mapping.user_id == requester_uuid
         can_link_identities_in_org = True  # Mirrors current link-identity access for org members.
@@ -1713,7 +1733,7 @@ async def get_masquerade_user(
         target_user = await session.get(User, target_uuid)
         if not target_user:
             raise HTTPException(status_code=404, detail="Target user not found")
-        if target_user.is_guest:
+        if getattr(target_user, "is_guest", False):
             raise HTTPException(status_code=403, detail="Guest users cannot be masqueraded as")
         
         # Fetch target user's organization if they have one

--- a/backend/db/migrations/versions/083_guest_locks.py
+++ b/backend/db/migrations/versions/083_guest_locks.py
@@ -1,0 +1,158 @@
+"""Lock guest identity updates and users-table writes for revtops_app.
+
+Revision ID: 083_guest_locks
+Revises: 082_guest_unique
+Create Date: 2026-03-02
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "083_guest_locks"
+down_revision: Union[str, None] = "082_guest_unique"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    assert len(revision) <= 32
+    assert isinstance(down_revision, str) and len(down_revision) <= 32
+
+    bind = op.get_bind()
+
+    bind.execute(
+        sa.text(
+            """
+            CREATE OR REPLACE FUNCTION prevent_guest_user_mutations()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF OLD.is_guest IS TRUE THEN
+                    IF NEW.email IS DISTINCT FROM OLD.email THEN
+                        RAISE EXCEPTION 'Guest user email is immutable';
+                    END IF;
+
+                    IF NEW.organization_id IS DISTINCT FROM OLD.organization_id THEN
+                        RAISE EXCEPTION 'Guest user organization is immutable';
+                    END IF;
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+            """
+        )
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            DROP TRIGGER IF EXISTS trg_prevent_guest_user_mutations ON users;
+            CREATE TRIGGER trg_prevent_guest_user_mutations
+            BEFORE UPDATE ON users
+            FOR EACH ROW
+            EXECUTE FUNCTION prevent_guest_user_mutations();
+            """
+        )
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            CREATE OR REPLACE FUNCTION prevent_guest_identity_mapping_mutations()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            DECLARE
+                existing_is_guest boolean;
+                incoming_is_guest boolean;
+            BEGIN
+                IF OLD.user_id IS NOT NULL THEN
+                    SELECT is_guest INTO existing_is_guest FROM users WHERE id = OLD.user_id;
+                    IF existing_is_guest IS TRUE THEN
+                        IF NEW.user_id IS DISTINCT FROM OLD.user_id
+                           OR NEW.revtops_email IS DISTINCT FROM OLD.revtops_email
+                           OR NEW.external_email IS DISTINCT FROM OLD.external_email
+                           OR NEW.match_source IS DISTINCT FROM OLD.match_source THEN
+                            RAISE EXCEPTION 'Identity mappings linked to guest users are immutable';
+                        END IF;
+                    END IF;
+                END IF;
+
+                IF NEW.user_id IS NOT NULL AND NEW.user_id IS DISTINCT FROM OLD.user_id THEN
+                    SELECT is_guest INTO incoming_is_guest FROM users WHERE id = NEW.user_id;
+                    IF incoming_is_guest IS TRUE THEN
+                        RAISE EXCEPTION 'Identity mappings cannot be linked to guest users';
+                    END IF;
+                END IF;
+
+                RETURN NEW;
+            END;
+            $$;
+            """
+        )
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            DROP TRIGGER IF EXISTS trg_prevent_guest_identity_mapping_mutations ON user_mappings_for_identity;
+            CREATE TRIGGER trg_prevent_guest_identity_mapping_mutations
+            BEFORE UPDATE ON user_mappings_for_identity
+            FOR EACH ROW
+            EXECUTE FUNCTION prevent_guest_identity_mapping_mutations();
+            """
+        )
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'revtops_app') THEN
+                    REVOKE INSERT, UPDATE, DELETE ON TABLE users FROM revtops_app;
+                END IF;
+            END $$;
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    bind.execute(
+        sa.text(
+            """
+            DROP TRIGGER IF EXISTS trg_prevent_guest_identity_mapping_mutations ON user_mappings_for_identity;
+            DROP FUNCTION IF EXISTS prevent_guest_identity_mapping_mutations();
+            """
+        )
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            DROP TRIGGER IF EXISTS trg_prevent_guest_user_mutations ON users;
+            DROP FUNCTION IF EXISTS prevent_guest_user_mutations();
+            """
+        )
+    )
+
+    bind.execute(
+        sa.text(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'revtops_app') THEN
+                    GRANT INSERT, UPDATE, DELETE ON TABLE users TO revtops_app;
+                END IF;
+            END $$;
+            """
+        )
+    )

--- a/backend/tests/test_auth_guest_identity_guards.py
+++ b/backend/tests/test_auth_guest_identity_guards.py
@@ -1,0 +1,101 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes import auth
+
+
+class _FakeSession:
+    def __init__(self, *, users, mapping):
+        self._users = users
+        self._mapping = mapping
+        self.committed = False
+
+    async def get(self, _model, model_id):
+        if model_id == self._mapping.id:
+            return self._mapping
+        return self._users.get(model_id)
+
+    async def commit(self):
+        self.committed = True
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_link_identity_rejects_guest_target(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    requester_id = UUID("22222222-2222-2222-2222-222222222222")
+    target_user_id = UUID("33333333-3333-3333-3333-333333333333")
+    mapping_id = UUID("44444444-4444-4444-4444-444444444444")
+
+    guest_user = SimpleNamespace(id=target_user_id, organization_id=org_id, email="g@x", is_guest=True)
+    mapping = SimpleNamespace(
+        id=mapping_id,
+        organization_id=org_id,
+        source="slack",
+        external_userid="U123",
+        external_email=None,
+        user_id=None,
+        revtops_email=None,
+        match_source="unmatched",
+    )
+
+    fake_session = _FakeSession(users={target_user_id: guest_user}, mapping=mapping)
+    monkeypatch.setattr(auth, "get_session", lambda: _FakeSessionContext(fake_session))
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            auth.link_identity(
+                org_id=str(org_id),
+                request=auth.LinkIdentityRequest(target_user_id=str(target_user_id), mapping_id=str(mapping_id)),
+                user_id=str(requester_id),
+            )
+        )
+
+    assert exc.value.status_code == 403
+    assert not fake_session.committed
+
+
+def test_unlink_identity_rejects_guest_mapping(monkeypatch):
+    org_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    requester_id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    guest_user_id = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+    mapping_id = UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+
+    requester = SimpleNamespace(id=requester_id, organization_id=org_id, is_guest=False)
+    guest_user = SimpleNamespace(id=guest_user_id, organization_id=org_id, is_guest=True)
+    mapping = SimpleNamespace(
+        id=mapping_id,
+        organization_id=org_id,
+        user_id=guest_user_id,
+        revtops_email="guest@example.com",
+        match_source="auto",
+    )
+
+    fake_session = _FakeSession(users={requester_id: requester, guest_user_id: guest_user}, mapping=mapping)
+    monkeypatch.setattr(auth, "get_session", lambda: _FakeSessionContext(fake_session))
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            auth.unlink_identity(
+                org_id=str(org_id),
+                request=auth.UnlinkIdentityRequest(mapping_id=str(mapping_id)),
+                user_id=str(requester_id),
+            )
+        )
+
+    assert exc.value.status_code == 403
+    assert mapping.user_id == guest_user_id
+    assert not fake_session.committed

--- a/backend/tests/test_tools_sql_write_users_blocked.py
+++ b/backend/tests/test_tools_sql_write_users_blocked.py
@@ -1,0 +1,11 @@
+from agents import tools
+
+
+def test_validate_sql_write_blocks_users_table_updates():
+    is_valid, error, operation = tools._validate_sql_write("UPDATE users SET phone_number = '+14155551234' WHERE id = 'x'")
+    assert is_valid
+    assert operation == "UPDATE"
+
+    table = tools._extract_table_from_write("UPDATE users SET phone_number = '+14155551234' WHERE id = 'x'")
+    assert table == "users"
+    assert table not in tools.WRITABLE_TABLES


### PR DESCRIPTION
### Motivation
- Prevent accidental or malicious changes to guest users and their linked identity rows by actors, agents, or direct SQL writes.
- Ensure agent/workflow paths cannot mutate sensitive `users` fields (notably `phone_number`) via `run_sql_write`.
- Enforce DB-level constraints so application bugs cannot circumvent guards.

### Description
- Add application-level guards in `api.routes.auth` to reject manual linking to guest users and reject unlinking identity mappings that are tied to guest users, and prevent masquerade of guest users by admins via `get_masquerade_user` (`backend/api/routes/auth.py`).
- Remove `users` from the agent writable allowlist and clear `WRITABLE_COLUMNS` so agent tools cannot write to the `users` table (`backend/agents/tools.py`).
- Update orchestrator guidance to stop recommending `run_sql_write` to write user phone numbers and instruct storing phone numbers as user memories instead (`backend/agents/orchestrator.py`).
- Add an Alembic migration `083_guest_locks` that: creates triggers to make guest `users.email` and `users.organization_id` immutable, prevents updates to `user_mappings_for_identity` for guest-linked mappings and prevents linking mappings to guest users, and revokes `INSERT/UPDATE/DELETE` on `users` for the `revtops_app` DB role (`backend/db/migrations/versions/083_guest_locks.py`).
- Add unit tests covering the new guest identity guardrails and the tools write configuration (`backend/tests/test_auth_guest_identity_guards.py`, `backend/tests/test_tools_sql_write_users_blocked.py`).
- Migration includes preflight assertions for `revision` and `down_revision` lengths to satisfy migration safety rules.

### Testing
- Ran targeted test suite: `cd backend && pytest -q tests/test_auth_guest_identity_guards.py tests/test_link_identity_slack.py tests/test_tools_sql_write_users_blocked.py`, and all tests passed (`5 passed`).
- Added unit tests exercise the new guards and the tools configuration and they succeed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5db070b4083219c4e4d14be7c6fa5)