### PR TITLE
Show admin pill for global admins in team view

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -996,7 +996,7 @@ async def get_organization_members(
                     job_title=membership.title if membership else None,
                     status=u.status,
                     is_guest=u.is_guest,
-                    can_login_as_admin=u.role == "admin",
+                    can_login_as_admin=(u.role == "admin" or "global_admin" in (u.roles or [])),
                     identities=identities,
                 )
             )

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -428,7 +428,9 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                     {sortedMembers.map((member) => {
                       const displayName: string = member.name ?? member.email.split('@')[0] ?? 'Unknown';
                       const isGuest: boolean = member.isGuest;
-                      const isAdmin: boolean = member.role === 'admin' || member.canLoginAsAdmin;
+                      const isAdmin: boolean = member.role === 'admin'
+                        || member.role === 'global_admin'
+                        || member.canLoginAsAdmin;
                       const isExpanded: boolean = expandedMemberId === member.id;
                       const identities: IdentityMapping[] = [...member.identities].sort((a, b) => {
                         const sourceCompare = sourceLabel(a.source).localeCompare(sourceLabel(b.source));


### PR DESCRIPTION
### Motivation
- The Team view only showed an admin pill for users with org `role === 'admin'` or when `canLoginAsAdmin` was true, but Global Admins are stored in the user's `roles` array and were not consistently surfaced as admin-capable.

### Description
- Set `can_login_as_admin` to true in the `/organizations/{org_id}/members` response when `"global_admin"` appears in the user's `roles` array in `backend/api/routes/auth.py`.
- Treat `member.role === 'global_admin'` as an admin-capable user in the Team view UI inside `frontend/src/components/OrganizationPanel.tsx` so the admin pill shows for those users.
- Changed only the API mapping and the UI admin-check logic to ensure both server and client consistently indicate admin capability.

### Testing
- Ran `python -m py_compile backend/api/routes/auth.py` and it succeeded.
- Ran `npm run lint` in `frontend/` and linting passed.
- Attempted `npm run typecheck` in `frontend/` but the `typecheck` script is not defined, so full TypeScript typecheck was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a62b0b66e883218e13b6fe768c77fd)