### PR TITLE
Update guest badge color to contrasting sky-blue

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -460,7 +460,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                                   </span>
                                 )}
                                 {isGuest && (
-                                  <span className="px-2 py-0.5 text-xs font-medium bg-amber-500/20 text-amber-300 rounded-full">
+                                  <span className="px-2 py-0.5 text-xs font-medium bg-sky-500/20 text-sky-200 rounded-full">
                                     guest
                                   </span>
                                 )}


### PR DESCRIPTION
### Motivation
- Make the guest user pill visually distinct from orange/warning tones while keeping it legible on the dark surface.

### Description
- Replace the guest pill color classes in `frontend/src/components/OrganizationPanel.tsx` from `bg-amber-500/20 text-amber-300` to `bg-sky-500/20 text-sky-200` keeping the same shape and typography.

### Testing
- Ran `npm --prefix frontend run lint` which completed successfully.
- Launched the dev server and executed an automated Playwright script to capture a screenshot of the updated UI (artifact created), confirming the visual change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a65cf3511c832184698cbe3f8b8af4)