### PR TITLE
Draggable sidebar resize divider

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -13,7 +13,7 @@
  * Tasks continue running server-side even when browser tabs are closed.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import Nango from '@nangohq/frontend';
 import { API_BASE } from '../lib/api';
@@ -255,6 +255,37 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
   // Mobile responsive state
   const isMobile = useIsMobile();
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+
+  // Sidebar resize drag
+  const sidebarWidth = useAppStore((state) => state.sidebarWidth);
+  const setSidebarWidth = useAppStore((state) => state.setSidebarWidth);
+  const isDraggingRef = useRef(false);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+
+  const handleDividerMouseDown = useCallback((e: React.MouseEvent): void => {
+    e.preventDefault();
+    isDraggingRef.current = true;
+    startXRef.current = e.clientX;
+    startWidthRef.current = sidebarWidth;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const onMouseMove = (ev: MouseEvent): void => {
+      if (!isDraggingRef.current) return;
+      const newWidth = Math.min(400, Math.max(200, startWidthRef.current + ev.clientX - startXRef.current));
+      setSidebarWidth(newWidth);
+    };
+    const onMouseUp = (): void => {
+      isDraggingRef.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }, [sidebarWidth, setSidebarWidth]);
   
   // Close mobile sidebar when view changes
   useEffect(() => {
@@ -1044,6 +1075,15 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
           onCloseMobile={() => setMobileSidebarOpen(false)}
         />
       </div>
+
+      {/* Resize divider (desktop only, expanded sidebar only) */}
+      {!isMobile && !sidebarCollapsed && (
+        <div
+          onMouseDown={handleDividerMouseDown}
+          onDoubleClick={() => setSidebarWidth(256)}
+          className="w-1 cursor-col-resize hover:bg-primary-500/40 active:bg-primary-500/60 transition-colors flex-shrink-0"
+        />
+      )}
 
       {/* Main Content */}
       <main className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -193,7 +193,8 @@ export function Sidebar({
   const togglePinChat = useAppStore((state) => state.togglePinChat);
   const isGlobalAdmin = useIsGlobalAdmin();
   const activeTasksByConversation = useActiveTasksByConversation();
-  const sidebarWidth = collapsed ? 'w-16' : 'w-64';
+  const storedWidth = useAppStore((state) => state.sidebarWidth);
+  const widthPx = collapsed ? 64 : storedWidth;
   const orderedChats = useMemo(() => {
     if (pinnedChatIds.length === 0) {
       return recentChats;
@@ -206,7 +207,8 @@ export function Sidebar({
 
   return (
     <aside
-      className={`${sidebarWidth} h-full bg-surface-900 border-r border-surface-800 flex flex-col transition-all duration-200 ease-in-out`}
+      style={{ width: widthPx }}
+      className="h-full bg-surface-900 border-r border-surface-800 flex flex-col transition-all duration-200 ease-in-out flex-shrink-0"
     >
       {/* Header with logo and collapse toggle */}
       <div className={`border-b border-surface-800 ${collapsed ? 'py-3' : 'h-14 flex items-center justify-between px-3'}`}>

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -249,6 +249,7 @@ interface AppState {
 
   // UI State
   sidebarCollapsed: boolean;
+  sidebarWidth: number;
   currentView: View;
   currentChatId: string | null;
   currentAppId: string | null;
@@ -297,6 +298,7 @@ interface AppState {
 
   // Actions - UI
   setSidebarCollapsed: (collapsed: boolean) => void;
+  setSidebarWidth: (width: number) => void;
   setCurrentView: (view: View) => void;
   setCurrentChatId: (id: string | null) => void;
   setCurrentAppId: (id: string | null) => void;
@@ -401,6 +403,7 @@ export const useAppStore = create<AppState>()(
       isAuthenticated: false,
       masquerade: null,
       sidebarCollapsed: false,
+      sidebarWidth: 256,
       currentView: "home",
       currentChatId: null,
       currentAppId: null,
@@ -674,6 +677,7 @@ export const useAppStore = create<AppState>()(
 
       // UI actions
       setSidebarCollapsed: (sidebarCollapsed) => set({ sidebarCollapsed }),
+      setSidebarWidth: (sidebarWidth) => set({ sidebarWidth }),
       setCurrentView: (currentView) =>
         set({
           currentView,
@@ -1566,6 +1570,7 @@ export const useAppStore = create<AppState>()(
         organizations: state.organizations,
         isAuthenticated: state.isAuthenticated,
         sidebarCollapsed: state.sidebarCollapsed,
+        sidebarWidth: state.sidebarWidth,
         pinnedChatIds: state.pinnedChatIds,
         masquerade: state.masquerade, // Persist masquerade state so admin can exit after reload
       }),


### PR DESCRIPTION
## Summary
- Adds a thin draggable divider between sidebar and main content area
- Users can drag to resize the sidebar between 200px and 400px
- Double-click the divider to reset to default width (256px)
- Width persists across sessions via Zustand store + localStorage
- Desktop only — hidden on mobile and when sidebar is collapsed

## Files changed
- `store/index.ts` — added `sidebarWidth` state + `setSidebarWidth` action (persisted)
- `Sidebar.tsx` — uses `style={{ width }}` instead of Tailwind `w-64` class
- `AppLayout.tsx` — draggable divider element + mousedown/move/up handlers

## Test plan
- [ ] Drag divider left/right — sidebar resizes smoothly
- [ ] Width persists after page reload
- [ ] Double-click divider — resets to default 256px
- [ ] Collapse sidebar — divider disappears, sidebar snaps to 64px
- [ ] Mobile — no divider visible, sidebar behaves as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)