### PR TITLE
Fix migration order so 084_org_admin_seed runs after 084_app_archived_at_index

### DIFF
--- a/backend/db/migrations/versions/084_org_admin_seed.py
+++ b/backend/db/migrations/versions/084_org_admin_seed.py
@@ -1,7 +1,7 @@
 """Seed org admins from first joined member.
 
 Revision ID: 084_org_admin_seed
-Revises: 083_guest_locks
+Revises: 084_app_archived_at_index
 Create Date: 2026-03-02
 """
 from __future__ import annotations
@@ -13,7 +13,7 @@ from alembic import op
 
 
 revision: str = "084_org_admin_seed"
-down_revision: Union[str, None] = "083_guest_locks"
+down_revision: Union[str, None] = "084_app_archived_at_index"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
### Motivation
- Ensure the org admin seeding migration executes after the apps `archived_at` index migration to avoid a parallel head and enforce linear migration ordering.

### Description
- Updated `backend/db/migrations/versions/084_org_admin_seed.py` to set `down_revision` to `084_app_archived_at_index` instead of `083_guest_locks`, keeping `085_admin_org_scope` chained after it and retaining the existing preflight assertions on revision lengths.

### Testing
- Ran a Python preflight check that verifies `revision` and `down_revision` lengths (`<= 32`) which passed using a small script that inspected the three related migration files; the check succeeded.
- Ran `cd backend && alembic -c alembic.ini heads` which now reports a single head (`085_admin_org_scope`) confirming the migration chain is linear; the command succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a743df3f6c8321bb1c07b69129b11c)