### PR TITLE
Fix organization delete button behavior for admin users

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -70,6 +70,7 @@ interface OrganizationPanelProps {
 
 export function OrganizationPanel({ organization, currentUser, initialTab = 'team', onClose }: OrganizationPanelProps): JSX.Element {
   const setOrganization = useAppStore((state) => state.setOrganization);
+  const logout = useAppStore((state) => state.logout);
   const [activeTab, setActiveTab] = useState<'team' | 'billing' | 'settings'>(initialTab);
 
   useEffect(() => {
@@ -293,7 +294,18 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
   const isOrgAdmin = currentMember?.role === 'admin';
 
   const handleDeleteOrganization = async (): Promise<void> => {
-    if (!isOrgAdmin) {
+    console.info('[OrganizationPanel] Delete organization clicked', {
+      organizationId: organization.id,
+      userId: currentUser.id,
+      isOrgAdmin,
+      isGlobalAdmin,
+    });
+
+    if (!canAdministerOrg) {
+      console.warn('[OrganizationPanel] Delete organization blocked: user is not an org admin/global admin', {
+        organizationId: organization.id,
+        userId: currentUser.id,
+      });
       alert("You can't do that. Only organization admins can delete organizations.");
       return;
     }
@@ -304,13 +316,32 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
     if (!confirmed) return;
 
     try {
+      console.info('[OrganizationPanel] Confirmed organization deletion', {
+        organizationId: organization.id,
+        userId: currentUser.id,
+      });
       await deleteOrganizationMutation.mutateAsync({
         orgId: organization.id,
         userId: currentUser.id,
       });
+
+      console.info('[OrganizationPanel] Organization deleted; signing out user', {
+        organizationId: organization.id,
+        userId: currentUser.id,
+      });
+      await supabase.auth.signOut();
+      logout();
+      localStorage.clear();
+      sessionStorage.clear();
+
       alert('Organization deleted. You will be signed out.');
-      window.location.reload();
+      window.location.href = '/auth';
     } catch (error) {
+      console.error('[OrganizationPanel] Failed to delete organization', {
+        organizationId: organization.id,
+        userId: currentUser.id,
+        error,
+      });
       alert(`Failed to delete organization: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   };


### PR DESCRIPTION
### Motivation
- The organization delete action in the panel was not reliably performing the expected flow for admins and could silently do nothing for non-admins.
- The intent is to ensure non-admin clicks show a clear warning and admin/global-admin users see a confirmation and then are signed out after deletion.

### Description
- Use the store `logout` action and the existing `canAdministerOrg` boolean (org admin or global admin) to gate the delete action and cover global admins as well as org admins.
- Add structured console logging for `clicked`, `blocked`, `confirmed`, `deleted`, and `failed` states to aid debugging.
- After successful deletion, sign out from Supabase (`supabase.auth.signOut()`), call the store `logout()`, clear `localStorage` and `sessionStorage`, and redirect the user to `/auth` instead of reloading the page.
- Replace the previous admin check path with an explicit alert for non-admins and preserve the confirmation dialog before proceeding with deletion.

### Testing
- Ran the frontend production build via `npm --prefix frontend run build` which completed successfully (TypeScript compile + Vite build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a746647f98832181c38054217299ed)