### PR TITLE
Fix org deletion to remove guest users before detaching members

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1857,10 +1857,26 @@ async def delete_organization(
 
         logger.warning("Deleting organization org=%s requested_by=%s", org_uuid, user_uuid)
 
-        # Remove org links from users first so organization FK deletion succeeds.
-        await session.execute(
-            text("UPDATE users SET organization_id = NULL WHERE organization_id = :org_id"),
+        # Delete guest users first: guest rows forbid organization_id updates.
+        deleted_guest_users = await session.execute(
+            text("DELETE FROM users WHERE organization_id = :org_id AND is_guest IS TRUE"),
             {"org_id": org_uuid},
+        )
+        logger.info(
+            "Deleted guest users for organization org=%s count=%s",
+            org_uuid,
+            deleted_guest_users.rowcount,
+        )
+
+        # Remove org links from non-guest users so organization FK deletion succeeds.
+        detached_users = await session.execute(
+            text("UPDATE users SET organization_id = NULL WHERE organization_id = :org_id AND is_guest IS NOT TRUE"),
+            {"org_id": org_uuid},
+        )
+        logger.info(
+            "Detached non-guest users from organization org=%s count=%s",
+            org_uuid,
+            detached_users.rowcount,
         )
 
         # Delete org-scoped records in a deterministic order to avoid lock contention.

--- a/backend/tests/test_delete_organization_guest_cleanup.py
+++ b/backend/tests/test_delete_organization_guest_cleanup.py
@@ -1,0 +1,82 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID
+
+from api.routes import auth
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _ExecResult:
+    def __init__(self, rowcount=0):
+        self.rowcount = rowcount
+
+
+class _FakeSession:
+    def __init__(self, *, membership, org):
+        self._membership = membership
+        self._org = org
+        self.committed = False
+        self.deleted = []
+        self.statements = []
+
+    async def execute(self, query, params=None):
+        if not self.statements:
+            self.statements.append((str(query), params))
+            return _ScalarResult(self._membership)
+
+        sql = str(query)
+        self.statements.append((sql, params))
+        if "DELETE FROM users WHERE organization_id = :org_id AND is_guest IS TRUE" in sql:
+            return _ExecResult(rowcount=1)
+        if "UPDATE users SET organization_id = NULL WHERE organization_id = :org_id AND is_guest IS NOT TRUE" in sql:
+            return _ExecResult(rowcount=3)
+        return _ExecResult(rowcount=0)
+
+    async def get(self, _model, _id):
+        return self._org
+
+    async def delete(self, obj):
+        self.deleted.append(obj)
+
+    async def commit(self):
+        self.committed = True
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_delete_organization_deletes_guest_users_before_detach(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    requester_id = UUID("22222222-2222-2222-2222-222222222222")
+
+    membership = SimpleNamespace(user_id=requester_id, organization_id=org_id, status="active", role="admin")
+    org = SimpleNamespace(id=org_id)
+
+    fake_session = _FakeSession(membership=membership, org=org)
+    monkeypatch.setattr(auth, "get_admin_session", lambda: _FakeSessionContext(fake_session))
+
+    result = asyncio.run(auth.delete_organization(org_id=str(org_id), user_id=str(requester_id)))
+
+    assert result["status"] == "deleted"
+    assert fake_session.committed
+    assert fake_session.deleted == [org]
+
+    sql_statements = [sql for sql, _params in fake_session.statements]
+    guest_delete_ix = next(i for i, sql in enumerate(sql_statements) if "DELETE FROM users WHERE organization_id = :org_id AND is_guest IS TRUE" in sql)
+    detach_ix = next(i for i, sql in enumerate(sql_statements) if "UPDATE users SET organization_id = NULL WHERE organization_id = :org_id AND is_guest IS NOT TRUE" in sql)
+    assert guest_delete_ix < detach_ix


### PR DESCRIPTION
### Motivation
- Deleting an organization previously ran `UPDATE users SET organization_id = NULL ...` for all users which fails due to the DB trigger that makes guest users' `organization_id` immutable. 
- The change ensures org deletion respects the guest-user immutability and avoids the `Guest user organization is immutable` error.

### Description
- Update the organization deletion flow in `backend/api/routes/auth.py` to first `DELETE FROM users WHERE organization_id = :org_id AND is_guest IS TRUE` and log the affected row count. 
- Then `UPDATE users SET organization_id = NULL WHERE organization_id = :org_id AND is_guest IS NOT TRUE` to detach only non-guest users and log that row count. 
- Add a regression test `backend/tests/test_delete_organization_guest_cleanup.py` that mocks the admin session and asserts the guest-user deletion statement is executed before the non-guest detachment and that the org deletion completes.

### Testing
- Ran `pytest -q backend/tests/test_delete_organization_guest_cleanup.py` and the test passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a74b64095c8321abde8206f7ce567c)