### PR TITLE
Fix organization deletion when legacy crm_operations table is absent

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1915,6 +1915,18 @@ async def delete_organization(
             "org_members",
         )
         for table_name in org_scoped_tables:
+            table_exists_result = await session.execute(
+                text("SELECT to_regclass(:table_name)"),
+                {"table_name": f"public.{table_name}"},
+            )
+            if table_exists_result.scalar_one_or_none() is None:
+                logger.warning(
+                    "Skipping delete for missing org-scoped table table=%s org=%s",
+                    table_name,
+                    org_uuid,
+                )
+                continue
+
             await session.execute(
                 text(f"DELETE FROM {table_name} WHERE organization_id = :org_id"),
                 {"org_id": org_uuid},

--- a/backend/tests/test_delete_organization_guest_cleanup.py
+++ b/backend/tests/test_delete_organization_guest_cleanup.py
@@ -33,6 +33,11 @@ class _FakeSession:
 
         sql = str(query)
         self.statements.append((sql, params))
+        if "SELECT to_regclass(:table_name)" in sql:
+            table_name = (params or {}).get("table_name", "")
+            if table_name.endswith("crm_operations"):
+                return _ScalarResult(None)
+            return _ScalarResult(table_name)
         if "DELETE FROM users WHERE organization_id = :org_id AND is_guest IS TRUE" in sql:
             return _ExecResult(rowcount=1)
         if "UPDATE users SET organization_id = NULL WHERE organization_id = :org_id AND is_guest IS NOT TRUE" in sql:
@@ -80,3 +85,5 @@ def test_delete_organization_deletes_guest_users_before_detach(monkeypatch):
     guest_delete_ix = next(i for i, sql in enumerate(sql_statements) if "DELETE FROM users WHERE organization_id = :org_id AND is_guest IS TRUE" in sql)
     detach_ix = next(i for i, sql in enumerate(sql_statements) if "UPDATE users SET organization_id = NULL WHERE organization_id = :org_id AND is_guest IS NOT TRUE" in sql)
     assert guest_delete_ix < detach_ix
+    assert not any("DELETE FROM crm_operations" in sql for sql in sql_statements)
+    assert any("DELETE FROM pending_operations" in sql for sql in sql_statements)


### PR DESCRIPTION
### Motivation
- Organization deletion previously failed with `UndefinedTableError` when a legacy table like `crm_operations` had been renamed/migrated, causing the DELETE loop to crash.
- The change aims to make org-scoped cleanup robust across mixed-schema states so deletion can complete even if some legacy tables are absent.

### Description
- Added a `to_regclass` existence check before issuing each `DELETE` in the org-scoped table cleanup loop and skip the delete if the table is missing while logging a warning.  
- This prevents attempts to delete from non-existent tables such as `crm_operations` while still allowing deletion from migrated tables like `pending_operations`.  
- Extended the unit test to simulate `to_regclass` behavior by returning `None` for `crm_operations` and asserting that `crm_operations` is skipped while `pending_operations` is still deleted.

### Testing
- Ran `pytest -q backend/tests/test_delete_organization_guest_cleanup.py` which passed (`1 passed`) and produced only expected warnings.  
- The updated test verifies the `to_regclass` skip behavior and that org deletion logic still commits and deletes the organization record.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a74d0ce1cc832195286cf2bcd75f25)