### PR TITLE
Chat rename, scope toggle & creator permissions

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -451,6 +451,14 @@ async def update_conversation(
         if not conversation:
             raise HTTPException(status_code=404, detail="Conversation not found")
 
+        # Only the creator can rename shared conversations
+        if request.title is not None and conversation.scope == "shared":
+            if str(conversation.user_id) != str(auth.user_id):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Only the chat creator can rename shared conversations",
+                )
+
         # Update fields
         if request.title is not None:
             conversation.title = request.title
@@ -681,7 +689,7 @@ async def remove_participant(
 
 class UpdateScopeRequest(BaseModel):
     """Request model for updating conversation scope."""
-    scope: str  # Only "shared" is allowed (one-way conversion)
+    scope: str  # "shared" or "private"
 
 
 @router.patch("/conversations/{conversation_id}/scope", response_model=ConversationResponse)
@@ -690,14 +698,14 @@ async def update_scope(
     request: UpdateScopeRequest,
     auth: AuthContext = Depends(get_current_auth),
 ) -> ConversationResponse:
-    """Convert a private conversation to shared (one-way)."""
+    """Toggle conversation scope between private and shared."""
     try:
         conv_uuid = UUID(conversation_id)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid conversation ID format")
 
-    if request.scope != "shared":
-        raise HTTPException(status_code=400, detail="Can only convert to 'shared' scope")
+    if request.scope not in ("shared", "private"):
+        raise HTTPException(status_code=400, detail="Scope must be 'shared' or 'private'")
 
     org_id = auth.organization_id_str
 
@@ -713,12 +721,16 @@ async def update_scope(
         if not conversation:
             raise HTTPException(status_code=404, detail="Conversation not found")
 
-        if conversation.scope == "shared":
-            # Already shared, just return current state
+        # Only the creator can make a shared conversation private
+        if request.scope == "private" and conversation.scope == "shared":
+            if str(conversation.user_id) != str(auth.user_id):
+                raise HTTPException(status_code=403, detail="Only the chat creator can make a shared conversation private")
+
+        if conversation.scope == request.scope:
+            # Already in the requested state, just return current state
             pass
         else:
-            # Convert to shared
-            conversation.scope = "shared"
+            conversation.scope = request.scope
             conversation.updated_at = datetime.utcnow()
 
         # Capture values before commit

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -19,7 +19,7 @@ import { AppTile } from './apps/AppTile';
 import { AppViewer } from './apps/AppViewer';
 import { Avatar } from './Avatar';
 import { PendingApprovalCard, type ApprovalResult } from './PendingApprovalCard';
-import { getConversation, uploadChatFile, type UploadResponse } from '../api/client';
+import { getConversation, updateConversation, uploadChatFile, type UploadResponse } from '../api/client';
 import { crossTab } from '../lib/crossTab';
 import { APP_NAME, LOGO_PATH } from '../lib/brand';
 import {
@@ -119,6 +119,10 @@ export function Chat({
   const [pendingThinking, setPendingThinking] = useState<boolean>(false);
   const [conversationType, setConversationType] = useState<string | null>(null);
   const [conversationScope, setConversationScope] = useState<'private' | 'shared'>('shared');
+  const [conversationCreatorId, setConversationCreatorId] = useState<string | null>(null);
+  const [isEditingHeaderTitle, setIsEditingHeaderTitle] = useState(false);
+  const [headerTitleDraft, setHeaderTitleDraft] = useState('');
+  const headerTitleInputRef = useRef<HTMLInputElement>(null);
   const [conversationParticipants, setConversationParticipants] = useState<Array<{
     id: string;
     name: string | null;
@@ -284,7 +288,9 @@ export function Chat({
       setConversationType(null);
       setIsWorkflowPolling(false);
       setNewConversationScope('shared'); // Default to shared for new conversations
+      setConversationCreatorId(null);
     }
+    setIsEditingHeaderTitle(false);
     // Reset workflow-done flag whenever the conversation changes
     workflowDoneRef.current = false;
     // Only clear pending messages if we're switching to an EXISTING chat
@@ -390,6 +396,7 @@ export function Chat({
           setConversationTitle(chatId, data.title ?? 'New Chat');
           setConversationType(data.type ?? null);
           setConversationScope((data.scope ?? 'shared') as 'private' | 'shared');
+          setConversationCreatorId(data.user_id ?? null);
           setConversationParticipants(
             (data.participants ?? []).map((p: { id: string; name: string | null; email: string; avatar_url?: string | null }) => ({
               id: p.id,
@@ -939,6 +946,36 @@ export function Chat({
     }
   }, [messages]);
 
+  // Check if the current user can rename this conversation
+  const canRenameHeader = chatId && (
+    conversationScope === 'private' || conversationCreatorId === userId
+  );
+
+  const startEditingHeaderTitle = useCallback(() => {
+    if (!canRenameHeader) return;
+    setHeaderTitleDraft(chatTitle);
+    setIsEditingHeaderTitle(true);
+    setTimeout(() => {
+      headerTitleInputRef.current?.focus();
+      headerTitleInputRef.current?.select();
+    }, 0);
+  }, [canRenameHeader, chatTitle]);
+
+  const saveHeaderTitle = useCallback(async () => {
+    setIsEditingHeaderTitle(false);
+    const trimmed = headerTitleDraft.trim();
+    if (!trimmed || !chatId || trimmed === chatTitle) return;
+    setConversationTitle(chatId, trimmed);
+    const { error } = await updateConversation(chatId, trimmed);
+    if (error) {
+      setConversationTitle(chatId, chatTitle);
+    }
+  }, [headerTitleDraft, chatId, chatTitle, setConversationTitle]);
+
+  const cancelEditingHeaderTitle = useCallback(() => {
+    setIsEditingHeaderTitle(false);
+  }, []);
+
   // Convert private conversation to shared
   const handleMakeShared = useCallback(async () => {
     if (!chatId) return;
@@ -972,6 +1009,31 @@ export function Chat({
     }
   }, [chatId]);
 
+  // Convert shared conversation to private (creator only)
+  const handleMakePrivate = useCallback(async () => {
+    if (!chatId) return;
+
+    try {
+      const response = await fetch(`/api/chat/conversations/${chatId}/scope`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scope: 'private' }),
+        credentials: 'include',
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        console.error('Failed to make private:', data.detail);
+        return;
+      }
+
+      setConversationScope('private');
+      setConversationParticipants([]);
+    } catch (err) {
+      console.error('Failed to make private:', err);
+    }
+  }, [chatId]);
+
   if (isLoading) {
     return (
       <div className="flex-1 flex items-center justify-center min-h-0 overflow-hidden">
@@ -988,19 +1050,64 @@ export function Chat({
       {/* Header - hidden on mobile since AppLayout has mobile header */}
       <header className="hidden md:flex h-14 border-b border-surface-800 items-center justify-between px-4 md:px-6 flex-shrink-0">
         <div className="flex items-center gap-3 min-w-0">
-          <h1 className="text-lg font-semibold text-surface-100 truncate max-w-[200px] md:max-w-md">
-            {chatTitle}
-          </h1>
-          {/* Scope badge */}
-          {chatId && (
-            <span className={`px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide rounded ${
-              conversationScope === 'shared' 
-                ? 'bg-primary-500/20 text-primary-400' 
-                : 'bg-surface-700 text-surface-400'
-            }`}>
-              {conversationScope}
-            </span>
+          {isEditingHeaderTitle ? (
+            <input
+              ref={headerTitleInputRef}
+              type="text"
+              value={headerTitleDraft}
+              onChange={(e) => setHeaderTitleDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void saveHeaderTitle();
+                if (e.key === 'Escape') cancelEditingHeaderTitle();
+              }}
+              onBlur={() => void saveHeaderTitle()}
+              className="text-lg font-semibold text-surface-100 bg-transparent border-b border-primary-500 outline-none max-w-[200px] md:max-w-md"
+              maxLength={100}
+            />
+          ) : (
+            <div
+              className={`flex items-center gap-1.5 group/title min-w-0 ${canRenameHeader ? 'cursor-pointer' : ''}`}
+              onClick={canRenameHeader ? startEditingHeaderTitle : undefined}
+              title={canRenameHeader ? 'Click to rename' : undefined}
+            >
+              <h1 className="text-lg font-semibold text-surface-100 truncate max-w-[200px] md:max-w-md">
+                {chatTitle}
+              </h1>
+              {canRenameHeader && (
+                <svg className="w-3.5 h-3.5 text-surface-500 opacity-0 group-hover/title:opacity-100 transition-opacity flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                </svg>
+              )}
+            </div>
           )}
+          {/* Scope badge / toggle */}
+          {chatId && (() => {
+            const canToggleScope = conversationScope === 'private' || conversationCreatorId === userId;
+            if (canToggleScope) {
+              return (
+                <button
+                  onClick={() => void (conversationScope === 'private' ? handleMakeShared() : handleMakePrivate())}
+                  className={`px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide rounded transition-colors cursor-pointer ${
+                    conversationScope === 'shared'
+                      ? 'bg-primary-500/20 text-primary-400 hover:bg-primary-500/30'
+                      : 'bg-surface-700 text-surface-400 hover:bg-surface-600'
+                  }`}
+                  title={conversationScope === 'shared' ? 'Click to make private' : 'Click to share with team'}
+                >
+                  {conversationScope}
+                </button>
+              );
+            }
+            return (
+              <span className={`px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide rounded ${
+                conversationScope === 'shared'
+                  ? 'bg-primary-500/20 text-primary-400'
+                  : 'bg-surface-700 text-surface-400'
+              }`}>
+                {conversationScope}
+              </span>
+            );
+          })()}
           {/* Uncommitted changes indicator */}
           {hasUncommittedChanges && (
             <span 
@@ -1034,19 +1141,6 @@ export function Chat({
           )}
         </div>
         <div className="flex items-center gap-3">
-          {/* Make Shared button for private conversations */}
-          {conversationScope === 'private' && chatId && (
-            <button
-              onClick={() => void handleMakeShared()}
-              className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-surface-300 hover:text-surface-100 bg-surface-800 hover:bg-surface-700 rounded-lg transition-colors"
-              title="Convert to shared conversation so teammates can participate"
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-              </svg>
-              Make Shared
-            </button>
-          )}
           {/* Participant avatars for shared conversations */}
           {conversationScope === 'shared' && conversationParticipants.length > 0 && (
             <div className="flex items-center gap-2">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -11,9 +11,10 @@
  * - Profile section
  */
 
-import { useMemo, useState, useRef, useEffect } from 'react';
+import { useMemo, useState, useRef, useEffect, useCallback } from 'react';
 import type { View, ChatSummary, OrganizationInfo } from './AppLayout';
 import { useAppStore, useIsGlobalAdmin, useActiveTasksByConversation, type UserOrganization } from '../store';
+import { updateConversation } from '../api/client';
 import { Avatar } from './Avatar';
 import { APP_NAME, LOGO_PATH } from '../lib/brand';
 
@@ -394,6 +395,7 @@ export function Sidebar({
         currentChatId={currentChatId}
         activeTasksByConversation={activeTasksByConversation}
         pinnedChatIds={pinnedChatIds}
+        currentUserId={user?.id ?? null}
         onSelectChat={onSelectChat}
         onDeleteChat={onDeleteChat}
         togglePinChat={togglePinChat}
@@ -455,6 +457,7 @@ function ChatAccordion({
   currentChatId,
   activeTasksByConversation,
   pinnedChatIds,
+  currentUserId,
   onSelectChat,
   onDeleteChat,
   togglePinChat,
@@ -464,21 +467,63 @@ function ChatAccordion({
   currentChatId: string | null;
   activeTasksByConversation: Record<string, string>;
   pinnedChatIds: string[];
+  currentUserId: string | null;
   onSelectChat: (id: string) => void;
   onDeleteChat: (id: string) => void;
   togglePinChat: (id: string) => void;
 }): JSX.Element | null {
   const [expandedSection, setExpandedSection] = useState<'shared' | 'private'>('shared');
-  
+  const [editingChatId, setEditingChatId] = useState<string | null>(null);
+  const [editingTitle, setEditingTitle] = useState('');
+  const editInputRef = useRef<HTMLInputElement>(null);
+  const setConversationTitle = useAppStore((s) => s.setConversationTitle);
+
+  const canRename = useCallback((chat: ChatSummary): boolean => {
+    if (chat.scope === 'private') return true;
+    return chat.userId === currentUserId;
+  }, [currentUserId]);
+
+  const startEditing = useCallback((chat: ChatSummary) => {
+    if (!canRename(chat)) return;
+    setEditingChatId(chat.id);
+    setEditingTitle(chat.title);
+  }, [canRename]);
+
+  const saveTitle = useCallback(async (chatId: string) => {
+    const trimmed = editingTitle.trim();
+    setEditingChatId(null);
+    if (!trimmed || trimmed === orderedChats.find(c => c.id === chatId)?.title) return;
+    setConversationTitle(chatId, trimmed);
+    const { error } = await updateConversation(chatId, trimmed);
+    if (error) {
+      const original = orderedChats.find(c => c.id === chatId)?.title ?? 'New Chat';
+      setConversationTitle(chatId, original);
+    }
+  }, [editingTitle, orderedChats, setConversationTitle]);
+
+  const cancelEditing = useCallback(() => {
+    setEditingChatId(null);
+  }, []);
+
+  // Auto-focus and select-all when entering edit mode
+  useEffect(() => {
+    if (editingChatId && editInputRef.current) {
+      editInputRef.current.focus();
+      editInputRef.current.select();
+    }
+  }, [editingChatId]);
+
   if (collapsed) return null;
-  
+
   const sharedChats = orderedChats.filter(c => c.scope === 'shared').slice(0, 20);
   const privateChats = orderedChats.filter(c => c.scope === 'private').slice(0, 20);
-  
+
   const renderChatItem = (chat: ChatSummary, showLockIcon: boolean) => {
     const hasActiveTask = chat.id in activeTasksByConversation;
     const isPinned = pinnedChatIds.includes(chat.id);
-    
+    const isEditing = editingChatId === chat.id;
+    const isRenamable = canRename(chat);
+
     return (
       <div
         key={chat.id}
@@ -487,9 +532,9 @@ function ChatAccordion({
             ? 'bg-surface-800 text-surface-100'
             : 'text-surface-400 hover:text-surface-200 hover:bg-surface-800/50'
         }`}
-        onClick={() => onSelectChat(chat.id)}
+        onClick={() => { if (!isEditing) onSelectChat(chat.id); }}
       >
-        <div className="flex items-center gap-1.5 pr-10">
+        <div className="flex items-center gap-1.5 pr-14">
           {showLockIcon && (
             <svg className="w-3 h-3 text-surface-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
@@ -500,7 +545,29 @@ function ChatAccordion({
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
             </svg>
           )}
-          <div className="truncate text-sm flex-1">{chat.title}</div>
+          {isEditing ? (
+            <input
+              ref={editInputRef}
+              type="text"
+              value={editingTitle}
+              onChange={(e) => setEditingTitle(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void saveTitle(chat.id);
+                if (e.key === 'Escape') cancelEditing();
+              }}
+              onBlur={() => void saveTitle(chat.id)}
+              onClick={(e) => e.stopPropagation()}
+              className="truncate text-sm flex-1 bg-transparent border-b border-primary-500 outline-none text-surface-100 py-0 px-0"
+              maxLength={100}
+            />
+          ) : (
+            <div
+              className="truncate text-sm flex-1"
+              onDoubleClick={(e) => { e.stopPropagation(); startEditing(chat); }}
+            >
+              {chat.title}
+            </div>
+          )}
           {hasActiveTask && (
             <svg className="w-3 h-3 text-primary-400 flex-shrink-0 animate-spin" fill="none" viewBox="0 0 24 24">
               <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
@@ -534,6 +601,21 @@ function ChatAccordion({
             {formatRelativeTime(chat.lastMessageAt)}
           </span>
         </div>
+        {/* Rename button */}
+        {isRenamable && !isEditing && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              startEditing(chat);
+            }}
+            className="absolute right-12 top-1/2 -translate-y-1/2 p-1 rounded opacity-0 group-hover:opacity-100 hover:bg-surface-700 text-surface-500 hover:text-surface-300 transition-all"
+            title="Rename conversation"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+          </button>
+        )}
         <button
           onClick={(e) => {
             e.stopPropagation();

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -111,6 +111,7 @@ export interface ChatSummary {
   type?: "agent" | "workflow"; // 'agent' for interactive, 'workflow' for automated
   workflowId?: string; // ID of the workflow that triggered this conversation
   scope: "private" | "shared";
+  userId?: string; // Creator's user ID
   participants?: Participant[];
 }
 
@@ -763,6 +764,7 @@ export const useAppStore = create<AppState>()(
           type ConversationApiResponse = {
             conversations: Array<{
               id: string;
+              user_id?: string;
               title: string | null;
               updated_at: string;
               last_message_preview: string | null;
@@ -809,6 +811,7 @@ export const useAppStore = create<AppState>()(
             type: (conv.type ?? "agent") as "agent" | "workflow",
             workflowId: conv.workflow_id,
             scope: (conv.scope ?? "shared") as "private" | "shared",
+            userId: conv.user_id,
             participants: conv.participants?.map((p) => ({
               id: p.id,
               name: p.name,
@@ -1140,7 +1143,7 @@ export const useAppStore = create<AppState>()(
       },
 
       setConversationTitle: (conversationId, title) => {
-        const { conversations } = get();
+        const { conversations, recentChats } = get();
         const current = conversations[conversationId] ?? {
           ...defaultConversationState,
         };
@@ -1149,6 +1152,9 @@ export const useAppStore = create<AppState>()(
             ...conversations,
             [conversationId]: { ...current, title },
           },
+          recentChats: recentChats.map((c) =>
+            c.id === conversationId ? { ...c, title } : c,
+          ),
         });
       },
 


### PR DESCRIPTION
## Summary
- **Inline rename**: Double-click chat title in sidebar or click title in header to rename. Pencil icon appears on hover for discoverability.
- **Creator permissions**: Only the chat creator can rename shared conversations (enforced both frontend and backend with 403). Non-creators see no rename affordance.
- **Bidirectional scope toggle**: Clickable scope badge in header toggles between shared/private. Creator-only for shared→private; anyone can share their private chat.
- **Store fix**: `setConversationTitle` now updates both per-conversation state and `recentChats` so sidebar reflects renames immediately.

## Test plan
- [ ] Double-click a chat title in sidebar → input appears → rename → Enter saves → persists after reload
- [ ] Click title in chat header → same rename flow
- [ ] In a shared chat as non-creator: no pencil icon, double-click/click does nothing
- [ ] Click scope badge to toggle private↔shared; verify tooltips explain the action
- [ ] As non-creator on shared chat: badge is static (not clickable)
- [ ] Backend: `PATCH /conversations/{id}` returns 403 for non-creator rename on shared chat
- [ ] Backend: `PATCH /conversations/{id}/scope` accepts `"private"` for creator

🤖 Generated with [Claude Code](https://claude.com/claude-code)