### PR TITLE
Add GIN index on conversations.participating_user_ids

### DIFF
--- a/backend/db/migrations/versions/089_gin_index_participating_user_ids.py
+++ b/backend/db/migrations/versions/089_gin_index_participating_user_ids.py
@@ -1,0 +1,35 @@
+"""Add GIN index on conversations.participating_user_ids for fast array lookups.
+
+Revision ID: 089_gin_index_participating_user_ids
+Revises: 088_add_org_company_summary
+Create Date: 2026-03-03
+
+Array containment checks (ANY) on participating_user_ids cause sequential scans
+on every chat list request. A GIN index enables indexed array lookups.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "089_gin_index_participating_user_ids"
+down_revision: Union[str, None] = "088_add_org_company_summary"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_conversations_participating_user_ids_gin",
+        "conversations",
+        ["participating_user_ids"],
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_conversations_participating_user_ids_gin",
+        table_name="conversations",
+    )


### PR DESCRIPTION
## Summary
- **Problem**: Every chat list / sidebar request runs an array containment check (`ANY`) on `conversations.participating_user_ids` (a `ARRAY(UUID)` column). Without an index, PostgreSQL performs a sequential scan on the entire conversations table for each request.
- **Fix**: Add a GIN index on the `participating_user_ids` column. GIN indexes are purpose-built for indexing composite values like arrays, enabling PostgreSQL to use indexed lookups for array containment operators.
- **Impact**: Faster sidebar and chat list loading for all users, especially as the conversations table grows.

## Changes
- New Alembic migration `089_gin_index_participating_user_ids` that creates a GIN index `ix_conversations_participating_user_ids_gin` on `conversations.participating_user_ids`.

## Test plan
- [ ] Run `alembic upgrade head` and verify the migration applies cleanly
- [ ] Confirm the index exists: `\di ix_conversations_participating_user_ids_gin` in psql
- [ ] Run `EXPLAIN ANALYZE` on a chat list query to verify the GIN index is used instead of a sequential scan
- [ ] Run `alembic downgrade -1` and verify the rollback drops the index cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)