### PR TITLE
Fix chat rename not working for WebSocket-loaded conversations

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -345,6 +345,8 @@ export function Chat({
     // Use ref to avoid re-running effect when pendingMessages changes
     if (pendingMessagesRef.current.length > 0) {
       console.log('[Chat] Skipping load - have pending messages to move');
+      // New conversation created by this user — set creator to self
+      setConversationCreatorId(userId ?? null);
       setIsLoading(false);
       return;
     }
@@ -354,6 +356,12 @@ export function Chat({
     const existingState = useAppStore.getState().conversations[chatId];
     if (existingState && existingState.messages.length > 0) {
       console.log('[Chat] Using existing state for conversation:', chatId);
+      // Still set conversation metadata from recentChats (skipping API fetch skips this otherwise)
+      const chatInfo = useAppStore.getState().recentChats.find(c => c.id === chatId);
+      if (chatInfo) {
+        setConversationScope(chatInfo.scope);
+        setConversationCreatorId(chatInfo.userId ?? null);
+      }
       setIsLoading(false);
       return;
     }


### PR DESCRIPTION
## Summary
- Chat rename (click title to edit) was broken: showed I-beam cursor but clicking did nothing
- Root cause: when messages were already in the Zustand store (loaded via WebSocket), the `getConversation()` API fetch was skipped, so `conversationCreatorId` was never set
- `canRenameHeader` evaluated to `false` for shared conversations, meaning no click handler was attached
- Fix: populate conversation metadata (scope, creatorId) from `recentChats` in both early-return paths

## Test plan
- [ ] Open a shared chat you created → click the title → should enter edit mode
- [ ] Open a private chat → click the title → should enter edit mode
- [ ] Open a shared chat someone else created → title should NOT be editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)