### PR TITLE
Add auto-generated conversation summaries

### DIFF
--- a/backend/services/conversation_summary.py
+++ b/backend/services/conversation_summary.py
@@ -1,0 +1,157 @@
+"""
+Async AI-generated conversation summaries.
+
+Generates two-section summaries ("Overall" and "Recent Updates") using
+Claude Haiku. Summaries are stored as JSON in the existing Conversation.summary
+Text column and delivered to clients via WebSocket broadcast.
+
+This is a non-critical background task — all errors are caught and logged,
+never raised.
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+
+from anthropic import AsyncAnthropic
+
+from config import settings
+from models.conversation import Conversation
+from models.chat_message import ChatMessage as ChatMessageModel
+from models.database import get_session
+from sqlalchemy import select, update
+
+logger = logging.getLogger(__name__)
+
+_MIN_MESSAGES_FOR_SUMMARY = 4
+_REGENERATION_THRESHOLD = 2
+_MAX_MESSAGES_FOR_PROMPT = 50
+
+_MODEL = "claude-3-5-haiku-20241022"
+
+_SYSTEM_PROMPT = (
+    "You summarize conversations between a user and an AI assistant called Penny. "
+    "Return ONLY valid JSON with two keys:\n"
+    '- "overall": A 1-2 sentence summary of the entire conversation so far.\n'
+    '- "recent": A 1-2 sentence summary of the most recent exchange(s).\n'
+    "Be concise and informative. No markdown, no extra keys."
+)
+
+
+def _should_regenerate(
+    current_message_count: int,
+    existing_summary: str | None,
+) -> bool:
+    """Check whether we should (re)generate the summary."""
+    if current_message_count < _MIN_MESSAGES_FOR_SUMMARY:
+        return False
+
+    if not existing_summary:
+        return True
+
+    try:
+        parsed = json.loads(existing_summary)
+        last_count = parsed.get("message_count_at_generation", 0)
+    except (json.JSONDecodeError, TypeError):
+        return True
+
+    return (current_message_count - last_count) >= _REGENERATION_THRESHOLD
+
+
+def _format_messages(messages: list[ChatMessageModel]) -> str:
+    """Format messages into a compact text representation for the prompt."""
+    lines: list[str] = []
+    for msg in messages:
+        role = msg.role.upper()
+        parts: list[str] = []
+        for block in msg.content_blocks or []:
+            if isinstance(block, dict):
+                if block.get("type") == "text":
+                    text = str(block.get("text", ""))
+                    if len(text) > 500:
+                        text = text[:500] + "..."
+                    parts.append(text)
+                elif block.get("type") == "tool_use":
+                    parts.append(f"[Tool call: {block.get('name', 'unknown')}]")
+        if parts:
+            lines.append(f"{role}: {' '.join(parts)}")
+    return "\n".join(lines)
+
+
+async def generate_conversation_summary(
+    conversation_id: str,
+    organization_id: str,
+) -> dict | None:
+    """
+    Generate (or regenerate) an AI summary for a conversation.
+
+    Returns the parsed summary dict on success, None if skipped or on failure.
+    """
+    try:
+        async with get_session(organization_id=organization_id) as session:
+            conv = await session.get(Conversation, conversation_id)
+            if not conv:
+                logger.warning("Summary: conversation %s not found", conversation_id)
+                return None
+
+            if not _should_regenerate(conv.message_count, conv.summary):
+                return None
+
+            # Load recent messages
+            result = await session.execute(
+                select(ChatMessageModel)
+                .where(ChatMessageModel.conversation_id == conv.id)
+                .order_by(ChatMessageModel.created_at.desc())
+                .limit(_MAX_MESSAGES_FOR_PROMPT)
+            )
+            messages = list(reversed(result.scalars().all()))
+
+            if len(messages) < _MIN_MESSAGES_FOR_SUMMARY:
+                return None
+
+            current_count = conv.message_count
+
+        # Build prompt
+        formatted = _format_messages(messages)
+        user_prompt = f"Summarize this conversation:\n\n{formatted}"
+
+        # Call Claude Haiku
+        client = AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
+        response = await client.messages.create(
+            model=_MODEL,
+            max_tokens=300,
+            system=_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": user_prompt}],
+        )
+
+        # Parse response
+        raw_text = response.content[0].text if response.content else ""
+        parsed = json.loads(raw_text)
+
+        summary_data = {
+            "overall": parsed.get("overall", ""),
+            "recent": parsed.get("recent", ""),
+            "message_count_at_generation": current_count,
+            "updated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+
+        # Persist to DB
+        summary_json = json.dumps(summary_data)
+        async with get_session(organization_id=organization_id) as session:
+            await session.execute(
+                update(Conversation)
+                .where(Conversation.id == conversation_id)
+                .values(summary=summary_json)
+            )
+            await session.commit()
+
+        logger.info(
+            "Summary generated for conversation %s (msg_count=%d)",
+            conversation_id,
+            current_count,
+        )
+        return summary_data
+
+    except Exception:
+        logger.exception("Failed to generate summary for conversation %s", conversation_id)
+        return None

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -272,7 +272,12 @@ class TaskManager:
             })
             
             logger.info("Task %s completed successfully", task_id)
-            
+
+            # Fire-and-forget: generate conversation summary in background
+            asyncio.create_task(
+                self._generate_and_broadcast_summary(conversation_id, organization_id)
+            )
+
         except asyncio.CancelledError:
             logger.info("Task %s was cancelled", task_id)
             await self._complete_task(task_id, "cancelled")
@@ -346,6 +351,33 @@ class TaskManager:
             )
             await session.commit()
     
+    async def _generate_and_broadcast_summary(
+        self,
+        conversation_id: str,
+        organization_id: str,
+    ) -> None:
+        """Fire-and-forget: generate summary and broadcast via WebSocket."""
+        try:
+            from services.conversation_summary import generate_conversation_summary
+            from api.websockets import sync_broadcaster
+
+            summary = await generate_conversation_summary(conversation_id, organization_id)
+            if summary:
+                await sync_broadcaster.broadcast(
+                    organization_id,
+                    "summary_updated",
+                    {
+                        "conversation_id": conversation_id,
+                        "summary": summary,
+                    },
+                )
+        except Exception:
+            logger.warning(
+                "Background summary generation failed for conversation %s",
+                conversation_id,
+                exc_info=True,
+            )
+
     async def _broadcast(self, task_id: str, message: dict[str, Any]) -> None:
         """Broadcast a message to all WebSockets subscribed to a task."""
         async with self._lock:

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -132,7 +132,13 @@ interface WsNewMessage {
   sender_user_id: string;
 }
 
-type WsMessage = WsActiveTasks | WsTaskStarted | WsTaskChunk | WsTaskComplete | WsConversationCreated | WsCatchup | WsCrmApprovalResult | WsToolApprovalResult | WsToolProgress | WsError | WsNewMessage;
+interface WsSummaryUpdated {
+  type: 'summary_updated';
+  conversation_id: string;
+  summary: { overall: string; recent: string; message_count_at_generation: number; updated_at: string };
+}
+
+type WsMessage = WsActiveTasks | WsTaskStarted | WsTaskChunk | WsTaskComplete | WsConversationCreated | WsCatchup | WsCrmApprovalResult | WsToolApprovalResult | WsToolProgress | WsError | WsNewMessage | WsSummaryUpdated;
 
 // Props
 interface AppLayoutProps {
@@ -412,6 +418,7 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
       'crm_approval_result',
       'tool_approval_result',
       'new_message',
+      'summary_updated',
     ].includes(type);
   }, []);
 
@@ -865,6 +872,14 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
               senderEmail: message.sender_email ?? undefined,
             };
             addConversationMessage(conversation_id, chatMessage);
+          }
+          break;
+        }
+
+        case 'summary_updated': {
+          const { conversation_id, summary } = parsed;
+          if (conversation_id && summary) {
+            useAppStore.getState().setConversationSummary(conversation_id, summary);
           }
           break;
         }

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -28,6 +28,7 @@ import {
   useConnectedIntegrations,
   type AppBlock,
   type ChatMessage,
+  type ConversationSummaryData,
   type Integration,
   type ToolCallData,
   type ToolUseBlock,
@@ -79,6 +80,48 @@ interface ToolApprovalState {
   result: WsToolApprovalResult | null;
 }
 
+function SummaryCard({ summary }: { summary: ConversationSummaryData }): JSX.Element {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="mx-auto max-w-3xl mb-3">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full text-left rounded-lg border border-surface-700 bg-surface-850 px-4 py-3 transition-colors hover:bg-surface-800"
+      >
+        <div className="flex items-center gap-2">
+          <svg className="w-4 h-4 text-primary-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+          </svg>
+          <span className="text-sm font-medium text-surface-300">Conversation Summary</span>
+          <svg
+            className={`w-4 h-4 text-surface-400 ml-auto transition-transform ${expanded ? 'rotate-180' : ''}`}
+            fill="none" viewBox="0 0 24 24" stroke="currentColor"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </div>
+        {!expanded && (
+          <p className="mt-1 text-sm text-surface-400 truncate">{summary.overall}</p>
+        )}
+      </button>
+      {expanded && (
+        <div className="mt-0 rounded-b-lg border border-t-0 border-surface-700 bg-surface-850 px-4 py-3 space-y-3">
+          <div>
+            <h4 className="text-xs font-semibold uppercase tracking-wider text-surface-400 mb-1">Overall</h4>
+            <p className="text-sm text-surface-200">{summary.overall}</p>
+          </div>
+          <div>
+            <h4 className="text-xs font-semibold uppercase tracking-wider text-surface-400 mb-1">Recent Updates</h4>
+            <p className="text-sm text-surface-200">{summary.recent}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function Chat({
   userId,
   organizationId: _organizationId,
@@ -100,6 +143,7 @@ export function Chat({
   const addConversationMessage = useAppStore((s) => s.addConversationMessage);
   const setConversationMessages = useAppStore((s) => s.setConversationMessages);
   const setConversationTitle = useAppStore((s) => s.setConversationTitle);
+  const setConversationSummary = useAppStore((s) => s.setConversationSummary);
   const setConversationThinking = useAppStore((s) => s.setConversationThinking);
   const pendingChatInput = useAppStore((s) => s.pendingChatInput);
   const setPendingChatInput = useAppStore((s) => s.setPendingChatInput);
@@ -388,6 +432,14 @@ export function Chat({
           // Set conversation state
           setConversationMessages(chatId, loadedMessages);
           setConversationTitle(chatId, data.title ?? 'New Chat');
+          if (data.summary) {
+            try {
+              const parsed = JSON.parse(data.summary) as ConversationSummaryData;
+              setConversationSummary(chatId, parsed);
+            } catch {
+              // Invalid summary JSON, ignore
+            }
+          }
           setConversationType(data.type ?? null);
           setConversationScope((data.scope ?? 'shared') as 'private' | 'shared');
           setConversationParticipants(
@@ -433,7 +485,7 @@ export function Chat({
       loadInFlightChatIdRef.current = null; // Allow re-run to start load (e.g. Strict Mode)
       setIsLoading(false);
     };
-  }, [chatId, userId, setConversationMessages, setConversationTitle, onConversationNotFound]);
+  }, [chatId, userId, setConversationMessages, setConversationTitle, setConversationSummary, onConversationNotFound]);
 
   // Keep messagesRef in sync for polling comparison (avoids stale closure)
   useEffect(() => {
@@ -1091,6 +1143,7 @@ export function Chat({
         {/* Messages */}
         <div className={`relative md:transition-all md:duration-300 md:ease-in-out ${currentArtifact || currentApp ? 'md:w-1/2' : ''} flex-1`}>
           <div ref={messagesContainerRef} className="absolute inset-0 overflow-y-auto overflow-x-hidden p-3 md:p-6">
+          {conversationState?.summary && <SummaryCard summary={conversationState.summary} />}
           {!userId && (
             <div className="mb-3 rounded-lg border border-amber-600/50 bg-amber-900/20 px-3 py-2 text-sm text-amber-200">
               User context is missing — artifacts and apps may not save correctly. Please refresh or re-sign in.

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -210,6 +210,13 @@ export interface PendingChunk {
 }
 
 // Per-conversation state
+export interface ConversationSummaryData {
+  overall: string;
+  recent: string;
+  message_count_at_generation: number;
+  updated_at: string;
+}
+
 export interface ConversationState {
   messages: ChatMessage[];
   title: string;
@@ -218,6 +225,7 @@ export interface ConversationState {
   activeTaskId: string | null;
   lastChunkIndex: number;
   pendingChunks: PendingChunk[]; // Buffer for out-of-order chunks
+  summary: ConversationSummaryData | null;
 }
 
 // Task state from backend
@@ -348,6 +356,7 @@ interface AppState {
   ) => void;
   markConversationMessageComplete: (conversationId: string) => void;
   setConversationTitle: (conversationId: string, title: string) => void;
+  setConversationSummary: (conversationId: string, summary: ConversationSummaryData) => void;
   setConversationThinking: (conversationId: string, thinking: boolean) => void;
   setConversationActiveTask: (
     conversationId: string,
@@ -400,6 +409,7 @@ const defaultConversationState: ConversationState = {
   activeTaskId: null,
   lastChunkIndex: -1, // -1 means no chunks received yet, first chunk should be 0
   pendingChunks: [],
+  summary: null,
 };
 
 // =============================================================================
@@ -1148,6 +1158,19 @@ export const useAppStore = create<AppState>()(
           conversations: {
             ...conversations,
             [conversationId]: { ...current, title },
+          },
+        });
+      },
+
+      setConversationSummary: (conversationId, summary) => {
+        const { conversations } = get();
+        const current = conversations[conversationId] ?? {
+          ...defaultConversationState,
+        };
+        set({
+          conversations: {
+            ...conversations,
+            [conversationId]: { ...current, summary },
           },
         });
       },


### PR DESCRIPTION
## Summary
- Adds background AI-generated conversation summaries using Claude Haiku (~1-2s, ~$0.0025/call)
- Two sections: "Overall" and "Recent Updates", displayed as a collapsible card at the top of each chat
- Summaries regenerate after every 2+ new messages (one full exchange), skipping conversations with < 4 messages
- Delivered in real-time via WebSocket broadcast; also loaded from API on conversation open
- Zero latency impact on chat — runs as fire-and-forget `asyncio.create_task` after task completion

## Files changed
| File | Change |
|------|--------|
| `backend/services/conversation_summary.py` | **New** — summary generation service |
| `backend/services/task_manager.py` | Hook `asyncio.create_task` after task completion |
| `frontend/src/store/index.ts` | `ConversationSummaryData` type + `setConversationSummary` action |
| `frontend/src/components/AppLayout.tsx` | `summary_updated` WS handler + cross-tab broadcast |
| `frontend/src/components/Chat.tsx` | Parse summary on load + collapsible `SummaryCard` component |

## Test plan
- [ ] Send 2+ exchanges in a chat — summary appears after ~2s via WebSocket
- [ ] Refresh page — summary loads from API response
- [ ] Open same chat in second tab — summary syncs via BroadcastChannel
- [ ] Short conversations (< 4 messages) — no summary generated
- [ ] Backend errors — logged, chat continues to work normally
- [ ] `cd frontend && npx tsc --noEmit` — zero errors
- [ ] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)