### PR TITLE
Refresh organization right panel when switching orgs

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1260,6 +1260,7 @@ export function AppLayout({ onLogout }: AppLayoutProps): JSX.Element {
       {/* Organization Panel */}
       {showOrgPanel && (
         <OrganizationPanel
+          key={`org-panel-${organization.id}`}
           organization={organization}
           currentUser={user}
           initialTab={orgPanelTab}

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -133,6 +133,13 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
 
   const [expandedMemberId, setExpandedMemberId] = useState<string | null>(null);
 
+  useEffect(() => {
+    setOrgName(organization.name);
+    setLogoUrl(organization.logoUrl);
+    setSettingsSaved(false);
+    setExpandedMemberId(null);
+  }, [organization.id, organization.name, organization.logoUrl]);
+
   // React Query: Fetch team members with automatic caching and refetch
   const { 
     data: teamData,


### PR DESCRIPTION
### Motivation
- When the user switches the active organization while the Organization panel is open, the panel could show stale data for the previous org instead of immediately reflecting the new org.
- Remounting the panel or resetting its local state on org change ensures users always see the current org's settings and members.

### Description
- Force a remount of `OrganizationPanel` by adding a `key={`org-panel-${organization.id}`}` in `AppLayout.tsx` so the panel re-initializes when the active organization changes.
- Reset org-scoped local state in `OrganizationPanel.tsx` by adding a `useEffect` that updates `orgName`, `logoUrl`, `settingsSaved`, and `expandedMemberId` when `organization.id`, `organization.name`, or `organization.logoUrl` change.
- Modified files: `frontend/src/components/AppLayout.tsx` and `frontend/src/components/OrganizationPanel.tsx`.

### Testing
- Ran the frontend production build with `npm run -C frontend build`, which completed successfully (Vite emitted non-fatal chunk-size/import warnings but the build succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8844ddd5c832189e689576aeb4491)