### PR TITLE
Remove workspace auto-join helper text from company setup

### DIFF
--- a/frontend/src/components/CompanySetup.tsx
+++ b/frontend/src/components/CompanySetup.tsx
@@ -137,9 +137,6 @@ export function CompanySetup({ emailDomain, onComplete, onBack }: CompanySetupPr
             </button>
           </form>
 
-          <p className="text-center text-surface-500 text-xs mt-6">
-            Your teammates from @{emailDomain} will automatically join this workspace
-          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Remove misleading UI copy that indicated teammates with the same email domain would automatically join the workspace.

### Description
- Deleted the footer paragraph in `frontend/src/components/CompanySetup.tsx` that rendered "Your teammates from @{emailDomain} will automatically join this workspace".

### Testing
- Built the frontend with `npm run build` and the build completed successfully.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and it started successfully.
- Captured a Playwright screenshot of the company setup page to visually verify the change; the screenshot artifact was generated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a886eace4883218de94f5590590ec8)