### PR TITLE
Use canonical hosted logo URL in org invitation email

### DIFF
--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -422,7 +422,7 @@ async def send_org_invitation_email(
           <tr>
             <td style="padding:36px 32px 12px;text-align:center;">
               <img
-                src="{settings.FRONTEND_URL.rstrip("/")}/basebase_logo-256.png"
+                src="https://www.basebase.com/basebase_logo-512.png"
                 alt="Basebase"
                 width="52"
                 height="52"


### PR DESCRIPTION
### Motivation
- Ensure invitation emails render the correct logo by replacing the frontend-relative image path with a canonical, hosted absolute URL so email clients don't depend on `FRONTEND_URL`.

### Description
- In `send_org_invitation_email` (`backend/services/email.py`) replaced `"{settings.FRONTEND_URL.rstrip("/")}/basebase_logo-256.png"` with `"https://www.basebase.com/basebase_logo-512.png"` in the email HTML template.

### Testing
- Ran `python -m compileall backend/services/email.py` and it compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a889bce5388321a731946361ce26cd)