### PR TITLE
Replace 'Beta' with 'Alpha' in UI and add test to block 'beta' strings

### DIFF
--- a/backend/api/routes/waitlist.py
+++ b/backend/api/routes/waitlist.py
@@ -1,5 +1,5 @@
 """
-Waitlist routes for managing early access signups.
+Waitlist routes for managing Alpha signups.
 
 Endpoints:
 - POST /api/waitlist - Submit waitlist form

--- a/backend/tests/test_no_beta_public_strings.py
+++ b/backend/tests/test_no_beta_public_strings.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+PUBLIC_SOURCE_DIRS = (
+    Path("frontend/src"),
+    Path("backend/api"),
+    Path("backend/services"),
+)
+ALLOWED_SUFFIXES = {".py", ".ts", ".tsx", ".js", ".jsx", ".md"}
+BETA_WORD_RE = re.compile(r"\bbeta\b", re.IGNORECASE)
+
+
+def test_no_beta_word_in_public_source_strings() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    violations: list[str] = []
+
+    for relative_dir in PUBLIC_SOURCE_DIRS:
+        source_dir = repo_root / relative_dir
+        if not source_dir.exists():
+            continue
+
+        for path in sorted(source_dir.rglob("*")):
+            if not path.is_file() or path.suffix not in ALLOWED_SUFFIXES:
+                continue
+            if path.name.endswith(".test.ts") or path.name.endswith(".test.tsx"):
+                continue
+
+            for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+                if BETA_WORD_RE.search(line):
+                    rel_path = path.relative_to(repo_root)
+                    violations.append(f"{rel_path}:{line_number}: {line.strip()}")
+
+    assert not violations, "Found disallowed 'beta' usage in public source:\n" + "\n".join(violations)

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -275,7 +275,7 @@ export function Sidebar({
               </div>
               <span className="font-semibold text-surface-100">{APP_NAME}</span>
               <span className="px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-primary-500/20 text-primary-400 rounded">
-                Beta
+                Alpha
               </span>
             </div>
             {isMobile ? (


### PR DESCRIPTION
### Motivation

- Update public-facing language from "Beta" to "Alpha" to reflect the current release stage.
- Prevent accidental reintroduction of the term "beta" in public source files by adding an automated check.

### Description

- Changed the sidebar badge text from `Beta` to `Alpha` in `frontend/src/components/Sidebar.tsx`.
- Updated the waitlist module docstring to reference "Alpha signups" in `backend/api/routes/waitlist.py`.
- Added a new test `backend/tests/test_no_beta_public_strings.py` that scans `frontend/src`, `backend/api`, and `backend/services` for the word "beta" (case-insensitive) in public source file types and fails on any occurrences.

### Testing

- Ran the test suite with `pytest`, and the new `test_no_beta_public_strings.py` passed.
- Existing automated tests were run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a88dd958ac8321b783e10b5e58b4fc)