### PR TITLE
Reset view to Home when switching organizations

### DIFF
--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -541,6 +541,7 @@ export const useAppStore = create<AppState>()(
             data.organization.handle ??
             organizations.find((o) => o.id === orgId)?.handle ??
             null;
+          console.log("[Store] Resetting view to home for switched organization");
           set({
             organization: {
               id: data.organization.id,
@@ -552,8 +553,11 @@ export const useAppStore = create<AppState>()(
               ...o,
               isActive: o.id === orgId,
             })),
+            currentView: "home",
             // Clear org-scoped state when switching
             currentChatId: null,
+            currentAppId: null,
+            currentArtifactId: null,
             recentChats: [],
             conversations: {},
             activeTasksByConversation: {},


### PR DESCRIPTION
### Motivation
- Ensure that when the active organization is changed we land on the new org's Home view and avoid carrying over stale deep-link/app/artifact context from the previous org.

### Description
- Update `switchActiveOrganization` in `frontend/src/store/index.ts` to set `currentView` to `"home"` when an organization is switched and to clear `currentAppId` and `currentArtifactId` so deep-linked state does not persist across orgs.
- Add an explicit debug log `"[Store] Resetting view to home for switched organization"` to make the navigation reset visible in logs.

### Testing
- Ran lint in `frontend/` with `npm run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a89780b7f08321b04de2e5ba1791a4)