### PR TITLE
Improve Penny websocket throughput under load

### DIFF
--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -26,6 +26,9 @@ from uuid import UUID, uuid4
 from fastapi import WebSocket, WebSocketDisconnect
 
 
+WEBSOCKET_SEND_TIMEOUT_SECONDS = 0.75
+
+
 # =============================================================================
 # Sync Progress Broadcasting
 # =============================================================================
@@ -68,13 +71,24 @@ class SyncProgressBroadcaster:
             **data,
         })
         
-        # Send to all, collect any dead connections
-        dead: Set[WebSocket] = set()
-        for ws in websockets:
-            try:
-                await ws.send_text(message)
-            except Exception:
-                dead.add(ws)
+        # Send concurrently so one stalled client cannot block org-wide updates.
+        async def _send_with_timeout(ws: WebSocket) -> None:
+            await asyncio.wait_for(
+                ws.send_text(message),
+                timeout=WEBSOCKET_SEND_TIMEOUT_SECONDS,
+            )
+
+        send_tasks = [asyncio.create_task(_send_with_timeout(ws)) for ws in websockets]
+        send_results = await asyncio.gather(*send_tasks, return_exceptions=True)
+        dead: Set[WebSocket] = {
+            ws for ws, result in zip(websockets, send_results) if isinstance(result, Exception)
+        }
+        if dead:
+            logger.warning(
+                "[sync_broadcaster] Removing %d dead/stalled websocket(s) for org=%s",
+                len(dead),
+                organization_id,
+            )
         
         # Clean up dead connections
         for ws in dead:
@@ -192,20 +206,40 @@ class ConversationBroadcaster:
         })
         
         dead_connections: list[tuple[str, WebSocket]] = []
+        send_jobs: list[tuple[str, WebSocket, asyncio.Task[None]]] = []
+
+        async def _send_with_timeout(ws: WebSocket) -> None:
+            await asyncio.wait_for(
+                ws.send_text(message),
+                timeout=WEBSOCKET_SEND_TIMEOUT_SECONDS,
+            )
+
         for user_id in user_ids:
             if exclude_user_id and user_id == exclude_user_id:
                 continue
             
             websockets = self._user_connections.get(user_id, set())
             for ws in websockets:
-                try:
-                    await ws.send_text(message)
-                except Exception:
+                send_jobs.append((user_id, ws, asyncio.create_task(_send_with_timeout(ws))))
+
+        if send_jobs:
+            send_results = await asyncio.gather(
+                *[task for _, _, task in send_jobs],
+                return_exceptions=True,
+            )
+            for (user_id, ws, _), result in zip(send_jobs, send_results):
+                if isinstance(result, Exception):
                     dead_connections.append((user_id, ws))
-        
+
         # Clean up dead connections
         for user_id, ws in dead_connections:
             self._user_connections[user_id].discard(ws)
+
+        if dead_connections:
+            logger.warning(
+                "[conversation_broadcaster] Removed %d dead/stalled websocket(s)",
+                len(dead_connections),
+            )
 
 
 # Global conversation broadcaster instance

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -26,6 +26,10 @@ from models.database import get_session
 logger = logging.getLogger(__name__)
 
 
+# Prevent one stalled socket from slowing every Penny chunk broadcast.
+WEBSOCKET_SEND_TIMEOUT_SECONDS = 0.75
+
+
 # Type alias for broadcast callback
 BroadcastCallback = Callable[[str], Coroutine[Any, Any, None]]
 
@@ -388,19 +392,35 @@ class TaskManager:
         
         message_str = json.dumps(message)
         dead_sockets: list[WebSocket] = []
-        
-        for ws in subscribers:
-            try:
-                await ws.send_text(message_str)
-            except Exception:
-                # WebSocket is dead, mark for removal
+
+        async def _send_with_timeout(ws: WebSocket) -> None:
+            await asyncio.wait_for(
+                ws.send_text(message_str),
+                timeout=WEBSOCKET_SEND_TIMEOUT_SECONDS,
+            )
+
+        send_tasks = [asyncio.create_task(_send_with_timeout(ws)) for ws in subscribers]
+        send_results = await asyncio.gather(*send_tasks, return_exceptions=True)
+
+        for ws, result in zip(subscribers, send_results):
+            if isinstance(result, Exception):
                 dead_sockets.append(ws)
+                logger.warning(
+                    "WebSocket send failed for task=%s; removing subscriber (error=%s)",
+                    task_id,
+                    result,
+                )
         
         # Clean up dead sockets
         if dead_sockets:
             async with self._lock:
                 for ws in dead_sockets:
                     self._subscriptions.get(task_id, set()).discard(ws)
+            logger.info(
+                "Removed %d dead/stalled websocket subscriber(s) for task=%s",
+                len(dead_sockets),
+                task_id,
+            )
     
     async def subscribe(self, task_id: str, websocket: WebSocket) -> None:
         """

--- a/backend/tests/test_websocket_broadcast_load.py
+++ b/backend/tests/test_websocket_broadcast_load.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+from api.websockets import (
+    ConversationBroadcaster,
+    SyncProgressBroadcaster,
+    WEBSOCKET_SEND_TIMEOUT_SECONDS as API_WS_TIMEOUT,
+)
+from services.task_manager import TaskManager, WEBSOCKET_SEND_TIMEOUT_SECONDS as TASK_WS_TIMEOUT
+
+
+class _FakeWebSocket:
+    def __init__(self, *, delay_seconds: float = 0.0, should_fail: bool = False) -> None:
+        self.delay_seconds = delay_seconds
+        self.should_fail = should_fail
+        self.messages: list[str] = []
+
+    async def send_text(self, message: str) -> None:
+        if self.delay_seconds > 0:
+            await asyncio.sleep(self.delay_seconds)
+        if self.should_fail:
+            raise RuntimeError("socket send failed")
+        self.messages.append(message)
+
+
+def test_sync_broadcaster_timeout_isolation_under_load() -> None:
+    async def _run() -> None:
+        broadcaster = SyncProgressBroadcaster()
+        fast_ws = _FakeWebSocket()
+        slow_ws = _FakeWebSocket(delay_seconds=5.0)
+
+        broadcaster.register("org-1", fast_ws)
+        broadcaster.register("org-1", slow_ws)
+
+        started = time.perf_counter()
+        await broadcaster.broadcast("org-1", "sync_progress", {"count": 1})
+        elapsed = time.perf_counter() - started
+
+        assert elapsed < API_WS_TIMEOUT + 0.7
+        assert len(fast_ws.messages) == 1
+        assert slow_ws not in broadcaster._connections["org-1"]
+
+    asyncio.run(_run())
+
+
+def test_conversation_broadcaster_timeout_isolation_under_load() -> None:
+    async def _run() -> None:
+        broadcaster = ConversationBroadcaster()
+        fast_ws = _FakeWebSocket()
+        slow_ws = _FakeWebSocket(delay_seconds=5.0)
+
+        broadcaster.register("user-1", fast_ws)
+        broadcaster.register("user-2", slow_ws)
+
+        started = time.perf_counter()
+        await broadcaster.broadcast_to_users(
+            user_ids=["user-1", "user-2"],
+            event_type="new_message",
+            data={"conversation_id": "c1", "message": {"text": "hello"}},
+        )
+        elapsed = time.perf_counter() - started
+
+        assert elapsed < API_WS_TIMEOUT + 0.7
+        assert len(fast_ws.messages) == 1
+        assert slow_ws not in broadcaster._user_connections["user-2"]
+
+    asyncio.run(_run())
+
+
+def test_task_manager_broadcast_timeout_isolation_under_load() -> None:
+    async def _run() -> None:
+        manager = TaskManager()
+        fast_ws = _FakeWebSocket()
+        slow_ws = _FakeWebSocket(delay_seconds=5.0)
+
+        async with manager._lock:
+            manager._subscriptions["task-1"] = {fast_ws, slow_ws}  # type: ignore[assignment]
+
+        started = time.perf_counter()
+        await manager._broadcast("task-1", {"type": "task_chunk", "chunk": {"index": 0}})
+        elapsed = time.perf_counter() - started
+
+        assert elapsed < TASK_WS_TIMEOUT + 0.7
+        assert len(fast_ws.messages) == 1
+
+        async with manager._lock:
+            assert slow_ws not in manager._subscriptions["task-1"]
+
+    asyncio.run(_run())


### PR DESCRIPTION
### Motivation
- Websocket fanout was serialized per-connection which allowed one slow or stalled client to delay every Penny update in a fanout path. 
- The intent is to reduce tail latency for streaming chunks and org-wide events so interactive assistant responses remain responsive under load.

### Description
- Change broadcasting to send concurrently with per-socket timeouts by adding `WEBSOCKET_SEND_TIMEOUT_SECONDS = 0.75` and using `asyncio.create_task` + `asyncio.gather` for fanout in `backend/api/websockets.py` and `backend/services/task_manager.py`.
- Add timeout-protected send helpers and treat send failures/timeouts as dead/stalled sockets, removing them from internal subscription sets and emitting warnings/info logs.
- Preserve previous semantics of delivering messages first (for TaskManager chunk streaming) while isolating slow clients from blocking others.
- Add regression tests `backend/tests/test_websocket_broadcast_load.py` that simulate slow sockets and assert broadcasts remain bounded by the configured timeout and that stalled sockets are removed.

### Testing
- Ran the new regression suite with `cd backend && pytest -q tests/test_websocket_broadcast_load.py` and all tests passed (`3 passed`).
- The new tests verify: sync broadcaster, conversation broadcaster, and TaskManager broadcast complete within the timeout bound and that slow sockets are removed as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9f204ac388321b4b87022482608b8)