### PR TITLE
Fix websocket fanout serialization bottlenecks

### DIFF
--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -25,6 +25,42 @@ from uuid import UUID, uuid4
 
 from fastapi import WebSocket, WebSocketDisconnect
 
+logger = logging.getLogger(__name__)
+
+
+FANOUT_SEND_TIMEOUT_SECONDS = 1.5
+
+
+async def _send_with_timeout(websocket: WebSocket, message: str) -> bool:
+    """Send a message to one websocket with timeout protection."""
+    try:
+        await asyncio.wait_for(
+            websocket.send_text(message),
+            timeout=FANOUT_SEND_TIMEOUT_SECONDS,
+        )
+        return True
+    except Exception:
+        return False
+
+
+async def _fanout_message(websockets: Set[WebSocket], message: str) -> Set[WebSocket]:
+    """Fan out a message concurrently and return websockets that failed."""
+    if not websockets:
+        return set()
+
+    send_tasks = [
+        asyncio.create_task(_send_with_timeout(ws, message))
+        for ws in websockets
+    ]
+    results = await asyncio.gather(*send_tasks, return_exceptions=True)
+
+    dead: Set[WebSocket] = set()
+    for ws, result in zip(websockets, results, strict=False):
+        if isinstance(result, Exception) or result is not True:
+            dead.add(ws)
+
+    return dead
+
 
 # =============================================================================
 # Sync Progress Broadcasting
@@ -68,13 +104,14 @@ class SyncProgressBroadcaster:
             **data,
         })
         
-        # Send to all, collect any dead connections
-        dead: Set[WebSocket] = set()
-        for ws in websockets:
-            try:
-                await ws.send_text(message)
-            except Exception:
-                dead.add(ws)
+        # Send to all concurrently so one stalled client can't block fanout.
+        dead = await _fanout_message(websockets, message)
+        if dead:
+            logger.debug(
+                "sync fanout removed %s stale websocket(s) for organization %s",
+                len(dead),
+                organization_id,
+            )
         
         # Clean up dead connections
         for ws in dead:
@@ -197,11 +234,14 @@ class ConversationBroadcaster:
                 continue
             
             websockets = self._user_connections.get(user_id, set())
-            for ws in websockets:
-                try:
-                    await ws.send_text(message)
-                except Exception:
-                    dead_connections.append((user_id, ws))
+            dead_for_user = await _fanout_message(websockets, message)
+            dead_connections.extend((user_id, ws) for ws in dead_for_user)
+            if dead_for_user:
+                logger.debug(
+                    "conversation fanout removed %s stale websocket(s) for user %s",
+                    len(dead_for_user),
+                    user_id,
+                )
         
         # Clean up dead connections
         for user_id, ws in dead_connections:

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -26,6 +26,9 @@ from models.database import get_admin_session, get_session
 logger = logging.getLogger(__name__)
 
 
+FANOUT_SEND_TIMEOUT_SECONDS = 1.5
+
+
 # Type alias for broadcast callback
 BroadcastCallback = Callable[[str], Coroutine[Any, Any, None]]
 
@@ -387,22 +390,34 @@ class TaskManager:
         """Broadcast a message to all WebSockets subscribed to a task."""
         async with self._lock:
             subscribers = self._subscriptions.get(task_id, set()).copy()
-        
+
         if not subscribers:
             return
-        
+
         message_str = json.dumps(message)
-        dead_sockets: list[WebSocket] = []
-        
-        for ws in subscribers:
-            try:
-                await ws.send_text(message_str)
-            except Exception:
-                # WebSocket is dead, mark for removal
-                dead_sockets.append(ws)
-        
+        send_tasks = [
+            asyncio.create_task(
+                asyncio.wait_for(
+                    ws.send_text(message_str),
+                    timeout=FANOUT_SEND_TIMEOUT_SECONDS,
+                )
+            )
+            for ws in subscribers
+        ]
+        results = await asyncio.gather(*send_tasks, return_exceptions=True)
+        dead_sockets = [
+            ws
+            for ws, result in zip(subscribers, results, strict=False)
+            if isinstance(result, Exception)
+        ]
+
         # Clean up dead sockets
         if dead_sockets:
+            logger.debug(
+                "Removed %s stale websocket subscription(s) for task %s",
+                len(dead_sockets),
+                task_id,
+            )
             async with self._lock:
                 for ws in dead_sockets:
                     self._subscriptions.get(task_id, set()).discard(ws)

--- a/backend/tests/test_websocket_fanout.py
+++ b/backend/tests/test_websocket_fanout.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import asyncio
+import time
+
+from api import websockets
+from services.task_manager import TaskManager
+
+
+class _FakeSocket:
+    def __init__(self, delay_seconds: float = 0.0, should_fail: bool = False) -> None:
+        self.delay_seconds = delay_seconds
+        self.should_fail = should_fail
+        self.messages: list[str] = []
+
+    async def send_text(self, message: str) -> None:
+        if self.delay_seconds:
+            await asyncio.sleep(self.delay_seconds)
+        if self.should_fail:
+            raise RuntimeError("socket closed")
+        self.messages.append(message)
+
+
+def test_fanout_message_sends_concurrently() -> None:
+    fast = _FakeSocket()
+    slow = _FakeSocket(delay_seconds=0.2)
+
+    start = time.perf_counter()
+    dead = asyncio.run(websockets._fanout_message({fast, slow}, '{"ok": true}'))
+    elapsed = time.perf_counter() - start
+
+    assert dead == set()
+    assert len(fast.messages) == 1
+    assert len(slow.messages) == 1
+    assert elapsed < 0.35
+
+
+def test_task_manager_broadcast_does_not_block_on_stalled_socket() -> None:
+    manager = TaskManager()
+    task_id = "task-for-fanout-test"
+    fast = _FakeSocket()
+    stalled = _FakeSocket(delay_seconds=5.0)
+
+    async def _run() -> float:
+        async with manager._lock:
+            manager._subscriptions[task_id] = {fast, stalled}  # noqa: SLF001
+
+        start = time.perf_counter()
+        await manager._broadcast(task_id, {"event": "tick"})  # noqa: SLF001
+        elapsed_inner = time.perf_counter() - start
+
+        async with manager._lock:
+            remaining = manager._subscriptions[task_id]  # noqa: SLF001
+
+        assert fast in remaining
+        assert stalled not in remaining
+        return elapsed_inner
+
+    elapsed = asyncio.run(_run())
+    assert elapsed < 2.2
+    assert len(fast.messages) == 1


### PR DESCRIPTION
### Motivation
- Under load broadcasts were serialized via sequential `await ws.send_text(...)` loops so a single slow or stalled client could delay all fanout paths and cause UI/perf issues.

### Description
- Added `FANOUT_SEND_TIMEOUT_SECONDS` and helper functions ` _send_with_timeout` and `_fanout_message` to perform concurrent, timeout-guarded sends to websockets.
- Replaced serial `send_text` loops in `SyncProgressBroadcaster.broadcast` and `ConversationBroadcaster.broadcast_to_users` with concurrent fanout via `_fanout_message` and debug logging when stale sockets are pruned.
- Updated `TaskManager._broadcast` to send to task subscribers concurrently using `asyncio.create_task` + `asyncio.wait_for` and remove/log dead sockets on failure.
- Added regression tests `backend/tests/test_websocket_fanout.py` that verify concurrent fanout timing and that a stalled socket does not block task broadcasts.

### Testing
- Ran the new regression tests with `cd backend && pytest -q tests/test_websocket_fanout.py` and they passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9f9b12f6883219feaa0270f387157)