### PR TITLE
Invited user experience: personalized auth, onboarding, email redesign, team UI

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1264,6 +1264,7 @@ async def get_organization_members(
                 for m in user_mappings
             ]
             membership: OrgMember | None = membership_by_user.get(u.id)
+            member_status: str = membership.status if membership else (u.status or "active")
             members.append(
                 TeamMemberResponse(
                     id=str(u.id),
@@ -1272,7 +1273,7 @@ async def get_organization_members(
                     role=membership.role if membership else "member",
                     avatar_url=u.avatar_url,
                     job_title=membership.title if membership else None,
-                    status=u.status,
+                    status=member_status,
                     is_guest=u.is_guest,
                     can_login_as_admin=(
                         bool(membership and membership.role == "admin")
@@ -1630,9 +1631,24 @@ async def invite_to_organization(
                     detail="User is already a member of this organization",
                 )
             if existing_membership.status == "invited":
-                raise HTTPException(
-                    status_code=409,
-                    detail="User has already been invited to this organization",
+                existing_membership.invited_by_user_id = inviter_uuid
+                existing_membership.invited_at = datetime.utcnow()
+                await session.commit()
+                membership_id_str = str(existing_membership.id)
+                inviter_name = inviter.name or inviter.email
+                background_tasks.add_task(
+                    send_org_invitation_email,
+                    invite_email,
+                    org.name,
+                    inviter_name,
+                    org_logo_url=org.logo_url,
+                    inviter_avatar_url=inviter.avatar_url,
+                )
+                return InviteToOrgResponse(
+                    membership_id=membership_id_str,
+                    user_id=str(target_user.id),
+                    email=invite_email,
+                    status="invited",
                 )
             # Re-invite a deactivated member
             existing_membership.status = "invited"
@@ -1661,6 +1677,8 @@ async def invite_to_organization(
             invite_email,
             org.name,
             inviter_name,
+            org_logo_url=org.logo_url,
+            inviter_avatar_url=inviter.avatar_url,
         )
 
         return InviteToOrgResponse(

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -301,53 +301,77 @@ async def send_invitation_email(to_email: str, name: str) -> bool:
         return False
 
     html_content = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    </head>
-    <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-        <div style="text-align: center; margin-bottom: 30px;">
-            <div style="display: inline-block; width: 48px; height: 48px; background: linear-gradient(135deg, #6366f1, #4f46e5); border-radius: 12px; margin-bottom: 16px;"></div>
-            <h1 style="margin: 0; font-size: 24px; color: #111;">You're In!</h1>
-        </div>
-        
-        <p>Hey {name},</p>
-        
-        <p>Great news — you're off the waitlist! Your spot at Basebase is ready.</p>
-        
-        <p>Basebase connects your CRM, Slack, email, and calendar so you can chat with your revenue data and build automations that save your team hours every week.</p>
-        
-        <div style="text-align: center; margin: 30px 0;">
-            <a href="{settings.FRONTEND_URL}" style="display: inline-block; background: linear-gradient(135deg, #6366f1, #4f46e5); color: white; text-decoration: none; padding: 14px 28px; border-radius: 8px; font-weight: 600;">Sign In to Get Started</a>
-        </div>
-        
-        <p>Questions? Just reply to this email.</p>
-        
-        <p>— The Basebase Team</p>
-        
-        <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
-        
-        <p style="font-size: 12px; color: #666;">
-            You received this email because you signed up for the Basebase waitlist.
-        </p>
-    </body>
-    </html>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>You're off the waitlist!</title>
+</head>
+<body style="margin:0;padding:0;background:#f8f9fa;color:#1a1a1a;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f8f9fa;padding:32px 12px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;background:#ffffff;border:1px solid #e5e7eb;border-radius:16px;overflow:hidden;">
+          <tr>
+            <td style="padding:40px 36px 0;text-align:center;">
+              <img
+                src="https://www.basebase.com/basebase_logo-512.png"
+                alt="Basebase"
+                width="48"
+                height="48"
+                style="display:inline-block;height:48px;width:48px;border-radius:12px;"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 36px 0;text-align:center;">
+              <h1 style="margin:0 0 12px;font-size:24px;line-height:1.3;color:#111;font-weight:700;">You&apos;re in, {name}!</h1>
+              <p style="margin:0;color:#6b7280;font-size:15px;line-height:1.6;">Your spot at Basebase is ready. Sign in and get your team AI-powered in 10 minutes.</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:28px 36px 0;text-align:center;">
+              <a href="{settings.FRONTEND_URL}" style="display:inline-block;background:#FF9F1C;color:#111111;text-decoration:none;font-size:16px;font-weight:600;padding:14px 32px;border-radius:10px;">Sign in to get started</a>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:32px 36px 0;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f9fafb;border:1px solid #f3f4f6;border-radius:10px;">
+                <tr>
+                  <td style="padding:20px 24px;">
+                    <p style="margin:0 0 12px;font-size:14px;font-weight:600;color:#111;">One AI for your whole team</p>
+                    <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.6;">Connect your CRM, Slack, email, and calendar &mdash; then ask Penny anything right from Slack. When one person learns something, the whole team benefits.</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:28px 36px;text-align:center;">
+              <p style="margin:0;color:#9ca3af;font-size:12px;line-height:1.6;">You received this email because you signed up for the Basebase waitlist.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
     """
 
     text_content = f"""
 Hey {name},
 
-Great news — you're off the waitlist! Your spot at Basebase is ready.
+Your spot at Basebase is ready. Sign in and get your team AI-powered in 10 minutes.
 
-Basebase connects your CRM, Slack, email, and calendar so you can chat with your revenue data and build automations that save your team hours every week.
+One AI for your whole team -- connect your CRM, Slack, email, and calendar, then ask Penny anything right from Slack. When one person learns something, the whole team benefits.
 
 Sign in to get started: {settings.FRONTEND_URL}
 
 Questions? Just reply to this email.
 
-— The Basebase Team
+-- The Basebase Team
 """
 
     async with httpx.AsyncClient() as client:
@@ -384,6 +408,8 @@ async def send_org_invitation_email(
     to_email: str,
     org_name: str,
     invited_by_name: Optional[str] = None,
+    org_logo_url: Optional[str] = None,
+    inviter_avatar_url: Optional[str] = None,
 ) -> bool:
     """
     Send an invitation email to join an organization.
@@ -392,13 +418,26 @@ async def send_org_invitation_email(
         to_email: Recipient email address
         org_name: Name of the organization they're being invited to
         invited_by_name: Name of the person who sent the invite
+        org_logo_url: URL of the organization's logo (passed to frontend via query params)
+        inviter_avatar_url: URL of the inviter's avatar (passed to frontend via query params)
 
     Returns:
         True if email sent successfully, False otherwise
     """
+    from urllib.parse import quote
+
     if not settings.RESEND_API_KEY:
         print(f"[Email] RESEND_API_KEY not set, skipping org invite to {to_email}")
         return False
+
+    params: list[str] = [f"invite=1", f"org_name={quote(org_name)}"]
+    if org_logo_url:
+        params.append(f"org_logo={quote(org_logo_url)}")
+    if invited_by_name:
+        params.append(f"inviter_name={quote(invited_by_name)}")
+    if inviter_avatar_url:
+        params.append(f"inviter_avatar={quote(inviter_avatar_url)}")
+    invite_url: str = f"{settings.FRONTEND_URL}?{'&'.join(params)}"
 
     inviter_line: str = (
         f"{invited_by_name} has invited you to join <strong>{org_name}</strong> on Basebase."
@@ -412,49 +451,51 @@ async def send_org_invitation_email(
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>You're invited to Basebase</title>
+  <title>You're invited to {org_name} on Basebase</title>
 </head>
-<body style="margin:0;padding:0;background:#0b0f1a;color:#e5e7eb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
-  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#0b0f1a;padding:24px 12px;">
+<body style="margin:0;padding:0;background:#f8f9fa;color:#1a1a1a;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+  <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f8f9fa;padding:32px 12px;">
     <tr>
       <td align="center">
-        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:640px;background:linear-gradient(160deg,#111827,#0f172a);border:1px solid #1f2937;border-radius:20px;overflow:hidden;">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:560px;background:#ffffff;border:1px solid #e5e7eb;border-radius:16px;overflow:hidden;">
           <tr>
-            <td style="padding:36px 32px 12px;text-align:center;">
+            <td style="padding:40px 36px 0;text-align:center;">
               <img
                 src="https://www.basebase.com/basebase_logo-512.png"
                 alt="Basebase"
-                width="52"
-                height="52"
-                style="display:inline-block;height:52px;width:52px;border-radius:14px;"
+                width="48"
+                height="48"
+                style="display:inline-block;height:48px;width:48px;border-radius:12px;"
               />
-              <h1 style="margin:18px 0 8px;font-size:30px;line-height:1.2;color:#f8fafc;font-weight:700;">You're invited</h1>
-              <p style="margin:0;color:#94a3b8;font-size:15px;line-height:1.6;">{inviter_line}</p>
             </td>
           </tr>
           <tr>
-            <td style="padding:20px 32px 0;">
-              <div style="background:#0b1222;border:1px solid #1e293b;border-radius:14px;padding:18px;">
-                <p style="margin:0 0 8px;color:#cbd5e1;font-size:14px;line-height:1.5;">Invitation sent to:</p>
-                <p style="margin:0;color:#f8fafc;font-size:16px;line-height:1.5;font-weight:600;">{to_email}</p>
-                <p style="margin:10px 0 0;color:#94a3b8;font-size:13px;line-height:1.6;">Organization: <strong style="color:#f8fafc;">{org_name}</strong></p>
-              </div>
+            <td style="padding:24px 36px 0;text-align:center;">
+              <h1 style="margin:0 0 12px;font-size:24px;line-height:1.3;color:#111;font-weight:700;">Join {org_name} on Basebase</h1>
+              <p style="margin:0;color:#6b7280;font-size:15px;line-height:1.6;">{inviter_line}</p>
             </td>
           </tr>
           <tr>
-            <td style="padding:28px 32px 8px;text-align:center;">
-              <a href="{settings.FRONTEND_URL}" style="display:inline-block;background:linear-gradient(135deg,#6366f1,#4f46e5);color:#ffffff;text-decoration:none;font-size:16px;font-weight:700;padding:14px 28px;border-radius:12px;">Accept invitation</a>
+            <td style="padding:28px 36px 0;text-align:center;">
+              <a href="{invite_url}" style="display:inline-block;background:#FF9F1C;color:#111111;text-decoration:none;font-size:16px;font-weight:600;padding:14px 32px;border-radius:10px;">Accept invitation</a>
             </td>
           </tr>
           <tr>
-            <td style="padding:8px 32px 30px;text-align:center;">
-              <p style="margin:0;color:#64748b;font-size:13px;line-height:1.6;">If the button doesn&apos;t work, copy and paste this link into your browser:</p>
-              <p style="margin:8px 0 0;color:#94a3b8;font-size:12px;line-height:1.6;word-break:break-all;">{settings.FRONTEND_URL}</p>
+            <td style="padding:32px 36px 0;">
+              <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background:#f9fafb;border:1px solid #f3f4f6;border-radius:10px;">
+                <tr>
+                  <td style="padding:20px 24px;">
+                    <p style="margin:0 0 12px;font-size:14px;font-weight:600;color:#111;">One AI for your whole team</p>
+                    <p style="margin:0 0 6px;color:#6b7280;font-size:13px;line-height:1.6;">See what&apos;s happening across every tool. Know what matters most. Act on it &mdash; right from Slack.</p>
+                    <p style="margin:10px 0 0;color:#6b7280;font-size:13px;line-height:1.6;">When one person learns something, the whole team benefits. Shared context. Shared memory. Shared momentum.</p>
+                  </td>
+                </tr>
+              </table>
             </td>
           </tr>
           <tr>
-            <td style="padding:20px 32px;border-top:1px solid #1f2937;background:#0b1222;">
-              <p style="margin:0;color:#64748b;font-size:12px;line-height:1.6;">You received this email because someone invited you to {org_name} on Basebase. If this wasn&apos;t expected, you can safely ignore this message.</p>
+            <td style="padding:28px 36px;text-align:center;">
+              <p style="margin:0;color:#9ca3af;font-size:12px;line-height:1.6;">You received this email because someone invited you to {org_name} on Basebase.<br/>If this wasn&apos;t expected, you can safely ignore it.</p>
             </td>
           </tr>
         </table>
@@ -474,13 +515,15 @@ async def send_org_invitation_email(
     text_content: str = f"""
 {inviter_text}
 
-Basebase connects your CRM, Slack, email, and calendar so you can chat with your revenue data and build automations.
+Join {org_name} on Basebase -- one AI for your whole team.
 
-Accept the invitation: {settings.FRONTEND_URL}
+See what's happening across every tool. Know what matters most. Act on it -- right from Slack. When one person learns something, the whole team benefits.
+
+Accept the invitation: {invite_url}
 
 Questions? Just reply to this email.
 
-— The Basebase Team
+-- The Basebase Team
 """
 
     async with httpx.AsyncClient() as client:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -247,7 +247,7 @@ function App(): JSX.Element {
         // Waitlist status is no longer used - all users are auto-activated
 
         // If sync returned an organization (e.g. invited user who auto-activated),
-        // set it and go directly to app (orgs are auto-enrolled in free tier)
+        // set it and go to app — or to onboarding in invited mode if they came via invite link
         if (userData.organization) {
           const org = userData.organization as { id: string; name: string; logo_url: string | null; handle?: string | null };
           setOrganization({
@@ -257,6 +257,12 @@ function App(): JSX.Element {
             handle: org.handle ?? null,
           });
           await fetchUserOrganizations();
+          if (localStorage.getItem('invite_mode') === '1') {
+            localStorage.setItem('onboarding_invited', '1');
+            localStorage.removeItem('invite_mode');
+            setScreen('onboarding-wizard');
+            return;
+          }
           setScreen('app');
           return;
         }

--- a/frontend/src/components/Auth.tsx
+++ b/frontend/src/components/Auth.tsx
@@ -10,6 +10,26 @@ import { validateGoodPassword } from '../lib/password';
 import { API_BASE } from '../lib/api';
 import { APP_NAME, LOGO_PATH } from '../lib/brand';
 
+interface InviteContext {
+  orgName: string;
+  orgLogo: string | null;
+  inviterName: string | null;
+  inviterAvatar: string | null;
+}
+
+function parseInviteParams(): InviteContext | null {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('invite') !== '1') return null;
+  const orgName: string | null = params.get('org_name');
+  if (!orgName) return null;
+  return {
+    orgName,
+    orgLogo: params.get('org_logo') || null,
+    inviterName: params.get('inviter_name') || null,
+    inviterAvatar: params.get('inviter_avatar') || null,
+  };
+}
+
 interface AuthProps {
   onBack: () => void;
   onSuccess: () => void;
@@ -25,6 +45,14 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
+  const [inviteContext] = useState<InviteContext | null>(() => parseInviteParams());
+
+  // Persist invite_mode so post-auth flow can detect it
+  useEffect(() => {
+    if (inviteContext) {
+      localStorage.setItem('invite_mode', '1');
+    }
+  }, [inviteContext]);
 
   // Check if this is a password reset callback
   useEffect(() => {
@@ -153,23 +181,61 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
           Back to home
         </button>
 
+        {/* Invite banner */}
+        {inviteContext && (mode === 'signin' || mode === 'signup') && (
+          <div className="mb-6 p-5 rounded-2xl bg-surface-900/80 backdrop-blur-sm border border-surface-800">
+            <div className="flex flex-col items-center gap-3 text-center">
+              {inviteContext.inviterAvatar ? (
+                <img
+                  src={inviteContext.inviterAvatar}
+                  alt={inviteContext.inviterName ?? 'Inviter'}
+                  className="w-12 h-12 rounded-full ring-2 ring-primary-500/30"
+                />
+              ) : inviteContext.inviterName ? (
+                <div className="w-12 h-12 rounded-full bg-primary-500/20 flex items-center justify-center text-primary-300 text-lg font-semibold">
+                  {inviteContext.inviterName.charAt(0).toUpperCase()}
+                </div>
+              ) : null}
+              <p className="text-surface-300 text-sm leading-relaxed">
+                {inviteContext.inviterName ? (
+                  <><span className="text-surface-100 font-medium">{inviteContext.inviterName}</span> invited you to join</>
+                ) : (
+                  <>You've been invited to join</>
+                )}
+              </p>
+              <div className="flex items-center gap-2.5">
+                {inviteContext.orgLogo && (
+                  <img
+                    src={inviteContext.orgLogo}
+                    alt={inviteContext.orgName}
+                    className="w-8 h-8 rounded-lg object-cover"
+                  />
+                )}
+                <span className="text-xl font-bold text-surface-50">{inviteContext.orgName}</span>
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* Logo */}
         <div className="text-center mb-8">
-          <div className="inline-flex items-center gap-3 mb-4">
-            <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-surface-800">
-              <img src={LOGO_PATH} alt={APP_NAME} className="w-8 h-8" />
+          {!inviteContext && (
+            <div className="inline-flex items-center gap-3 mb-4">
+              <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-surface-800">
+                <img src={LOGO_PATH} alt={APP_NAME} className="w-8 h-8" />
+              </div>
+              <span className="text-2xl font-bold text-surface-50">{APP_NAME}</span>
             </div>
-            <span className="text-2xl font-bold text-surface-50">{APP_NAME}</span>
-          </div>
+          )}
           <h1 className="text-2xl font-bold text-surface-50">
-            {mode === 'signin' && 'Welcome back'}
-            {mode === 'signup' && 'Create your account'}
+            {mode === 'signin' && (inviteContext ? `Join ${inviteContext.orgName}` : 'Welcome back')}
+            {mode === 'signup' && (inviteContext ? `Join ${inviteContext.orgName}` : 'Create your account')}
             {mode === 'forgot' && 'Reset your password'}
             {mode === 'reset' && 'Set new password'}
           </h1>
           <p className="text-surface-400 mt-2">
-            {mode === 'signin' && 'Sign in to access your revenue insights'}
-            {mode === 'signup' && 'Start your free trial today'}
+            {mode === 'signin' && (inviteContext ? 'Sign in to accept your invitation' : 'Sign in to access your revenue insights')}
+            {mode === 'signup' && (inviteContext ? 'Create an account to accept your invitation' : 'Start your free trial today')}
             {mode === 'forgot' && "Enter your email and we'll send you a reset link"}
             {mode === 'reset' && 'Choose a new password for your account'}
           </p>

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -14,7 +14,17 @@ import { supabase } from '../lib/supabase';
 import { useAppStore, useIntegrations } from '../store';
 import { useIsMobile } from '../hooks';
 
-const TOTAL_STEPS = 6;
+const TOTAL_STEPS_NORMAL = 6;
+const TOTAL_STEPS_INVITED = 5;
+
+interface TeamMember {
+  id: string;
+  name: string | null;
+  email: string;
+  avatar_url: string | null;
+  role: string | null;
+  status: string | null;
+}
 
 interface OnboardingWizardProps {
   emailDomain: string;
@@ -82,9 +92,14 @@ const SKIP_MESSAGES: Record<number, string> = {
 };
 
 export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBack }: OnboardingWizardProps): JSX.Element {
+  const [isInvitedMode] = useState<boolean>(() => localStorage.getItem('onboarding_invited') === '1');
+  const TOTAL_STEPS: number = isInvitedMode ? TOTAL_STEPS_INVITED : TOTAL_STEPS_NORMAL;
+
   const onComplete = (): void => {
     localStorage.removeItem('onboarding_incomplete');
     localStorage.removeItem('onboarding_step');
+    localStorage.removeItem('onboarding_invited');
+    localStorage.removeItem('invite_mode');
     rawOnComplete();
   };
   const [step, setStep] = useState<number>(() => {
@@ -102,6 +117,7 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
   const [invitedEmails, setInvitedEmails] = useState<ReadonlyArray<string>>([]);
   const [companySummary, setCompanySummary] = useState<string | null>(null);
   const [companySummaryLoading, setCompanySummaryLoading] = useState<boolean>(false);
+  const [teamMembers, setTeamMembers] = useState<ReadonlyArray<TeamMember>>([]);
 
   const { user, organization, setOrganization, syncUserToBackend, fetchUserOrganizations, fetchIntegrations } =
     useAppStore();
@@ -116,14 +132,40 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
     localStorage.setItem('onboarding_step', String(step));
   }, [step]);
 
+  // Fetch team members for invited mode step 1
   useEffect(() => {
-    if (orgId && userId && step >= 2) {
-      void fetchIntegrations();
-    }
-  }, [orgId, userId, step, fetchIntegrations]);
+    if (!isInvitedMode || !orgId || !userId) return;
+    let cancelled = false;
+    const loadMembers = async (): Promise<void> => {
+      try {
+        const { data: { session } } = await supabase.auth.getSession();
+        const headers: Record<string, string> = {};
+        if (session?.access_token) headers['Authorization'] = `Bearer ${session.access_token}`;
+        const res = await fetch(
+          `${API_BASE}/auth/organizations/${orgId}/members?user_id=${encodeURIComponent(userId)}`,
+          { headers },
+        );
+        if (!res.ok || cancelled) return;
+        const data = (await res.json()) as { members: TeamMember[] };
+        if (!cancelled) {
+          setTeamMembers(data.members.filter((m) => m.id !== userId && m.status === 'active'));
+        }
+      } catch {
+        // ignore
+      }
+    };
+    void loadMembers();
+    return () => { cancelled = true; };
+  }, [isInvitedMode, orgId, userId]);
 
   useEffect(() => {
-    if (step !== 6 || !orgId || !userId) return;
+    if (orgId && userId && (isInvitedMode ? step >= 1 : step >= 2)) {
+      void fetchIntegrations();
+    }
+  }, [orgId, userId, step, fetchIntegrations, isInvitedMode]);
+
+  useEffect(() => {
+    if (contentStep !== 6 || !orgId || !userId) return;
     let cancelled = false;
     let retryTid: ReturnType<typeof setTimeout> | null = null;
     const loadOrg = async (): Promise<void> => {
@@ -156,6 +198,7 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
       cancelled = true;
       if (retryTid) clearTimeout(retryTid);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [step, orgId, userId, websiteUrl]);
 
   const slackConnected: boolean =
@@ -333,9 +376,15 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
     }
   };
 
+  /**
+   * In invited mode, logical step 4 (invite teammates) is skipped.
+   * Map step numbers to content: steps 1-3 are the same, then 4→5 and 5→6 in normal numbering.
+   */
+  const contentStep: number = isInvitedMode && step >= 4 ? step + 1 : step;
+
+  const skipMessageForStep: string | undefined = SKIP_MESSAGES[contentStep];
   const handleSkip = (): void => {
-    const msg: string | undefined = SKIP_MESSAGES[step];
-    if (msg && window.confirm(msg)) {
+    if (skipMessageForStep && window.confirm(skipMessageForStep)) {
       setStep((prev) => Math.min(prev + 1, TOTAL_STEPS));
     }
   };
@@ -346,15 +395,16 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
   };
 
   const renderFooter = (nextLabel?: string, continueDisabled?: boolean): JSX.Element => {
-    const step3HasConnection = integrations.some((i) =>
+    const step3HasConnection: boolean = integrations.some((i) =>
       INTEGRATION_KEYS_STEP3.includes(i.provider) && i.currentUserConnected
     );
-    const isDisabled: boolean =
-      continueDisabled ??
-      (step === 2 ? !slackConnected : step === 3 ? !step3HasConnection : step === 4 ? invitedEmails.length === 0 : false);
+    const defaultDisabled: boolean =
+      contentStep === 2 ? !slackConnected : contentStep === 3 ? !step3HasConnection : contentStep === 4 ? invitedEmails.length === 0 : false;
+    const isDisabled: boolean = continueDisabled ?? defaultDisabled;
+    const showContinue: boolean = isInvitedMode ? step >= 1 && step <= TOTAL_STEPS - 1 : step >= 2 && step <= 5;
     return (
     <div className="mt-8 space-y-3">
-      {SKIP_MESSAGES[step] !== undefined && (
+      {skipMessageForStep !== undefined && (
         <button
           type="button"
           onClick={handleSkip}
@@ -363,7 +413,7 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
           I&apos;ll do this later
         </button>
       )}
-      {step >= 2 && step <= 5 && (
+      {showContinue && (
         <button
           type="button"
           onClick={handleNext}
@@ -409,8 +459,8 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
         </button>
 
         <div className="bg-surface-900/80 backdrop-blur-sm border border-surface-800 rounded-2xl p-8">
-          {/* Step 1: Welcome */}
-          {step === 1 && (
+          {/* Step 1: Welcome (normal) or Welcome to [Org] (invited) */}
+          {step === 1 && !isInvitedMode && (
             <>
               <div className="text-center mb-8">
                 <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-primary-500 to-primary-700 mb-5 shadow-lg shadow-primary-500/20">
@@ -487,19 +537,126 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
             </>
           )}
 
+          {/* Step 1 (invited): Welcome to [Org] */}
+          {step === 1 && isInvitedMode && (
+            <>
+              <div className="text-center mb-6">
+                {organization?.logoUrl ? (
+                  <img
+                    src={organization.logoUrl}
+                    alt={organization.name}
+                    className="w-16 h-16 rounded-2xl mx-auto mb-5 object-cover shadow-lg"
+                  />
+                ) : (
+                  <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-primary-500 to-primary-700 mb-5 shadow-lg shadow-primary-500/20">
+                    <span className="text-3xl">&#x1F44B;</span>
+                  </div>
+                )}
+                <h1 className="text-2xl font-bold text-white leading-tight">
+                  Welcome to {organization?.name ?? 'your team'}!
+                </h1>
+                <p className="text-surface-300 mt-3 text-[15px] leading-relaxed max-w-sm mx-auto">
+                  You&apos;re all set as a member. Let&apos;s connect your tools so Penny
+                  can help you alongside your team.
+                </p>
+              </div>
+
+              {/* Team members already here */}
+              {teamMembers.length > 0 && (
+                <div className="mb-4 p-4 rounded-xl bg-surface-800/50 border border-surface-700/50">
+                  <p className="text-surface-400 text-xs font-medium mb-3">Your teammates</p>
+                  <div className="space-y-2.5">
+                    {teamMembers.slice(0, 6).map((member) => (
+                      <div key={member.id} className="flex items-center gap-3">
+                        {member.avatar_url ? (
+                          <img
+                            src={member.avatar_url}
+                            alt={member.name ?? member.email}
+                            className="w-8 h-8 rounded-full"
+                          />
+                        ) : (
+                          <div className="w-8 h-8 rounded-full bg-surface-700 flex items-center justify-center text-surface-300 text-sm font-medium">
+                            {(member.name ?? member.email).charAt(0).toUpperCase()}
+                          </div>
+                        )}
+                        <div className="min-w-0 flex-1">
+                          <div className="text-sm text-surface-200 font-medium truncate">
+                            {member.name ?? member.email}
+                          </div>
+                          {member.name && (
+                            <div className="text-xs text-surface-500 truncate">{member.email}</div>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                    {teamMembers.length > 6 && (
+                      <p className="text-xs text-surface-500">
+                        + {teamMembers.length - 6} more
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {/* Integrations already connected by the org */}
+              {(() => {
+                const orgConnectedProviders: ReadonlyArray<string> = integrations
+                  .filter((i) => i.teamConnections.length > 0 || (i.isActive && !i.currentUserConnected))
+                  .map((i) => i.provider);
+                const uniqueProviders: ReadonlyArray<string> = [...new Set(orgConnectedProviders)];
+                if (uniqueProviders.length === 0) return null;
+                return (
+                  <div className="mb-4 p-4 rounded-xl bg-surface-800/50 border border-surface-700/50">
+                    <p className="text-surface-400 text-xs font-medium mb-3">Already connected by your team</p>
+                    <div className="flex flex-wrap gap-2">
+                      {uniqueProviders.map((provider) => {
+                        const config = INTEGRATION_CONFIG[provider];
+                        if (!config) return null;
+                        const Icon = ICON_MAP[config.icon] ?? HiGlobeAlt;
+                        return (
+                          <div key={provider} className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-emerald-500/10 border border-emerald-500/20">
+                            <Icon className="w-4 h-4 text-emerald-400" />
+                            <span className="text-sm text-emerald-300">{config.name}</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })()}
+
+              {renderFooter('Get started', false)}
+            </>
+          )}
+
           {/* Step 2: Connect Slack */}
-          {step === 2 && (
+          {contentStep === 2 && (
             <>
               <div className="text-center mb-6">
                 <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-white mb-4 shadow-lg shadow-surface-900/20">
                   <SlackLogo className="w-8 h-8" />
                 </div>
-                <h2 className="text-xl font-bold text-white">Bring Penny where your team already works</h2>
+                <h2 className="text-xl font-bold text-white">
+                  {isInvitedMode ? 'Connect your Slack account' : 'Bring Penny where your team already works'}
+                </h2>
                 <p className="text-surface-300 mt-3 text-sm leading-relaxed">
-                  Connect Slack and your team can ask Penny anything right from the channels they&apos;re
-                  already in &mdash; deal updates, meeting prep, customer research &mdash; no tab-switching required.
+                  {isInvitedMode && integrations.some((i) => i.provider === 'slack' && i.teamConnections.length > 0)
+                    ? 'Your team already has Slack connected. Add your own account so Penny can help you too.'
+                    : <>Connect Slack and your team can ask Penny anything right from the channels they&apos;re
+                      already in &mdash; deal updates, meeting prep, customer research &mdash; no tab-switching required.</>
+                  }
                 </p>
               </div>
+              {isInvitedMode && integrations.some((i) => i.provider === 'slack' && i.teamConnections.length > 0) && !slackConnected && (
+                <div className="flex items-center gap-3 p-3 rounded-xl bg-surface-800/50 border border-surface-700/50 text-surface-400 text-sm mb-4">
+                  <svg className="w-4 h-4 text-emerald-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  <span>
+                    Connected by {integrations.find((i) => i.provider === 'slack')?.teamConnections.map((tc) => tc.userName).join(', ')}
+                  </span>
+                </div>
+              )}
               {slackConnected ? (
                 <div className="flex items-center gap-3 p-4 rounded-xl bg-emerald-500/10 border border-emerald-500/20 text-emerald-400">
                   <svg className="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -527,12 +684,17 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
           )}
 
           {/* Step 3: Data sources */}
-          {step === 3 && (
+          {contentStep === 3 && (
             <>
               <div className="mb-6">
-                <h2 className="text-xl font-bold text-white">Give Penny superpowers</h2>
+                <h2 className="text-xl font-bold text-white">
+                  {isInvitedMode ? 'Connect your data sources' : 'Give Penny superpowers'}
+                </h2>
                 <p className="text-surface-300 mt-2 text-sm leading-relaxed">
-                Now that you can ask Penny questions directly in Slack, what data sources do you want her to be able to read/write?
+                  {isInvitedMode
+                    ? 'Your team has some sources connected already. Add your own accounts so Penny has full context.'
+                    : 'Now that you can ask Penny questions directly in Slack, what data sources do you want her to be able to read/write?'
+                  }
                 </p>
               </div>
               <div className="grid grid-cols-2 gap-3 max-h-64 overflow-y-auto">
@@ -540,8 +702,10 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
                   const config = INTEGRATION_CONFIG[key];
                   if (!config) return null;
                   const Icon = ICON_MAP[config.icon] ?? HiGlobeAlt;
-                  const connected = integrations.some((i) => i.provider === key && i.currentUserConnected);
-                  const isConnecting = connectingProvider === key;
+                  const connected: boolean = integrations.some((i) => i.provider === key && i.currentUserConnected);
+                  const isConnecting: boolean = connectingProvider === key;
+                  const matchedIntegration = integrations.find((i) => i.provider === key);
+                  const teamConnected: boolean = isInvitedMode && !!matchedIntegration && matchedIntegration.teamConnections.length > 0 && !connected;
                   return (
                     <button
                       key={key}
@@ -551,7 +715,9 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
                       className={`flex items-center gap-3 p-3 rounded-xl border text-left transition-colors ${
                         connected
                           ? 'border-emerald-500/30 bg-emerald-500/10'
-                          : 'border-surface-700 bg-surface-800 hover:bg-surface-700'
+                          : teamConnected
+                            ? 'border-blue-500/20 bg-blue-500/5'
+                            : 'border-surface-700 bg-surface-800 hover:bg-surface-700'
                       } disabled:opacity-50`}
                     >
                       <div
@@ -561,11 +727,23 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
                       </div>
                       <div className="min-w-0 flex-1">
                         <div className="font-medium text-surface-100 truncate">{config.name}</div>
-                        <div className="text-xs text-surface-500 truncate">{config.description}</div>
+                        <div className="text-xs text-surface-500 truncate">
+                          {connected
+                            ? 'Connected'
+                            : teamConnected
+                              ? `By ${matchedIntegration!.teamConnections[0]?.userName ?? 'team'}`
+                              : config.description
+                          }
+                        </div>
                       </div>
                       {connected && (
                         <svg className="w-4 h-4 text-emerald-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                        </svg>
+                      )}
+                      {teamConnected && (
+                        <svg className="w-4 h-4 text-blue-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
                         </svg>
                       )}
                       {isConnecting && (
@@ -579,8 +757,8 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
             </>
           )}
 
-          {/* Step 4: Invite teammates */}
-          {step === 4 && (
+          {/* Step 4: Invite teammates (skipped in invited mode) */}
+          {contentStep === 4 && !isInvitedMode && (
             <>
               <div className="text-center mb-6">
                 <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-gradient-to-br from-blue-500 to-indigo-600 mb-4 shadow-lg shadow-blue-500/20">
@@ -628,7 +806,7 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
           )}
 
           {/* Step 5: Free plan */}
-          {step === 5 && (
+          {contentStep === 5 && (
             <>
               <div className="text-center mb-6">
                 <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-primary-500 to-primary-700 mb-5 shadow-lg shadow-primary-500/20">
@@ -662,7 +840,7 @@ export function OnboardingWizard({ emailDomain, onComplete: rawOnComplete, onBac
           )}
 
           {/* Step 6: Success — Penny's research + launch */}
-          {step === 6 && (
+          {contentStep === 6 && (
             <>
               <div className="text-center mb-6">
                 <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-emerald-500 to-emerald-700 mb-5 shadow-lg shadow-emerald-500/20">

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -132,6 +132,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [expandedMemberId, setExpandedMemberId] = useState<string | null>(null);
+  const [resendingMemberId, setResendingMemberId] = useState<string | null>(null);
 
   useEffect(() => {
     setOrgName(organization.name);
@@ -298,6 +299,32 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
       alert(`Failed to invite: ${error instanceof Error ? error.message : 'Unknown error'}`);
     } finally {
       setIsInviting(false);
+    }
+  };
+
+  const handleResendInvite = async (email: string, memberId: string): Promise<void> => {
+    setResendingMemberId(memberId);
+    try {
+      const { API_BASE } = await import('../lib/api');
+      const response = await fetch(
+        `${API_BASE}/auth/organizations/${organization.id}/invitations?user_id=${currentUser.id}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email }),
+        },
+      );
+      if (!response.ok) {
+        const errData = (await response.json().catch(() => ({}))) as { detail?: string };
+        alert(errData.detail ?? `Failed to resend: ${response.status}`);
+        return;
+      }
+      alert('Invitation resent!');
+    } catch (error) {
+      console.error('Failed to resend invite:', error);
+      alert(`Failed to resend: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    } finally {
+      setResendingMemberId(null);
     }
   };
 
@@ -558,6 +585,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                     {sortedMembers.map((member) => {
                       const displayName: string = member.name ?? member.email.split('@')[0] ?? 'Unknown';
                       const isGuest: boolean = member.isGuest;
+                      const isInvited: boolean = member.status === 'invited';
                       const isAdmin: boolean = member.role === 'admin'
                         || member.role === 'global_admin'
                         || member.canLoginAsAdmin;
@@ -571,6 +599,31 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                       });
                       const canUnlinkForMember: boolean = member.id === currentUser.id || canLinkIdentityInOrg;
                       const canDeleteMember: boolean = canAdministerOrg && !isGuest;
+
+                      if (isInvited) {
+                        return (
+                          <div key={member.id} className="rounded-lg bg-surface-800/50 overflow-hidden">
+                            <div className="flex items-center gap-3 p-3">
+                              <Avatar user={member} size="lg" />
+                              <div className="flex-1 min-w-0">
+                                <span className="font-medium text-surface-100 truncate block">
+                                  {displayName}
+                                </span>
+                                <p className="text-sm text-surface-400 truncate">{member.email}</p>
+                                <p className="text-xs text-amber-400/80 mt-0.5 italic">Invitation pending</p>
+                              </div>
+                              <button
+                                type="button"
+                                onClick={() => void handleResendInvite(member.email, member.id)}
+                                disabled={resendingMemberId === member.id}
+                                className="px-3 py-1.5 text-sm font-medium rounded-lg border border-surface-600 text-surface-300 hover:text-surface-100 hover:border-surface-500 hover:bg-surface-700/50 transition-colors disabled:opacity-50 flex-shrink-0"
+                              >
+                                {resendingMemberId === member.id ? 'Sending...' : 'Resend'}
+                              </button>
+                            </div>
+                          </div>
+                        );
+                      }
 
                       return (
                         <div key={member.id} className="rounded-lg bg-surface-800/50 overflow-hidden">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -106,38 +106,45 @@ function OrgSwitcherSection({
         <div className="absolute bottom-full left-0 right-0 mb-1 mx-2 bg-surface-800 border border-surface-700 rounded-lg shadow-xl overflow-hidden z-50">
           <div className="py-1">
             {organizations.map((org) => (
-              <button
+              <div
                 key={org.id}
-                onClick={() => void handleSwitchOrg(org.id)}
-                className={`w-full flex items-center gap-3 px-3 py-2.5 text-left transition-colors ${
+                className={`flex items-center transition-colors ${
                   org.isActive
                     ? 'bg-primary-500/10 text-primary-400'
                     : 'text-surface-300 hover:bg-surface-700'
                 }`}
               >
-                {org.logoUrl ? (
-                  <img src={org.logoUrl} alt={org.name} className="w-6 h-6 rounded object-cover" />
-                ) : (
-                  <div className="w-6 h-6 rounded bg-surface-600 flex items-center justify-center text-surface-300 text-xs font-medium">
-                    {org.name.charAt(0).toUpperCase()}
-                  </div>
-                )}
-                <span className="text-sm truncate flex-1">{org.name}</span>
+                <button
+                  onClick={() => void handleSwitchOrg(org.id)}
+                  className="flex-1 min-w-0 flex items-center gap-3 px-3 py-2.5 text-left"
+                >
+                  {org.logoUrl ? (
+                    <img src={org.logoUrl} alt={org.name} className="w-6 h-6 rounded object-cover flex-shrink-0" />
+                  ) : (
+                    <div className="w-6 h-6 rounded bg-surface-600 flex items-center justify-center text-surface-300 text-xs font-medium flex-shrink-0">
+                      {org.name.charAt(0).toUpperCase()}
+                    </div>
+                  )}
+                  <span className="text-sm truncate flex-1">{org.name}</span>
+                  {org.isActive && (
+                    <svg className="w-4 h-4 text-primary-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                  )}
+                </button>
                 {org.isActive && (
-                  <svg className="w-4 h-4 text-primary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
+                  <button
+                    onClick={() => { setShowDropdown(false); onOpenOrgPanel(); }}
+                    className="p-1.5 mr-1 rounded-md hover:bg-surface-700/60 transition-colors flex-shrink-0"
+                    title="Organization settings"
+                  >
+                    <svg className="w-4 h-4 text-amber-400" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 00.12-.61l-1.92-3.32a.49.49 0 00-.59-.22l-2.39.96c-.5-.38-1.03-.69-1.62-.89l-.36-2.54a.484.484 0 00-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.2-1.13.52-1.62.89l-2.39-.96a.49.49 0 00-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 00-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.69 1.62.89l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.2 1.13-.52 1.62-.89l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1115.6 12 3.611 3.611 0 0112 15.6z" />
+                    </svg>
+                  </button>
                 )}
-              </button>
+              </div>
             ))}
-          </div>
-          <div className="border-t border-surface-700">
-            <button
-              onClick={() => { setShowDropdown(false); onOpenOrgPanel(); }}
-              className="w-full px-3 py-2 text-xs text-surface-400 hover:text-surface-200 hover:bg-surface-700/50 transition-colors text-left"
-            >
-              Organization settings
-            </button>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

- **Personalized sign-in page**: Invite emails now include query params (org name/logo, inviter name/avatar) so the Auth page shows a contextual "Join [Org]" banner when an invited user clicks through.
- **Invited onboarding flow**: Invited users go through an adapted 5-step onboarding that shows existing team members, which integrations the team has connected, and skips the "invite teammates" step.
- **Email redesign**: Both the org invite and waitlist emails are now light-themed (white card on light background) with brand-orange CTA buttons and on-brand "One AI for your whole team" messaging.
- **Team member list**: Invited members show "Invitation pending" with a "Resend" button (re-sends the invite email). Backend now returns OrgMember status instead of User status, and re-inviting no longer 409s.
- **Org switcher**: Replaced the "Organization settings" text link with a gear icon on the active org row in the dropdown.

## Test plan

- [ ] Invite a new email from the org panel and verify the email arrives with light theme, orange button, and query-param link
- [ ] Click the invite link and confirm the Auth page shows the invite banner with org name and inviter info
- [ ] Sign in/up as the invited user and confirm the onboarding wizard runs in invited mode (Welcome to [Org], team members listed, team-connected integrations shown, invite step skipped)
- [ ] Verify the team member list in Org Panel shows "Invitation pending" + "Resend" for invited members
- [ ] Click "Resend" and verify the email is re-sent
- [ ] Verify the org switcher dropdown shows a gear icon on the active org that opens settings


Made with [Cursor](https://cursor.com)