### PR TITLE
Add "Invite all missing users from Slack" action and backend bulk-invite endpoint

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1542,6 +1542,24 @@ class InviteToOrgResponse(BaseModel):
     status: str
 
 
+class SlackMissingInviteRequest(BaseModel):
+    """Bulk invite Slack users missing from this org."""
+
+    dry_run: bool = True
+    confirm_large_invite: bool = False
+
+
+class SlackMissingInviteResponse(BaseModel):
+    """Summary of Slack bulk invite attempt/preview."""
+
+    total_slack_users_with_email: int
+    already_in_org: int
+    missing_users: int
+    invited_count: int
+    requires_confirmation: bool
+    invited_emails: list[str]
+
+
 @router.post("/organizations/{org_id}/invitations", response_model=InviteToOrgResponse)
 async def invite_to_organization(
     org_id: str,
@@ -1686,6 +1704,178 @@ async def invite_to_organization(
             user_id=str(target_user.id),
             email=invite_email,
             status="invited",
+        )
+
+
+@router.post(
+    "/organizations/{org_id}/invitations/slack-missing",
+    response_model=SlackMissingInviteResponse,
+)
+async def invite_missing_slack_users_to_organization(
+    org_id: str,
+    request: SlackMissingInviteRequest,
+    background_tasks: BackgroundTasks,
+    user_id: Optional[str] = None,
+) -> SlackMissingInviteResponse:
+    """Invite Slack users (with email) who are not already present in the org."""
+    from models.org_member import OrgMember
+    from models.slack_user_mapping import SlackUserMapping
+    from services.email import send_org_invitation_email
+
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    try:
+        org_uuid = UUID(org_id)
+        inviter_uuid = UUID(user_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    async with get_admin_session() as session:
+        inviter: Optional[User] = await session.get(User, inviter_uuid)
+        if not inviter:
+            raise HTTPException(status_code=403, detail="Not authorized")
+
+        org: Optional[Organization] = await session.get(Organization, org_uuid)
+        if not org:
+            raise HTTPException(status_code=404, detail="Organization not found")
+
+        if not _is_global_admin(inviter):
+            inviter_membership = await _get_org_membership(session, inviter_uuid, org_uuid)
+            if not inviter_membership:
+                raise HTTPException(status_code=403, detail="Not a member of this organization")
+
+        slack_integration_result = await session.execute(
+            select(Integration.id).where(
+                Integration.organization_id == org_uuid,
+                Integration.provider == "slack",
+                Integration.is_active == True,
+            )
+        )
+        if not slack_integration_result.scalar_one_or_none():
+            raise HTTPException(status_code=404, detail="Slack integration not connected")
+
+        slack_rows = await session.execute(
+            select(SlackUserMapping.external_email)
+            .where(
+                SlackUserMapping.organization_id == org_uuid,
+                SlackUserMapping.source == "slack",
+                SlackUserMapping.external_email.is_not(None),
+            )
+            .distinct()
+        )
+        raw_emails = [row[0] for row in slack_rows.all()]
+        slack_emails: set[str] = {
+            str(email).strip().lower()
+            for email in raw_emails
+            if isinstance(email, str) and "@" in email
+        }
+
+        memberships_result = await session.execute(
+            select(User.email)
+            .join(OrgMember, OrgMember.user_id == User.id)
+            .where(
+                OrgMember.organization_id == org_uuid,
+                User.email.is_not(None),
+            )
+        )
+        existing_org_emails: set[str] = {
+            str(row[0]).strip().lower()
+            for row in memberships_result.all()
+            if isinstance(row[0], str)
+        }
+
+        missing_emails = sorted(slack_emails - existing_org_emails)
+        requires_confirmation = len(missing_emails) > 10
+
+        if request.dry_run:
+            return SlackMissingInviteResponse(
+                total_slack_users_with_email=len(slack_emails),
+                already_in_org=len(slack_emails & existing_org_emails),
+                missing_users=len(missing_emails),
+                invited_count=0,
+                requires_confirmation=requires_confirmation,
+                invited_emails=[],
+            )
+
+        if requires_confirmation and not request.confirm_large_invite:
+            raise HTTPException(
+                status_code=400,
+                detail="Large invite requires explicit confirmation",
+            )
+
+        if not missing_emails:
+            return SlackMissingInviteResponse(
+                total_slack_users_with_email=len(slack_emails),
+                already_in_org=len(slack_emails & existing_org_emails),
+                missing_users=0,
+                invited_count=0,
+                requires_confirmation=False,
+                invited_emails=[],
+            )
+
+        target_users_result = await session.execute(
+            select(User).where(User.email.in_(missing_emails))
+        )
+        target_users = {user.email.lower(): user for user in target_users_result.scalars().all() if user.email}
+
+        invited_emails: list[str] = []
+        for email in missing_emails:
+            target_user = target_users.get(email)
+            if not target_user:
+                target_user = User(
+                    email=email,
+                    name=None,
+                    status="invited",
+                    role="member",
+                    invited_at=datetime.utcnow(),
+                )
+                session.add(target_user)
+                await session.flush()
+                target_users[email] = target_user
+
+            membership_result = await session.execute(
+                select(OrgMember).where(
+                    OrgMember.user_id == target_user.id,
+                    OrgMember.organization_id == org_uuid,
+                )
+            )
+            existing_membership: Optional[OrgMember] = membership_result.scalar_one_or_none()
+            if existing_membership:
+                continue
+
+            session.add(
+                OrgMember(
+                    user_id=target_user.id,
+                    organization_id=org_uuid,
+                    role="member",
+                    status="invited",
+                    invited_by_user_id=inviter_uuid,
+                    invited_at=datetime.utcnow(),
+                )
+            )
+            invited_emails.append(email)
+
+        await session.commit()
+
+        inviter_name: str = inviter.name or inviter.email
+        for email in invited_emails:
+            background_tasks.add_task(
+                send_org_invitation_email,
+                email,
+                org.name,
+                inviter_name,
+                org_logo_url=org.logo_url,
+                inviter_avatar_url=inviter.avatar_url,
+            )
+
+        return SlackMissingInviteResponse(
+            total_slack_users_with_email=len(slack_emails),
+            already_in_org=len(slack_emails & existing_org_emails),
+            missing_users=len(missing_emails),
+            invited_count=len(invited_emails),
+            requires_confirmation=False,
+            invited_emails=invited_emails,
         )
 
 

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -73,6 +73,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
   const logout = useAppStore((state) => state.logout);
   const fetchUserOrganizations = useAppStore((state) => state.fetchUserOrganizations);
   const switchActiveOrganization = useAppStore((state) => state.switchActiveOrganization);
+  const setCurrentView = useAppStore((state) => state.setCurrentView);
   const [activeTab, setActiveTab] = useState<'team' | 'billing' | 'settings'>(initialTab);
 
   useEffect(() => {
@@ -125,6 +126,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
 
   const [inviteEmail, setInviteEmail] = useState('');
   const [isInviting, setIsInviting] = useState(false);
+  const [isInvitingMissingFromSlack, setIsInvitingMissingFromSlack] = useState(false);
   const [orgName, setOrgName] = useState(organization.name);
   const [logoUrl, setLogoUrl] = useState(organization.logoUrl);
   const [settingsSaved, setSettingsSaved] = useState(false);
@@ -325,6 +327,77 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
       alert(`Failed to resend: ${error instanceof Error ? error.message : 'Unknown error'}`);
     } finally {
       setResendingMemberId(null);
+    }
+  };
+
+  interface SlackMissingInviteSummary {
+    total_slack_users_with_email: number;
+    already_in_org: number;
+    missing_users: number;
+    invited_count: number;
+    requires_confirmation: boolean;
+    invited_emails: string[];
+  }
+
+  const handleInviteMissingFromSlack = async (): Promise<void> => {
+    setIsInvitingMissingFromSlack(true);
+    try {
+      const { API_BASE } = await import('../lib/api');
+      const endpoint = `${API_BASE}/auth/organizations/${organization.id}/invitations/slack-missing?user_id=${currentUser.id}`;
+
+      const previewResponse = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dry_run: true }),
+      });
+
+      if (!previewResponse.ok) {
+        const errData = (await previewResponse.json().catch(() => ({}))) as { detail?: string };
+        if (previewResponse.status === 404 && (errData.detail ?? '').toLowerCase().includes('slack integration not connected')) {
+          alert('Slack is not connected for this org. You will be redirected to Connectors to connect Slack.');
+          onClose();
+          setCurrentView('data-sources');
+          return;
+        }
+        alert(errData.detail ?? `Failed to check Slack users: ${previewResponse.status}`);
+        return;
+      }
+
+      const previewData = (await previewResponse.json()) as SlackMissingInviteSummary;
+      if (previewData.missing_users === 0) {
+        alert('No missing Slack users to invite.');
+        return;
+      }
+
+      if (previewData.requires_confirmation) {
+        const confirmed = window.confirm(
+          `This will invite ${previewData.missing_users} users from Slack who are not in this organization. Continue?`
+        );
+        if (!confirmed) return;
+      }
+
+      const inviteResponse = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          dry_run: false,
+          confirm_large_invite: previewData.requires_confirmation,
+        }),
+      });
+
+      if (!inviteResponse.ok) {
+        const errData = (await inviteResponse.json().catch(() => ({}))) as { detail?: string };
+        alert(errData.detail ?? `Failed to invite missing Slack users: ${inviteResponse.status}`);
+        return;
+      }
+
+      const inviteData = (await inviteResponse.json()) as SlackMissingInviteSummary;
+      alert(`Sent ${inviteData.invited_count} invitation${inviteData.invited_count === 1 ? '' : 's'} from Slack users.`);
+    } catch (error) {
+      console.error('Failed to invite missing Slack users:', error);
+      alert(`Failed to invite missing Slack users: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    } finally {
+      setIsInvitingMissingFromSlack(false);
     }
   };
 
@@ -569,6 +642,16 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                     {isInviting ? 'Sending...' : 'Send Invite'}
                   </button>
                 </div>
+                <button
+                  type="button"
+                  onClick={() => void handleInviteMissingFromSlack()}
+                  disabled={isInvitingMissingFromSlack}
+                  className="mt-2 text-sm text-primary-400 hover:text-primary-300 disabled:opacity-50"
+                >
+                  {isInvitingMissingFromSlack
+                    ? 'Checking Slack users...'
+                    : 'Invite all missing users from Slack'}
+                </button>
               </div>
 
               {/* Team List */}


### PR DESCRIPTION
### Motivation
- Provide a one-click way for org admins to invite Slack users (by email) who appear in the workspace but are not yet members of the organization.
- Ensure the flow respects Slack connector presence and protects against accidentally inviting large numbers of users without confirmation.

### Description
- Add backend endpoint `POST /auth/organizations/{org_id}/invitations/slack-missing` that enumerates Slack user emails from `SlackUserMapping`, compares them to org members, supports a preview (`dry_run`), requires explicit confirmation when inviting more than ten users, creates `OrgMember` invites for missing users, and enqueues invitation emails. (file: `backend/api/routes/auth.py`)
- Add request/response models `SlackMissingInviteRequest` and `SlackMissingInviteResponse` and enforce inviter authorization and Slack integration connectivity in the endpoint. (file: `backend/api/routes/auth.py`)
- Add a UI action under the team invite field in `OrganizationPanel` labeled “Invite all missing users from Slack” which: runs the backend preview first, shows a confirmation when >10 users would be invited, redirects to the connectors page when Slack is not connected, and dispatches the confirmed invite request. (file: `frontend/src/components/OrganizationPanel.tsx`)
- Wire small UI state: `isInvitingMissingFromSlack` plus use of the app store `setCurrentView` to navigate to `data-sources` when Slack is not connected. (file: `frontend/src/components/OrganizationPanel.tsx`)

### Testing
- Verified Python syntax by running `python -m py_compile backend/api/routes/auth.py` which succeeded. 
- Built the frontend with `cd frontend && npm run build`, which completed successfully (Vite emitted non-blocking warnings about chunk sizes/dynamic imports). 
- Launched the dev frontend (`vite`) and captured a runtime screenshot to validate the new button and panel flow locally. 
- No automated unit tests were added; existing backend file compiled and frontend build passed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa0b5d75c883218db6f5f02e578b7e)