### PR TITLE
Add iframe CSS compatibility guidance for Penny app generation

### DIFF
--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -581,6 +581,7 @@ register_tool(
 - All SQL must be SELECT-only. No INSERT/UPDATE/DELETE.
 - Do NOT add organization_id to WHERE clauses (RLS handles it).
 - frontend_code must export a default React component.
+- When creating or updating app UI, include iframe-friendly CSS resets/layout safeguards (e.g., `html, body, #root { margin: 0; padding: 0; width: 100%; max-width: 100%; overflow-x: hidden; }` and `box-sizing: border-box`) so embeds render correctly across host pages.
 
 **Example create:**
 {


### PR DESCRIPTION
### Motivation
- Ensure Penny-generated apps render correctly when embedded in third-party pages by asking app frontend code to include iframe-friendly CSS resets and layout safeguards.

### Description
- Added a single-line guidance to the `write_app` tool documentation in `backend/agents/registry.py` instructing that created/updated app UI include iframe-friendly CSS (example: `html, body, #root { margin: 0; padding: 0; width: 100%; max-width: 100%; overflow-x: hidden; }` and `box-sizing: border-box`) so embeds render consistently across host pages.

### Testing
- Ran `python -m compileall backend/agents/registry.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa0d5a49a8832180732da78619521c)