### PR TITLE
Handle Supabase auth timeout errors in login/sign-up UI

### DIFF
--- a/frontend/src/components/Auth.tsx
+++ b/frontend/src/components/Auth.tsx
@@ -17,6 +17,33 @@ interface InviteContext {
   inviterAvatar: string | null;
 }
 
+function extractTimeoutFromError(message: string): string | null {
+  const timeoutPatterns: RegExp[] = [
+    /(?:try again|retry)\s+in\s+(\d+\s*(?:ms|milliseconds?|s|sec|secs|seconds?|m|min|mins|minutes?))/i,
+    /(?:wait|timeout|timed\s*out)\s*(?:for)?\s*(\d+\s*(?:ms|milliseconds?|s|sec|secs|seconds?|m|min|mins|minutes?))/i,
+  ];
+
+  for (const pattern of timeoutPatterns) {
+    const match = message.match(pattern);
+    if (match?.[1]) {
+      return match[1].trim();
+    }
+  }
+
+  return null;
+}
+
+function mapSupabaseAuthError(message: string): string {
+  const timeout = extractTimeoutFromError(message);
+  if (timeout) {
+    console.info('Parsed Supabase auth timeout error', { timeout, message });
+    return `Either you've done this a lot or our servers are slammed! Sorry, try again in ${timeout}, please.`;
+  }
+
+  console.warn('Unable to parse timeout from Supabase auth error', { message });
+  return 'Backend service error, please try again later.';
+}
+
 function parseInviteParams(): InviteContext | null {
   const params = new URLSearchParams(window.location.search);
   if (params.get('invite') !== '1') return null;
@@ -68,6 +95,7 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
     setLoading(true);
     setError(null);
     setMessage(null);
+    const isSupabaseCredentialFlow = mode === 'signup' || mode === 'signin';
 
     try {
       if (mode === 'signup') {
@@ -132,7 +160,8 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
         onSuccess();
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
+      const rawMessage = err instanceof Error ? err.message : 'An error occurred';
+      setError(isSupabaseCredentialFlow ? mapSupabaseAuthError(rawMessage) : rawMessage);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
### Motivation
- Provide a friendlier, actionable message in the auth UI when Supabase returns timeout-like errors during login/sign-up flows. 
- Preserve existing raw error behavior for non-credential flows (`forgot`/`reset`) to avoid changing other UX surface.

### Description
- Added `extractTimeoutFromError` and `mapSupabaseAuthError` helpers to `frontend/src/components/Auth.tsx` to parse timeout values from backend error text and map them to the friendly message `Either you've done this a lot or our servers are slammed! Sorry, try again in (timeout), please.`.
- Applied the mapping only for credential flows by checking `mode === 'signup' || mode === 'signin'` and leaving other flows to show the original backend error text.
- Added `console.info`/`console.warn` logging for parsed and unparsed Supabase auth error cases and replaced the previous direct error assignment with `mapSupabaseAuthError` where applicable.

### Testing
- Ran the frontend build with `npm --prefix frontend run build`, which completed successfully (production build produced artifacts with standard warnings about chunk sizes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa210c392c832180647e939dd02526)