### PR TITLE
Refresh team pane after invites and update Slack invite copy

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -11,10 +11,11 @@
  */
 
 import { useState, useRef, useEffect, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import type { OrganizationInfo, UserProfile } from './AppLayout';
 import { supabase } from '../lib/supabase';
 import { useAppStore } from '../store';
-import { useTeamMembers, useUpdateOrganization, useLinkIdentity, useUnlinkIdentity, useUpdateGuestUser, useUpdateMemberRole, useDeleteMember, useDeleteOrganization } from '../hooks';
+import { useTeamMembers, useUpdateOrganization, useLinkIdentity, useUnlinkIdentity, useUpdateGuestUser, useUpdateMemberRole, useDeleteMember, useDeleteOrganization, organizationKeys } from '../hooks';
 import type { TeamMember, IdentityMapping } from '../hooks';
 import { apiRequest } from '../lib/api';
 import { Avatar } from './Avatar';
@@ -69,6 +70,7 @@ interface OrganizationPanelProps {
 }
 
 export function OrganizationPanel({ organization, currentUser, initialTab = 'team', onClose }: OrganizationPanelProps): JSX.Element {
+  const queryClient = useQueryClient();
   const setOrganization = useAppStore((state) => state.setOrganization);
   const logout = useAppStore((state) => state.logout);
   const fetchUserOrganizations = useAppStore((state) => state.fetchUserOrganizations);
@@ -295,6 +297,8 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
       }
 
       setInviteEmail('');
+      await queryClient.invalidateQueries({ queryKey: organizationKeys.members(organization.id) });
+      await queryClient.refetchQueries({ queryKey: organizationKeys.members(organization.id), type: 'active' });
       alert('Invitation sent!');
     } catch (error) {
       console.error('Failed to invite:', error);
@@ -392,6 +396,8 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
       }
 
       const inviteData = (await inviteResponse.json()) as SlackMissingInviteSummary;
+      await queryClient.invalidateQueries({ queryKey: organizationKeys.members(organization.id) });
+      await queryClient.refetchQueries({ queryKey: organizationKeys.members(organization.id), type: 'active' });
       alert(`Sent ${inviteData.invited_count} invitation${inviteData.invited_count === 1 ? '' : 's'} from Slack users.`);
     } catch (error) {
       console.error('Failed to invite missing Slack users:', error);
@@ -650,7 +656,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                 >
                   {isInvitingMissingFromSlack
                     ? 'Checking Slack users...'
-                    : 'Invite all missing users from Slack'}
+                    : "Invite all Slack users that aren't yet in Basebase"}
                 </button>
               </div>
 


### PR DESCRIPTION
### Motivation
- Ensure the Team pane reflects new invitations immediately after sending an email invite or using the Slack "missing users" invite flow.
- Clarify the Slack invite button copy to be more explicit about which Slack users are targeted.

### Description
- Added `useQueryClient` and `organizationKeys` imports and a `queryClient` instance in `OrganizationPanel` to manage React Query cache.
- After a successful single-email invite in `handleInvite`, the code now calls `queryClient.invalidateQueries` and `queryClient.refetchQueries` for `organizationKeys.members(organization.id)` so the team list updates immediately.
- After completing the Slack missing-user invite flow in `handleInviteMissingFromSlack`, the code also invalidates and refetches the same members query to update the UI right away.
- Changed the team pane button text from `Invite all missing users from Slack` to `Invite all Slack users that aren't yet in Basebase`.

### Testing
- Built the frontend with `cd frontend && npm run -s build` and the build completed successfully.
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served locally.
- Ran a Playwright script to load the app and capture a screenshot of the Organization panel, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa21b506f08321987c636d1253076b)