### PR TITLE
Throttle duplicate PagerDuty incidents for recurring health-check failures

### DIFF
--- a/backend/api/auth_middleware.py
+++ b/backend/api/auth_middleware.py
@@ -28,6 +28,7 @@ from sqlalchemy import select
 from config import settings
 from models.database import get_session
 from models.user import User
+from services.incident_throttling import evaluate_incident_creation
 from services.pagerduty import create_pagerduty_incident
 
 logger = logging.getLogger(__name__)
@@ -172,13 +173,18 @@ async def _get_jwks() -> dict:
             return _jwks_cache
 
     logger.error("Failed to fetch JWKS from %s after %d attempts: %s", jwks_url, max_retries, last_error)
-    await create_pagerduty_incident(
-        title="Auth JWKS endpoint unreachable",
-        details=(
-            "Auth middleware failed to fetch JWKS after 3 attempts and has no cache fallback. "
-            f"JWKS URL: {jwks_url}. Last error: {last_error}"
-        ),
-    )
+    should_create, reason = await evaluate_incident_creation("Auth JWKS")
+    if should_create:
+        logger.warning("PagerDuty incident allowed for Auth JWKS reason=%s", reason)
+        await create_pagerduty_incident(
+            title="Auth JWKS endpoint unreachable",
+            details=(
+                "Auth middleware failed to fetch JWKS after 3 attempts and has no cache fallback. "
+                f"JWKS URL: {jwks_url}. Last error: {last_error}"
+            ),
+        )
+    else:
+        logger.info("PagerDuty incident suppressed for Auth JWKS reason=%s", reason)
     raise HTTPException(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         detail="Authentication service temporarily unavailable",

--- a/backend/services/incident_throttling.py
+++ b/backend/services/incident_throttling.py
@@ -1,0 +1,88 @@
+"""Redis-backed throttling for recurring dependency outage incidents."""
+from __future__ import annotations
+
+import logging
+import time
+from urllib.parse import quote
+
+import redis.asyncio as aioredis
+
+from config import get_redis_connection_kwargs, settings
+
+logger = logging.getLogger(__name__)
+
+_INCIDENT_COOLDOWN_SECONDS = 3 * 60 * 60
+_INCIDENT_KEY_PREFIX = "monitoring:incident_throttle"
+_INCIDENT_KEY_TTL_SECONDS = 7 * 24 * 60 * 60
+
+
+def _incident_key(check_name: str) -> str:
+    """Build Redis key for check-level incident throttling state."""
+    return f"{_INCIDENT_KEY_PREFIX}:{quote(check_name, safe='')}"
+
+
+async def evaluate_incident_creation(check_name: str) -> tuple[bool, str]:
+    """Return whether a new incident should be raised for a failing check."""
+    now = int(time.time())
+    redis_client = aioredis.from_url(
+        settings.REDIS_URL,
+        **get_redis_connection_kwargs(decode_responses=True),
+    )
+    key = _incident_key(check_name)
+
+    try:
+        async with redis_client:
+            payload = await redis_client.hgetall(key)
+            if not payload:
+                await redis_client.hset(
+                    key,
+                    mapping={
+                        "first_failed_at": str(now),
+                        "last_incident_at": str(now),
+                    },
+                )
+                await redis_client.expire(key, _INCIDENT_KEY_TTL_SECONDS)
+                return True, "new_failure"
+
+            last_incident_raw = payload.get("last_incident_at")
+            try:
+                last_incident_at = int(last_incident_raw) if last_incident_raw is not None else 0
+            except ValueError:
+                logger.warning(
+                    "Invalid incident throttle timestamp for check=%s payload=%s",
+                    check_name,
+                    payload,
+                )
+                last_incident_at = 0
+
+            if now - last_incident_at >= _INCIDENT_COOLDOWN_SECONDS:
+                await redis_client.hset(key, mapping={"last_incident_at": str(now)})
+                await redis_client.expire(key, _INCIDENT_KEY_TTL_SECONDS)
+                return True, "cooldown_elapsed"
+
+            suppress_for = _INCIDENT_COOLDOWN_SECONDS - (now - last_incident_at)
+            return False, f"suppressed_for_{max(0, suppress_for)}s"
+    except Exception:
+        logger.exception(
+            "Incident throttling unavailable for check=%s; failing open and allowing incident",
+            check_name,
+        )
+        return True, "throttle_unavailable"
+
+
+async def clear_incident_failure(check_name: str) -> None:
+    """Clear failure-throttle state after a check recovers."""
+    redis_client = aioredis.from_url(
+        settings.REDIS_URL,
+        **get_redis_connection_kwargs(),
+    )
+    key = _incident_key(check_name)
+
+    try:
+        async with redis_client:
+            deleted = await redis_client.delete(key)
+        if deleted:
+            logger.info("Cleared incident throttle state for recovered check=%s", check_name)
+    except Exception:
+        logger.exception("Failed to clear incident throttle state for check=%s", check_name)
+

--- a/backend/tests/test_auth_middleware_jwks.py
+++ b/backend/tests/test_auth_middleware_jwks.py
@@ -65,7 +65,12 @@ async def test_get_jwks_raises_incident_after_final_failure(monkeypatch: pytest.
         calls.append((title, details))
         return True
 
+    async def _fake_evaluate_incident_creation(check_name: str) -> tuple[bool, str]:
+        assert check_name == "Auth JWKS"
+        return True, "new_failure"
+
     monkeypatch.setattr(am, "create_pagerduty_incident", _fake_create_pagerduty_incident)
+    monkeypatch.setattr(am, "evaluate_incident_creation", _fake_evaluate_incident_creation)
     am._jwks_cache = None
     am._jwks_cache_fetched_at = None
 
@@ -74,3 +79,29 @@ async def test_get_jwks_raises_incident_after_final_failure(monkeypatch: pytest.
 
     assert len(calls) == 1
     assert calls[0][0] == "Auth JWKS endpoint unreachable"
+
+
+@pytest.mark.asyncio
+async def test_get_jwks_suppresses_incident_when_throttled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(am.settings, "SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setattr(am.httpx, "AsyncClient", _FailingClient)
+
+    calls: list[tuple[str, str]] = []
+
+    async def _fake_create_pagerduty_incident(*, title: str, details: str) -> bool:
+        calls.append((title, details))
+        return True
+
+    async def _fake_evaluate_incident_creation(check_name: str) -> tuple[bool, str]:
+        assert check_name == "Auth JWKS"
+        return False, "suppressed_for_1000s"
+
+    monkeypatch.setattr(am, "create_pagerduty_incident", _fake_create_pagerduty_incident)
+    monkeypatch.setattr(am, "evaluate_incident_creation", _fake_evaluate_incident_creation)
+    am._jwks_cache = None
+    am._jwks_cache_fetched_at = None
+
+    with pytest.raises(HTTPException):
+        await am._get_jwks()
+
+    assert calls == []

--- a/backend/tests/test_incident_throttling.py
+++ b/backend/tests/test_incident_throttling.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from services import incident_throttling as throttling
+
+
+class _FakeRedis:
+    data: dict[str, dict[str, str]] = {}
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def __aenter__(self) -> "_FakeRedis":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+    async def hgetall(self, key: str) -> dict[str, str]:
+        return dict(self.data.get(key, {}))
+
+    async def hset(self, key: str, mapping: dict[str, str]) -> None:
+        current = self.data.setdefault(key, {})
+        current.update(mapping)
+
+    async def expire(self, key: str, seconds: int) -> None:
+        return None
+
+    async def delete(self, key: str) -> int:
+        existed = key in self.data
+        self.data.pop(key, None)
+        return 1 if existed else 0
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_redis() -> None:
+    _FakeRedis.data = {}
+
+
+def test_evaluate_incident_creation_first_failure_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(throttling.aioredis, "from_url", lambda *args, **kwargs: _FakeRedis())
+    monkeypatch.setattr(throttling.time, "time", lambda: 1000)
+
+    import asyncio
+
+    should_create, reason = asyncio.run(throttling.evaluate_incident_creation("Auth JWKS"))
+
+    assert should_create is True
+    assert reason == "new_failure"
+
+
+def test_evaluate_incident_creation_suppresses_repeated_failure_within_3h(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(throttling.aioredis, "from_url", lambda *args, **kwargs: _FakeRedis())
+
+    import asyncio
+
+    monkeypatch.setattr(throttling.time, "time", lambda: 1000)
+    asyncio.run(throttling.evaluate_incident_creation("Auth JWKS"))
+
+    monkeypatch.setattr(throttling.time, "time", lambda: 1000 + 120)
+    should_create, reason = asyncio.run(throttling.evaluate_incident_creation("Auth JWKS"))
+
+    assert should_create is False
+    assert reason.startswith("suppressed_for_")
+
+
+def test_evaluate_incident_creation_allows_after_3h(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(throttling.aioredis, "from_url", lambda *args, **kwargs: _FakeRedis())
+
+    import asyncio
+
+    monkeypatch.setattr(throttling.time, "time", lambda: 1000)
+    asyncio.run(throttling.evaluate_incident_creation("Auth JWKS"))
+
+    monkeypatch.setattr(throttling.time, "time", lambda: 1000 + (3 * 60 * 60))
+    should_create, reason = asyncio.run(throttling.evaluate_incident_creation("Auth JWKS"))
+
+    assert should_create is True
+    assert reason == "cooldown_elapsed"
+
+
+def test_clear_incident_failure_removes_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(throttling.aioredis, "from_url", lambda *args, **kwargs: _FakeRedis())
+
+    import asyncio
+
+    monkeypatch.setattr(throttling.time, "time", lambda: 1000)
+    asyncio.run(throttling.evaluate_incident_creation("Auth JWKS"))
+
+    asyncio.run(throttling.clear_incident_failure("Auth JWKS"))
+    should_create, reason = asyncio.run(throttling.evaluate_incident_creation("Auth JWKS"))
+
+    assert should_create is True
+    assert reason == "new_failure"

--- a/backend/tests/test_monitoring_task.py
+++ b/backend/tests/test_monitoring_task.py
@@ -94,6 +94,15 @@ def test_monitor_dependencies_logs_health_check_outcome(monkeypatch: Any, caplog
         created_incidents.append(kwargs["check_result"].name)
 
     monkeypatch.setattr(monitoring, "_create_pagerduty_incident", _fake_create_pagerduty_incident)
+
+    async def _fake_clear_incident_failure(check_name: str) -> None:
+        return None
+
+    async def _fake_evaluate_incident_creation(check_name: str) -> tuple[bool, str]:
+        return True, "new_failure"
+
+    monkeypatch.setattr(monitoring, "clear_incident_failure", _fake_clear_incident_failure)
+    monkeypatch.setattr(monitoring, "evaluate_incident_creation", _fake_evaluate_incident_creation)
     monkeypatch.setenv("PAGERDUTY_FROM_EMAIL", "alerts@revtops.com")
     monkeypatch.setenv("PagerDuty_Key", "pd_test_key")
     monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
@@ -105,7 +114,7 @@ def test_monitor_dependencies_logs_health_check_outcome(monkeypatch: Any, caplog
     assert result["down_services"] == ["Redis"]
     assert created_incidents == ["Redis"]
     assert "PagerDuty health check succeeded for Supabase; incident creation skipped" in caplog.text
-    assert "PagerDuty health check failed for Redis; incident will be created" in caplog.text
+    assert "PagerDuty health check failed for Redis; evaluating incident throttle" in caplog.text
 
 
 def test_monitor_dependencies_creates_incident_when_checks_fail(monkeypatch: Any) -> None:
@@ -215,7 +224,83 @@ def test_monitor_dependencies_raises_incident_for_supabase_522(monkeypatch: Any)
     monkeypatch.setattr(monitoring, "_record_check_heartbeat", _fake_record_check_heartbeat)
     monkeypatch.setattr(monitoring, "_create_pagerduty_incident", _fake_create_pagerduty_incident)
 
+    async def _fake_clear_incident_failure(check_name: str) -> None:
+        return None
+
+    async def _fake_evaluate_incident_creation(check_name: str) -> tuple[bool, str]:
+        return True, "new_failure"
+
+    monkeypatch.setattr(monitoring, "clear_incident_failure", _fake_clear_incident_failure)
+    monkeypatch.setattr(monitoring, "evaluate_incident_creation", _fake_evaluate_incident_creation)
+
     result = monitoring.monitor_dependencies.__wrapped__()
 
     assert result["down_services"] == ["Supabase"]
     assert created_incidents == ["Supabase"]
+
+
+def test_monitor_dependencies_suppresses_repeated_incident_for_same_failure(monkeypatch: Any) -> None:
+    async def _fake_run_dependency_checks() -> list[monitoring.CheckResult]:
+        return [
+            monitoring.CheckResult(name="Redis", healthy=False, details="timeout"),
+        ]
+
+    async def _fake_record_check_heartbeat() -> None:
+        return None
+
+    created_incidents: list[str] = []
+
+    async def _fake_create_pagerduty_incident(**kwargs: Any) -> None:
+        created_incidents.append(kwargs["check_result"].name)
+
+    async def _fake_clear_incident_failure(check_name: str) -> None:
+        return None
+
+    async def _fake_evaluate_incident_creation(check_name: str) -> tuple[bool, str]:
+        return False, "suppressed_for_7200s"
+
+    monkeypatch.setattr(monitoring, "_run_dependency_checks", _fake_run_dependency_checks)
+    monkeypatch.setattr(monitoring, "_record_check_heartbeat", _fake_record_check_heartbeat)
+    monkeypatch.setattr(monitoring, "_create_pagerduty_incident", _fake_create_pagerduty_incident)
+    monkeypatch.setattr(monitoring, "clear_incident_failure", _fake_clear_incident_failure)
+    monkeypatch.setattr(monitoring, "evaluate_incident_creation", _fake_evaluate_incident_creation)
+
+    result = monitoring.monitor_dependencies.__wrapped__()
+
+    assert result["down_services"] == ["Redis"]
+    assert created_incidents == []
+
+
+def test_monitor_dependencies_allows_incident_when_different_check_fails(monkeypatch: Any) -> None:
+    async def _fake_run_dependency_checks() -> list[monitoring.CheckResult]:
+        return [
+            monitoring.CheckResult(name="Redis", healthy=False, details="timeout"),
+            monitoring.CheckResult(name="Nango", healthy=False, details="HTTP 503"),
+        ]
+
+    async def _fake_record_check_heartbeat() -> None:
+        return None
+
+    created_incidents: list[str] = []
+
+    async def _fake_create_pagerduty_incident(**kwargs: Any) -> None:
+        created_incidents.append(kwargs["check_result"].name)
+
+    async def _fake_clear_incident_failure(check_name: str) -> None:
+        return None
+
+    async def _fake_evaluate_incident_creation(check_name: str) -> tuple[bool, str]:
+        if check_name == "Redis":
+            return False, "suppressed_for_100s"
+        return True, "new_failure"
+
+    monkeypatch.setattr(monitoring, "_run_dependency_checks", _fake_run_dependency_checks)
+    monkeypatch.setattr(monitoring, "_record_check_heartbeat", _fake_record_check_heartbeat)
+    monkeypatch.setattr(monitoring, "_create_pagerduty_incident", _fake_create_pagerduty_incident)
+    monkeypatch.setattr(monitoring, "clear_incident_failure", _fake_clear_incident_failure)
+    monkeypatch.setattr(monitoring, "evaluate_incident_creation", _fake_evaluate_incident_creation)
+
+    result = monitoring.monitor_dependencies.__wrapped__()
+
+    assert result["down_services"] == ["Redis", "Nango"]
+    assert created_incidents == ["Nango"]

--- a/backend/workers/tasks/monitoring.py
+++ b/backend/workers/tasks/monitoring.py
@@ -9,6 +9,7 @@ from typing import Any
 import httpx
 
 from config import get_redis_connection_kwargs, settings
+from services.incident_throttling import clear_incident_failure, evaluate_incident_creation
 from services.pagerduty import create_pagerduty_incident
 from workers.celery_app import celery_app
 
@@ -211,13 +212,28 @@ def monitor_dependencies(self: Any) -> dict[str, Any]:
                     "PagerDuty health check succeeded for %s; incident creation skipped",
                     result.name,
                 )
+                await clear_incident_failure(result.name)
             else:
                 logger.warning(
-                    "PagerDuty health check failed for %s; incident will be created",
+                    "PagerDuty health check failed for %s; evaluating incident throttle",
                     result.name,
                 )
 
         for result in down:
+            should_create, reason = await evaluate_incident_creation(result.name)
+            if not should_create:
+                logger.info(
+                    "PagerDuty incident suppressed for %s due to throttle reason=%s",
+                    result.name,
+                    reason,
+                )
+                continue
+
+            logger.warning(
+                "PagerDuty incident allowed for %s reason=%s",
+                result.name,
+                reason,
+            )
             await _create_pagerduty_incident(
                 check_result=result,
             )


### PR DESCRIPTION
### Motivation
- Prevent noisy, repeated PagerDuty incidents when the same dependency stays failing over time by suppressing duplicate alerts for that check.
- Reuse a central Redis-backed policy so both periodic monitoring and JWKS fetch failure paths share consistent throttling behavior.
- Ensure operators can still get alerted when a different dependency fails or when the failing dependency recovers, and fail open if throttling storage is unavailable.

### Description
- Added `services/incident_throttling.py`, a Redis-backed service that tracks per-check incident timestamps and enforces a 3-hour cooldown while keeping keys for 7 days, with a fail-open behavior if Redis is unavailable.
- Updated the dependency monitor (`workers/tasks/monitoring.py`) to clear throttle state when a check becomes healthy, evaluate throttle state before creating incidents for failing checks, and suppress or allow incidents accordingly.
- Updated JWKS fetch error handling in the auth middleware (`api/auth_middleware.py`) to consult the same throttling policy before creating a PagerDuty incident for JWKS outages.
- Added tests covering the throttling service and integration points: `backend/tests/test_incident_throttling.py`, updates to `backend/tests/test_monitoring_task.py`, and updates to `backend/tests/test_auth_middleware_jwks.py` to assert suppression and allowance behaviors.

### Testing
- Ran the focused test suite: `pytest -q backend/tests/test_monitoring_task.py backend/tests/test_auth_middleware_jwks.py backend/tests/test_incident_throttling.py` and all tests passed (`20 passed`).
- Unit tests validate first-failure incident creation, suppression within the 3-hour window, allowance after cooldown, clear-on-recovery behavior, and that JWKS incidenting is suppressed when throttled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa440d64d483219827f31a53b74958)