### PR TITLE
Increase sidebar conversation limit from 20 to 50

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -522,8 +522,8 @@ function ChatAccordion({
 
   if (collapsed) return null;
 
-  const sharedChats = orderedChats.filter(c => c.scope === 'shared').slice(0, 20);
-  const privateChats = orderedChats.filter(c => c.scope === 'private').slice(0, 20);
+  const sharedChats = orderedChats.filter(c => c.scope === 'shared').slice(0, 50);
+  const privateChats = orderedChats.filter(c => c.scope === 'private').slice(0, 50);
 
   const renderChatItem = (chat: ChatSummary, showLockIcon: boolean) => {
     const hasActiveTask = chat.id in activeTasksByConversation;


### PR DESCRIPTION
## Summary
- Sidebar was hard-capped at 20 conversations per section (shared/private), hiding older conversations
- Bumped to 50 to match the API fetch limit
- No perf impact — these are lightweight list items (title + timestamp metadata)

## Test plan
- [ ] Verify sidebar shows up to 50 conversations per section
- [ ] Verify scrolling works smoothly with more items

🤖 Generated with [Claude Code](https://claude.com/claude-code)