### PR TITLE
Retry Slack unknown-user mapping before refusal

### DIFF
--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -1376,6 +1376,60 @@ async def _resolve_guest_user_after_unmapped_actor(
     return await _resolve_guest_user_for_org(organization_id)
 
 
+async def _ingest_unknown_slack_actor_and_retry_mapping(
+    organization_id: str,
+    team_id: str,
+    slack_user_id: str,
+    slack_user: dict[str, Any] | None,
+) -> User | None:
+    """Ingest latest Slack identity data for an unresolved actor, then retry mapping."""
+    normalized_slack_user_id: str = _normalize_slack_user_id(slack_user_id)
+    logger.info(
+        "[slack_conversations] Ingesting unknown Slack actor before refusal org=%s team=%s user=%s",
+        organization_id,
+        team_id,
+        normalized_slack_user_id,
+    )
+    try:
+        resolved_slack_user = slack_user or await _fetch_slack_user_info(
+            organization_id=organization_id,
+            slack_user_id=slack_user_id,
+        )
+        resolved_email: str | None = _extract_slack_email(resolved_slack_user)
+        await _upsert_slack_user_mapping(
+            organization_id=organization_id,
+            user_id=None,
+            slack_user_id=normalized_slack_user_id,
+            slack_email=resolved_email,
+            match_source="unknown_actor_ingest",
+        )
+
+        await refresh_slack_user_mappings_for_org(organization_id)
+        connector = SlackConnector(organization_id=organization_id, team_id=team_id)
+        await refresh_slack_user_mappings_from_directory(organization_id, connector)
+
+        resolved_user = await resolve_revtops_user_for_slack_actor(
+            organization_id=organization_id,
+            slack_user_id=normalized_slack_user_id,
+            slack_user=resolved_slack_user,
+        )
+        logger.info(
+            "[slack_conversations] Unknown Slack actor ingestion result org=%s user=%s mapped=%s",
+            organization_id,
+            normalized_slack_user_id,
+            bool(resolved_user),
+        )
+        return resolved_user
+    except Exception:
+        logger.exception(
+            "[slack_conversations] Failed ingestion pass for unknown Slack actor org=%s team=%s user=%s",
+            organization_id,
+            team_id,
+            normalized_slack_user_id,
+        )
+        return None
+
+
 async def resolve_revtops_user_for_slack_actor(
     organization_id: str,
     slack_user_id: str,
@@ -2201,6 +2255,14 @@ async def process_slack_dm(
     slack_user_email: str | None = _extract_slack_email(slack_user)
     slack_user_tz: str | None = _extract_slack_timezone(slack_user)
     if not linked_user:
+        linked_user = await _ingest_unknown_slack_actor_and_retry_mapping(
+            organization_id=organization_id,
+            team_id=team_id,
+            slack_user_id=user_id,
+            slack_user=slack_user,
+        )
+
+    if not linked_user:
         logger.info(
             "[slack_conversations] No linked RevTops user for Slack actor=%s org=%s; refusing to run turn",
             user_id,
@@ -2395,6 +2457,14 @@ async def process_slack_mention(
     slack_user_name: str | None = _extract_slack_display_name(slack_user)
     slack_user_email: str | None = _extract_slack_email(slack_user)
     slack_user_tz: str | None = _extract_slack_timezone(slack_user)
+    if not linked_user:
+        linked_user = await _ingest_unknown_slack_actor_and_retry_mapping(
+            organization_id=organization_id,
+            team_id=team_id,
+            slack_user_id=user_id,
+            slack_user=slack_user,
+        )
+
     if not linked_user:
         logger.info(
             "[slack_conversations] No linked RevTops user for Slack actor=%s org=%s; refusing to run turn",
@@ -2598,6 +2668,14 @@ async def process_slack_thread_reply(
         slack_user_id=user_id,
         slack_user=slack_user,
     )
+    if not linked_user:
+        linked_user = await _ingest_unknown_slack_actor_and_retry_mapping(
+            organization_id=organization_id,
+            team_id=team_id,
+            slack_user_id=user_id,
+            slack_user=slack_user,
+        )
+
     if not linked_user:
         logger.info(
             "[slack_conversations] No linked RevTops user for Slack actor=%s org=%s; refusing to run turn",

--- a/backend/tests/test_slack_user_resolution.py
+++ b/backend/tests/test_slack_user_resolution.py
@@ -619,3 +619,131 @@ def test_process_slack_mention_returns_identity_unmapped_for_unresolved_speaker_
 
     assert result == {"status": "error", "error": "identity_unmapped"}
     assert "post_message:111.222" in events
+
+
+def test_process_slack_dm_retries_unknown_identity_with_ingest_before_refusal(monkeypatch):
+    events: list[str] = []
+
+    class _FakeConnector:
+        def __init__(self, organization_id: str, team_id: str | None = None):
+            self.organization_id = organization_id
+
+        async def add_reaction(self, channel: str, timestamp: str):
+            events.append("add_reaction")
+
+        async def remove_reaction(self, channel: str, timestamp: str):
+            events.append("remove_reaction")
+
+        async def post_message(self, channel: str, text: str, thread_ts: str | None = None):
+            events.append("post_message")
+
+    async def _fake_find_org(_team_id: str):
+        return "11111111-1111-1111-1111-111111111111"
+
+    async def _fake_fetch_slack_user_info(**_kwargs):
+        events.append("fetch_slack_user")
+        return {"profile": {"email": "new.user@acme.com"}}
+
+    async def _fake_resolve_user(**_kwargs):
+        events.append("resolve_user")
+        return None
+
+    async def _fake_ingest_retry(**_kwargs):
+        events.append("ingest_retry")
+        return None
+
+    monkeypatch.setattr(slack_conversations, "find_organization_by_slack_team", _fake_find_org)
+    monkeypatch.setattr(slack_conversations, "_fetch_slack_user_info", _fake_fetch_slack_user_info)
+    monkeypatch.setattr(slack_conversations, "resolve_revtops_user_for_slack_actor", _fake_resolve_user)
+    monkeypatch.setattr(slack_conversations, "_ingest_unknown_slack_actor_and_retry_mapping", _fake_ingest_retry)
+    monkeypatch.setattr(slack_conversations, "SlackConnector", _FakeConnector)
+
+    result = asyncio.run(
+        slack_conversations.process_slack_dm(
+            team_id="T123",
+            channel_id="D123",
+            user_id="U_NEW",
+            message_text="hello",
+            event_ts="111.333",
+            thread_ts="111.222",
+            files=None,
+        )
+    )
+
+    assert result == {"status": "error", "error": "identity_unmapped"}
+    assert events.index("resolve_user") < events.index("ingest_retry")
+    assert events.index("ingest_retry") < events.index("post_message")
+
+
+def test_process_slack_dm_unknown_identity_ingest_can_recover_user(monkeypatch):
+    events: list[str] = []
+
+    class _FakeConnector:
+        def __init__(self, organization_id: str, team_id: str | None = None):
+            self.organization_id = organization_id
+
+        async def add_reaction(self, channel: str, timestamp: str):
+            events.append("add_reaction")
+
+        async def remove_reaction(self, channel: str, timestamp: str):
+            events.append("remove_reaction")
+
+        async def post_message(self, channel: str, text: str, thread_ts: str | None = None):
+            events.append("post_message")
+
+    class _FakeOrchestrator:
+        def __init__(self, **kwargs):
+            self.user_id = kwargs.get("user_id")
+            events.append(f"orchestrator_user:{self.user_id}")
+
+    async def _fake_find_org(_team_id: str):
+        return "11111111-1111-1111-1111-111111111111"
+
+    async def _fake_fetch_slack_user_info(**_kwargs):
+        return {"profile": {"email": "new.user@acme.com"}}
+
+    async def _fake_resolve_user(**_kwargs):
+        return None
+
+    async def _fake_ingest_retry(**_kwargs):
+        events.append("ingest_retry")
+        return SimpleNamespace(
+            id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            email="new.user@acme.com",
+        )
+
+    async def _fake_find_or_create_conversation(**_kwargs):
+        return SimpleNamespace(id=UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+
+    async def _fake_stream_and_post_responses(**_kwargs):
+        events.append("stream")
+        return 1
+
+    async def _fake_can_use_credits(_org_id: str) -> bool:
+        return True
+
+    monkeypatch.setattr(slack_conversations, "find_organization_by_slack_team", _fake_find_org)
+    monkeypatch.setattr(slack_conversations, "_fetch_slack_user_info", _fake_fetch_slack_user_info)
+    monkeypatch.setattr(slack_conversations, "resolve_revtops_user_for_slack_actor", _fake_resolve_user)
+    monkeypatch.setattr(slack_conversations, "_ingest_unknown_slack_actor_and_retry_mapping", _fake_ingest_retry)
+    monkeypatch.setattr(slack_conversations, "find_or_create_conversation", _fake_find_or_create_conversation)
+    monkeypatch.setattr(slack_conversations, "_stream_and_post_responses", _fake_stream_and_post_responses)
+    monkeypatch.setattr(slack_conversations, "can_use_credits", _fake_can_use_credits)
+    monkeypatch.setattr(slack_conversations, "ChatOrchestrator", _FakeOrchestrator)
+    monkeypatch.setattr(slack_conversations, "SlackConnector", _FakeConnector)
+
+    result = asyncio.run(
+        slack_conversations.process_slack_dm(
+            team_id="T123",
+            channel_id="D123",
+            user_id="U_NEW",
+            message_text="hello",
+            event_ts="111.333",
+            thread_ts="111.222",
+            files=None,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert "ingest_retry" in events
+    assert "stream" in events


### PR DESCRIPTION
### Motivation
- Unknown Slack actors were immediately refused with `identity_unmapped` even when fresh profile or directory data could allow mapping; we should attempt to ingest and map the Slack identity before returning an error. 
- Improve reliability and debuggability by performing an immediate ingestion pass (profile upsert + mapping refresh) and logging the outcome before refusing the request.

### Description
- Add ` _ingest_unknown_slack_actor_and_retry_mapping` in `backend/services/slack_conversations.py` which fetches `users.info`, upserts an unmapped `SlackUserMapping`, refreshes org mappings from integration metadata and workspace directory, and retries `resolve_revtops_user_for_slack_actor`.
- Wire the ingest-and-retry flow into `process_slack_dm`, `process_slack_mention`, and `process_slack_thread_reply` so handlers attempt mapping before returning `identity_unmapped`.
- Add logging around ingestion, mapping refresh, and retry outcomes for easier debugging and observability.
- Add unit tests in `backend/tests/test_slack_user_resolution.py` that assert the ingest+retry is attempted before refusal and that the DM flow succeeds if the ingestion pass resolves the user.

### Testing
- Ran `pytest -q backend/tests/test_slack_user_resolution.py backend/tests/test_slack_dm_threading.py` and the suite completed successfully with all tests passing (`26 passed`).
- Tests specifically cover the new ingest-and-retry behavior for the DM path and verify background streaming and reaction behavior remained unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab32cbab9c8321a6d0a3a8c89f48a7)