### PR TITLE
Run Alembic migrations automatically during Railway backend startup

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -41,6 +41,10 @@ The deployment consists of two services:
 
 5. Click "Deploy"
 
+5. On startup, the backend now automatically runs `alembic upgrade head` before launching the API process.
+   - This ensures Railway applies any unapplied migrations during deploy/startup.
+   - For non-API services (worker/beat) using the same image, set `RUN_DB_MIGRATIONS=0` to skip this step.
+
 ## Step 3: Deploy the Frontend
 
 1. Click "New Service" → "GitHub Repo" (same repo)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -32,5 +32,7 @@ ENV PYTHONPATH=/app
 # Expose port (Railway provides PORT env var)
 EXPOSE 8000
 
-# Run the application - use shell to expand $PORT
+# Run DB migrations before startup, then launch the API service
+ENTRYPOINT ["/app/scripts/entrypoint.sh"]
+# Use shell to expand $PORT
 CMD ["/bin/sh", "-c", "uvicorn api.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] [entrypoint] $*"
+}
+
+run_migrations="${RUN_DB_MIGRATIONS:-1}"
+if [[ "$run_migrations" == "1" || "$run_migrations" == "true" || "$run_migrations" == "TRUE" ]]; then
+  log "Running Alembic migrations (alembic upgrade head)."
+  alembic upgrade head
+  log "Alembic migrations complete."
+else
+  log "Skipping Alembic migrations because RUN_DB_MIGRATIONS=$run_migrations."
+fi
+
+log "Starting application command: $*"
+exec "$@"


### PR DESCRIPTION
### Motivation
- Ensure Railway-deployed backend containers apply any standing/unapplied Alembic migrations at service startup so schema drift doesn't cause runtime errors.

### Description
- Add `backend/scripts/entrypoint.sh` which logs startup steps and runs `alembic upgrade head` by default, with opt-out via `RUN_DB_MIGRATIONS=0`.
- Update `backend/Dockerfile` to use the new `ENTRYPOINT` while preserving the existing `CMD` that launches Uvicorn.
- Document the new behavior in `DEPLOY.md`, including the `RUN_DB_MIGRATIONS` opt-out note for non-API services.

### Testing
- Shell syntax check: `bash -n backend/scripts/entrypoint.sh` (succeeded).
- Unit/test run: `cd backend && pytest -q tests/test_alembic_migration_numbering.py` (1 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab34ed19348321914c0eff709b5491)