### PR TITLE
Fix chat rename not syncing to sidebar

### DIFF
--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -642,7 +642,7 @@ export const useChatStore = create<ChatState>()(
     },
 
     setConversationTitle: (conversationId, title) => {
-      const { conversations } = get();
+      const { conversations, recentChats } = get();
       const current = conversations[conversationId] ?? {
         ...defaultConversationState,
       };
@@ -651,6 +651,9 @@ export const useChatStore = create<ChatState>()(
           ...conversations,
           [conversationId]: { ...current, title },
         },
+        recentChats: recentChats.map((c) =>
+          c.id === conversationId ? { ...c, title } : c,
+        ),
       });
     },
 


### PR DESCRIPTION
## Summary

- `setConversationTitle()` updated `conversations[id].title` (what the header reads) but never updated `recentChats[]` (what the sidebar reads)
- Renames appeared to work in the header but the sidebar showed the stale title until a full page refresh
- Now updates both stores simultaneously, matching the pattern already used by `setChatScope()`

## Test plan

- [ ] Rename a chat via header click — sidebar title updates immediately
- [ ] Rename a chat via sidebar double-click — header title updates immediately
- [ ] Navigate away and back — renamed title persists
- [ ] Rename fails (disconnect network) — title reverts in both header and sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)