### PR TITLE
feat: activity visibility scoping — Penny respects per-connector 'others can read'

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -827,7 +827,9 @@ async def _run_sql_query(
     )
 
     try:
-        async with get_session(organization_id=organization_id) as session:
+        async with get_session(
+            organization_id=organization_id, user_id=user_id
+        ) as session:
             result = await session.execute(text(query_to_run))
             rows = result.fetchall()
             columns: list[str] = list(result.keys())

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -3073,6 +3073,17 @@ async def update_integration_sharing(
         user_id_str = str(integration.user_id) if integration.user_id else ""
         provider = integration.provider
 
+    # Propagate share_synced_data to activity visibility
+    new_visibility: str = "team" if request.share_synced_data else "owner_only"
+    async with get_admin_session() as prop_session:
+        await prop_session.execute(
+            text(
+                "UPDATE activities SET visibility = :vis WHERE integration_id = :iid"
+            ),
+            {"vis": new_visibility, "iid": integration_uuid},
+        )
+        await prop_session.commit()
+
     # If this was the initial sharing config, trigger sync now
     if was_pending:
         background_tasks.add_task(run_initial_sync, org_id_str, provider, user_id_str)
@@ -3133,6 +3144,17 @@ async def patch_integration_sharing(
         integration.updated_at = datetime.utcnow()
 
         await session.commit()
+
+    # Propagate share_synced_data to activity visibility
+    new_visibility: str = "team" if request.share_synced_data else "owner_only"
+    async with get_admin_session() as prop_session:
+        await prop_session.execute(
+            text(
+                "UPDATE activities SET visibility = :vis WHERE integration_id = :iid"
+            ),
+            {"vis": new_visibility, "iid": integration_uuid},
+        )
+        await prop_session.commit()
 
     return {
         "status": "updated",

--- a/backend/api/routes/data.py
+++ b/backend/api/routes/data.py
@@ -73,7 +73,10 @@ async def get_data_summary(
     """Get counts for all synced data tables."""
     org_uuid = auth.organization_id
 
-    async with get_session(organization_id=auth.organization_id_str) as session:
+    async with get_session(
+        organization_id=auth.organization_id_str,
+        user_id=auth.user_id_str,
+    ) as session:
         # Count each table
         contacts_count = await session.scalar(
             select(func.count(Contact.id)).where(Contact.organization_id == org_uuid)
@@ -109,7 +112,10 @@ async def get_activity_types(
     """Get distinct activity types for filtering."""
     org_uuid = auth.organization_id
 
-    async with get_session(organization_id=auth.organization_id_str) as session:
+    async with get_session(
+        organization_id=auth.organization_id_str,
+        user_id=auth.user_id_str,
+    ) as session:
         result = await session.execute(
             select(Activity.type)
             .where(Activity.organization_id == org_uuid)
@@ -142,7 +148,10 @@ async def get_filter_options(
 
     model = table_models[table]
 
-    async with get_session(organization_id=auth.organization_id_str) as session:
+    async with get_session(
+        organization_id=auth.organization_id_str,
+        user_id=auth.user_id_str,
+    ) as session:
         # Get distinct source systems
         result = await session.execute(
             select(model.source_system)
@@ -220,7 +229,10 @@ async def get_data(
     model = config["model"]
     columns: list[str] = config["columns"]
 
-    async with get_session(organization_id=auth.organization_id_str) as session:
+    async with get_session(
+        organization_id=auth.organization_id_str,
+        user_id=auth.user_id_str,
+    ) as session:
         # Base query
         base_query = select(model).where(model.organization_id == org_uuid)
 

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -116,6 +116,19 @@ class BaseConnector(ABC):
 
         self._integration = integration
 
+    def _activity_visibility_fields(self) -> dict[str, Any]:
+        """Return integration_id, owner_user_id, visibility for Activity creation.
+
+        Call after ensure_sync_active. Returns empty dict if no integration.
+        """
+        if not self._integration:
+            return {}
+        return {
+            "integration_id": self._integration.id,
+            "owner_user_id": self._integration.user_id,
+            "visibility": "team" if self._integration.share_synced_data else "owner_only",
+        }
+
     async def _resolve_stale_pending_sharing_config(
         self,
         session: Any,
@@ -358,8 +371,15 @@ class BaseConnector(ABC):
         if isinstance(raw, list):
             from connectors.persistence import persist_records
 
+            kwargs: dict[str, Any] = {}
+            if entity == "activities" and self._integration:
+                kwargs["integration_id"] = self._integration.id
+                kwargs["owner_user_id"] = self._integration.user_id
+                kwargs["visibility"] = (
+                    "team" if self._integration.share_synced_data else "owner_only"
+                )
             return await persist_records(
-                self.organization_id, entity, raw, self.source_system,
+                self.organization_id, entity, raw, self.source_system, **kwargs
             )
 
         return 0

--- a/backend/connectors/fireflies.py
+++ b/backend/connectors/fireflies.py
@@ -189,6 +189,7 @@ class FirefliesConnector(BaseConnector):
         
         This ensures transcripts are properly associated with real-world meetings.
         """
+        await self.ensure_sync_active("sync_activities:start")
         # Broadcast that we're starting
         await broadcast_sync_progress(
             organization_id=self.organization_id,
@@ -236,11 +237,13 @@ class FirefliesConnector(BaseConnector):
                     activity: Activity | None = existing_result.scalar_one_or_none()
 
                     if activity is None:
+                        vis: dict[str, Any] = self._activity_visibility_fields()
                         activity = Activity(
                             id=uuid.uuid4(),
                             organization_id=org_uuid,
                             source_system=self.source_system,
                             source_id=parsed["transcript_id"],
+                            **vis,
                         )
                         session.add(activity)
 

--- a/backend/connectors/gmail.py
+++ b/backend/connectors/gmail.py
@@ -184,6 +184,7 @@ class GmailConnector(BaseConnector):
         This captures email activity and resolves email addresses to
         CRM contacts, accounts, and deals using synced HubSpot data.
         """
+        await self.ensure_sync_active("sync_activities:start")
         from connectors.resolution import build_activity_resolver
         from sqlalchemy import select
         from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -349,6 +350,7 @@ class GmailConnector(BaseConnector):
             for part in gmail_msg.get("payload", {}).get("parts", [])
         )
 
+        vis: dict[str, Any] = self._activity_visibility_fields()
         return Activity(
             id=uuid.uuid4(),
             organization_id=uuid.UUID(self.organization_id),
@@ -358,6 +360,7 @@ class GmailConnector(BaseConnector):
             subject=subject,
             description=snippet[:2000] if snippet else None,
             activity_date=activity_date,
+            **vis,
             custom_fields={
                 "from_email": from_email,
                 "from_name": from_name,

--- a/backend/connectors/google_calendar.py
+++ b/backend/connectors/google_calendar.py
@@ -152,6 +152,7 @@ class GoogleCalendarConnector(BaseConnector):
         3. Link the Activity to the Meeting
         4. Resolve attendee emails to CRM contact/account/deal FKs
         """
+        await self.ensure_sync_active("sync_activities:start")
         from connectors.resolution import build_activity_resolver
 
         # Get events from primary calendar for the last 30 days and next 30 days
@@ -261,6 +262,7 @@ class GoogleCalendarConnector(BaseConnector):
                         )
                         
                         # Create new Activity record linked to the Meeting
+                        vis: dict[str, Any] = self._activity_visibility_fields()
                         activity: Activity = Activity(
                             id=uuid.uuid4(),
                             organization_id=uuid.UUID(self.organization_id),
@@ -274,6 +276,7 @@ class GoogleCalendarConnector(BaseConnector):
                             subject=parsed["summary"] or "Untitled Event",
                             description=parsed["description"],
                             activity_date=activity_date,
+                            **vis,
                             custom_fields={
                                 "calendar_id": parsed["calendar_id"],
                                 "location": parsed["location"],

--- a/backend/connectors/hubspot.py
+++ b/backend/connectors/hubspot.py
@@ -879,6 +879,7 @@ class HubSpotConnector(BaseConnector):
         companies.  We request those associations from the API and resolve them
         to internal FK UUIDs so that activities are properly linked.
         """
+        await self.ensure_sync_active("sync_activities:start")
         total_count: int = 0
         org_uuid: uuid.UUID = uuid.UUID(self.organization_id)
 
@@ -1088,6 +1089,7 @@ class HubSpotConnector(BaseConnector):
             "notes": "note",
         }
 
+        vis: dict[str, Any] = self._activity_visibility_fields()
         return Activity(
             id=existing_id or uuid.uuid4(),
             organization_id=uuid.UUID(self.organization_id),
@@ -1097,6 +1099,7 @@ class HubSpotConnector(BaseConnector):
             subject=subject,
             description=description,
             activity_date=activity_date,
+            **vis,
         )
 
     async def _discover_goal_owner_property(self) -> Optional[str]:

--- a/backend/connectors/microsoft_calendar.py
+++ b/backend/connectors/microsoft_calendar.py
@@ -170,6 +170,7 @@ class MicrosoftCalendarConnector(BaseConnector):
         2. Create an Activity record for the calendar event
         3. Link the Activity to the Meeting
         """
+        await self.ensure_sync_active("sync_activities:start")
         # Get events from default calendar for the last 30 days and next 30 days
         time_min = datetime.utcnow() - timedelta(days=30)
         time_max = datetime.utcnow() + timedelta(days=30)
@@ -201,6 +202,7 @@ class MicrosoftCalendarConnector(BaseConnector):
                     )
                     
                     # Create the Activity record linked to the Meeting
+                    vis: dict[str, Any] = self._activity_visibility_fields()
                     activity = Activity(
                         id=uuid.uuid4(),
                         organization_id=uuid.UUID(self.organization_id),
@@ -211,6 +213,7 @@ class MicrosoftCalendarConnector(BaseConnector):
                         subject=parsed["subject"] or "Untitled Event",
                         description=parsed["body_preview"],
                         activity_date=parsed["activity_date"],
+                        **vis,
                         custom_fields={
                             "organizer_email": parsed["organizer_email"],
                             "location": parsed["location"],

--- a/backend/connectors/microsoft_mail.py
+++ b/backend/connectors/microsoft_mail.py
@@ -176,6 +176,7 @@ class MicrosoftMailConnector(BaseConnector):
         This captures email activity that can be correlated
         with deals and accounts.
         """
+        await self.ensure_sync_active("sync_activities:start")
         # Get emails from the last 30 days
         received_after = datetime.utcnow() - timedelta(days=30)
         received_before = datetime.utcnow()
@@ -240,6 +241,7 @@ class MicrosoftMailConnector(BaseConnector):
             if addr:
                 cc_emails.append(addr)
 
+        vis: dict[str, Any] = self._activity_visibility_fields()
         return Activity(
             id=uuid.uuid4(),
             organization_id=uuid.UUID(self.organization_id),
@@ -249,6 +251,7 @@ class MicrosoftMailConnector(BaseConnector):
             subject=subject or "(No Subject)",
             description=body_preview[:2000] if body_preview else None,
             activity_date=activity_date,
+            **vis,
             custom_fields={
                 "from_email": from_email,
                 "from_name": from_name,

--- a/backend/connectors/persistence.py
+++ b/backend/connectors/persistence.py
@@ -133,10 +133,17 @@ async def persist_records(
     entity: str,
     records: Sequence[BaseModel],
     source_system: str,
+    *,
+    integration_id: UUID | None = None,
+    owner_user_id: UUID | None = None,
+    visibility: str | None = None,
 ) -> int:
     """Upsert a batch of Pydantic records into the corresponding DB table.
 
     Returns the number of records persisted.
+
+    For entity='activities', pass integration_id, owner_user_id, visibility
+    to set activity visibility (owner_only vs team) per share_synced_data.
     """
     if not records:
         return 0
@@ -162,16 +169,27 @@ async def persist_records(
                 row[db_column] = record_dict[pydantic_field]
         if "source_system" in row and not row["source_system"]:
             row["source_system"] = source_system
+        if entity == "activities":
+            if integration_id is not None:
+                row["integration_id"] = integration_id
+            if owner_user_id is not None:
+                row["owner_user_id"] = owner_user_id
+            if visibility is not None:
+                row["visibility"] = visibility
         rows.append(row)
 
     async with get_session(organization_id=organization_id) as session:
         table = model_cls.__table__
-        update_cols = {
+        update_cols: dict[str, Any] = {
             col: getattr(pg_insert(table).excluded, col)
             for col in field_map.values()
             if col not in conflict_keys
         }
         update_cols["synced_at"] = now
+        if entity == "activities":
+            for col in ("integration_id", "owner_user_id", "visibility"):
+                if col in rows[0]:
+                    update_cols[col] = getattr(pg_insert(table).excluded, col)
 
         stmt = (
             pg_insert(table)

--- a/backend/connectors/salesforce.py
+++ b/backend/connectors/salesforce.py
@@ -401,7 +401,8 @@ class SalesforceConnector(BaseConnector):
 
     async def sync_activities(self) -> int:
         """Sync Tasks and Events from Salesforce."""
-        count = 0
+        await self.ensure_sync_active("sync_activities:start")
+        count: int = 0
 
         # Sync Tasks
         task_soql = """
@@ -487,6 +488,7 @@ class SalesforceConnector(BaseConnector):
             except (ValueError, TypeError):
                 pass
 
+        vis: dict[str, Any] = self._activity_visibility_fields()
         return Activity(
             id=existing_id or uuid.uuid4(),
             organization_id=uuid.UUID(self.organization_id),
@@ -497,6 +499,7 @@ class SalesforceConnector(BaseConnector):
             description=sf_task.get("Description"),
             activity_date=activity_date,
             created_by_id=created_by_id,
+            **vis,
         )
 
     async def _normalize_event(
@@ -516,6 +519,7 @@ class SalesforceConnector(BaseConnector):
             except (ValueError, TypeError):
                 pass
 
+        vis: dict[str, Any] = self._activity_visibility_fields()
         return Activity(
             id=existing_id or uuid.uuid4(),
             organization_id=uuid.UUID(self.organization_id),
@@ -526,6 +530,7 @@ class SalesforceConnector(BaseConnector):
             description=sf_event.get("Description"),
             activity_date=activity_date,
             created_by_id=created_by_id,
+            **vis,
         )
 
     async def _map_sf_owner_to_user(

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -643,6 +643,7 @@ class SlackConnector(BaseConnector):
         source_id = f"{channel_id}:{msg_ts}"
 
         sender_fields = self._extract_sender_fields(slack_msg)
+        vis: dict[str, Any] = self._activity_visibility_fields()
         return Activity(
             id=uuid.uuid4(),
             organization_id=uuid.UUID(self.organization_id),
@@ -652,6 +653,7 @@ class SlackConnector(BaseConnector):
             subject=f"#{channel_name}",
             description=text[:1000],  # Truncate very long messages
             activity_date=activity_date,
+            **vis,
             custom_fields={
                 "channel_id": channel_id,
                 "channel_name": channel_name,

--- a/backend/connectors/zoom.py
+++ b/backend/connectors/zoom.py
@@ -159,6 +159,7 @@ class ZoomConnector(BaseConnector):
 
     async def sync_activities(self) -> int:
         """Sync Zoom meeting transcripts as activities."""
+        await self.ensure_sync_active("sync_activities:start")
         now = datetime.utcnow()
         start_date = (now - timedelta(days=7)).date()
         end_date = now.date()
@@ -259,6 +260,7 @@ class ZoomConnector(BaseConnector):
                             continue
 
                         source_id = f"{meeting_uuid}:{transcript_file.get('id') or transcript_file.get('file_id')}"
+                        vis: dict[str, Any] = self._activity_visibility_fields()
                         activity = Activity(
                             id=uuid.uuid4(),
                             organization_id=uuid.UUID(self.organization_id),
@@ -269,6 +271,7 @@ class ZoomConnector(BaseConnector):
                             subject=topic,
                             description=transcript_text[:MAX_TRANSCRIPT_LENGTH],
                             activity_date=start_time,
+                            **vis,
                             custom_fields={
                                 "meeting_id": meeting_id,
                                 "meeting_uuid": meeting_uuid,

--- a/backend/db/migrations/versions/093_activity_visibility_scoping.py
+++ b/backend/db/migrations/versions/093_activity_visibility_scoping.py
@@ -1,0 +1,156 @@
+"""Add activity visibility scoping (integration_id, owner_user_id, visibility).
+
+Enables per-connector "others can read" enforcement so Penny respects
+share_synced_data when querying activities (e.g., private emails).
+
+Revision ID: 093_activity_visibility_scoping
+Revises: 092_org_handle_not_null
+Create Date: 2026-03-06
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "093_activity_visibility_scoping"
+down_revision: Union[str, None] = "092_org_handle_not_null"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+NULL_UUID: str = "00000000-0000-0000-0000-000000000000"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # 1. Add integration_id (nullable, FK to integrations)
+    op.add_column(
+        "activities",
+        sa.Column(
+            "integration_id",
+            sa.UUID(),
+            sa.ForeignKey("integrations.id", ondelete="SET NULL", onupdate="CASCADE"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_activities_integration_id",
+        "activities",
+        ["integration_id"],
+        unique=False,
+    )
+
+    # 2. Add owner_user_id (nullable for legacy rows)
+    op.add_column(
+        "activities",
+        sa.Column(
+            "owner_user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id", ondelete="SET NULL", onupdate="CASCADE"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_activities_owner_user_id",
+        "activities",
+        ["owner_user_id"],
+        unique=False,
+    )
+
+    # 3. Add visibility column ('team' | 'owner_only')
+    op.add_column(
+        "activities",
+        sa.Column(
+            "visibility",
+            sa.String(20),
+            nullable=False,
+            server_default="team",
+        ),
+    )
+
+    # 4. Backfill integration_id, owner_user_id, visibility from integrations
+    # Match by (organization_id, source_system); if multiple integrations exist,
+    # pick the most recently updated one (arbitrary heuristic for legacy data).
+    conn.execute(
+        text("""
+            UPDATE activities a
+            SET
+                integration_id = sub.integration_id,
+                owner_user_id = sub.owner_user_id,
+                visibility = sub.visibility
+            FROM (
+                SELECT
+                    a2.id AS activity_id,
+                    i.id AS integration_id,
+                    i.user_id AS owner_user_id,
+                    CASE WHEN i.share_synced_data THEN 'team'::varchar ELSE 'owner_only'::varchar END AS visibility
+                FROM activities a2
+                CROSS JOIN LATERAL (
+                    SELECT id, user_id, share_synced_data
+                    FROM integrations
+                    WHERE organization_id = a2.organization_id
+                      AND provider = a2.source_system
+                      AND is_active = true
+                      AND user_id IS NOT NULL
+                    ORDER BY updated_at DESC NULLS LAST
+                    LIMIT 1
+                ) i
+            ) sub
+            WHERE a.id = sub.activity_id
+        """)
+    )
+
+    # 5. For activities with no matching integration, visibility is already 'team'
+    # from server_default; leave integration_id and owner_user_id NULL.
+
+    # 6. Replace org_isolation RLS policy with org_and_user_isolation
+    conn.execute(text("DROP POLICY IF EXISTS org_isolation ON activities"))
+    conn.execute(
+        text(f"""
+            CREATE POLICY org_and_user_isolation ON activities
+            FOR ALL
+            USING (
+                organization_id::text = COALESCE(
+                    NULLIF(current_setting('app.current_org_id', true), ''),
+                    '{NULL_UUID}'
+                )
+                AND (
+                    visibility = 'team'
+                    OR owner_user_id IS NULL
+                    OR owner_user_id::text = COALESCE(
+                        NULLIF(current_setting('app.current_user_id', true), ''),
+                        '{NULL_UUID}'
+                    )
+                )
+            )
+        """)
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    # Restore org_isolation policy
+    conn.execute(text("DROP POLICY IF EXISTS org_and_user_isolation ON activities"))
+    conn.execute(
+        text(f"""
+            CREATE POLICY org_isolation ON activities
+            FOR ALL
+            USING (
+                organization_id::text = COALESCE(
+                    NULLIF(current_setting('app.current_org_id', true), ''),
+                    '{NULL_UUID}'
+                )
+            )
+        """)
+    )
+
+    op.drop_index("ix_activities_owner_user_id", table_name="activities")
+    op.drop_column("activities", "visibility")
+    op.drop_column("activities", "owner_user_id")
+    op.drop_index("ix_activities_integration_id", table_name="activities")
+    op.drop_column("activities", "integration_id")

--- a/backend/models/activity.py
+++ b/backend/models/activity.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from models.account import Account
     from models.contact import Contact
     from models.deal import Deal
+    from models.integration import Integration
     from models.meeting import Meeting
     from models.user import User
 
@@ -49,6 +50,21 @@ class Activity(Base):
     )
     organization_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    integration_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("integrations.id", ondelete="SET NULL", onupdate="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    owner_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL", onupdate="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    visibility: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="team", server_default="team"
     )
     source_system: Mapped[str] = mapped_column(
         String(50), default="salesforce", nullable=False
@@ -96,11 +112,15 @@ class Activity(Base):
     )
 
     # Relationships
+    integration: Mapped[Optional["Integration"]] = relationship("Integration")
     deal: Mapped[Optional["Deal"]] = relationship("Deal", back_populates="activities")
     account: Mapped[Optional["Account"]] = relationship("Account")
     contact: Mapped[Optional["Contact"]] = relationship("Contact")
     meeting: Mapped[Optional["Meeting"]] = relationship("Meeting", back_populates="activities")
     created_by: Mapped[Optional["User"]] = relationship("User", foreign_keys=[created_by_id])
+    owner: Mapped[Optional["User"]] = relationship(
+        "User", foreign_keys=[owner_user_id]
+    )
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for API responses."""

--- a/backend/models/database.py
+++ b/backend/models/database.py
@@ -198,33 +198,39 @@ def dispose_engine() -> None:
 
 
 @asynccontextmanager
-async def get_session(organization_id: str | None = None) -> AsyncGenerator[AsyncSession, None]:
+async def get_session(
+    organization_id: str | None = None,
+    user_id: str | None = None,
+) -> AsyncGenerator[AsyncSession, None]:
     """
     Yield an async database session with Row-Level Security (RLS) context.
-    
+
     IMPORTANT: organization_id SHOULD be provided to ensure RLS is enforced.
-    Calling without it will log a warning. For system-level operations that 
+    Calling without it will log a warning. For system-level operations that
     legitimately need to bypass RLS, use get_admin_session() instead.
-    
+
     How it works:
     - Session checks out a connection from the pool
     - Sets role to non-superuser (revtops_app) that respects RLS
     - If organization_id provided, sets RLS context (app.current_org_id)
-    - All queries are automatically filtered to this organization
+    - If user_id provided, sets app.current_user_id for activity visibility
+    - All queries are automatically filtered per RLS policies
     - When session closes, connection returns to pool (NOT destroyed)
-    
+
     Args:
         organization_id: Organization ID for RLS context. Should always be provided
                         for tenant-scoped operations. If None, a warning is logged.
-    
+        user_id: User ID for activity visibility (owner_only vs team). When set,
+                activities RLS policy filters owner_only rows to this user.
+
     Usage:
-        async with get_session(organization_id="...") as session:
+        async with get_session(organization_id="...", user_id="...") as session:
             result = await session.execute(query)
             await session.commit()  # Explicit commit if needed
-    
+
     The session is automatically closed when the context exits.
     Any uncommitted changes are rolled back on error.
-    
+
     SECURITY: We connect as postgres superuser but immediately SET ROLE to
     revtops_app, which respects RLS policies. This is required because
     superusers bypass RLS entirely.
@@ -257,6 +263,16 @@ async def get_session(organization_id: str | None = None) -> AsyncGenerator[Asyn
                         text("SELECT set_config('app.current_org_id', :org_id, false)"),
                         {"org_id": str(organization_id)}
                     )
+                # Set user context for activity visibility (owner_only vs team)
+                if user_id:
+                    await session.execute(
+                        text("SELECT set_config('app.current_user_id', :uid, false)"),
+                        {"uid": str(user_id)}
+                    )
+                else:
+                    await session.execute(
+                        text("SELECT set_config('app.current_user_id', '', false)")
+                    )
                 break
             except DBAPIError as exc:
                 await session.close()
@@ -283,6 +299,7 @@ async def get_session(organization_id: str | None = None) -> AsyncGenerator[Asyn
             logger.debug("Session cleanup: resetting RLS context (set_config + RESET ROLE)")
             if session is not None:
                 await session.execute(text("SELECT set_config('app.current_org_id', '', false)"))
+                await session.execute(text("SELECT set_config('app.current_user_id', '', false)"))
                 await session.execute(text("RESET ROLE"))
         except Exception:
             pass  # Connection might already be closed

--- a/backend/scripts/dbq.py
+++ b/backend/scripts/dbq.py
@@ -48,15 +48,28 @@ def _serialise(obj: object) -> str:
 
 
 def run_query(sql: str) -> None:
-    """Execute *sql*, pretty-print results (or row count for non-SELECT)."""
+    """Execute *sql*, pretty-print results (or row count for non-SELECT).
+
+    Supports multiple statements separated by semicolons (e.g. SET ...; SELECT ...).
+    psycopg2 executes one statement per call, so we run each in sequence.
+    """
     conn: psycopg2.extensions.connection = psycopg2.connect(DB_URL)
     try:
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
-            cur.execute(sql)
+            statements: list[str] = [
+                s.strip() for s in sql.split(";") if s.strip()
+            ]
+            if not statements:
+                print("No SQL provided.", file=sys.stderr)
+                return
+
+            for stmt in statements:
+                cur.execute(stmt)
+                if cur.description is None:
+                    conn.commit()
+                # Keep going; we'll print the last result set below
 
             if cur.description is None:
-                # DML / DDL — no result set
-                conn.commit()
                 print(f"OK — {cur.rowcount} row(s) affected")
                 return
 

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -1974,10 +1974,10 @@ export function DataSources(): JSX.Element {
                   />
                   <div>
                     <div className="font-medium text-surface-100 group-hover:text-white">
-                      Share synced data with team
+                      Others can read
                     </div>
                     <div className="text-xs text-surface-500 mt-0.5">
-                      Team members can see deals, contacts, and other synced records
+                      When on: teammates and Penny can see synced records (emails, meetings, etc.). When off: only you can see it.
                     </div>
                   </div>
                 </label>


### PR DESCRIPTION
## Summary
Implements activity visibility scoping so Penny won't surface private connector data (e.g. emails) to teammates. When you connect Gmail with "Others can read" off, only you can see that data when chatting with Penny.

## Changes
- **Migration 093**: Adds `integration_id`, `owner_user_id`, `visibility` to activities; RLS policy enforces org + user visibility
- **get_session()**: Accepts optional `user_id`, sets `app.current_user_id` for RLS
- **run_sql_query** + Data API: Pass `user_id` so activity queries respect visibility
- **Connectors**: All activity-syncing connectors set ownership/visibility during sync
- **Toggle propagation**: POST/PATCH sharing endpoints batch-update activities when `share_synced_data` changes
- **Frontend**: Relabeled sharing toggle to "Others can read" with clearer description
- **dbq.py**: Fix multi-statement execution (SET commands now persist for RLS testing)

## Testing
- Migration run successfully; backfill populated ownership
- RLS verified: owner sees 16k+ activities, teammate sees only 2 (shared)
- Run `alembic upgrade head` before deploying

Made with [Cursor](https://cursor.com)