### PR TITLE
Rename 'organization' to 'team' in user-facing UI strings

### DIFF
--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -157,7 +157,7 @@ function OrgRowActions({
         type="button"
         onClick={() => setOrgMenuOpenId(isOpen ? null : org.id)}
         className="p-1.5 rounded-lg text-surface-400 hover:text-surface-200 hover:bg-surface-700 transition-colors"
-        aria-label="Organization options"
+        aria-label="Team options"
       >
         <ThreeDotsIcon />
       </button>
@@ -283,7 +283,7 @@ export function AdminPanel(): JSX.Element {
   const [orgsError, setOrgsError] = useState<string | null>(null);
   const [orgSearch, setOrgSearch] = useState<string>('');
 
-  // Create organization modal state
+  // Create team modal state
   const [showCreateOrgModal, setShowCreateOrgModal] = useState<boolean>(false);
   const [createOrgStep, setCreateOrgStep] = useState<1 | 2>(1);
   const [createOrgName, setCreateOrgName] = useState<string>('');
@@ -383,7 +383,7 @@ export function AdminPanel(): JSX.Element {
       );
 
       if (requestError || !data) {
-        setOrgsError(requestError ?? 'Failed to fetch organizations');
+        setOrgsError(requestError ?? 'Failed to fetch teams');
         setAdminOrgs([]);
         return;
       }
@@ -561,7 +561,7 @@ export function AdminPanel(): JSX.Element {
         { method: 'POST', body: JSON.stringify({ name, email_domain: domain, logo_url: createOrgLogoUrl.trim() || undefined }) }
       );
       if (reqError || !data) {
-        setCreateOrgError(reqError ?? 'Failed to create organization');
+        setCreateOrgError(reqError ?? 'Failed to create team');
         return;
       }
       setCreatedOrgId(data.id);
@@ -657,7 +657,7 @@ export function AdminPanel(): JSX.Element {
   };
 
   const handleDeleteOrg = async (orgId: string, orgName: string): Promise<void> => {
-    if (!window.confirm(`Delete ${orgName}? This permanently removes the organization and its data.`)) return;
+    if (!window.confirm(`Delete ${orgName}? This permanently removes the team and its data.`)) return;
     try {
       await deleteOrganizationMutation.mutateAsync({ orgId });
       await fetchOrganizations();
@@ -673,9 +673,9 @@ export function AdminPanel(): JSX.Element {
         sessionStorage.clear();
         window.location.href = '/auth';
       }
-      alert('Organization deleted.');
+      alert('Team deleted.');
     } catch (err) {
-      alert(`Failed to delete organization: ${err instanceof Error ? err.message : 'Unknown error'}`);
+      alert(`Failed to delete team: ${err instanceof Error ? err.message : 'Unknown error'}`);
     }
   };
 
@@ -826,7 +826,7 @@ export function AdminPanel(): JSX.Element {
   const tabs: { id: AdminTab; label: string; available: boolean }[] = [
     { id: 'waitlist', label: 'Waitlist', available: true },
     { id: 'users', label: 'Users', available: true },
-    { id: 'organizations', label: 'Organizations', available: true },
+    { id: 'organizations', label: 'Teams', available: true },
     { id: 'sources', label: 'Sources', available: true },
     { id: 'jobs', label: 'Running Jobs', available: true },
   ];
@@ -1091,7 +1091,7 @@ export function AdminPanel(): JSX.Element {
                 </svg>
                 <input
                   type="text"
-                  placeholder="Search by name, email, or organization..."
+                  placeholder="Search by name, email, or team..."
                   value={userSearch}
                   onChange={(e) => setUserSearch(e.target.value)}
                   className="w-full pl-10 pr-4 py-2 rounded-lg bg-surface-800 border border-surface-700 text-surface-100 placeholder-surface-500 focus:outline-none focus:border-primary-500"
@@ -1145,7 +1145,7 @@ export function AdminPanel(): JSX.Element {
                   <thead>
                     <tr className="border-b border-surface-800 text-left">
                       <th className="px-4 py-3 text-sm font-medium text-surface-400">User</th>
-                      <th className="px-4 py-3 text-sm font-medium text-surface-400">Organization</th>
+                      <th className="px-4 py-3 text-sm font-medium text-surface-400">Team</th>
                       <th className="px-4 py-3 text-sm font-medium text-surface-400">Status</th>
                       <th className="px-4 py-3 text-sm font-medium text-surface-400">Last Login</th>
                       <th className="px-4 py-3 text-sm font-medium text-surface-400">Joined</th>
@@ -1282,7 +1282,7 @@ export function AdminPanel(): JSX.Element {
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
                   </svg>
-                  Create organization
+                  Create team
                 </button>
                 <button
                   onClick={() => void fetchOrganizations()}
@@ -1308,7 +1308,7 @@ export function AdminPanel(): JSX.Element {
             {orgsLoading && (
               <div className="text-center py-12 text-surface-400">
                 <div className="w-8 h-8 border-2 border-primary-500 border-t-transparent rounded-full animate-spin mx-auto mb-3" />
-                Loading organizations...
+                Loading teams...
               </div>
             )}
 
@@ -1321,7 +1321,7 @@ export function AdminPanel(): JSX.Element {
                   </svg>
                 </div>
                 <p className="text-surface-400">
-                  {orgSearch ? 'No organizations match your search' : 'No organizations found'}
+                  {orgSearch ? 'No teams match your search' : 'No teams found'}
                 </p>
               </div>
             )}
@@ -1332,7 +1332,7 @@ export function AdminPanel(): JSX.Element {
                 <table className="w-full">
                   <thead>
                     <tr className="border-b border-surface-800 text-left">
-                      <th className="px-4 py-3 text-sm font-medium text-surface-400">Organization</th>
+                      <th className="px-4 py-3 text-sm font-medium text-surface-400">Team</th>
                       <th className="px-4 py-3 text-sm font-medium text-surface-400">Domain</th>
                       <th className="px-4 py-3 text-sm font-medium text-surface-400">Users</th>
                       <th className="px-4 py-3 text-sm font-medium text-surface-400">Last Sync</th>
@@ -1386,19 +1386,19 @@ export function AdminPanel(): JSX.Element {
             {/* Stats */}
             {!orgsLoading && !orgsError && (
               <div className="text-sm text-surface-500 text-center">
-                Showing {filteredOrgs.length} of {adminOrgs.length} organizations
+                Showing {filteredOrgs.length} of {adminOrgs.length} teams
                 {orgSearch && ` matching "${orgSearch}"`}
               </div>
             )}
 
-            {/* Create organization modal */}
+            {/* Create team modal */}
             {showCreateOrgModal && (
               <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" onClick={() => { if (!createOrgSubmitting) { setShowCreateOrgModal(false); setInviteModalOrg(null); } }}>
                 <div className="bg-surface-900 border border-surface-700 rounded-xl shadow-xl max-w-lg w-full max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
                   <div className="p-6">
                     <h3 className="text-lg font-semibold text-surface-100 mb-4">
                       {createOrgStep === 1
-                        ? 'Create organization'
+                        ? 'Create team'
                         : inviteModalOrg
                           ? `Invite users to ${inviteModalOrg.name}`
                           : 'Invite users'}
@@ -1412,7 +1412,7 @@ export function AdminPanel(): JSX.Element {
                       <>
                         <div className="space-y-4">
                           <div>
-                            <label className="block text-sm font-medium text-surface-400 mb-1">Organization name</label>
+                            <label className="block text-sm font-medium text-surface-400 mb-1">Team name</label>
                             <input
                               type="text"
                               value={createOrgName}
@@ -1556,7 +1556,7 @@ export function AdminPanel(): JSX.Element {
                 </svg>
                 <input
                   type="text"
-                  placeholder="Search by organization or provider..."
+                  placeholder="Search by team or provider..."
                   value={sourceSearch}
                   onChange={(e) => setSourceSearch(e.target.value)}
                   className="w-full pl-10 pr-4 py-2 rounded-lg bg-surface-800 border border-surface-700 text-surface-100 placeholder-surface-500 focus:outline-none focus:border-primary-500"
@@ -1589,7 +1589,7 @@ export function AdminPanel(): JSX.Element {
                   onClick={() => void handleGlobalSync()}
                   disabled={syncing}
                   className="px-4 py-2 rounded-lg bg-emerald-500/20 border border-emerald-500/30 text-emerald-400 hover:bg-emerald-500/30 transition-colors disabled:opacity-50 flex items-center gap-2"
-                  title="Trigger sync for all organizations (same as hourly scheduled sync)"
+                  title="Trigger sync for all teams (same as hourly scheduled sync)"
                 >
                   <svg className={`w-4 h-4 ${syncing ? 'animate-spin' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -1701,7 +1701,7 @@ export function AdminPanel(): JSX.Element {
                 <table className="w-full">
                   <thead>
                     <tr className="border-b border-surface-800 text-left">
-                      <th className="px-4 py-3 text-sm font-medium text-surface-400">Organization</th>
+                      <th className="px-4 py-3 text-sm font-medium text-surface-400">Team</th>
                       <th className="px-4 py-3 text-sm font-medium text-surface-400">Provider</th>
                       <th className="px-4 py-3 text-sm font-medium text-surface-400">Status</th>
                       <th className="px-4 py-3 text-sm font-medium text-surface-400">Last Sync</th>
@@ -1794,7 +1794,7 @@ export function AdminPanel(): JSX.Element {
                     <tr className="border-b border-surface-800 text-left">
                       <th className="px-4 py-3 text-sm font-medium text-surface-400">Type</th>
                       <th className="px-4 py-3 text-sm font-medium text-surface-400">Title</th>
-                      <th className="px-4 py-3 text-sm font-medium text-surface-400">Organization</th>
+                      <th className="px-4 py-3 text-sm font-medium text-surface-400">Team</th>
                       <th className="px-4 py-3 text-sm font-medium text-surface-400">Started</th>
                       <th className="px-4 py-3 text-sm font-medium text-surface-400">Action</th>
                     </tr>

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1033,7 +1033,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
                 role: 'assistant' as const,
                 contentBlocks: [{
                   type: 'text' as const,
-                  text: "I wasn't able to complete your request because your organization has run out of credits for this billing period. You can view your usage and upgrade your plan in the **Billing** tab under Organization Settings.",
+                  text: "I wasn't able to complete your request because your team has run out of credits for this billing period. You can view your usage and upgrade your plan in the **Billing** tab under Team Settings.",
                 }],
                 timestamp: new Date(),
               };

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1805,7 +1805,7 @@ function InviteParticipantModal({
             <p className="mt-2 text-sm text-red-400">{error}</p>
           )}
           <p className="mt-2 text-xs text-surface-500">
-            The user must be a member of your organization.
+            The user must be a member of your team.
           </p>
         </div>
         <div className="flex justify-end gap-2 px-4 py-3 border-t border-surface-700">

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -1231,7 +1231,7 @@ export function DataSources(): JSX.Element {
               <p className="text-xs text-surface-400 mt-0.5">
                 {showCompact
                   ? `${trackedCount} repo${trackedCount !== 1 ? 's' : ''} tracked`
-                  : 'Select which repositories to sync. Tracking for this organization.'}
+                  : 'Select which repositories to sync. Tracking for this team.'}
               </p>
             </div>
             {showCompact && (

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -92,7 +92,7 @@ function generateUUID(): string {
 const SKIP_MESSAGES: Record<number, string> = {
   2: "Without Slack, Penny won't respond in your workspace. You can connect Slack later from Connectors. Skip for now?",
   3: "Fewer connections mean Penny has less context. You can add sources anytime from Connectors. Skip?",
-  4: "You can invite teammates later from Organization settings. Skip?",
+  4: "You can invite teammates later from Team settings. Skip?",
 };
 
 export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatingNewOrg = false, onComplete: rawOnComplete, onBack }: OnboardingWizardProps): JSX.Element {
@@ -255,7 +255,7 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
       });
       if (!response.ok) {
         const text = await response.text();
-        throw new Error(text || `Failed to create organization: ${response.status}`);
+        throw new Error(text || `Failed to create team: ${response.status}`);
       }
       const data = (await response.json()) as { id: string; name: string; logo_url: string | null; handle?: string | null };
       const orgHandle: string | null = data.handle ?? null;
@@ -674,7 +674,7 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
                 </h2>
                 <p className="text-surface-300 mt-3 text-sm leading-relaxed">
                   {slackSatisfied && !slackConnected
-                    ? 'Your team already connected Slack for this organization. Penny is available in any channel the bot has been invited to.'
+                    ? 'Your team already connected Slack for this team. Penny is available in any channel the bot has been invited to.'
                     : <>Connect Slack and your team can ask Penny anything right from the channels they&apos;re
                       already in &mdash; deal updates, meeting prep, customer research &mdash; no tab-switching required.</>
                   }
@@ -686,7 +686,7 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
                   <div>
-                    <span className="font-medium">Slack connected for your organization</span>
+                    <span className="font-medium">Slack connected for your team</span>
                     <span className="block text-sm text-emerald-400/70 mt-0.5">
                       Connected by {integrations.find((i) => i.provider === 'slack')?.teamConnections.map((tc) => tc.userName).join(', ')}
                     </span>
@@ -727,7 +727,7 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
                 </h2>
                 <p className="text-surface-300 mt-2 text-sm leading-relaxed">
                   {isInvitedMode
-                    ? 'Organization-wide sources are already set up. Connect your personal accounts (email, calendar) so Penny has full context.'
+                    ? 'Team-wide sources are already set up. Connect your personal accounts (email, calendar) so Penny has full context.'
                     : 'Now that you can ask Penny questions directly in Slack, what data sources do you want her to be able to read/write?'
                   }
                 </p>

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -248,7 +248,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
 
   const handleDeleteMember = async (targetUserId: string): Promise<void> => {
     const confirmed = window.confirm(
-      'Delete this user from the organization? This will unlink all identities and remove organization access.'
+      'Delete this user from the team? This will unlink all identities and remove team access.'
     );
     if (!confirmed) return;
 
@@ -401,7 +401,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
 
       if (previewData.requires_confirmation) {
         const confirmed = window.confirm(
-          `This will invite ${previewData.missing_users} users from Slack who are not in this organization. Continue?`
+          `This will invite ${previewData.missing_users} users from Slack who are not in this team. Continue?`
         );
         if (!confirmed) return;
       }
@@ -468,12 +468,12 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
         organizationId: organization.id,
         userId: currentUser.id,
       });
-      alert("You can't do that. Only organization admins can delete organizations.");
+      alert("You can't do that. Only team admins can delete teams.");
       return;
     }
 
     const confirmed = window.confirm(
-      `Delete ${organization.name}? This permanently removes the organization and its data.`
+      `Delete ${organization.name}? This permanently removes the team and its data.`
     );
     if (!confirmed) return;
 
@@ -493,13 +493,13 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
       const nextOrg: { id: string } | undefined = remainingOrgs[0];
       if (nextOrg) {
         await switchActiveOrganization(nextOrg.id);
-        alert('Organization deleted.');
+        alert('Team deleted.');
       } else {
         await supabase.auth.signOut();
         logout();
         localStorage.clear();
         sessionStorage.clear();
-        alert('Organization deleted. You will be signed out.');
+        alert('Team deleted. You will be signed out.');
         window.location.href = '/auth';
       }
     } catch (error) {
@@ -512,7 +512,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
         const nextOrg: { id: string } | undefined = remainingOrgs[0];
         if (nextOrg) {
           await switchActiveOrganization(nextOrg.id);
-          alert('Organization was already removed.');
+          alert('Team was already removed.');
         } else {
           await supabase.auth.signOut();
           logout();
@@ -527,7 +527,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
         userId: currentUser.id,
         error,
       });
-      alert(`Failed to delete organization: ${message}`);
+      alert(`Failed to delete team: ${message}`);
     }
   };
 
@@ -621,7 +621,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
             )}
             <div>
               <h2 className="font-semibold text-surface-100">{organization.name}</h2>
-              <p className="text-xs text-surface-400">Organization settings</p>
+              <p className="text-xs text-surface-400">Team settings</p>
             </div>
           </div>
           <button
@@ -1228,7 +1228,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
               {/* Organization Name */}
               <div>
                 <label className="block text-sm font-medium text-surface-200 mb-2">
-                  Organization name
+                  Team name
                 </label>
                 <input
                   type="text"
@@ -1293,7 +1293,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
 
               {/* Organization Info */}
               <div className="pt-6 border-t border-surface-800">
-                <h3 className="text-sm font-medium text-surface-200 mb-3">Organization Info</h3>
+                <h3 className="text-sm font-medium text-surface-200 mb-3">Team Info</h3>
                 <div className="card p-4 space-y-3 text-sm">
                   {organization.handle != null && (
                     <div className="flex justify-between items-center gap-2">
@@ -1315,7 +1315,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                     </div>
                   )}
                   <div className="flex justify-between items-center gap-2">
-                    <span className="text-surface-400">Organization ID</span>
+                    <span className="text-surface-400">Team ID</span>
                     <div className="flex items-center gap-2 min-w-0">
                       <span className="text-surface-300 font-mono text-xs truncate">
                         {organization.id}
@@ -1342,7 +1342,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                   disabled={deleteOrganizationMutation.isPending}
                   className="px-4 py-2 text-sm font-medium text-red-400 border border-red-500/30 hover:bg-red-500/10 rounded-lg transition-colors disabled:opacity-50"
                 >
-                  {deleteOrganizationMutation.isPending ? 'Deleting...' : 'Delete organization'}
+                  {deleteOrganizationMutation.isPending ? 'Deleting...' : 'Delete team'}
                 </button>
               </div>
             </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -159,7 +159,7 @@ function OrgSwitcherSection({
                   <button
                     onClick={() => { setShowDropdown(false); onOpenOrgPanel(); }}
                     className="p-1.5 mr-1 rounded-md hover:bg-surface-700/60 transition-colors flex-shrink-0"
-                    title="Organization settings"
+                    title="Team settings"
                   >
                     <svg className="w-4 h-4 text-amber-400" viewBox="0 0 24 24" fill="currentColor">
                       <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 00.12-.61l-1.92-3.32a.49.49 0 00-.59-.22l-2.39.96c-.5-.38-1.03-.69-1.62-.89l-.36-2.54a.484.484 0 00-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.2-1.13.52-1.62.89l-2.39-.96a.49.49 0 00-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 00-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.69 1.62.89l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.2 1.13-.52 1.62-.89l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1115.6 12 3.611 3.611 0 0112 15.6z" />
@@ -179,7 +179,7 @@ function OrgSwitcherSection({
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
                 </svg>
               </div>
-              <span className="text-sm">Create new organization</span>
+              <span className="text-sm">Create new team</span>
             </button>
           </div>
         </div>

--- a/frontend/src/hooks/useOrganization.ts
+++ b/frontend/src/hooks/useOrganization.ts
@@ -163,7 +163,7 @@ async function updateOrganization(params: UpdateOrganizationParams): Promise<Org
   );
 
   if (error || !data) {
-    throw new Error(error ?? 'Failed to update organization');
+    throw new Error(error ?? 'Failed to update team');
   }
 
   return {
@@ -202,7 +202,7 @@ async function deleteOrganization(params: DeleteOrganizationParams): Promise<{ s
     { method: 'DELETE' }
   );
   if (error || !data) {
-    throw new Error(error ?? 'Failed to delete organization');
+    throw new Error(error ?? 'Failed to delete team');
   }
   return data;
 }


### PR DESCRIPTION
Changes all user-visible strings from "organization" to "team" across the frontend. Variables, functions, API paths, and DB fields are unchanged.

**Files updated:**
- OrganizationPanel.tsx — settings labels, delete confirmations, alerts
- AdminPanel.tsx — tab label, table headers, placeholders, create modal, error messages
- AppLayout.tsx — credits exhaustion message
- Sidebar.tsx — settings tooltip, create new button
- DataSources.tsx — GitHub repo tracking message
- OnboardingWizard.tsx — skip messages, Slack copy, data sources copy, create error
- Chat.tsx — invite modal helper text
- useOrganization.ts — update/delete error messages

Made with [Cursor](https://cursor.com)