### PR TITLE
fix: onboarding favicon/logo and org creation improvements

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -36,6 +36,7 @@ from models.integration import Integration
 from models.memory import Memory
 from models.user import User
 from models.organization import Organization
+from services.favicon import update_org_logo_from_website
 from services.nango import extract_connection_metadata, get_nango_client
 from services.slack_conversations import upsert_slack_user_mappings_from_metadata
 
@@ -700,6 +701,8 @@ async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
         if existing:
             if existing.is_guest:
                 raise HTTPException(status_code=403, detail="Guest users cannot sign in")
+            # Capture user's org before we update it — skip Drive sync when switching orgs (e.g. new org creation)
+            user_org_before_sync: Optional[UUID] = existing.organization_id
             # If the user was found by email but has a different DB ID than the
             # Supabase ID, migrate the ID so JWT auth works without fallback.
             # This happens for waitlist/invited users who later sign in via OAuth.
@@ -828,7 +831,9 @@ async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
             await session.refresh(existing)
 
             # Trigger a user-scoped Google Drive sync on login (throttled to >=5 min).
-            if existing.organization_id:
+            # Skip when switching orgs (e.g. new org creation) — avoids flooding Celery and DB during onboarding
+            is_switching_org: bool = org_uuid is not None and user_org_before_sync is not None and org_uuid != user_org_before_sync
+            if existing.organization_id and not is_switching_org:
                 drive_integration_result = await session.execute(
                     select(Integration).where(
                         Integration.organization_id == existing.organization_id,
@@ -1046,6 +1051,7 @@ async def get_organization_by_domain(email_domain: str) -> OrganizationResponse:
 
 @router.post("/organizations", response_model=OrganizationResponse)
 async def create_organization(
+    background_tasks: BackgroundTasks,
     request: CreateOrganizationRequest,
     auth: AuthContext = Depends(get_current_auth),
 ) -> OrganizationResponse:
@@ -1208,6 +1214,11 @@ async def create_organization(
         )
         session.add(research_workflow)
         await session.commit()
+
+        website_url_trimmed: str | None = (request.website_url or "").strip() or None
+        if website_url_trimmed:
+            logger.info("[auth] Queuing favicon fetch for org %s from %s", org_uuid, website_url_trimmed)
+            background_tasks.add_task(update_org_logo_from_website, org_uuid, website_url_trimmed)
 
         return OrganizationResponse(
             id=str(new_org.id),

--- a/backend/services/favicon.py
+++ b/backend/services/favicon.py
@@ -1,0 +1,190 @@
+"""Extract favicon URL from website HTML for use as organization logo."""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional
+from uuid import UUID
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from models.database import get_admin_session
+from models.organization import Organization
+
+logger = logging.getLogger(__name__)
+
+# Link tag regex: captures rel, href, type, sizes
+_LINK_RE = re.compile(
+    r'<link\s+([^>]*?)>',
+    re.IGNORECASE | re.DOTALL,
+)
+
+_ATTR_RE = re.compile(
+    r'\b(rel|href|type|sizes)\s*=\s*["\']([^"\']*)["\']',
+    re.IGNORECASE,
+)
+
+
+def _parse_link_tag(match: re.Match[str]) -> Optional[dict[str, str]]:
+    """Parse a single link tag, return dict with rel, href, type, sizes or None."""
+    attrs: dict[str, str] = {}
+    for m in _ATTR_RE.finditer(match.group(1)):
+        attrs[m.group(1).lower()] = m.group(2).strip()
+    href: Optional[str] = attrs.get("href")
+    rel: Optional[str] = attrs.get("rel")
+    if not href or not rel:
+        return None
+    rel_lower: str = rel.lower()
+    if "icon" not in rel_lower and "shortcut" not in rel_lower:
+        return None
+    return {
+        "href": href,
+        "rel": rel_lower,
+        "type": attrs.get("type", "").lower(),
+        "sizes": attrs.get("sizes", "").lower(),
+    }
+
+
+def _score_candidate(c: dict[str, str]) -> int:
+    """Higher score = better. Prefer SVG, then apple-touch-icon, then large sizes."""
+    score: int = 0
+    if "image/svg+xml" in c.get("type", ""):
+        score += 100  # SVG is scalable, best for logos
+    if "apple-touch-icon" in c.get("rel", ""):
+        score += 80  # Usually 180x180 or larger
+    sizes: str = c.get("sizes", "")
+    if sizes:
+        if sizes == "any":
+            score += 50
+        else:
+            # Parse "192x192" or "192x192 512x512"
+            for part in sizes.replace("x", " ").split():
+                try:
+                    n: int = int(part)
+                    if n >= 192:
+                        score += 60
+                        break
+                    if n >= 64:
+                        score += 30
+                        break
+                except ValueError:
+                    pass
+    return score
+
+
+def extract_favicon_from_html(html: str, base_url: str) -> Optional[str]:
+    """Extract the best favicon URL from HTML <head> link tags.
+
+    Prefers: SVG > apple-touch-icon > large sizes > default icon.
+    Resolves relative hrefs to absolute URLs.
+    """
+    # Limit to <head> to avoid body content
+    head_match: Optional[re.Match[str]] = re.search(
+        r"<head[^>]*>(.*?)</head>",
+        html,
+        re.IGNORECASE | re.DOTALL,
+    )
+    search_region: str = head_match.group(1) if head_match else html
+
+    candidates: list[tuple[int, str]] = []
+    for m in _LINK_RE.finditer(search_region):
+        parsed: Optional[dict[str, str]] = _parse_link_tag(m)
+        if not parsed:
+            continue
+        try:
+            absolute: str = urljoin(base_url, parsed["href"])
+            if not absolute.startswith(("http://", "https://")):
+                continue
+            parsed_url = urlparse(absolute)
+            if not parsed_url.netloc:
+                continue
+            score: int = _score_candidate(parsed)
+            candidates.append((score, absolute))
+        except Exception:
+            continue
+
+    if not candidates:
+        return None
+    candidates.sort(key=lambda x: (-x[0], x[1]))
+    return candidates[0][1]
+
+
+def _normalize_url_for_fetch(raw: str) -> Optional[str]:
+    """Ensure URL has a scheme so httpx can fetch it. Returns None if invalid."""
+    s: str = (raw or "").strip()
+    if not s:
+        return None
+    if s.startswith(("http://", "https://")):
+        return s
+    # Common input: "nango.dev" or "www.nango.dev" — assume HTTPS
+    return f"https://{s}"
+
+
+async def fetch_favicon_from_url(page_url: str) -> Optional[str]:
+    """Fetch a webpage and extract its favicon URL from the HTML head.
+
+    Returns the absolute favicon URL, or None if not found or on error.
+    Falls back to /favicon.ico if no link tags found.
+    Accepts URLs with or without scheme (e.g. "nango.dev" → "https://nango.dev").
+    """
+    url: Optional[str] = _normalize_url_for_fetch(page_url)
+    if not url:
+        logger.info("[favicon] Skipping empty or invalid URL: %r", page_url[:100] if page_url else "")
+        return None
+    if url != (page_url or "").strip():
+        logger.info("[favicon] Normalized URL %r -> %s", page_url[:80], url)
+    try:
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+            response = await client.get(
+                url,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (compatible; Basebase/1.0)",
+                    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                },
+            )
+            base: str = str(response.url)
+            if response.status_code >= 400:
+                logger.info("[favicon] HTTP %s for %s (final URL %s)", response.status_code, url, base)
+                return None
+            logger.info("[favicon] Fetched %s -> %s (%d bytes)", url, base, len(response.text))
+            html: str = response.text
+    except Exception as e:
+        logger.warning("[favicon] Failed to fetch %s: %s", url, e)
+        return None
+
+    favicon: Optional[str] = extract_favicon_from_html(html, base)
+    if favicon:
+        logger.info("[favicon] Extracted favicon from link tag: %s", favicon[:100])
+        return favicon
+    fallback: str = urljoin(base, "/favicon.ico")
+    logger.info(
+        "[favicon] No icon link tags in HTML (%d bytes), using fallback: %s",
+        len(html),
+        fallback,
+    )
+    return fallback
+
+
+async def update_org_logo_from_website(org_id: UUID, website_url: str) -> None:
+    """Background task: fetch favicon from website and update organization.logo_url."""
+    logger.info("[favicon] Starting favicon fetch for org %s from %s", org_id, website_url)
+    favicon_url: Optional[str] = await fetch_favicon_from_url(website_url)
+    if not favicon_url:
+        logger.info("[favicon] No favicon found for org %s from %s", org_id, website_url)
+        return
+    # Truncate to column limit (512)
+    if len(favicon_url) > 512:
+        logger.info("[favicon] Truncating favicon URL from %d to 512 chars for org %s", len(favicon_url), org_id)
+        favicon_url = favicon_url[:512]
+    try:
+        async with get_admin_session() as session:
+            org: Organization | None = await session.get(Organization, org_id)
+            if not org:
+                logger.warning("[favicon] Org %s not found, cannot update logo", org_id)
+                return
+            org.logo_url = favicon_url
+            await session.commit()
+            logger.info("[favicon] Updated org %s logo from %s -> %s", org_id, website_url, favicon_url[:80])
+    except Exception as e:
+        logger.warning("[favicon] Failed to update org %s logo: %s", org_id, e)

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -262,14 +262,31 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
       setOrganization({ id: data.id, name: data.name, logoUrl: data.logo_url ?? null, handle: orgHandle });
       // Clear integrations so we don't show the previous org's connections (e.g. Slack) as connected
       setIntegrations([]);
-      await syncUserToBackend();
-      await fetchUserOrganizations();
-      // Switch fully to the new org (backend + URL) as if user had selected it from the org dropdown
-      await switchActiveOrganization(data.id);
+      const ONBOARDING_TIMEOUT_MS: number = 45_000;
+      const timeoutPromise: Promise<never> = new Promise((_, reject) => {
+        setTimeout(
+          () => reject(new Error('Request timed out. Please refresh the page — your team was created.')),
+          ONBOARDING_TIMEOUT_MS,
+        );
+      });
+      await Promise.race([
+        (async (): Promise<void> => {
+          await syncUserToBackend();
+          await fetchUserOrganizations();
+          await switchActiveOrganization(data.id);
+        })(),
+        timeoutPromise,
+      ]);
       const { organization: updatedOrg } = useAppStore.getState();
       const handle: string | null = orgHandle ?? updatedOrg?.handle ?? null;
       const prefix = handle ? `/${handle}` : '';
       window.history.replaceState({}, '', `${prefix}/chat`);
+      // Delayed refetch to pick up logo_url once background favicon task completes
+      if (urlTrimmed) {
+        setTimeout(() => {
+          void fetchUserOrganizations().then(() => switchActiveOrganization(data.id));
+        }, 3000);
+      }
       // Fire-and-forget: trigger company research workflow if website URL provided
       if (urlTrimmed && user?.id) {
         void (async (): Promise<void> => {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -93,29 +93,92 @@ function OrgSwitcherSection({
 
   return (
     <div className="relative" ref={dropdownRef}>
-      {/* Org identity row */}
-      <button
-        onClick={() => setShowDropdown((prev) => !prev)}
-        className="w-full flex items-center gap-3 px-3 pt-3 pb-1 hover:bg-surface-800/50 transition-colors"
-      >
-        {organization.logoUrl ? (
-          <img
-            src={organization.logoUrl}
-            alt={organization.name}
-            className="w-9 h-9 rounded-lg object-cover flex-shrink-0"
-          />
-        ) : (
-          <div className="w-9 h-9 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0">
-            <img src={LOGO_PATH} alt={APP_NAME} className="w-6 h-6" />
+      {/* Org identity row + dropdown (positioned relative to this row only) */}
+      <div className="relative">
+        <button
+          onClick={() => setShowDropdown((prev) => !prev)}
+          className="w-full flex items-center gap-3 px-3 pt-3 pb-1 hover:bg-surface-800/50 transition-colors"
+        >
+          {organization.logoUrl ? (
+            <img
+              src={organization.logoUrl}
+              alt={organization.name}
+              className="w-9 h-9 rounded-lg object-cover flex-shrink-0"
+            />
+          ) : (
+            <div className="w-9 h-9 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0">
+              <img src={LOGO_PATH} alt={APP_NAME} className="w-6 h-6" />
+            </div>
+          )}
+          <span className="text-lg font-semibold text-surface-100 truncate flex-1 text-left leading-tight">
+            {organization.name}
+          </span>
+          <svg className="w-4 h-4 text-surface-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        {/* Org switcher dropdown — appears directly below the org identity row */}
+        {showDropdown && (
+          <div className="absolute top-full left-0 right-0 mt-1 mx-2 bg-surface-800 border border-surface-700 rounded-lg shadow-xl overflow-hidden z-50">
+            <div className="py-1">
+              {organizations.map((org) => (
+                <div
+                  key={org.id}
+                  className={`flex items-center transition-colors ${
+                    org.isActive
+                      ? 'bg-primary-500/10 text-primary-400'
+                      : 'text-surface-300 hover:bg-surface-700'
+                  }`}
+                >
+                  <button
+                    onClick={() => void handleSwitchOrg(org.id)}
+                    className="flex-1 min-w-0 flex items-center gap-3 px-3 py-2.5 text-left"
+                  >
+                    {org.logoUrl ? (
+                      <img src={org.logoUrl} alt={org.name} className="w-6 h-6 rounded object-cover flex-shrink-0" />
+                    ) : (
+                      <div className="w-6 h-6 rounded bg-surface-700 flex items-center justify-center flex-shrink-0">
+                        <img src={LOGO_PATH} alt={APP_NAME} className="w-4 h-4" />
+                      </div>
+                    )}
+                    <span className="text-sm truncate flex-1">{org.name}</span>
+                    {org.isActive && (
+                      <svg className="w-4 h-4 text-primary-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                      </svg>
+                    )}
+                  </button>
+                  {org.isActive && (
+                    <button
+                      onClick={() => { setShowDropdown(false); onOpenOrgPanel(); }}
+                      className="p-1.5 mr-1 rounded-md hover:bg-surface-700/60 transition-colors flex-shrink-0"
+                      title="Team settings"
+                    >
+                      <svg className="w-4 h-4 text-amber-400" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 00.12-.61l-1.92-3.32a.49.49 0 00-.59-.22l-2.39.96c-.5-.38-1.03-.69-1.62-.89l-.36-2.54a.484.484 0 00-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.2-1.13.52-1.62.89l-2.39-.96a.49.49 0 00-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 00-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.69 1.62.89l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.2 1.13-.52 1.62-.89l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1115.6 12 3.611 3.611 0 0112 15.6z" />
+                      </svg>
+                    </button>
+                  )}
+                </div>
+              ))}
+              <div className="border-t border-surface-700 my-1" />
+              <button
+                type="button"
+                onClick={() => { setShowDropdown(false); onCreateNewOrg(); }}
+                className="w-full flex items-center gap-3 px-3 py-2.5 text-left text-surface-400 hover:bg-surface-700 hover:text-surface-200 transition-colors"
+              >
+                <div className="w-6 h-6 rounded bg-surface-600 flex items-center justify-center text-surface-300 text-xs font-medium flex-shrink-0">
+                  <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                  </svg>
+                </div>
+                <span className="text-sm">Create new team</span>
+              </button>
+            </div>
           </div>
         )}
-        <span className="text-lg font-semibold text-surface-100 truncate flex-1 text-left leading-tight">
-          {organization.name}
-        </span>
-        <svg className="w-4 h-4 text-surface-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
+      </div>
 
       {/* Team members row */}
       {members.length > 0 && (
@@ -170,67 +233,6 @@ function OrgSwitcherSection({
 
       {/* Bottom padding for the header block */}
       <div className="pb-1" />
-
-      {/* Org switcher dropdown */}
-      {showDropdown && (
-        <div className="absolute top-full left-0 right-0 mt-1 mx-2 bg-surface-800 border border-surface-700 rounded-lg shadow-xl overflow-hidden z-50">
-          <div className="py-1">
-            {organizations.map((org) => (
-              <div
-                key={org.id}
-                className={`flex items-center transition-colors ${
-                  org.isActive
-                    ? 'bg-primary-500/10 text-primary-400'
-                    : 'text-surface-300 hover:bg-surface-700'
-                }`}
-              >
-                <button
-                  onClick={() => void handleSwitchOrg(org.id)}
-                  className="flex-1 min-w-0 flex items-center gap-3 px-3 py-2.5 text-left"
-                >
-                  {org.logoUrl ? (
-                    <img src={org.logoUrl} alt={org.name} className="w-6 h-6 rounded object-cover flex-shrink-0" />
-                  ) : (
-                    <div className="w-6 h-6 rounded bg-surface-700 flex items-center justify-center flex-shrink-0">
-                      <img src={LOGO_PATH} alt={APP_NAME} className="w-4 h-4" />
-                    </div>
-                  )}
-                  <span className="text-sm truncate flex-1">{org.name}</span>
-                  {org.isActive && (
-                    <svg className="w-4 h-4 text-primary-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
-                  )}
-                </button>
-                {org.isActive && (
-                  <button
-                    onClick={() => { setShowDropdown(false); onOpenOrgPanel(); }}
-                    className="p-1.5 mr-1 rounded-md hover:bg-surface-700/60 transition-colors flex-shrink-0"
-                    title="Team settings"
-                  >
-                    <svg className="w-4 h-4 text-amber-400" viewBox="0 0 24 24" fill="currentColor">
-                      <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 00.12-.61l-1.92-3.32a.49.49 0 00-.59-.22l-2.39.96c-.5-.38-1.03-.69-1.62-.89l-.36-2.54a.484.484 0 00-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.2-1.13.52-1.62.89l-2.39-.96a.49.49 0 00-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 00-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.69 1.62.89l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.2 1.13-.52 1.62-.89l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1115.6 12 3.611 3.611 0 0112 15.6z" />
-                    </svg>
-                  </button>
-                )}
-              </div>
-            ))}
-            <div className="border-t border-surface-700 my-1" />
-            <button
-              type="button"
-              onClick={() => { setShowDropdown(false); onCreateNewOrg(); }}
-              className="w-full flex items-center gap-3 px-3 py-2.5 text-left text-surface-400 hover:bg-surface-700 hover:text-surface-200 transition-colors"
-            >
-              <div className="w-6 h-6 rounded bg-surface-600 flex items-center justify-center text-surface-300 text-xs font-medium flex-shrink-0">
-                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                </svg>
-              </div>
-              <span className="text-sm">Create new team</span>
-            </button>
-          </div>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **Favicon service**: New `backend/services/favicon.py` to fetch org logo from website URL during onboarding. Normalizes URLs (e.g. `nango.dev` → `https://nango.dev`), extracts favicon from HTML link tags with fallback to `/favicon.ico`, and includes logging for debugging.
- **Org creation**: Queue background favicon fetch when `website_url` is provided; fix `create_organization` parameter order (BackgroundTasks).
- **Drive sync**: Skip login-triggered Google Drive sync when user is switching orgs (e.g. new org creation) to avoid flooding Celery during onboarding.
- **OnboardingWizard**: 45s timeout for sync/fetch/switch; 3s delayed refetch to pick up `logo_url` once favicon task completes.
- **Sidebar**: Org dropdown layout adjustments.

Made with [Cursor](https://cursor.com)