### PR TITLE
Persist context window progress bar across page reloads

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -205,6 +205,7 @@ class ConversationDetailResponse(BaseModel):
     participants: list[ParticipantResponse] = []
     messages: list[ChatMessageResponse]
     has_more: bool = False
+    context_tokens: Optional[int] = None
 
 
 class ChatHistoryResponse(BaseModel):
@@ -502,6 +503,7 @@ async def get_conversation(
                 for msg, sender_name, sender_email, sender_avatar_url in message_rows
             ],
             has_more=has_more,
+            context_tokens=conversation.context_tokens,
         )
 
 

--- a/backend/db/migrations/versions/093_add_context_tokens_to_conversations.py
+++ b/backend/db/migrations/versions/093_add_context_tokens_to_conversations.py
@@ -1,0 +1,29 @@
+"""Add context_tokens column to conversations table.
+
+Revision ID: 093_add_context_tokens_to_conversations
+Revises: 092_org_handle_not_null
+Create Date: 2026-03-06
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "093_add_context_tokens_to_conversations"
+down_revision: Union[str, None] = "092_org_handle_not_null"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversations",
+        sa.Column("context_tokens", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("conversations", "context_tokens")

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -119,6 +119,9 @@ class Conversation(Base):
     last_message_preview: Mapped[Optional[str]] = mapped_column(
         String(200), nullable=True
     )
+    context_tokens: Mapped[Optional[int]] = mapped_column(
+        Integer, nullable=True
+    )  # Last known input token count for context window progress
 
     # Relationships
     messages: Mapped[list["ChatMessage"]] = relationship(

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -21,6 +21,7 @@ from sqlalchemy import select, update
 
 from agents.orchestrator import ChatOrchestrator
 from models.agent_task import AgentTask
+from models.conversation import Conversation
 from models.database import get_admin_session, get_session
 
 logger = logging.getLogger(__name__)
@@ -266,6 +267,14 @@ class TaskManager:
                     if chunk_data["type"] != "text_delta":
                         asyncio.create_task(self._append_chunk_safe(task_id, chunk_data))
 
+                    # Persist context_tokens on the conversation row so it survives page reloads
+                    if chunk_data["type"] == "context_usage" and isinstance(chunk_data.get("data"), dict):
+                        tokens = chunk_data["data"].get("input_tokens")
+                        if isinstance(tokens, int):
+                            asyncio.create_task(
+                                self._update_conversation_context_tokens(conversation_id, tokens)
+                            )
+
                     chunk_index += 1
             
             # Mark task as completed
@@ -319,6 +328,21 @@ class TaskManager:
             await self._append_chunk(task_id, chunk)
         except Exception as e:
             logger.warning("Background chunk persist failed for task %s: %s", task_id, e)
+
+    async def _update_conversation_context_tokens(
+        self, conversation_id: str, tokens: int,
+    ) -> None:
+        """Fire-and-forget: persist last known context token count on the conversation row."""
+        try:
+            async with get_admin_session() as session:
+                await session.execute(
+                    update(Conversation)
+                    .where(Conversation.id == conversation_id)
+                    .values(context_tokens=tokens)
+                )
+                await session.commit()
+        except Exception as e:
+            logger.warning("Failed to persist context_tokens for %s: %s", conversation_id, e)
 
     async def _append_chunk(self, task_id: str, chunk: dict[str, Any]) -> None:
         """Append a chunk to the task's output_chunks in the database."""

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -76,6 +76,7 @@ export interface ConversationDetailResponse {
   }>;
   messages: ChatMessage[];
   has_more: boolean;
+  context_tokens?: number | null;
 }
 
 export interface ChatHistoryResponse {

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1010,6 +1010,9 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
                     frontendCode: string;
                   } | undefined;
                   if (app) addConversationAppBlock(conversationId, app);
+                } else if (data.type === 'context_usage') {
+                  const usage = data as { input_tokens: number; output_tokens: number };
+                  setConversationContextTokens(conversationId, usage.input_tokens);
                 }
               }
             }

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -531,6 +531,9 @@ export function Chat({
               avatarUrl: p.avatar_url,
             }))
           );
+          if (data.context_tokens != null) {
+            useAppStore.getState().setConversationContextTokens(chatId, data.context_tokens);
+          }
           console.log('[Chat] Loaded', loadedMessages.length, 'messages, has_more:', data.has_more, 'type:', data.type, 'scope:', data.scope);
 
           // Scroll to bottom immediately after loading

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -246,6 +246,7 @@ export const useChatStore = create<ChatState>()(
                 messages,
                 title: data.title ?? "New Chat",
                 hasMore: data.has_more,
+                contextTokens: data.context_tokens ?? null,
                 summary: data.summary ? (() => {
                   try { return JSON.parse(data.summary!) as ConversationSummaryData; }
                   catch { return null; }


### PR DESCRIPTION
## Summary
- The context token progress bar was **ephemeral** — stored only in Zustand memory, lost on page reload or WebSocket reconnect
- Adds `context_tokens` column to `conversations` table and persists it after each agent response
- Frontend restores the value from the API response when loading a conversation, and from the catchup handler on WS reconnect

## Changes
| File | What |
|------|------|
| `backend/db/migrations/versions/093_...` | Add nullable `context_tokens` INT column |
| `backend/models/conversation.py` | Add field to SQLAlchemy model |
| `backend/services/task_manager.py` | Fire-and-forget save after broadcasting `context_usage` |
| `backend/api/routes/chat.py` | Return `context_tokens` in `ConversationDetailResponse` |
| `frontend/src/api/client.ts` | Add `context_tokens` to TS interface |
| `frontend/src/components/Chat.tsx` | Set `contextTokens` when loading conversation from API |
| `frontend/src/components/AppLayout.tsx` | Handle `context_usage` in catchup handler |
| `frontend/src/store/chatStore.ts` | Set `contextTokens` in prefetch action |

## Test plan
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `pytest` — 142 passed
- [ ] Run migration (`alembic upgrade head`) — Supabase pooler was temporarily unreachable during dev; trivial add-column migration
- [ ] Send a message, see progress bar, refresh page → progress bar should persist
- [ ] Hover prefetch a conversation → progress bar should show immediately on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)