### PR TITLE
Remove org-scoped memories (security)

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -619,12 +619,10 @@ a channel @mention, thread reply, or automated workflow), **after completing the
 ask 1-2 friendly questions to learn more about them. Prioritize in this order:
 
 1. **Job**: title, general responsibilities, current projects or initiatives
-2. **Organization**: what the company does, approximate size, mission
-3. **Personal**: location, timezone, work-style preferences
+2. **Personal**: location, timezone, work-style preferences
 
 Use `manage_memory` with the appropriate `entity_type` to persist what you learn:
 - `entity_type="user"` for personal facts/preferences
-- `entity_type="organization"` for company-wide facts
 - `entity_type="organization_member"` for role/job-specific facts
 
 **Phone number**: If the user has no phone number on file and has not declined to share one
@@ -973,11 +971,10 @@ class ChatOrchestrator:
             return None
 
     async def _load_context_profile(self) -> dict[str, Any]:
-        """Load the three-tier context profile: user, organization, and job memories + structured fields.
+        """Load the two-tier context profile: user and job memories + structured fields.
 
         Returns a dict with keys:
             user_memories: list of {id, content}
-            org_memories: list of {id, content}
             job_memories: list of {id, content}
             membership_title: str | None
             reports_to_name: str | None
@@ -987,7 +984,6 @@ class ChatOrchestrator:
 
         profile: dict[str, Any] = {
             "user_memories": [],
-            "org_memories": [],
             "job_memories": [],
             "membership_title": None,
             "reports_to_name": None,
@@ -1002,7 +998,7 @@ class ChatOrchestrator:
                     select(Memory)
                     .where(Memory.organization_id == UUID(self.organization_id))  # type: ignore[arg-type]
                     .where(
-                        Memory.entity_type.in_(["user", "organization", "organization_member"])
+                        Memory.entity_type.in_(["user", "organization_member"])
                     )
                     .order_by(Memory.created_at.asc())
                 )
@@ -1062,8 +1058,6 @@ class ChatOrchestrator:
                         if mem.category == _AGENT_GLOBAL_COMMANDS_CATEGORY:
                             continue
                         profile["user_memories"].append(entry)
-                    elif mem.entity_type == "organization" and mem.entity_id == org_uuid:
-                        profile["org_memories"].append(entry)
                     elif (
                         mem.entity_type == "organization_member"
                         and membership_id
@@ -1342,12 +1336,11 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
                 )
                 system_prompt += systems_manifest
 
-        # Load and inject three-tier context profile (user, org, job memories + structured fields)
+        # Load and inject two-tier context profile (user, job memories + structured fields)
         if self.organization_id and (self.user_id or self.conversation_id):
             profile: dict[str, Any] = await self._load_context_profile()
 
             user_memories: list[dict[str, str]] = profile["user_memories"]
-            org_memories: list[dict[str, str]] = profile["org_memories"]
             job_memories: list[dict[str, str]] = profile["job_memories"]
             participant_job_memories: list[dict[str, Any]] = profile.get("participant_job_memories", [])
             membership_title: str | None = profile["membership_title"]
@@ -1355,13 +1348,13 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
             phone_number: str | None = profile["phone_number"]
 
             has_any_context: bool = bool(
-                user_memories or org_memories or job_memories
+                user_memories or job_memories
                 or membership_title or reports_to_name or phone_number
             )
 
             if has_any_context:
                 system_prompt += "\n\n# Context Profile"
-                system_prompt += "\nThese are persisted facts about the user, their organization, and their role."
+                system_prompt += "\nThese are persisted facts about the user and their role."
                 system_prompt += " Follow preferences. Use manage_memory with action=\"update\" or action=\"delete\" and the [memory_id] shown in brackets to manage entries.\n"
 
             # -- User profile section --
@@ -1372,13 +1365,6 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
                 if phone_number:
                     system_prompt += f"- Phone: {phone_number}\n"
                 for mem in user_memories:
-                    system_prompt += f"- [{mem['id']}] {mem['content']}\n"
-
-            # -- Organization profile section --
-            if org_memories:
-                org_label: str = f" ({self.organization_name})" if self.organization_name else ""
-                system_prompt += f"\n## Organization Profile{org_label}\n"
-                for mem in org_memories:
                     system_prompt += f"- [{mem['id']}] {mem['content']}\n"
 
             # -- Job / role profile section --
@@ -1422,10 +1408,6 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
                 if not phone_number and phone_declined:
                     phone_status = "phone number declined"
                 completeness_parts.append(f"User profile: {user_count} memories, {phone_status}")
-
-                org_count: int = len(org_memories)
-                org_status: str = f"{org_count} memories" if org_count else "0 memories (needs attention)"
-                completeness_parts.append(f"Organization profile: {org_status}")
 
                 job_count: int = len(job_memories)
                 title_status: str = "title set" if membership_title else "no title set"

--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -696,7 +696,6 @@ Actions:
 
 Memories are scoped via entity_type:
 - "user": Personal facts/preferences (default).
-- "organization": Company-wide facts shared across all members.
 - "organization_member": Facts about the user's specific role.
 
 Use when the user asks you to "remember" or "forget" something, or when a saved memory needs revision.
@@ -720,7 +719,7 @@ Each memory should be a single, self-contained statement. Do NOT save conversati
             },
             "entity_type": {
                 "type": "string",
-                "enum": ["user", "organization", "organization_member"],
+                "enum": ["user", "organization_member"],
                 "description": "Scope level. Defaults to 'user'.",
                 "default": "user",
             },

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -5930,7 +5930,7 @@ async def _save_memory(
     user_id: str | None,
     skip_approval: bool = False,
 ) -> dict[str, Any]:
-    """Save a persistent memory at the user, organization, or job level."""
+    """Save a persistent memory at the user or job level."""
     content: str = params.get("content", "").strip()
     if not content:
         return {"error": "content is required."}
@@ -5938,8 +5938,8 @@ async def _save_memory(
         return {"error": "Cannot save memory without a user context."}
 
     entity_type: str = params.get("entity_type", "user").strip()
-    if entity_type not in ("user", "organization", "organization_member"):
-        return {"error": f"Invalid entity_type '{entity_type}'. Must be 'user', 'organization', or 'organization_member'."}
+    if entity_type not in ("user", "organization_member"):
+        return {"error": f"Invalid entity_type '{entity_type}'. Must be 'user' or 'organization_member'."}
 
     if skip_approval:
         logger.info("[Tools._save_memory] Auto-approved, saving memory immediately")
@@ -5989,8 +5989,6 @@ async def execute_save_memory(
     entity_id: UUID
     if entity_type == "user":
         entity_id = UUID(user_id)
-    elif entity_type == "organization":
-        entity_id = UUID(organization_id)
     elif entity_type == "organization_member":
         # Look up the membership for this user + org
         async with get_session(organization_id=organization_id) as session:
@@ -6053,11 +6051,8 @@ async def _delete_memory(
         if not memory:
             return {"error": f"Memory {memory_id} not found."}
 
-        # User-level and job-level memories can only be deleted by the owner.
-        # Org-level memories can be deleted by any org member.
-        if memory.entity_type != "organization":
-            if memory.created_by_user_id and str(memory.created_by_user_id) != user_id:
-                return {"error": f"Memory {memory_id} does not belong to this user."}
+        if memory.created_by_user_id and str(memory.created_by_user_id) != user_id:
+            return {"error": f"Memory {memory_id} does not belong to this user."}
 
         await session.delete(memory)
         await session.commit()
@@ -6093,10 +6088,8 @@ async def _update_memory(
         if not memory:
             return {"error": f"Memory {memory_id} not found."}
 
-        # Permission check: same rules as delete
-        if memory.entity_type != "organization":
-            if memory.created_by_user_id and str(memory.created_by_user_id) != user_id:
-                return {"error": f"Memory {memory_id} does not belong to this user."}
+        if memory.created_by_user_id and str(memory.created_by_user_id) != user_id:
+            return {"error": f"Memory {memory_id} does not belong to this user."}
 
         memory.content = new_content
         await session.commit()

--- a/backend/db/migrations/versions/094_remove_org_scoped_memories.py
+++ b/backend/db/migrations/versions/094_remove_org_scoped_memories.py
@@ -1,0 +1,27 @@
+"""Remove org-scoped memories (entity_type='organization') for security.
+
+Revision ID: 094_remove_org_scoped_memories
+Revises: 093_activity_visibility_scoping
+Create Date: 2026-03-06
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "094_remove_org_scoped_memories"
+down_revision: Union[str, None] = "093_activity_visibility_scoping"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(text("DELETE FROM memories WHERE entity_type = 'organization'"))
+
+
+def downgrade() -> None:
+    # Deleted org-scoped memories are not restored.
+    pass

--- a/backend/models/memory.py
+++ b/backend/models/memory.py
@@ -1,4 +1,4 @@
-"""Memory model for persistent agent memories/preferences at user, org, and job levels."""
+"""Memory model for persistent agent memories/preferences at user and job (org membership) levels."""
 from __future__ import annotations
 
 import uuid
@@ -13,7 +13,7 @@ from models.database import Base
 
 
 class Memory(Base):
-    """Stores persistent memories/preferences scoped to a user, organization, or job (org membership)."""
+    """Stores persistent memories/preferences scoped to a user or job (org membership)."""
 
     __tablename__ = "memories"
     __table_args__ = (
@@ -25,7 +25,7 @@ class Memory(Base):
     )
     entity_type: Mapped[str] = mapped_column(
         String(30), nullable=False
-    )  # 'user' | 'organization' | 'organization_member'
+    )  # 'user' | 'organization_member'
     entity_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), nullable=False
     )  # PK of the associated entity


### PR DESCRIPTION
## Summary
Removes org-scoped memories (`entity_type='organization'`) from the product. They are a security risk; user and job (`organization_member`) scoped memories are unchanged.

## Changes
- **Tool:** `manage_memory` no longer accepts `entity_type="organization"` (registry + tools).
- **Orchestrator:** No longer loads or injects org memories; context profile is two-tier (user + job). Removed Organization from context-gathering prompt and profile completeness.
- **Model:** Memory model docstrings/comment updated to `user | organization_member` only.
- **Migration 094:** `DELETE FROM memories WHERE entity_type = 'organization'` on upgrade.

## Testing
- Run `alembic upgrade head`, then `python3 backend/scripts/dbq.py "SELECT entity_type, COUNT(*) FROM memories GROUP BY entity_type"` — should show only `user` and `organization_member`.
- Chat: user/job memories still work; agent cannot save org-wide memories.

Made with [Cursor](https://cursor.com)