### PR TITLE
feat: clean up memory architecture

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -30,8 +30,6 @@ from models.memory import Memory
 
 logger = logging.getLogger(__name__)
 
-_AGENT_GLOBAL_COMMANDS_CATEGORY = "global_commands"
-
 # Hard timeout for a single tool run so the UI always gets a result (no infinite "Running")
 _TOOL_EXECUTION_TIMEOUT_SECONDS: float = 600.0  # 10 minutes
 
@@ -760,7 +758,6 @@ class ChatOrchestrator:
         self.user_email = user_email
         self.user_name = user_name
         self.organization_name = organization_name
-        self.agent_global_commands: str | None = None
         self.local_time = local_time
         self.timezone = timezone
         self.source_user_id = source_user_id
@@ -799,37 +796,14 @@ class ChatOrchestrator:
             )
             return None
 
-    async def _fetch_global_commands_from_memory(self, session: Any) -> str | None:
-        """Load latest per-user global commands from memory records only."""
-
-        if not self.organization_id or not self.user_id:
-            return None
-
-        result = await session.execute(
-            select(Memory.content)
-            .where(
-                Memory.organization_id == UUID(self.organization_id),  # type: ignore[arg-type]
-                Memory.entity_type == "user",
-                Memory.entity_id == UUID(self.user_id),
-                Memory.category == _AGENT_GLOBAL_COMMANDS_CATEGORY,
-            )
-            .order_by(Memory.updated_at.desc().nullslast(), Memory.created_at.desc().nullslast())
-            .limit(1)
-        )
-        return result.scalar_one_or_none()
-
     async def _resolve_user_context(self) -> None:
-        """Fetch user context fields (name, email, phone, commands) from DB if not already set."""
+        """Fetch user context fields (name, email, phone) from DB if not already set."""
         from models.organization import Organization
         from models.user import User
 
         try:
             async with get_session(organization_id=self.organization_id) as session:
-                if self.user_id and (
-                    not self.user_name
-                    or not self.user_email
-                    or self.agent_global_commands is None
-                ):
+                if self.user_id and (not self.user_name or not self.user_email):
                     result = await session.execute(
                         select(
                             User.name,
@@ -846,8 +820,6 @@ class ChatOrchestrator:
                             self.user_name = fetched_name
                         if not self.user_email and fetched_email:
                             self.user_email = fetched_email
-                        if self.organization_id:
-                            self.agent_global_commands = await self._fetch_global_commands_from_memory(session)
                         self._phone_number = fetched_phone
                     else:
                         self._phone_number = None
@@ -1055,8 +1027,6 @@ class ChatOrchestrator:
                 for mem in all_memories:
                     entry: dict[str, str] = {"id": str(mem.id), "content": mem.content}
                     if mem.entity_type == "user" and user_uuid and mem.entity_id == user_uuid:
-                        if mem.category == _AGENT_GLOBAL_COMMANDS_CATEGORY:
-                            continue
                         profile["user_memories"].append(entry)
                     elif (
                         mem.entity_type == "organization_member"
@@ -1132,8 +1102,6 @@ class ChatOrchestrator:
                             self.conversation_id,
                             missing_members,
                         )
-
-                self.agent_global_commands = await self._fetch_global_commands_from_memory(session)
 
         except Exception:
             logger.warning("Failed to load context profile", exc_info=True)
@@ -1235,7 +1203,7 @@ class ChatOrchestrator:
         system_prompt = SYSTEM_PROMPT
 
         # Resolve user_name, user_email, and organization_name if not already set
-        if self.user_id and (not self.user_name or not self.user_email or not self.organization_name or self.agent_global_commands is None):
+        if self.user_id and (not self.user_name or not self.user_email or not self.organization_name):
             await self._resolve_user_context()
         
         # Add message origination context
@@ -1274,10 +1242,6 @@ class ChatOrchestrator:
         elif not self.user_id:
             # Slack thread or unlinked conversation — no specific user context
             system_prompt += "\n\n## Current User\nThe specific user is not identified in Basebase."
-
-        if self.agent_global_commands:
-            system_prompt += "\n\n## User Global Commands\nThe user configured these standing instructions for every prompt. Follow them unless they conflict with higher-priority system/developer constraints:\n"
-            system_prompt += self.agent_global_commands.strip()
 
         # Add Slack channel/thread context so the agent can scope queries correctly
         slack_channel_id: str | None = (self.workflow_context or {}).get("slack_channel_id")

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -33,7 +33,6 @@ from sqlalchemy.exc import IntegrityError
 from config import settings, get_nango_integration_id, get_provider_sharing_defaults, PROVIDER_SHARING_DEFAULTS
 from models.database import get_admin_session, get_session
 from models.integration import Integration
-from models.memory import Memory
 from models.user import User
 from models.organization import Organization
 from services.favicon import update_org_logo_from_website
@@ -135,9 +134,6 @@ def _enqueue_google_drive_login_sync(organization_id: UUID, user_id: UUID, integ
         )
 
 
-_AGENT_GLOBAL_COMMANDS_CATEGORY = "global_commands"
-
-
 def _is_global_admin(user: Optional[User]) -> bool:
     """Return True when the user has the global admin role."""
     if not user:
@@ -221,65 +217,6 @@ async def _ensure_org_has_admin(session: Any, org_id: UUID) -> None:
         first_member.user_id,
     )
 
-
-async def _get_user_global_commands(session: Any, user: User) -> Optional[str]:
-    if not user.organization_id:
-        return None
-
-    result = await session.execute(
-        select(Memory.content)
-        .where(
-            Memory.organization_id == user.organization_id,
-            Memory.entity_type == "user",
-            Memory.entity_id == user.id,
-            Memory.category == _AGENT_GLOBAL_COMMANDS_CATEGORY,
-        )
-        .order_by(Memory.updated_at.desc().nullslast(), Memory.created_at.desc().nullslast())
-        .limit(1)
-    )
-    return result.scalar_one_or_none()
-
-
-async def _set_user_global_commands(
-    session: Any,
-    user: User,
-    commands: Optional[str],
-) -> Optional[str]:
-    if not user.organization_id:
-        return None
-
-    result = await session.execute(
-        select(Memory).where(
-            Memory.organization_id == user.organization_id,
-            Memory.entity_type == "user",
-            Memory.entity_id == user.id,
-            Memory.category == _AGENT_GLOBAL_COMMANDS_CATEGORY,
-        )
-    )
-    memory: Optional[Memory] = result.scalar_one_or_none()
-
-    normalized = (commands or "").strip()
-    if not normalized:
-        if memory:
-            await session.delete(memory)
-        return None
-
-    if memory:
-        memory.content = normalized
-        memory.created_by_user_id = user.id
-        return normalized
-
-    session.add(
-        Memory(
-            entity_type="user",
-            entity_id=user.id,
-            organization_id=user.organization_id,
-            category=_AGENT_GLOBAL_COMMANDS_CATEGORY,
-            content=normalized,
-            created_by_user_id=user.id,
-        )
-    )
-    return normalized
 
 _NANGO_SENSITIVE_KEYS = {"credentials", "access_token", "refresh_token", "api_key", "apiKey", "token"}
 _NANGO_HIGHLIGHT_KEYS = {"end_user", "errors", "id", "last_fetched_at", "metadata"}
@@ -406,7 +343,6 @@ class UserResponse(BaseModel):
     name: Optional[str]
     role: Optional[str]
     avatar_url: Optional[str]
-    agent_global_commands: Optional[str]
     phone_number: Optional[str]
     job_title: Optional[str]
     organization_id: Optional[str]
@@ -509,15 +445,12 @@ async def get_current_user(user_id: Optional[str] = None) -> UserResponse:
             )
             job_title = membership_result.scalar_one_or_none()
 
-        agent_global_commands = await _get_user_global_commands(session, user)
-
         return UserResponse(
             id=str(user.id),
             email=user.email,
             name=user.name,
             role=await _get_user_role_for_active_org(session, user),
             avatar_url=user.avatar_url,
-            agent_global_commands=agent_global_commands,
             phone_number=user.phone_number,
             job_title=job_title,
             organization_id=str(user.organization_id) if user.organization_id else None,
@@ -529,7 +462,6 @@ class UpdateProfileRequest(BaseModel):
 
     name: Optional[str] = None
     avatar_url: Optional[str] = None
-    agent_global_commands: Optional[str] = Field(default=None, max_length=500)
     phone_number: Optional[str] = Field(default=None, max_length=30)
     job_title: Optional[str] = Field(default=None, max_length=255)
 
@@ -560,11 +492,6 @@ async def update_profile(
             user.name = request.name
         if request.avatar_url is not None:
             user.avatar_url = request.avatar_url
-        agent_global_commands: Optional[str] = None
-        if request.agent_global_commands is not None:
-            agent_global_commands = await _set_user_global_commands(session, user, request.agent_global_commands)
-        else:
-            agent_global_commands = await _get_user_global_commands(session, user)
         if request.phone_number is not None:
             user.phone_number = request.phone_number or None
 
@@ -586,15 +513,12 @@ async def update_profile(
         await session.commit()
         await session.refresh(user)
 
-        agent_global_commands = await _get_user_global_commands(session, user)
-
         return UserResponse(
             id=str(user.id),
             email=user.email,
             name=user.name,
             role=await _get_user_role_for_active_org(session, user),
             avatar_url=user.avatar_url,
-            agent_global_commands=agent_global_commands,
             phone_number=user.phone_number,
             job_title=job_title,
             organization_id=str(user.organization_id) if user.organization_id else None,
@@ -635,7 +559,6 @@ class SyncUserRequest(BaseModel):
     email: str
     name: Optional[str] = None
     avatar_url: Optional[str] = None
-    agent_global_commands: Optional[str] = None
     organization_id: Optional[str] = None
 
 
@@ -656,7 +579,6 @@ class SyncUserResponse(BaseModel):
     email: str
     name: Optional[str]
     avatar_url: Optional[str]
-    agent_global_commands: Optional[str]
     phone_number: Optional[str] = None
     job_title: Optional[str] = None
     organization_id: Optional[str]
@@ -894,7 +816,6 @@ async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
                 email=existing.email,
                 name=existing.name,
                 avatar_url=existing.avatar_url,
-                agent_global_commands=await _get_user_global_commands(session, existing),
                 phone_number=existing.phone_number,
                 job_title=sync_job_title,
                 organization_id=str(existing.organization_id) if existing.organization_id else None,
@@ -918,7 +839,6 @@ async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
             last_login=datetime.utcnow(),
         )
         session.add(new_user)
-        global_commands = await _set_user_global_commands(session, new_user, request.agent_global_commands)
         try:
             await session.commit()
         except IntegrityError:
@@ -950,7 +870,6 @@ async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
                     email=existing.email,
                     name=existing.name,
                     avatar_url=existing.avatar_url,
-                    agent_global_commands=await _get_user_global_commands(session, existing),
                     phone_number=existing.phone_number,
                     job_title=None,
                     organization_id=str(existing.organization_id) if existing.organization_id else None,
@@ -966,7 +885,6 @@ async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
             email=new_user.email,
             name=new_user.name,
             avatar_url=new_user.avatar_url,
-            agent_global_commands=global_commands,
             phone_number=new_user.phone_number,
             job_title=None,
             organization_id=None,
@@ -2133,14 +2051,11 @@ async def switch_active_organization(
                 subscription_required=not _sub_ok,
             )
 
-        agent_global_commands = await _get_user_global_commands(session, user)
-
         return SyncUserResponse(
             id=str(user.id),
             email=user.email,
             name=user.name,
             avatar_url=user.avatar_url,
-            agent_global_commands=agent_global_commands,
             phone_number=user.phone_number,
             job_title=membership.title if membership else None,
             organization_id=str(user.organization_id) if user.organization_id else None,
@@ -2148,8 +2063,6 @@ async def switch_active_organization(
             status=user.status,
             roles=user.roles or [],
         )
-
-
 
 
 class UpdateMemberRoleRequest(BaseModel):

--- a/backend/api/routes/memories.py
+++ b/backend/api/routes/memories.py
@@ -1,17 +1,15 @@
-"""Memory and workflow-note management endpoints for the UI."""
+"""Memory management endpoints for the UI."""
 from __future__ import annotations
 
 import logging
-from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import and_, select
 
 from models.database import get_session
 from models.memory import Memory
-from models.workflow import Workflow, WorkflowRun
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -27,21 +25,13 @@ class MemoryResponse(BaseModel):
     updated_at: str | None
 
 
-class WorkflowNoteResponse(BaseModel):
-    note_id: str
-    run_id: str
-    workflow_id: str
-    workflow_name: str | None
-    note_index: int
-    content: str
-    created_by_user_id: str | None
-    created_at: str | None
-    run_started_at: str | None
-
-
 class MemoryDashboardResponse(BaseModel):
     memories: list[MemoryResponse]
-    workflow_notes: list[WorkflowNoteResponse]
+
+
+class CreateMemoryRequest(BaseModel):
+    content: str = Field(..., min_length=1)
+    category: str | None = None
 
 
 class UpdateMemoryRequest(BaseModel):
@@ -49,8 +39,8 @@ class UpdateMemoryRequest(BaseModel):
 
 
 @router.get("/{organization_id}", response_model=MemoryDashboardResponse)
-async def list_memories_and_notes(organization_id: str, user_id: str) -> MemoryDashboardResponse:
-    """Return user-stored memories and workflow notes for an org/user pair."""
+async def list_memories(organization_id: str, user_id: str) -> MemoryDashboardResponse:
+    """Return user-stored memories for an org/user pair."""
     try:
         org_uuid = UUID(organization_id)
         user_uuid = UUID(user_id)
@@ -68,37 +58,6 @@ async def list_memories_and_notes(organization_id: str, user_id: str) -> MemoryD
         )
         memories = memory_result.scalars().all()
 
-        workflow_result = await session.execute(
-            select(WorkflowRun, Workflow)
-            .join(Workflow, Workflow.id == WorkflowRun.workflow_id)
-            .where(
-                WorkflowRun.organization_id == org_uuid,
-                Workflow.created_by_user_id == user_uuid,
-            )
-            .order_by(WorkflowRun.started_at.desc())
-        )
-
-        workflow_notes: list[WorkflowNoteResponse] = []
-        for run, workflow in workflow_result.all():
-            notes: list[dict[str, Any]] = list(run.workflow_notes or [])
-            for idx, note in enumerate(notes):
-                content = str(note.get("content", "")).strip()
-                if not content:
-                    continue
-                workflow_notes.append(
-                    WorkflowNoteResponse(
-                        note_id=f"{run.id}:{idx}",
-                        run_id=str(run.id),
-                        workflow_id=str(workflow.id),
-                        workflow_name=workflow.name,
-                        note_index=idx,
-                        content=content,
-                        created_by_user_id=note.get("created_by_user_id"),
-                        created_at=note.get("created_at"),
-                        run_started_at=f"{run.started_at.isoformat()}Z" if run.started_at else None,
-                    )
-                )
-
     return MemoryDashboardResponse(
         memories=[
             MemoryResponse(
@@ -112,7 +71,48 @@ async def list_memories_and_notes(organization_id: str, user_id: str) -> MemoryD
             )
             for memory in memories
         ],
-        workflow_notes=workflow_notes,
+    )
+
+
+@router.post("/{organization_id}/user", response_model=MemoryResponse)
+async def create_user_memory(
+    organization_id: str,
+    user_id: str,
+    request: CreateMemoryRequest,
+) -> MemoryResponse:
+    """Create a user-stored memory."""
+    try:
+        org_uuid = UUID(organization_id)
+        user_uuid = UUID(user_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    content = request.content.strip()
+    if not content:
+        raise HTTPException(status_code=400, detail="content is required")
+
+    async with get_session(organization_id=organization_id) as session:
+        memory = Memory(
+            entity_type="user",
+            entity_id=user_uuid,
+            organization_id=org_uuid,
+            category=(request.category.strip() or None) if request.category else None,
+            content=content,
+            created_by_user_id=user_uuid,
+        )
+        session.add(memory)
+        await session.commit()
+        await session.refresh(memory)
+
+    logger.info("[Memories API] Created memory %s for user %s", memory.id, user_id)
+    return MemoryResponse(
+        id=str(memory.id),
+        entity_type=memory.entity_type,
+        category=memory.category,
+        content=memory.content,
+        created_by_user_id=str(memory.created_by_user_id) if memory.created_by_user_id else None,
+        created_at=f"{memory.created_at.isoformat()}Z" if memory.created_at else None,
+        updated_at=f"{memory.updated_at.isoformat()}Z" if memory.updated_at else None,
     )
 
 
@@ -188,43 +188,3 @@ async def delete_user_memory(organization_id: str, memory_id: str, user_id: str)
 
     logger.info("[Memories API] Deleted memory %s for user %s", memory_id, user_id)
     return {"status": "deleted", "memory_id": memory_id}
-
-
-@router.delete("/{organization_id}/workflow-notes/{run_id}/{note_index}")
-async def delete_workflow_note(organization_id: str, run_id: str, note_index: int, user_id: str) -> dict[str, str]:
-    """Delete one workflow note by run ID and note index."""
-    if note_index < 0:
-        raise HTTPException(status_code=400, detail="note_index must be >= 0")
-
-    try:
-        org_uuid = UUID(organization_id)
-        run_uuid = UUID(run_id)
-        user_uuid = UUID(user_id)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid ID format")
-
-    async with get_session(organization_id=organization_id) as session:
-        result = await session.execute(
-            select(WorkflowRun, Workflow)
-            .join(Workflow, Workflow.id == WorkflowRun.workflow_id)
-            .where(
-                WorkflowRun.id == run_uuid,
-                WorkflowRun.organization_id == org_uuid,
-                Workflow.created_by_user_id == user_uuid,
-            )
-        )
-        row = result.one_or_none()
-        if not row:
-            raise HTTPException(status_code=404, detail="Workflow run not found")
-
-        run, _workflow = row
-        notes = list(run.workflow_notes or [])
-        if note_index >= len(notes):
-            raise HTTPException(status_code=404, detail="Workflow note not found")
-
-        notes.pop(note_index)
-        run.workflow_notes = notes
-        await session.commit()
-
-    logger.info("[Memories API] Deleted workflow note run=%s index=%s user=%s", run_id, note_index, user_id)
-    return {"status": "deleted", "note_id": f"{run_id}:{note_index}"}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -106,7 +106,6 @@ function App(): JSX.Element {
               email: 'user@example.com',
               name: null,
               avatarUrl: null,
-              agentGlobalCommands: null,
               phoneNumber: null,
               jobTitle: null,
               roles: [],
@@ -201,7 +200,6 @@ function App(): JSX.Element {
       email,
       name,
       avatarUrl,
-      agentGlobalCommands: existingUser?.agentGlobalCommands ?? null,
       phoneNumber: existingUser?.phoneNumber ?? null,
       jobTitle: existingUser?.jobTitle ?? null,
       roles: [],
@@ -219,7 +217,6 @@ function App(): JSX.Element {
           email,
           name,
           avatar_url: avatarUrl,
-          agent_global_commands: existingUser?.agentGlobalCommands ?? null,
         }),
       });
 
@@ -231,7 +228,6 @@ function App(): JSX.Element {
           avatar_url: string | null;
           name: string | null;
           roles: string[];
-          agent_global_commands: string | null;
           phone_number: string | null;
           job_title: string | null;
           organization_id: string | null;
@@ -247,7 +243,6 @@ function App(): JSX.Element {
           email,
           name: userData.name ?? name,
           avatarUrl: userData.avatar_url ?? avatarUrl,
-          agentGlobalCommands: userData.agent_global_commands ?? existingUser?.agentGlobalCommands ?? null,
           phoneNumber: userData.phone_number ?? existingUser?.phoneNumber ?? null,
           jobTitle: userData.job_title ?? existingUser?.jobTitle ?? null,
           roles: userData.roles ?? [],

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -631,7 +631,6 @@ export function AdminPanel(): JSX.Element {
         email: data.email,
         name: data.name,
         avatarUrl: data.avatar_url,
-        agentGlobalCommands: null,
         phoneNumber: null,
         jobTitle: null,
         roles: data.roles,

--- a/frontend/src/components/Memories.tsx
+++ b/frontend/src/components/Memories.tsx
@@ -1,10 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiRequest } from '../lib/api';
 import { useAppStore } from '../store';
-
-const AGENT_GLOBAL_COMMANDS_MAX_LENGTH = 500;
-const USER_STORED_COLLAPSE_STATE_KEY = 'memory_user_stored_collapsed';
 
 interface StoredMemory {
   id: string;
@@ -26,23 +23,12 @@ function formatTime(value: string | null): string {
 }
 
 export function Memories(): JSX.Element {
-  const { organization, user, setUser } = useAppStore();
+  const { organization, user } = useAppStore();
   const queryClient = useQueryClient();
   const [editingMemoryId, setEditingMemoryId] = useState<string | null>(null);
   const [memoryDraft, setMemoryDraft] = useState<string>('');
-  const [agentGlobalCommands, setAgentGlobalCommands] = useState<string>('');
-  const [commandsError, setCommandsError] = useState<string | null>(null);
-  const [isUserStoredExpanded, setIsUserStoredExpanded] = useState<boolean>(() => {
-    return localStorage.getItem(USER_STORED_COLLAPSE_STATE_KEY) === 'false';
-  });
-
-  useEffect(() => {
-    setAgentGlobalCommands(user?.agentGlobalCommands ?? '');
-  }, [user?.agentGlobalCommands]);
-
-  useEffect(() => {
-    localStorage.setItem(USER_STORED_COLLAPSE_STATE_KEY, String(!isUserStoredExpanded));
-  }, [isUserStoredExpanded]);
+  const [newMemoryContent, setNewMemoryContent] = useState<string>('');
+  const [showAddForm, setShowAddForm] = useState<boolean>(false);
 
   const orgId = organization?.id;
   const userId = user?.id;
@@ -52,25 +38,21 @@ export function Memories(): JSX.Element {
     queryKey,
     enabled: !!orgId && !!userId,
     queryFn: async () => {
-      const { data, error } = await apiRequest<MemoryDashboardResponse>(`/memories/${orgId}?user_id=${userId}`);
-      if (error || !data) throw new Error(error ?? 'Failed to load memories');
-      return data;
+      const { data: res, error: err } = await apiRequest<MemoryDashboardResponse>(`/memories/${orgId}?user_id=${userId}`);
+      if (err || !res) throw new Error(err ?? 'Failed to load memories');
+      return res;
     },
   });
 
-
-  const userStoredMemories = useMemo(
-    () => (data?.memories ?? []).filter((memory) => memory.category !== 'global_commands'),
-    [data?.memories],
-  );
+  const memories: StoredMemory[] = data?.memories ?? [];
 
   const updateMemory = useMutation({
     mutationFn: async ({ memoryId, content }: { memoryId: string; content: string }) => {
-      const { error } = await apiRequest(`/memories/${orgId}/user/${memoryId}?user_id=${userId}`, {
+      const { error: err } = await apiRequest(`/memories/${orgId}/user/${memoryId}?user_id=${userId}`, {
         method: 'PATCH',
         body: JSON.stringify({ content }),
       });
-      if (error) throw new Error(error);
+      if (err) throw new Error(err);
     },
     onSuccess: () => {
       setEditingMemoryId(null);
@@ -80,10 +62,10 @@ export function Memories(): JSX.Element {
 
   const deleteMemory = useMutation({
     mutationFn: async (memoryId: string) => {
-      const { error } = await apiRequest(`/memories/${orgId}/user/${memoryId}?user_id=${userId}`, {
+      const { error: err } = await apiRequest(`/memories/${orgId}/user/${memoryId}?user_id=${userId}`, {
         method: 'DELETE',
       });
-      if (error) throw new Error(error);
+      if (err) throw new Error(err);
     },
     onSuccess: () => {
       setEditingMemoryId(null);
@@ -91,136 +73,133 @@ export function Memories(): JSX.Element {
     },
   });
 
-  const saveGlobalCommands = useMutation({
-    mutationFn: async () => {
-      if (!user) throw new Error('User is required');
-
-      const trimmedCommands = agentGlobalCommands.trim();
-      if (trimmedCommands.length > AGENT_GLOBAL_COMMANDS_MAX_LENGTH) {
-        throw new Error(`Agent global commands must be ${AGENT_GLOBAL_COMMANDS_MAX_LENGTH} characters or less.`);
-      }
-
-      const { data, error } = await apiRequest<{
-        name: string | null;
-        avatar_url: string | null;
-        agent_global_commands: string | null;
-        phone_number: string | null;
-        job_title: string | null;
-      }>(`/auth/me?user_id=${user.id}`, {
-        method: 'PATCH',
-        body: JSON.stringify({
-          name: user.name,
-          avatar_url: user.avatarUrl,
-          agent_global_commands: trimmedCommands || null,
-          phone_number: user.phoneNumber,
-          job_title: user.jobTitle,
-        }),
+  const createMemory = useMutation({
+    mutationFn: async (content: string) => {
+      const { error: err } = await apiRequest(`/memories/${orgId}/user?user_id=${userId}`, {
+        method: 'POST',
+        body: JSON.stringify({ content: content.trim() }),
       });
-
-      if (error || !data) throw new Error(error ?? 'Failed to update global commands');
-      return data;
+      if (err) throw new Error(err);
     },
-    onSuccess: (updatedUser) => {
-      if (!user) return;
-      setCommandsError(null);
-      setUser({
-        ...user,
-        name: updatedUser.name,
-        avatarUrl: updatedUser.avatar_url,
-        agentGlobalCommands: updatedUser.agent_global_commands,
-        phoneNumber: updatedUser.phone_number,
-        jobTitle: updatedUser.job_title,
-      });
-    },
-    onError: (err) => {
-      setCommandsError(err instanceof Error ? err.message : 'Failed to update global commands');
+    onSuccess: () => {
+      setNewMemoryContent('');
+      setShowAddForm(false);
+      void queryClient.invalidateQueries({ queryKey });
     },
   });
 
+  const handleAddMemory = (): void => {
+    const trimmed = newMemoryContent.trim();
+    if (!trimmed) return;
+    createMemory.mutate(trimmed);
+  };
+
   return (
     <div className="flex-1 overflow-hidden flex flex-col">
-      <header className="sticky top-0 bg-surface-950 border-b border-surface-800 px-4 md:px-8 py-4 md:py-6">
-        <h1 className="text-xl md:text-2xl font-bold text-surface-50">Memory</h1>
-        <p className="text-surface-400 mt-1 text-sm md:text-base">A shared place to manage user-saved memories.</p>
-      </header>
-
-      <div className="flex-1 overflow-y-auto px-4 md:px-8 py-4 md:py-6 space-y-6">
-        {isLoading && <div className="text-surface-400">Loading memory data...</div>}
-        {isError && <div className="text-red-400">{error instanceof Error ? error.message : 'Failed to load memory data'}</div>}
+      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+        {isLoading && <div className="text-surface-400 text-sm">Loading memories...</div>}
+        {isError && <div className="text-red-400 text-sm">{error instanceof Error ? error.message : 'Failed to load memories'}</div>}
 
         {!isLoading && !isError && (
           <>
-            <section className="rounded-xl border border-surface-800 bg-surface-900/40 p-4 md:p-6">
-              <div className="flex items-center justify-between gap-4">
-                <h2 className="text-lg font-semibold text-surface-100">Global commands</h2>
+            <div className="flex justify-end">
+              {!showAddForm && (
                 <button
-                  className="px-3 py-1.5 text-xs rounded-md bg-primary-600 hover:bg-primary-700 text-white disabled:opacity-60"
-                  disabled={saveGlobalCommands.isPending}
-                  onClick={() => saveGlobalCommands.mutate()}
+                  type="button"
+                  className="px-3 py-1.5 text-xs rounded-md bg-primary-600 hover:bg-primary-700 text-white"
+                  onClick={() => setShowAddForm(true)}
                 >
-                  {saveGlobalCommands.isPending ? 'Saving...' : 'Save'}
+                  Add memory
                 </button>
-              </div>
-              <p className="text-xs text-surface-500 mt-2">Persistent instructions included with every agent prompt.</p>
-              <textarea
-                value={agentGlobalCommands}
-                onChange={(e) => setAgentGlobalCommands(e.target.value)}
-                placeholder="Add global command guidance for the agent"
-                className="input-field min-h-28 mt-3"
-                maxLength={AGENT_GLOBAL_COMMANDS_MAX_LENGTH}
-              />
-              <div className="flex items-center justify-between mt-1">
-                <p className="text-xs text-surface-500">{agentGlobalCommands.length}/{AGENT_GLOBAL_COMMANDS_MAX_LENGTH}</p>
-                {commandsError && <p className="text-xs text-red-400">{commandsError}</p>}
-              </div>
-            </section>
+              )}
+            </div>
 
-            <section className="rounded-xl border border-surface-800 bg-surface-900/40 p-4 md:p-6">
-              <div className="flex items-center justify-between gap-4">
-                <button
-                  className="flex items-center gap-2 text-left text-primary-400 hover:text-primary-300 transition-colors"
-                  onClick={() => setIsUserStoredExpanded((value) => !value)}
-                  aria-expanded={isUserStoredExpanded}
-                >
-                  <span className="text-xs leading-none">{isUserStoredExpanded ? '▾' : '▸'}</span>
-                  <h2 className="text-lg font-semibold">User stored</h2>
-                </button>
-                <span className="text-xs text-surface-500">Editable + deletable</span>
+            {showAddForm && (
+              <div className="rounded-lg border border-surface-800 bg-surface-900 p-3 mb-4">
+                <textarea
+                  className="w-full min-h-20 rounded-lg bg-surface-800 border border-surface-700 px-3 py-2 text-sm text-surface-100"
+                  value={newMemoryContent}
+                  onChange={(e) => setNewMemoryContent(e.target.value)}
+                  placeholder="e.g. I prefer morning meetings before 10am"
+                  autoFocus
+                />
+                <div className="flex justify-end gap-2 mt-2">
+                  <button
+                    type="button"
+                    className="px-3 py-1.5 text-xs rounded-md bg-surface-800 hover:bg-surface-700 text-surface-200"
+                    onClick={() => { setShowAddForm(false); setNewMemoryContent(''); }}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    className="px-3 py-1.5 text-xs rounded-md bg-primary-600 hover:bg-primary-700 text-white disabled:opacity-60"
+                    disabled={!newMemoryContent.trim() || createMemory.isPending}
+                    onClick={handleAddMemory}
+                  >
+                    {createMemory.isPending ? 'Adding...' : 'Add'}
+                  </button>
+                </div>
               </div>
-              {isUserStoredExpanded && <div className="mt-4 space-y-3">
-                {userStoredMemories.length ? userStoredMemories.map((memory) => (
-                  <div key={memory.id} className="rounded-lg border border-surface-800 bg-surface-900 p-3">
-                    <div className="flex flex-col gap-3">
-                      <div className="w-full">
-                        <div className="text-xs text-surface-500 mb-2">
-                          {memory.category ?? 'uncategorized'} • Updated {formatTime(memory.updated_at)}
-                        </div>
-                        {editingMemoryId === memory.id ? (
-                          <textarea
-                            className="w-full min-h-20 rounded-lg bg-surface-800 border border-surface-700 px-3 py-2 text-sm text-surface-100"
-                            value={memoryDraft}
-                            onChange={(e) => setMemoryDraft(e.target.value)}
-                          />
-                        ) : (
-                          <p className="text-sm text-surface-200 whitespace-pre-wrap">{memory.content}</p>
-                        )}
+            )}
+
+            <div className="space-y-3">
+              {memories.length ? memories.map((memory) => (
+                <div key={memory.id} className="rounded-lg border border-surface-800 bg-surface-900 p-3">
+                  <div className="flex flex-col gap-3">
+                    <div className="w-full">
+                      <div className="text-xs text-surface-500 mb-2">
+                        {memory.category ?? 'uncategorized'} • Updated {formatTime(memory.updated_at)}
                       </div>
-                      <div className="flex flex-wrap justify-end gap-2">
-                        {editingMemoryId === memory.id ? (
-                          <>
-                            <button className="px-3 py-1.5 text-xs rounded-md bg-primary-600 hover:bg-primary-700 text-white" onClick={() => updateMemory.mutate({ memoryId: memory.id, content: memoryDraft })}>Save</button>
-                            <button className="px-3 py-1.5 text-xs rounded-md bg-surface-800 hover:bg-surface-700 text-surface-200" onClick={() => setEditingMemoryId(null)}>Cancel</button>
-                          </>
-                        ) : (
-                          <button className="px-3 py-1.5 text-xs rounded-md bg-surface-800 hover:bg-surface-700 text-surface-200" onClick={() => { setEditingMemoryId(memory.id); setMemoryDraft(memory.content); }}>Edit</button>
-                        )}
-                        <button className="px-3 py-1.5 text-xs rounded-md bg-red-600/20 hover:bg-red-600/30 text-red-300" onClick={() => deleteMemory.mutate(memory.id)}>Delete</button>
-                      </div>
+                      {editingMemoryId === memory.id ? (
+                        <textarea
+                          className="w-full min-h-20 rounded-lg bg-surface-800 border border-surface-700 px-3 py-2 text-sm text-surface-100"
+                          value={memoryDraft}
+                          onChange={(e) => setMemoryDraft(e.target.value)}
+                        />
+                      ) : (
+                        <p className="text-sm text-surface-200 whitespace-pre-wrap">{memory.content}</p>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap justify-end gap-2">
+                      {editingMemoryId === memory.id ? (
+                        <>
+                          <button
+                            type="button"
+                            className="px-3 py-1.5 text-xs rounded-md bg-primary-600 hover:bg-primary-700 text-white"
+                            onClick={() => updateMemory.mutate({ memoryId: memory.id, content: memoryDraft })}
+                          >
+                            Save
+                          </button>
+                          <button
+                            type="button"
+                            className="px-3 py-1.5 text-xs rounded-md bg-surface-800 hover:bg-surface-700 text-surface-200"
+                            onClick={() => setEditingMemoryId(null)}
+                          >
+                            Cancel
+                          </button>
+                        </>
+                      ) : (
+                        <button
+                          type="button"
+                          className="px-3 py-1.5 text-xs rounded-md bg-surface-800 hover:bg-surface-700 text-surface-200"
+                          onClick={() => { setEditingMemoryId(memory.id); setMemoryDraft(memory.content); }}
+                        >
+                          Edit
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        className="px-3 py-1.5 text-xs rounded-md bg-red-600/20 hover:bg-red-600/30 text-red-300"
+                        onClick={() => deleteMemory.mutate(memory.id)}
+                      >
+                        Delete
+                      </button>
                     </div>
                   </div>
-                )) : <p className="text-sm text-surface-500">No user memories found yet.</p>}
-              </div>}
-            </section>
+                </div>
+              )) : !showAddForm && <p className="text-sm text-surface-500">No memories yet. Add one above or ask the agent to remember something.</p>}
+            </div>
           </>
         )}
       </div>

--- a/frontend/src/components/ProfilePanel.tsx
+++ b/frontend/src/components/ProfilePanel.tsx
@@ -42,7 +42,6 @@ export function ProfilePanel({ user, onClose, onLogout, onUpdateUser }: ProfileP
         body: JSON.stringify({
           name: name || null,
           avatar_url: avatarPreview,
-          agent_global_commands: user.agentGlobalCommands,
           phone_number: phoneNumber.trim() || null,
           job_title: jobTitle.trim() || null,
         }),
@@ -56,7 +55,6 @@ export function ProfilePanel({ user, onClose, onLogout, onUpdateUser }: ProfileP
       const updatedUser = await response.json() as {
         name: string | null;
         avatar_url: string | null;
-        agent_global_commands: string | null;
         phone_number: string | null;
         job_title: string | null;
       };
@@ -65,7 +63,6 @@ export function ProfilePanel({ user, onClose, onLogout, onUpdateUser }: ProfileP
       onUpdateUser({
         name: updatedUser.name,
         avatarUrl: updatedUser.avatar_url,
-        agentGlobalCommands: updatedUser.agent_global_commands,
         phoneNumber: updatedUser.phone_number,
         jobTitle: updatedUser.job_title,
       });
@@ -124,29 +121,21 @@ export function ProfilePanel({ user, onClose, onLogout, onUpdateUser }: ProfileP
           </button>
         </header>
 
-        <div className="px-6 pt-4 border-b border-surface-800">
-          <div className="flex gap-2">
+        {/* Tabs - matches OrganizationPanel pattern */}
+        <div className="flex border-b border-surface-800">
+          {(['profile', 'memories'] as const).map((tab) => (
             <button
-              onClick={() => setActiveTab('profile')}
-              className={`px-3 py-2 text-sm rounded-t-lg transition-colors ${
-                activeTab === 'profile'
-                  ? 'bg-surface-800 text-surface-100'
-                  : 'text-surface-400 hover:text-surface-200 hover:bg-surface-800/60'
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`flex-1 px-2 py-3 text-sm font-medium transition-colors ${
+                activeTab === tab
+                  ? 'text-primary-400 border-b-2 border-primary-500'
+                  : 'text-surface-400 hover:text-surface-200'
               }`}
             >
-              Profile
+              {tab.charAt(0).toUpperCase() + tab.slice(1)}
             </button>
-            <button
-              onClick={() => setActiveTab('memories')}
-              className={`px-3 py-2 text-sm rounded-t-lg transition-colors ${
-                activeTab === 'memories'
-                  ? 'bg-surface-800 text-surface-100'
-                  : 'text-surface-400 hover:text-surface-200 hover:bg-surface-800/60'
-              }`}
-            >
-              Memories
-            </button>
-          </div>
+          ))}
         </div>
 
         {/* Content */}

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -287,7 +287,6 @@ export const useAuthStore = create<AuthState>()(
               email: user.email,
               name: user.name,
               avatar_url: user.avatarUrl,
-              agent_global_commands: user.agentGlobalCommands,
               organization_id: organization?.id,
             }),
           });
@@ -308,7 +307,6 @@ export const useAuthStore = create<AuthState>()(
             status: string;
             avatar_url: string | null;
             name: string | null;
-            agent_global_commands: string | null;
             phone_number: string | null;
             job_title: string | null;
             roles: string[];
@@ -329,7 +327,6 @@ export const useAuthStore = create<AuthState>()(
             data.id !== user.id ||
             data.avatar_url !== user.avatarUrl ||
             data.name !== user.name ||
-            data.agent_global_commands !== user.agentGlobalCommands ||
             data.phone_number !== user.phoneNumber ||
             data.job_title !== user.jobTitle ||
             JSON.stringify(newRoles) !== JSON.stringify(user.roles)
@@ -339,8 +336,6 @@ export const useAuthStore = create<AuthState>()(
               id: data.id,
               name: data.name ?? user.name,
               avatarUrl: data.avatar_url ?? user.avatarUrl,
-              agentGlobalCommands:
-                data.agent_global_commands ?? user.agentGlobalCommands,
               phoneNumber: data.phone_number ?? user.phoneNumber,
               jobTitle: data.job_title ?? user.jobTitle,
               roles: newRoles,

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -251,7 +251,6 @@ export const useConnectedIntegrations = () =>
       email: string;
       name: string | null;
       avatarUrl: string | null;
-      agentGlobalCommands: string | null;
       phoneNumber: string | null;
       jobTitle: string | null;
       roles: string[];

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -14,7 +14,6 @@ export interface UserProfile {
   email: string;
   name: string | null;
   avatarUrl: string | null;
-  agentGlobalCommands: string | null;
   phoneNumber: string | null;
   jobTitle: string | null;
   roles: string[]; // Global roles like ['global_admin']


### PR DESCRIPTION
## Summary
Merges global commands into regular memories, removes workflow notes from the memory UI/API, and simplifies the memory panel UX.

## Changes

### Backend
- **auth.py**: Removed `agent_global_commands` from UserResponse, UpdateProfileRequest, SyncUserRequest, SyncUserResponse. Removed `_get_user_global_commands` / `_set_user_global_commands` helpers.
- **orchestrator.py**: Removed global commands special handling. All memories (including former global_commands) now flow into `## Your Profile` / `## Your Role` sections.
- **memories.py**: Removed workflow notes from dashboard response and `delete_workflow_note` endpoint. Added `POST /{org_id}/user` for creating memories from the UI.

### Frontend
- **Store/types, authStore, App, ProfilePanel, AdminPanel**: Removed `agentGlobalCommands` from user state and API payloads.
- **Memories.tsx**: Flat list of all memories with Add memory button. Removed global commands section, collapsible sections, and extra headers. Reduced horizontal padding.
- **ProfilePanel**: Standard tab selection (underline indicator), reduced tab padding.

Made with [Cursor](https://cursor.com)