### PR TITLE
Fix disconnect orphaned meeting cleanup FK race

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -3757,20 +3757,34 @@ async def disconnect_integration(
             print(f"Disconnect: Deleted {deleted_pipelines} pipelines")
             
             # 8. Clean up orphaned meetings (meetings with no linked activities)
-            result = await db_session.execute(
-                text("""
-                    DELETE FROM meetings
-                    WHERE organization_id = :org_id
-                      AND id NOT IN (
-                          SELECT DISTINCT meeting_id FROM activities
-                          WHERE meeting_id IS NOT NULL
-                      )
-                    RETURNING id
-                """),
-                {"org_id": str(org_uuid)},
-            )
-            deleted_meetings = len(result.fetchall())
-            print(f"Disconnect: Deleted {deleted_meetings} orphaned meetings")
+            # NOTE: We use NOT EXISTS scoped by organization to avoid broad scans and
+            # reduce false positives. This can still race with concurrent writes, so
+            # we catch and skip on FK violations to keep disconnect idempotent.
+            try:
+                result = await db_session.execute(
+                    text("""
+                        DELETE FROM meetings m
+                        WHERE m.organization_id = :org_id
+                          AND NOT EXISTS (
+                              SELECT 1
+                              FROM activities a
+                              WHERE a.organization_id = :org_id
+                                AND a.meeting_id = m.id
+                          )
+                        RETURNING m.id
+                    """),
+                    {"org_id": str(org_uuid)},
+                )
+                deleted_meetings = len(result.fetchall())
+                print(f"Disconnect: Deleted {deleted_meetings} orphaned meetings")
+            except IntegrityError as exc:
+                logger.warning(
+                    "Disconnect: Skipping orphaned meeting cleanup due to FK race org=%s provider=%s error=%s",
+                    org_uuid,
+                    provider,
+                    exc,
+                )
+                print("Disconnect: Skipped orphaned meeting cleanup due to concurrent activity updates")
 
         print(f"Disconnect: Deleting integration from database")
         await db_session.delete(integration)


### PR DESCRIPTION
### Motivation
- The previous orphaned meetings cleanup used a `NOT IN (SELECT meeting_id FROM activities ...)` check which could produce incorrect cross-organization matches and cause foreign key violations during concurrent writes.
- A transient FK race caused `IntegrityError`/`ForeignKeyViolationError` and aborted the disconnect flow, making disconnects non-idempotent under concurrent activity updates.

### Description
- Replaced the `NOT IN` anti-join with an organization-scoped `NOT EXISTS` anti-join to more safely identify orphaned meetings (query now aliases `meetings m` and checks `activities a` for `a.meeting_id = m.id`).
- Wrapped the orphaned meetings `DELETE` in a `try/except IntegrityError` block to catch FK races and log a warning instead of failing the entire disconnect.
- Added a descriptive `logger.warning` and a `print` message when skipping cleanup due to concurrent activity updates to improve observability.
- Changes made in `backend/api/routes/auth.py` to keep the disconnect operation idempotent and more robust under concurrent DB writes.

### Testing
- Ran Python bytecode compilation with `python -m py_compile backend/api/routes/auth.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac6ed794688321b88a3a055dd24a53)