### PR TITLE
Skip PagerDuty incidents when runtime is localhost

### DIFF
--- a/backend/services/pagerduty.py
+++ b/backend/services/pagerduty.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 import httpx
 
 from config import settings
 
 logger = logging.getLogger(__name__)
+
+_LOCALHOST_HOSTNAMES = {"localhost", "127.0.0.1", "::1"}
 
 
 @dataclass(frozen=True)
@@ -21,8 +24,35 @@ class PagerDutyIncidentResult:
     response_body: str | None = None
 
 
+def _is_localhost_runtime() -> bool:
+    """Return True when runtime URLs indicate a localhost/developer environment."""
+    candidate_urls = [
+        settings.BACKEND_PUBLIC_URL,
+        settings.FRONTEND_URL,
+    ]
+
+    for value in candidate_urls:
+        if not value:
+            continue
+
+        parsed = urlparse(value)
+        hostname = parsed.hostname
+        if hostname and hostname.lower() in _LOCALHOST_HOSTNAMES:
+            logger.info(
+                "PagerDuty incidents disabled for localhost runtime (url=%s)",
+                value,
+            )
+            return True
+
+    return False
+
+
 def get_pagerduty_config() -> tuple[str, str, str] | None:
     """Return PagerDuty settings if complete, else log and skip."""
+    if _is_localhost_runtime():
+        logger.info("PagerDuty incident skipped: localhost runtime detected")
+        return None
+
     from_email = settings.PAGERDUTY_FROM_EMAIL
     api_key = settings.PAGERDUTY_KEY
     service_id = settings.PAGERDUTY_SERVICE_ID

--- a/backend/tests/test_pagerduty_service.py
+++ b/backend/tests/test_pagerduty_service.py
@@ -56,6 +56,8 @@ def test_create_pagerduty_incident_with_details_http_error(monkeypatch: Any) -> 
     monkeypatch.setenv("PAGERDUTY_FROM_EMAIL", "alerts@revtops.com")
     monkeypatch.setenv("PagerDuty_Key", "pd_test_key")
     monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
+    monkeypatch.setenv("FRONTEND_URL", "https://app.basebase.com")
+    monkeypatch.delenv("BACKEND_PUBLIC_URL", raising=False)
     monkeypatch.setattr(pagerduty, "settings", settings.__class__())
 
     import asyncio
@@ -77,6 +79,8 @@ def test_create_pagerduty_incident_with_details_success(monkeypatch: Any) -> Non
     monkeypatch.setenv("PAGERDUTY_FROM_EMAIL", "alerts@revtops.com")
     monkeypatch.setenv("PagerDuty_Key", "pd_test_key")
     monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
+    monkeypatch.setenv("FRONTEND_URL", "https://app.basebase.com")
+    monkeypatch.delenv("BACKEND_PUBLIC_URL", raising=False)
     monkeypatch.setattr(pagerduty, "settings", settings.__class__())
 
     import asyncio
@@ -91,3 +95,29 @@ def test_create_pagerduty_incident_with_details_success(monkeypatch: Any) -> Non
     assert result.ok is True
     assert result.reason == "created"
     assert result.status_code == 201
+
+
+def test_get_pagerduty_config_skips_when_frontend_url_is_localhost(monkeypatch: Any) -> None:
+    monkeypatch.setenv("PAGERDUTY_FROM_EMAIL", "alerts@revtops.com")
+    monkeypatch.setenv("PagerDuty_Key", "pd_test_key")
+    monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
+    monkeypatch.setenv("FRONTEND_URL", "http://localhost:5173")
+    monkeypatch.delenv("BACKEND_PUBLIC_URL", raising=False)
+    monkeypatch.setattr(pagerduty, "settings", settings.__class__())
+
+    config = pagerduty.get_pagerduty_config()
+
+    assert config is None
+
+
+def test_get_pagerduty_config_skips_when_backend_public_url_is_localhost(monkeypatch: Any) -> None:
+    monkeypatch.setenv("PAGERDUTY_FROM_EMAIL", "alerts@revtops.com")
+    monkeypatch.setenv("PagerDuty_Key", "pd_test_key")
+    monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
+    monkeypatch.setenv("FRONTEND_URL", "https://app.basebase.com")
+    monkeypatch.setenv("BACKEND_PUBLIC_URL", "http://127.0.0.1:8000")
+    monkeypatch.setattr(pagerduty, "settings", settings.__class__())
+
+    config = pagerduty.get_pagerduty_config()
+
+    assert config is None


### PR DESCRIPTION
### Motivation
- Avoid creating PagerDuty incidents while running the app in a developer/localhost environment so local runs do not trigger real alerting.
- Make suppression explicit and discoverable via logs so developers understand why incidents are not created.

### Description
- Added a `_is_localhost_runtime()` helper that parses `settings.BACKEND_PUBLIC_URL` and `settings.FRONTEND_URL` (via `urlparse`) and treats `localhost`, `127.0.0.1`, and `::1` as local runtimes. (`backend/services/pagerduty.py`)
- Gate `get_pagerduty_config()` to return `None` when a localhost runtime is detected and log an info-level message; existing missing-config behavior remains unchanged. (`backend/services/pagerduty.py`)
- Added info logging when suppression is applied to make the behavior visible in logs. (`backend/services/pagerduty.py`)
- Added unit tests covering localhost suppression and adjusted existing tests to explicitly set `FRONTEND_URL`/`BACKEND_PUBLIC_URL` so non-localhost behavior is still exercised. (`backend/tests/test_pagerduty_service.py`)

### Testing
- Ran `pytest -q backend/tests/test_pagerduty_service.py` and observed all tests passing with one deprecation warning. (Result: `5 passed, 1 warning`)
- The new tests exercise both paths: skipping when `FRONTEND_URL` or `BACKEND_PUBLIC_URL` points at localhost, and normal incident creation behavior when using non-localhost URLs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac7315d9a8832190522a42a735deca)