### PR TITLE
Add caution text for Slack bulk invite in Organization panel

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -684,6 +684,9 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                     ? 'Checking Slack users...'
                     : "Invite all Slack users that aren't yet in Basebase"}
                 </button>
+                <p className="mt-1 text-xs text-surface-500">
+                  Inviting someone grants access to your org&apos;s data and credit usage.
+                </p>
               </div>
 
               {/* Team List */}


### PR DESCRIPTION
### Motivation
- Clarify risk when bulk-inviting Slack users by warning that invited users gain access to the org's data and can use credits.

### Description
- Add a short helper paragraph under the Slack bulk-invite action in `frontend/src/components/OrganizationPanel.tsx` that reads: "Inviting someone grants access to your org's data and credit usage.".

### Testing
- Ran `npm run lint` which completed successfully.
- Launched the frontend with `npm run dev` for visual verification and captured a screenshot of the updated UI state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac7b42dd348321b506705946decf10)