### PR TITLE
Move invite access warning under Invite team member header

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -658,6 +658,9 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
               {/* Invite Section */}
               <div>
                 <h3 className="text-sm font-medium text-surface-200 mb-3">Invite team member</h3>
+                <p className="mb-2 text-xs text-surface-500">
+                  Inviting someone grants access to your org&apos;s data and credit usage.
+                </p>
                 <div className="flex gap-2">
                   <input
                     type="email"
@@ -684,9 +687,6 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                     ? 'Checking Slack users...'
                     : "Invite all Slack users that aren't yet in Basebase"}
                 </button>
-                <p className="mt-1 text-xs text-surface-500">
-                  Inviting someone grants access to your org&apos;s data and credit usage.
-                </p>
               </div>
 
               {/* Team List */}


### PR DESCRIPTION
### Motivation
- Make the warning about org data and credit usage more prominent by placing it directly under the `Invite team member` heading in the Team settings UI.

### Description
- Moved the warning paragraph into `frontend/src/components/OrganizationPanel.tsx` so it renders immediately below the `Invite team member` `<h3>` while keeping the existing styling and invite actions unchanged.

### Testing
- Ran linter with `cd frontend && npx eslint src/components/OrganizationPanel.tsx`, which completed successfully.
- Launched the dev server with `cd frontend && npm run dev -- --host 0.0.0.0 --port 4173` and verified the UI change; a Playwright-driven screenshot was captured to `artifacts/org-panel-invite-note.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac7e77d2548321bca47d0a24be473b)