### PR TITLE
Fix disconnect flow race when deleting orphan meetings

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -3752,23 +3752,33 @@ async def disconnect_integration(
             print(f"Disconnect: Deleted {deleted_pipelines} pipelines")
             
             # 8. Clean up orphaned meetings (meetings with no linked activities).
-            # Use NOT EXISTS instead of NOT IN to avoid edge cases and ensure
-            # PostgreSQL checks references row-by-row before deletion.
-            result = await db_session.execute(
-                text("""
-                    DELETE FROM meetings m
-                    WHERE m.organization_id = :org_id
-                      AND NOT EXISTS (
-                          SELECT 1
-                          FROM activities a
-                          WHERE a.meeting_id = m.id
-                      )
-                    RETURNING id
-                """),
-                {"org_id": str(org_uuid)},
-            )
-            deleted_meetings = len(result.fetchall())
-            print(f"Disconnect: Deleted {deleted_meetings} orphaned meetings")
+            # This is best-effort because activity ingestion can happen concurrently
+            # and create a fresh FK reference between orphan selection and deletion.
+            # Use a savepoint so a rare FK violation won't abort the entire disconnect.
+            try:
+                async with db_session.begin_nested():
+                    result = await db_session.execute(
+                        text("""
+                            DELETE FROM meetings m
+                            WHERE m.organization_id = :org_id
+                              AND NOT EXISTS (
+                                  SELECT 1
+                                  FROM activities a
+                                  WHERE a.meeting_id = m.id
+                              )
+                            RETURNING id
+                        """),
+                        {"org_id": str(org_uuid)},
+                    )
+                    deleted_meetings = len(result.fetchall())
+                print(f"Disconnect: Deleted {deleted_meetings} orphaned meetings")
+            except IntegrityError as exc:
+                logger.warning(
+                    "Disconnect: Skipped orphaned meeting cleanup due to FK race org_id=%s provider=%s error=%s",
+                    org_uuid,
+                    provider,
+                    exc,
+                )
 
         print(f"Disconnect: Deleting integration from database")
         await db_session.delete(integration)


### PR DESCRIPTION
### Motivation
- Disconnecting an integration with `delete_data=true` could abort due to a `ForeignKeyViolationError` when deleting orphaned `meetings` because a concurrent activity write can add a `meeting_id` FK between selection and deletion.

### Description
- Treat orphaned meeting deletion as best-effort and wrap the DELETE in a nested transaction savepoint via `async with db_session.begin_nested()` to avoid aborting the outer transaction.
- Catch `IntegrityError` from the nested block and emit a structured warning via `logger.warning(...)` including `org_id` and `provider` context so the disconnect continues.
- Change is localized to `backend/api/routes/auth.py` in the integration disconnect flow and does not alter other cleanup steps.

### Testing
- Ran `cd backend && pytest -q tests/test_sync_cancellation.py` which completed successfully (2 tests passed). 
- Ran `cd backend && python -m py_compile api/routes/auth.py` which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac82f6bd6083218694ea883494c3ba)