### PR TITLE
Update team menu label to 'Delete User' and remove duplicate delete action

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -720,7 +720,6 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                         return aTarget.localeCompare(bTarget);
                       });
                       const canUnlinkForMember: boolean = member.id === currentUser.id || canLinkIdentityInOrg;
-                      const canDeleteMember: boolean = canAdministerOrg && !isGuest;
 
                       if (isInvited) {
                         return (
@@ -865,7 +864,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                                           disabled={deleteMemberMutation.isPending}
                                           className="w-full text-left px-3 py-2 text-sm text-red-400 hover:bg-surface-600/60 transition-colors disabled:opacity-50"
                                         >
-                                          Remove
+                                          Delete User
                                         </button>
                                       </>
                                     )}
@@ -949,19 +948,6 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                                       </button>
                                     ))}
                                   </div>
-                                </div>
-                              )}
-
-                              {canDeleteMember && (
-                                <div className="mt-3 border-t border-surface-700/60 pt-3">
-                                  <button
-                                    type="button"
-                                    onClick={() => void handleDeleteMember(member.id)}
-                                    disabled={deleteMemberMutation.isPending}
-                                    className="text-xs text-red-300 hover:text-red-200 disabled:opacity-50"
-                                  >
-                                    {deleteMemberMutation.isPending ? 'Deleting user...' : 'Delete user'}
-                                  </button>
                                 </div>
                               )}
                             </div>


### PR DESCRIPTION
### Motivation
- Align UI wording and remove a duplicated deletion control so team member removal appears in one place and uses the requested label.

### Description
- Changed the three-dots team menu action label from `Remove` to `Delete User` in `frontend/src/components/OrganizationPanel.tsx`.
- Removed the duplicated `Delete user` button that appeared in the expanded "Link accounts" panel and the now-unused `canDeleteMember` local variable.
- Kept the deletion flow and handler (`handleDeleteMember`) intact and only adjusted presentation logic.

### Testing
- Ran frontend linting with `npm run lint` (from `frontend/`) and it completed successfully.
- Started the dev server with `npm run dev` and captured a Playwright smoke screenshot of the running UI, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac87dcf67c8321bf6c36b09297b8aa)