### PR TITLE
Require org/global admin to delete users and update menu label

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -2131,7 +2131,10 @@ async def remove_organization_member(
     target_user_id: str,
     user_id: Optional[str] = None,
 ) -> dict[str, str]:
-    """Remove a member from an organization, and unlink all identities."""
+    """Remove a member from an organization, and unlink all identities.
+
+    Requires org admin for this org, or global_admin.
+    """
     from models.org_member import OrgMember
     from models.slack_user_mapping import SlackUserMapping
 
@@ -2147,8 +2150,8 @@ async def remove_organization_member(
 
     async with get_admin_session() as session:
         requester: Optional[User] = await session.get(User, requester_uuid)
-        requester_membership = await _get_org_membership(session, requester_uuid, org_uuid)
-        can_manage_invites: bool = _is_global_admin(requester) or bool(requester_membership)
+        if not await _can_administer_org(session, requester, org_uuid):
+            raise HTTPException(status_code=403, detail="Org admin or global_admin required for this organization")
 
         result = await session.execute(
             select(OrgMember).where(
@@ -2160,12 +2163,6 @@ async def remove_organization_member(
         target_membership: Optional[OrgMember] = result.scalar_one_or_none()
         if not target_membership:
             raise HTTPException(status_code=404, detail="Member not found")
-
-        if target_membership.status == "invited":
-            if not can_manage_invites:
-                raise HTTPException(status_code=403, detail="Not a member of this organization")
-        elif not await _can_administer_org(session, requester, org_uuid):
-            raise HTTPException(status_code=403, detail="Org admin or global_admin required for this organization")
 
         target_user: Optional[User] = await session.get(User, target_uuid)
         if target_user and getattr(target_user, "is_guest", False):

--- a/backend/tests/test_remove_member_unlinks_identities.py
+++ b/backend/tests/test_remove_member_unlinks_identities.py
@@ -75,7 +75,7 @@ def test_remove_member_rejects_guest_user(monkeypatch):
 
     fake_session = _FakeSession(
         users={requester_id: requester, guest_user_id: guest_user},
-        execute_results=[_ScalarResult(None), _ScalarResult(membership)],
+        execute_results=[_ScalarResult(membership)],
     )
     monkeypatch.setattr(auth, "get_admin_session", lambda: _FakeSessionContext(fake_session))
 
@@ -112,7 +112,7 @@ def test_remove_member_unlinks_all_identities(monkeypatch):
 
     fake_session = _FakeSession(
         users={requester_id: requester, target_user_id: target_user},
-        execute_results=[_ScalarResult(None), _ScalarResult(membership), _ListResult(mappings)],
+        execute_results=[_ScalarResult(membership), _ListResult(mappings)],
     )
     monkeypatch.setattr(auth, "get_admin_session", lambda: _FakeSessionContext(fake_session))
 
@@ -143,39 +143,34 @@ def test_remove_member_unlinks_all_identities(monkeypatch):
         assert mapping.match_source == "manual_unlink"
 
 
-def test_remove_invited_member_allows_active_non_admin_requester(monkeypatch):
+def test_remove_invited_member_rejects_non_admin_requester(monkeypatch):
     org_id = UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
     requester_id = UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
     invited_user_id = UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
 
     requester = SimpleNamespace(id=requester_id, is_guest=False, role="member", roles=[])
     invited_user = SimpleNamespace(id=invited_user_id, is_guest=False, organization_id=org_id)
-    requester_membership = SimpleNamespace(user_id=requester_id, organization_id=org_id, status="active", role="member")
     invited_membership = SimpleNamespace(user_id=invited_user_id, organization_id=org_id, status="invited", role="member")
 
     fake_session = _FakeSession(
         users={requester_id: requester, invited_user_id: invited_user},
-        execute_results=[_ScalarResult(requester_membership), _ScalarResult(invited_membership), _ListResult([])],
+        execute_results=[_ScalarResult(invited_membership)],
     )
     monkeypatch.setattr(auth, "get_admin_session", lambda: _FakeSessionContext(fake_session))
 
     async def _deny_admin(*_args, **_kwargs):
         return False
 
-    async def _skip_admin_guard(*_args, **_kwargs):
-        return None
-
     monkeypatch.setattr(auth, "_can_administer_org", _deny_admin)
-    monkeypatch.setattr(auth, "_ensure_org_has_admin", _skip_admin_guard)
 
-    result = asyncio.run(
-        auth.remove_organization_member(
-            org_id=str(org_id),
-            target_user_id=str(invited_user_id),
-            user_id=str(requester_id),
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            auth.remove_organization_member(
+                org_id=str(org_id),
+                target_user_id=str(invited_user_id),
+                user_id=str(requester_id),
+            )
         )
-    )
 
-    assert result["status"] == "removed"
-    assert invited_membership.status == "deactivated"
-    assert fake_session.committed
+    assert exc.value.status_code == 403
+    assert not fake_session.committed

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -865,7 +865,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                                           disabled={deleteMemberMutation.isPending}
                                           className="w-full text-left px-3 py-2 text-sm text-red-400 hover:bg-surface-600/60 transition-colors disabled:opacity-50"
                                         >
-                                          Remove
+                                          Delete User
                                         </button>
                                       </>
                                     )}


### PR DESCRIPTION
### Motivation

- Prevent non-admin team members from deleting users via the team-row overflow action and make the destructive action label clearer as `Delete User`.

### Description

- Tightened authorization in `remove_organization_member` (route `DELETE /organizations/{org_id}/members/{target_user_id}`) so it now requires an org admin for that org or a `global_admin` before proceeding.  
- Removed the prior special-case allowing active non-admin members to delete invited users and preserved guest-user protections and identity unlinking logic in the same flow.  
- Updated the team-row overflow menu label in `frontend/src/components/OrganizationPanel.tsx` from `Remove` to `Delete User` and adjusted unit tests in `backend/tests/test_remove_member_unlinks_identities.py` to reflect the stricter auth behavior.

### Testing

- Ran `pytest -q backend/tests/test_remove_member_unlinks_identities.py` and the updated tests passed (3 passed).  
- Attempted a Playwright-based screenshot of the frontend, but no local dev server was reachable on ports `3000`, `5173`, or `4173` so no UI screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac88dd6b108321b0ecbe0c1660bfb3)