### PR TITLE
Fix PagerDuty monitoring test by setting non-local runtime URL

### DIFF
--- a/backend/tests/test_monitoring_task.py
+++ b/backend/tests/test_monitoring_task.py
@@ -46,6 +46,8 @@ def test_pagerduty_incident_request_shape(monkeypatch: Any) -> None:
     monkeypatch.setenv("PAGERDUTY_FROM_EMAIL", "alerts@revtops.com")
     monkeypatch.setenv("PagerDuty_Key", "pd_test_key")
     monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
+    monkeypatch.setenv("FRONTEND_URL", "https://app.basebase.com")
+    monkeypatch.delenv("BACKEND_PUBLIC_URL", raising=False)
     monkeypatch.setattr(pagerduty, "settings", settings.__class__())
 
     import asyncio


### PR DESCRIPTION
### Motivation
- The PagerDuty incident test was being skipped due to localhost runtime detection, causing `_FakeAsyncClient.last_call` to never be populated and the test to fail.

### Description
- In `test_pagerduty_incident_request_shape` set a non-local `FRONTEND_URL` and explicitly unset `BACKEND_PUBLIC_URL` so the PagerDuty request path is exercised and `_FakeAsyncClient.last_call` is populated.

### Testing
- Ran `cd /workspace/revtops/backend && pytest -q tests/test_monitoring_task.py::test_pagerduty_incident_request_shape` which passed.
- Ran `cd /workspace/revtops/backend && pytest -q tests/test_pagerduty_service.py tests/test_monitoring_task.py::test_pagerduty_alias_var_is_loaded` which passed (all targeted tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8d95d1608321903c8bf9d77efe3e)