### PR TITLE
Fix deprecation warnings in backend startup, config and tests

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -10,6 +10,7 @@ Responsibilities:
 """
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 import logging
 import os
 import sys
@@ -20,7 +21,7 @@ from fastapi.responses import JSONResponse
 
 from api.websockets import websocket_endpoint
 from api.routes import apps, artifacts, auth, billing, change_sessions, chat, connectors, data, deals, drive, memories, search, slack_events, slack_user_mappings, sync, tool_settings, twilio_events, whatsapp_events, waitlist, workflows
-from models.database import init_db, close_db, get_pool_status
+from models.database import close_db, get_pool_status
 from services.task_manager import task_manager
 from config import log_missing_env_vars, settings
 from services.celery_health import ensure_celery_workers_available
@@ -34,7 +35,29 @@ logging.basicConfig(
 # Set agents module to DEBUG for detailed tool logging
 logging.getLogger("agents").setLevel(logging.DEBUG)
 
-app = FastAPI(title="Revenue Copilot API", version="1.0.0")
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Manage application startup and shutdown lifecycle hooks."""
+    # Note: init_db() skipped - Alembic handles migrations
+    # await init_db()
+    log_missing_env_vars(logging.getLogger("config"))
+    await ensure_celery_workers_available()
+    task_manager._start_reaper()
+    logging.info("Database connection pool ready")
+
+    try:
+        yield
+    finally:
+        logging.info("Shutting down, closing database connections...")
+        task_manager._stop_reaper()
+        from connectors.code_sandbox import cleanup_all_sandboxes
+
+        await cleanup_all_sandboxes()
+        await close_db()
+        logging.info("Database connections closed")
+
+
+app = FastAPI(title="Revenue Copilot API", version="1.0.0", lifespan=lifespan)
 
 # CORS configuration - allow frontend origins
 def _normalize_origin(origin: str) -> str:
@@ -156,27 +179,6 @@ app.include_router(whatsapp_events.router, prefix="/api/whatsapp", tags=["whatsa
 # WebSocket - authenticated via JWT token in query parameter
 app.add_api_websocket_route("/ws/chat", websocket_endpoint)
 
-
-@app.on_event("startup")
-async def startup() -> None:
-    """Initialize database on startup."""
-    # Note: init_db() skipped - Alembic handles migrations
-    # await init_db()
-    log_missing_env_vars(logging.getLogger("config"))
-    await ensure_celery_workers_available()
-    task_manager._start_reaper()
-    logging.info("Database connection pool ready")
-
-
-@app.on_event("shutdown")
-async def shutdown() -> None:
-    """Clean up database connections and sandboxes on shutdown."""
-    logging.info("Shutting down, closing database connections...")
-    task_manager._stop_reaper()
-    from connectors.code_sandbox import cleanup_all_sandboxes
-    await cleanup_all_sandboxes()
-    await close_db()
-    logging.info("Database connections closed")
 
 
 @app.get("/")

--- a/backend/config.py
+++ b/backend/config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Optional
 
 from pydantic import AliasChoices, Field
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 def to_iso8601(dt: datetime | date | None) -> str | None:
@@ -150,10 +150,11 @@ class Settings(BaseSettings):
         """Sync Postgres URL for E2B sandbox (strips SQLAlchemy asyncpg prefix)."""
         return self.DATABASE_URL.replace("postgresql+asyncpg://", "postgresql://")
 
-    class Config:
-        env_file = str(_env_file)
-        env_file_encoding = "utf-8"
-        extra = "ignore"  # Ignore extra env vars from shared .env files
+    model_config = SettingsConfigDict(
+        env_file=str(_env_file),
+        env_file_encoding="utf-8",
+        extra="ignore",  # Ignore extra env vars from shared .env files
+    )
 
 
 settings = Settings()

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 # Collect tests only from tests/; exclude scripts/ (integration scripts run manually)
 testpaths = tests
+filterwarnings =
+    ignore:Please use `import python_multipart` instead\.:PendingDeprecationWarning
+    ignore:The 'app' shortcut is now deprecated\..*:DeprecationWarning

--- a/backend/tests/test_auth_password_reset.py
+++ b/backend/tests/test_auth_password_reset.py
@@ -1,4 +1,6 @@
-from fastapi.testclient import TestClient
+import types
+import httpx
+import pytest
 
 from api.main import app
 from config import settings
@@ -24,39 +26,47 @@ class _MockAsyncClient:
         return self.response
 
 
-def test_password_reset_request_success(monkeypatch):
+@pytest.mark.asyncio
+async def test_password_reset_request_success(monkeypatch):
     monkeypatch.setattr(settings, "SUPABASE_URL", "https://example.supabase.co")
     monkeypatch.setattr(settings, "SUPABASE_ANON_KEY", "anon-key")
 
     import api.routes.auth as auth_routes
 
     monkeypatch.setattr(
-        auth_routes.httpx,
-        "AsyncClient",
-        lambda *args, **kwargs: _MockAsyncClient(_response=_MockResponse(200)),
+        auth_routes,
+        "httpx",
+        types.SimpleNamespace(
+            AsyncClient=lambda *args, **kwargs: _MockAsyncClient(_response=_MockResponse(200))
+        ),
     )
 
-    client = TestClient(app)
-    response = client.post("/api/auth/password-reset/request", json={"email": "user@company.com"})
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post("/api/auth/password-reset/request", json={"email": "user@company.com"})
 
     assert response.status_code == 200
     payload = response.json()
     assert payload["success"] is True
 
 
-def test_password_reset_request_upstream_failure(monkeypatch):
+@pytest.mark.asyncio
+async def test_password_reset_request_upstream_failure(monkeypatch):
     monkeypatch.setattr(settings, "SUPABASE_URL", "https://example.supabase.co")
     monkeypatch.setattr(settings, "SUPABASE_ANON_KEY", "anon-key")
 
     import api.routes.auth as auth_routes
 
     monkeypatch.setattr(
-        auth_routes.httpx,
-        "AsyncClient",
-        lambda *args, **kwargs: _MockAsyncClient(_response=_MockResponse(500, "boom")),
+        auth_routes,
+        "httpx",
+        types.SimpleNamespace(
+            AsyncClient=lambda *args, **kwargs: _MockAsyncClient(_response=_MockResponse(500, "boom"))
+        ),
     )
 
-    client = TestClient(app)
-    response = client.post("/api/auth/password-reset/request", json={"email": "user@company.com"})
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post("/api/auth/password-reset/request", json={"email": "user@company.com"})
 
     assert response.status_code == 502


### PR DESCRIPTION
### Motivation
- Remove runtime deprecation warnings emitted by FastAPI lifecycle hooks, Pydantic settings, and httpx test usage. 
- Modernize application lifecycle handling and settings to align with current FastAPI/Pydantic/httpx best practices.
- Keep test output clean by filtering known third-party warnings that are not actionable in this codebase.

### Description
- Replaced deprecated `@app.on_event("startup")` / `@app.on_event("shutdown")` handlers with a `lifespan` async context manager and passed it to `FastAPI(..., lifespan=lifespan)` in `backend/api/main.py`, preserving the same startup/shutdown behavior. 
- Removed unused `init_db` import and consolidated shutdown cleanup (task reaper, sandbox cleanup, DB close) into the new `lifespan` handler in `backend/api/main.py`.
- Migrated Pydantic class-based `Config` to `model_config = SettingsConfigDict(...)` in `backend/config.py` to address Pydantic v2 deprecation warnings. 
- Updated `backend/tests/test_auth_password_reset.py` to use `httpx.AsyncClient` with `ASGITransport` (and adjusted monkeypatching) instead of `TestClient` to avoid httpx `app=` shortcut deprecation; also made tests async with `pytest.mark.asyncio`.
- Added `filterwarnings` entries to `backend/pytest.ini` to suppress known third-party warnings from Starlette and httpx during normal test runs.

### Testing
- Ran `cd backend && pytest -q tests/test_auth_password_reset.py` and the test passed (`2 passed`).
- Ran `cd backend && pytest -q tests/test_auth_password_reset.py tests/test_health.py tests/test_cors_csrf.py` and all selected tests passed (`8 passed`).
- Ran `cd backend && pytest -q tests/test_auth_password_reset.py -W default` to verify warnings behavior; tests passed while the `-W default` run intentionally surfaces third-party warnings (Starlette multipart message) as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8da730b48321b345d77218f84416)