### PR TITLE
Harden Celery startup worker health checks with retries

### DIFF
--- a/backend/services/celery_health.py
+++ b/backend/services/celery_health.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from typing import Any
 
 from services.pagerduty import create_pagerduty_incident
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_STARTUP_PING_ATTEMPTS = 3
+DEFAULT_STARTUP_RETRY_DELAY_SECONDS = 2.0
 
 
 async def _inspect_celery_workers(timeout_seconds: float = 5.0) -> dict[str, Any] | None:
@@ -23,33 +27,68 @@ async def _inspect_celery_workers(timeout_seconds: float = 5.0) -> dict[str, Any
 
 async def ensure_celery_workers_available() -> bool:
     """Verify Celery worker availability and raise PagerDuty incident if unavailable."""
-    logger.info("Checking Celery worker availability at API startup")
+    max_attempts = max(1, int(os.getenv("CELERY_STARTUP_PING_ATTEMPTS", DEFAULT_STARTUP_PING_ATTEMPTS)))
+    retry_delay_seconds = max(
+        0.0,
+        float(os.getenv("CELERY_STARTUP_RETRY_DELAY_SECONDS", DEFAULT_STARTUP_RETRY_DELAY_SECONDS)),
+    )
+    logger.info(
+        "Checking Celery worker availability at API startup attempts=%s retry_delay_seconds=%.2f",
+        max_attempts,
+        retry_delay_seconds,
+    )
 
-    try:
-        ping_response = await _inspect_celery_workers()
-    except Exception as exc:
-        logger.exception("Celery startup health check failed to execute")
+    last_exception: Exception | None = None
+    ping_response: dict[str, Any] | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            ping_response = await _inspect_celery_workers()
+        except Exception as exc:  # pragma: no cover - tested via behavior
+            last_exception = exc
+            logger.warning(
+                "Celery startup health check attempt %s/%s raised error: %s",
+                attempt,
+                max_attempts,
+                exc,
+            )
+        else:
+            if ping_response:
+                worker_names = sorted(ping_response.keys())
+                logger.info(
+                    "Celery worker startup check succeeded attempt=%s/%s workers=%s",
+                    attempt,
+                    max_attempts,
+                    worker_names,
+                )
+                return True
+
+            logger.warning(
+                "Celery startup health check attempt %s/%s received no worker responses",
+                attempt,
+                max_attempts,
+            )
+
+        if attempt < max_attempts and retry_delay_seconds > 0:
+            await asyncio.sleep(retry_delay_seconds)
+
+    if last_exception is not None:
+        logger.exception("Celery startup health check failed after %s attempts", max_attempts, exc_info=last_exception)
         await create_pagerduty_incident(
             title="Celery startup check failed",
             details=(
-                "API startup could not verify Celery worker availability. "
-                f"Error: {exc}"
+                "API startup could not verify Celery worker availability after "
+                f"{max_attempts} attempts. Error: {last_exception}"
             ),
         )
         return False
 
-    if not ping_response:
-        logger.error("No Celery workers responded to startup ping")
-        await create_pagerduty_incident(
-            title="Celery workers unavailable at startup",
-            details=(
-                "API startup pinged Celery workers but received no responses. "
-                "This usually means worker processes are not running or cannot "
-                "connect to the broker."
-            ),
-        )
-        return False
-
-    worker_names = sorted(ping_response.keys())
-    logger.info("Celery worker startup check succeeded workers=%s", worker_names)
-    return True
+    logger.error("No Celery workers responded to startup ping after %s attempts", max_attempts)
+    await create_pagerduty_incident(
+        title="Celery workers unavailable at startup",
+        details=(
+            "API startup pinged Celery workers but received no responses after "
+            f"{max_attempts} attempts. This usually means worker processes are "
+            "not running or cannot connect to the broker."
+        ),
+    )
+    return False

--- a/backend/tests/test_celery_health.py
+++ b/backend/tests/test_celery_health.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from services import celery_health
@@ -15,14 +16,43 @@ def test_ensure_celery_workers_available_success(monkeypatch: Any) -> None:
     monkeypatch.setattr(celery_health, "_inspect_celery_workers", _fake_inspect)
     monkeypatch.setattr(celery_health, "create_pagerduty_incident", _fake_incident)
 
-    import asyncio
-
     ok = asyncio.run(celery_health.ensure_celery_workers_available())
     assert ok is True
 
 
-def test_ensure_celery_workers_available_incidents_on_no_workers(monkeypatch: Any) -> None:
+def test_ensure_celery_workers_available_retries_before_success(monkeypatch: Any) -> None:
+    monkeypatch.setenv("CELERY_STARTUP_PING_ATTEMPTS", "3")
+    monkeypatch.setenv("CELERY_STARTUP_RETRY_DELAY_SECONDS", "0")
+
+    attempts = 0
+
     async def _fake_inspect() -> dict[str, Any] | None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            return None
+        return {"worker@a": {"ok": "pong"}}
+
+    async def _fake_incident(*, title: str, details: str) -> bool:
+        raise AssertionError("incident should not be called")
+
+    monkeypatch.setattr(celery_health, "_inspect_celery_workers", _fake_inspect)
+    monkeypatch.setattr(celery_health, "create_pagerduty_incident", _fake_incident)
+
+    ok = asyncio.run(celery_health.ensure_celery_workers_available())
+    assert ok is True
+    assert attempts == 3
+
+
+def test_ensure_celery_workers_available_incidents_on_no_workers(monkeypatch: Any) -> None:
+    monkeypatch.setenv("CELERY_STARTUP_PING_ATTEMPTS", "3")
+    monkeypatch.setenv("CELERY_STARTUP_RETRY_DELAY_SECONDS", "0")
+
+    attempts = 0
+
+    async def _fake_inspect() -> dict[str, Any] | None:
+        nonlocal attempts
+        attempts += 1
         return None
 
     incident_titles: list[str] = []
@@ -34,15 +64,21 @@ def test_ensure_celery_workers_available_incidents_on_no_workers(monkeypatch: An
     monkeypatch.setattr(celery_health, "_inspect_celery_workers", _fake_inspect)
     monkeypatch.setattr(celery_health, "create_pagerduty_incident", _fake_incident)
 
-    import asyncio
-
     ok = asyncio.run(celery_health.ensure_celery_workers_available())
     assert ok is False
+    assert attempts == 3
     assert incident_titles == ["Celery workers unavailable at startup"]
 
 
 def test_ensure_celery_workers_available_incidents_on_check_error(monkeypatch: Any) -> None:
+    monkeypatch.setenv("CELERY_STARTUP_PING_ATTEMPTS", "2")
+    monkeypatch.setenv("CELERY_STARTUP_RETRY_DELAY_SECONDS", "0")
+
+    attempts = 0
+
     async def _fake_inspect() -> dict[str, Any] | None:
+        nonlocal attempts
+        attempts += 1
         raise RuntimeError("broker unreachable")
 
     incident_titles: list[str] = []
@@ -54,8 +90,7 @@ def test_ensure_celery_workers_available_incidents_on_check_error(monkeypatch: A
     monkeypatch.setattr(celery_health, "_inspect_celery_workers", _fake_inspect)
     monkeypatch.setattr(celery_health, "create_pagerduty_incident", _fake_incident)
 
-    import asyncio
-
     ok = asyncio.run(celery_health.ensure_celery_workers_available())
     assert ok is False
+    assert attempts == 2
     assert incident_titles == ["Celery startup check failed"]


### PR DESCRIPTION
### Motivation
- The API startup Celery health check was flappy when workers briefly lagged or the broker was transiently unavailable, causing premature PagerDuty incidents.
- Introduce a small retry window so transient failures are retried before declaring an outage.

### Description
- Add configurable retry logic to `ensure_celery_workers_available` with defaults `DEFAULT_STARTUP_PING_ATTEMPTS = 3` and `DEFAULT_STARTUP_RETRY_DELAY_SECONDS = 2.0` and environment overrides `CELERY_STARTUP_PING_ATTEMPTS` and `CELERY_STARTUP_RETRY_DELAY_SECONDS`.
- Log per-attempt outcomes and return early on the first successful ping, while only creating PagerDuty incidents after all attempts are exhausted.
- Distinguish final incident titles for the two failure modes (`"Celery startup check failed"` on repeated exceptions and `"Celery workers unavailable at startup"` when no workers respond).
- Update unit tests in `backend/tests/test_celery_health.py` to cover immediate success, retry-then-success, repeated no-worker, and repeated exception scenarios.

### Testing
- Ran the specific test file with `pytest -q backend/tests/test_celery_health.py`, which passed: `4 passed`.
- The tests verify successful early-return behavior, correct retry counting under env-configured attempts, and that PagerDuty incidents are only fired after retries are exhausted for both no-worker and exception cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8e13f37883218be0acc48d2f94f8)