### PR TITLE
Non-blocking Celery startup PagerDuty incidents and richer logging

### DIFF
--- a/backend/services/celery_health.py
+++ b/backend/services/celery_health.py
@@ -6,12 +6,45 @@ import logging
 import os
 from typing import Any
 
-from services.pagerduty import create_pagerduty_incident
+from services.pagerduty import create_pagerduty_incident_with_details
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_STARTUP_PING_ATTEMPTS = 3
 DEFAULT_STARTUP_RETRY_DELAY_SECONDS = 2.0
+
+
+def _emit_startup_incident_nonblocking(*, title: str, details: str) -> None:
+    """Trigger startup incident creation without blocking API startup."""
+
+    async def _create_and_log() -> None:
+        result = await create_pagerduty_incident_with_details(title=title, details=details)
+        if result.ok:
+            logger.info(
+                "Startup incident request accepted title=%s status=%s reason=%s",
+                title,
+                result.status_code,
+                result.reason,
+            )
+            return
+
+        logger.error(
+            "Startup incident request failed title=%s reason=%s status=%s body=%s",
+            title,
+            result.reason,
+            result.status_code,
+            result.response_body,
+        )
+
+    task = asyncio.create_task(_create_and_log())
+
+    def _on_done(completed_task: asyncio.Task[None]) -> None:
+        try:
+            completed_task.result()
+        except Exception:
+            logger.exception("Startup incident task crashed title=%s", title)
+
+    task.add_done_callback(_on_done)
 
 
 async def _inspect_celery_workers(timeout_seconds: float = 5.0) -> dict[str, Any] | None:
@@ -39,7 +72,7 @@ async def ensure_celery_workers_available() -> bool:
     )
 
     last_exception: Exception | None = None
-    ping_response: dict[str, Any] | None = None
+    saw_no_worker_responses = False
     for attempt in range(1, max_attempts + 1):
         try:
             ping_response = await _inspect_celery_workers()
@@ -62,6 +95,7 @@ async def ensure_celery_workers_available() -> bool:
                 )
                 return True
 
+            saw_no_worker_responses = True
             logger.warning(
                 "Celery startup health check attempt %s/%s received no worker responses",
                 attempt,
@@ -73,7 +107,7 @@ async def ensure_celery_workers_available() -> bool:
 
     if last_exception is not None:
         logger.exception("Celery startup health check failed after %s attempts", max_attempts, exc_info=last_exception)
-        await create_pagerduty_incident(
+        _emit_startup_incident_nonblocking(
             title="Celery startup check failed",
             details=(
                 "API startup could not verify Celery worker availability after "
@@ -82,13 +116,20 @@ async def ensure_celery_workers_available() -> bool:
         )
         return False
 
-    logger.error("No Celery workers responded to startup ping after %s attempts", max_attempts)
-    await create_pagerduty_incident(
-        title="Celery workers unavailable at startup",
-        details=(
-            "API startup pinged Celery workers but received no responses after "
-            f"{max_attempts} attempts. This usually means worker processes are "
-            "not running or cannot connect to the broker."
-        ),
+    if saw_no_worker_responses:
+        logger.error("No Celery workers responded to startup ping after %s attempts", max_attempts)
+        _emit_startup_incident_nonblocking(
+            title="Celery workers unavailable at startup",
+            details=(
+                "API startup pinged Celery workers but received no responses after "
+                f"{max_attempts} attempts. This usually means worker processes are "
+                "not running or cannot connect to the broker."
+            ),
+        )
+        return False
+
+    logger.error(
+        "Celery startup health check exhausted attempts=%s without clear signal; skipping incident",
+        max_attempts,
     )
     return False

--- a/backend/tests/test_celery_health.py
+++ b/backend/tests/test_celery_health.py
@@ -6,15 +6,19 @@ from typing import Any
 from services import celery_health
 
 
+async def _drain_scheduled_tasks() -> None:
+    await asyncio.sleep(0)
+
+
 def test_ensure_celery_workers_available_success(monkeypatch: Any) -> None:
     async def _fake_inspect() -> dict[str, Any] | None:
         return {"worker@a": {"ok": "pong"}}
 
-    async def _fake_incident(*, title: str, details: str) -> bool:
+    async def _fake_incident(*, title: str, details: str) -> celery_health.PagerDutyIncidentResult:
         raise AssertionError("incident should not be called")
 
     monkeypatch.setattr(celery_health, "_inspect_celery_workers", _fake_inspect)
-    monkeypatch.setattr(celery_health, "create_pagerduty_incident", _fake_incident)
+    monkeypatch.setattr(celery_health, "create_pagerduty_incident_with_details", _fake_incident)
 
     ok = asyncio.run(celery_health.ensure_celery_workers_available())
     assert ok is True
@@ -33,11 +37,11 @@ def test_ensure_celery_workers_available_retries_before_success(monkeypatch: Any
             return None
         return {"worker@a": {"ok": "pong"}}
 
-    async def _fake_incident(*, title: str, details: str) -> bool:
+    async def _fake_incident(*, title: str, details: str) -> celery_health.PagerDutyIncidentResult:
         raise AssertionError("incident should not be called")
 
     monkeypatch.setattr(celery_health, "_inspect_celery_workers", _fake_inspect)
-    monkeypatch.setattr(celery_health, "create_pagerduty_incident", _fake_incident)
+    monkeypatch.setattr(celery_health, "create_pagerduty_incident_with_details", _fake_incident)
 
     ok = asyncio.run(celery_health.ensure_celery_workers_available())
     assert ok is True
@@ -57,14 +61,19 @@ def test_ensure_celery_workers_available_incidents_on_no_workers(monkeypatch: An
 
     incident_titles: list[str] = []
 
-    async def _fake_incident(*, title: str, details: str) -> bool:
+    async def _fake_incident(*, title: str, details: str) -> celery_health.PagerDutyIncidentResult:
         incident_titles.append(title)
-        return True
+        return celery_health.PagerDutyIncidentResult(ok=True, reason="created", status_code=201)
 
     monkeypatch.setattr(celery_health, "_inspect_celery_workers", _fake_inspect)
-    monkeypatch.setattr(celery_health, "create_pagerduty_incident", _fake_incident)
+    monkeypatch.setattr(celery_health, "create_pagerduty_incident_with_details", _fake_incident)
 
-    ok = asyncio.run(celery_health.ensure_celery_workers_available())
+    async def _run() -> bool:
+        ok = await celery_health.ensure_celery_workers_available()
+        await _drain_scheduled_tasks()
+        return ok
+
+    ok = asyncio.run(_run())
     assert ok is False
     assert attempts == 3
     assert incident_titles == ["Celery workers unavailable at startup"]
@@ -83,14 +92,19 @@ def test_ensure_celery_workers_available_incidents_on_check_error(monkeypatch: A
 
     incident_titles: list[str] = []
 
-    async def _fake_incident(*, title: str, details: str) -> bool:
+    async def _fake_incident(*, title: str, details: str) -> celery_health.PagerDutyIncidentResult:
         incident_titles.append(title)
-        return True
+        return celery_health.PagerDutyIncidentResult(ok=False, reason="http_error", status_code=500)
 
     monkeypatch.setattr(celery_health, "_inspect_celery_workers", _fake_inspect)
-    monkeypatch.setattr(celery_health, "create_pagerduty_incident", _fake_incident)
+    monkeypatch.setattr(celery_health, "create_pagerduty_incident_with_details", _fake_incident)
 
-    ok = asyncio.run(celery_health.ensure_celery_workers_available())
+    async def _run() -> bool:
+        ok = await celery_health.ensure_celery_workers_available()
+        await _drain_scheduled_tasks()
+        return ok
+
+    ok = asyncio.run(_run())
     assert ok is False
     assert attempts == 2
     assert incident_titles == ["Celery startup check failed"]


### PR DESCRIPTION
### Motivation
- Celery startup health checks were creating incidents synchronously which could delay API startup and produced insufficient visibility into why incident creation failed.
- Incidents were being raised regardless of whether a successful worker ping had occurred in some code paths, so startup could incorrectly trigger alerts.

### Description
- Added a non-blocking helper `._emit_startup_incident_nonblocking` that schedules `create_pagerduty_incident_with_details` as an `asyncio` background task and logs the structured result (accepted vs failed with `reason`/`status_code`/`response_body`).
- Added a done-callback to the background task to surface and log any unexpected task exceptions without blocking startup.
- Adjusted `ensure_celery_workers_available` to track the explicit "no worker responses" path and only emit startup incidents for the appropriate failure cases (`last_exception` vs no responses) while returning immediately when a successful ping is observed.
- Updated tests in `backend/tests/test_celery_health.py` to patch `create_pagerduty_incident_with_details`, drain scheduled tasks when needed, and assert correct behavior for success, retry, no-workers, and inspect-error scenarios.

### Testing
- Ran unit tests: `pytest -q backend/tests/test_celery_health.py` and all tests passed (`4 passed`).
- The updated tests verify that successful pings do not trigger incident creation and that both failure paths schedule incident creation (and report titles) as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb49e4d048321bf3eee0e18f433e9)