### PR TITLE
Add onRelayout to react-plotly type defs

### DIFF
--- a/frontend/src/types/react-plotly.d.ts
+++ b/frontend/src/types/react-plotly.d.ts
@@ -10,6 +10,7 @@ declare module "react-plotly.js" {
     useResizeHandler?: boolean;
     onInitialized?: (figure: unknown, graphDiv: unknown) => void;
     onUpdate?: (figure: unknown, graphDiv: unknown) => void;
+    onRelayout?: (event: unknown) => void;
     onPurge?: (figure: unknown, graphDiv: unknown) => void;
     onError?: (err: unknown) => void;
   }


### PR DESCRIPTION
### Motivation
- Fix a TypeScript build failure in `OrganizationPanel.tsx` where the `onRelayout` prop was used but missing from the local `react-plotly.js` types, causing `TS2769` and an implicit `any` (`TS7006`).

### Description
- Added `onRelayout?: (event: unknown) => void;` to `PlotParams` in `frontend/src/types/react-plotly.d.ts` as a type-only change so the relayout callback is accepted by TypeScript.

### Testing
- Ran `cd frontend && npm run build`, which completed successfully and removed the `TS2769`/`TS7006` errors; Vite emitted non-fatal chunk-size/dynamic-import warnings but the build passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acb7c3ea948321b0a9c7bd33416af1)