### PR TITLE
fix: connector rename, GitHub sync fixes, last-synced UI, migrations, and related updates

### DIFF
--- a/backend/access_control/data_protection.py
+++ b/backend/access_control/data_protection.py
@@ -65,7 +65,7 @@ async def check_connector_call(
             result = await session.execute(
                 select(Integration).where(
                     Integration.organization_id == UUID(context.organization_id),
-                    Integration.provider == context.provider,
+                    Integration.connector == context.provider,
                     Integration.user_id == UUID(context.user_id),
                     Integration.is_active == True,  # noqa: E712
                 )
@@ -89,7 +89,7 @@ async def check_connector_call(
             result = await session.execute(
                 select(Integration).where(
                     Integration.organization_id == UUID(context.organization_id),
-                    Integration.provider == context.provider,
+                    Integration.connector == context.provider,
                     Integration.is_active == True,  # noqa: E712
                     share_flag == True,  # noqa: E712
                 )

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -203,8 +203,8 @@ All external connectors (HubSpot, Linear, Gmail, Slack, etc.) are **user-scoped*
 
 ### Reading & Analyzing Data
 - **run_sql_query**: Execute SELECT queries against the database. Use for structured analysis, filtering, joins, aggregations, exact text matching (ILIKE). Always prefer this for questions that can be answered with SQL. **Includes GitHub data**: query github_repositories, github_commits, github_pull_requests for repo activity, who's committing, recent PRs, etc. **Do NOT add organization_id to WHERE clauses** — data is automatically scoped to the user's organization via row-level security. **Semantic search**: Use `semantic_embed('text')` inline to search activities by meaning (e.g. `ORDER BY embedding <=> semantic_embed('pricing discussion') LIMIT 10`).
-- **run_action** with system=code_sandbox (Code Sandbox): Run shell commands in a persistent Linux sandbox. Use for complex multi-step data analysis, Python/bash/Node scripts, CLI tools, or computation beyond SQL. Only use if **code_sandbox** is listed under Connected Systems (enabled) below. If not enabled, offer to connect it using `initiate_connector`.
-- **query_system** with system=web_search (Web Search): Search the web for external information. Only use if **web_search** is listed under Connected Systems below; if not enabled, offer to connect it using `initiate_connector`.
+- **run_action** with connector=code_sandbox (Code Sandbox): Run shell commands in a persistent Linux sandbox. Use for complex multi-step data analysis, Python/bash/Node scripts, CLI tools, or computation beyond SQL. Only use if **code_sandbox** is listed under Connected Connectors (enabled) below. If not enabled, offer to connect it using `initiate_connector`.
+- **query_system** with connector=web_search (Web Search): Search the web for external information. Only use if **web_search** is listed under Connected Connectors below; if not enabled, offer to connect it using `initiate_connector`.
 
 
 ### Writing & Modifying Data
@@ -275,11 +275,11 @@ When the user provides a CSV or file for import, include ALL available fields fr
 | File a GitHub issue | **write_to_system_of_record** (target_system="github", record_type="issue") |
 | Create a report or chart | **run_sql_query** → **create_artifact** |
 | Create an interactive dashboard or chart with filters | **run_sql_query** (inspect data) → **write_app** (create) → **write_app** (test_query to verify) |
-| Complex multi-step data analysis, statistical modeling, or ML | **run_action** (system=code_sandbox, action=execute_command) — only if code_sandbox is enabled in Connected Systems |
+| Complex multi-step data analysis, statistical modeling, or ML | **run_action** (connector=code_sandbox, action=execute_command) — only if code_sandbox is enabled in Connected Connectors |
 | Generate a chart programmatically (matplotlib, seaborn) | **run_action** (code_sandbox, execute_command) — only if enabled |
 | Transform or combine data in ways SQL can't handle | **run_action** (code_sandbox, execute_command) — only if enabled |
 | Set up a recurring task | **run_sql_write** (INSERT INTO workflows) |
-| Research a company externally | **query_system** (system=web_search) — only if web_search is enabled in Connected Systems |
+| Research a company externally | **query_system** (connector=web_search) — only if web_search is enabled in Connected Connectors |
 
 ### Workflow Automations
 
@@ -852,7 +852,7 @@ class ChatOrchestrator:
             async with get_session(organization_id=self.organization_id) as session:
                 result = await session.execute(
                     select(
-                        Integration.provider,
+                        Integration.connector,
                         Integration.last_sync_at,
                         Integration.last_error,
                     )
@@ -860,7 +860,7 @@ class ChatOrchestrator:
                         Integration.organization_id == UUID(self.organization_id),
                         Integration.is_active == True,  # noqa: E712
                     )
-                    .order_by(Integration.provider)
+                    .order_by(Integration.connector)
                 )
                 rows = result.all()
 
@@ -1285,11 +1285,11 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
         if self.organization_id:
             systems_manifest: str | None = await self._build_systems_manifest()
             if systems_manifest:
-                system_prompt += "\n\n## Connected Systems\n"
+                system_prompt += "\n\n## Connected Connectors\n"
                 system_prompt += (
-                    "Use `query_system`, `write_to_system`, and `run_action` only for systems listed **above** under the enabled connectors. "
+                    "Use `query_system`, `write_to_system`, and `run_action` only for connectors listed **above** under the enabled connectors. "
                     "Use `list_connected_systems` to refresh this list mid-conversation.\n\n"
-                    "**IMPORTANT**: Before calling any of these tools, check that the target system (e.g. code_sandbox, web_search, google_drive) "
+                    "**IMPORTANT**: Before calling any of these tools, check that the target connector (e.g. code_sandbox, web_search, google_drive) "
                     "appears in the **enabled** list above, not under \"Connectors not currently enabled\". "
                     "If the user's request needs a connector that is only in the not-enabled list, do **not** call the tool — "
                     "instead, offer to help them connect it using `initiate_connector` which will open the OAuth authorization flow in their browser.\n\n"

--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -145,12 +145,12 @@ IMPORTANT: Only SELECT queries are allowed. No INSERT, UPDATE, DELETE, DROP, etc
 
 register_tool(
     name="list_connected_systems",
-    description="""Refresh and return the capabilities manifest for all connected systems.
+    description="""Refresh and return the capabilities manifest for all connected connectors.
 
 Use this to get an up-to-date list of connected integrations and their capabilities
 (query, write, action). The manifest shows available operations and their parameters
-for each system. Useful when the user asks about available integrations or when you
-need to verify a system is connected before using it.""",
+for each connector. Useful when the user asks about available integrations or when you
+need to verify a connector is connected before using it.""",
     input_schema={
         "type": "object",
         "properties": {},
@@ -163,26 +163,26 @@ need to verify a system is connected before using it.""",
 
 register_tool(
     name="query_system",
-    description="""Query a connected system for on-demand data retrieval.
+    description="""Query a connected connector for on-demand data retrieval.
 
 Use this for any QUERY-capable connector: web search (web_search), Apollo enrichment,
 Google Drive file search/read, or any future connector with query capability.
 
-The query string format depends on the system — check the Connected Systems manifest
-in the system prompt for each system's query_description.""",
+The query string format depends on the connector — check the Connected Connectors manifest
+in the system prompt for each connector's query_description.""",
     input_schema={
         "type": "object",
         "properties": {
-            "system": {
+            "connector": {
                 "type": "string",
                 "description": "Connector slug (e.g. 'web_search', 'apollo', 'google_drive')",
             },
             "query": {
                 "type": "string",
-                "description": "Query string — format depends on the system (see Connected Systems manifest)",
+                "description": "Query string — format depends on the connector (see Connected Connectors manifest)",
             },
         },
-        "required": ["system", "query"],
+        "required": ["connector", "query"],
     },
     category=ToolCategory.EXTERNAL_READ,
     default_requires_approval=False,
@@ -191,16 +191,16 @@ in the system prompt for each system's query_description.""",
 
 register_tool(
     name="write_to_system",
-    description="""Create or update records in a connected system.
+    description="""Create or update records in a connected connector.
 
 Use this for any WRITE-capable connector: HubSpot (deals, contacts, companies),
 GitHub/Linear/Asana (issues), or any future connector with write capability.
 
-Check the Connected Systems manifest for available operations and their required parameters.""",
+Check the Connected Connectors manifest for available operations and their required parameters.""",
     input_schema={
         "type": "object",
         "properties": {
-            "system": {
+            "connector": {
                 "type": "string",
                 "description": "Connector slug (e.g. 'hubspot', 'linear', 'github', 'asana')",
             },
@@ -210,10 +210,10 @@ Check the Connected Systems manifest for available operations and their required
             },
             "data": {
                 "type": "object",
-                "description": "Record data — fields depend on system and operation (see Connected Systems manifest)",
+                "description": "Record data — fields depend on connector and operation (see Connected Connectors manifest)",
             },
         },
-        "required": ["system", "operation", "data"],
+        "required": ["connector", "operation", "data"],
     },
     category=ToolCategory.EXTERNAL_WRITE,
     default_requires_approval=False,
@@ -222,17 +222,17 @@ Check the Connected Systems manifest for available operations and their required
 
 register_tool(
     name="run_action",
-    description="""Execute a side-effect action on a connected system.
+    description="""Execute a side-effect action on a connected connector.
 
 Use this for any ACTION-capable connector: sending Slack messages, sending emails
 (Gmail/Outlook), sending SMS (Twilio), fetching URLs (web_search), creating Google Drive
 files, executing sandbox commands (code_sandbox), or any future connector with action capability.
 
-Check the Connected Systems manifest for available actions and their required parameters.""",
+Check the Connected Connectors manifest for available actions and their required parameters.""",
     input_schema={
         "type": "object",
         "properties": {
-            "system": {
+            "connector": {
                 "type": "string",
                 "description": "Connector slug (e.g. 'slack', 'gmail', 'twilio', 'web_search', 'code_sandbox')",
             },
@@ -242,10 +242,10 @@ Check the Connected Systems manifest for available actions and their required pa
             },
             "params": {
                 "type": "object",
-                "description": "Action parameters — fields depend on system and action (see Connected Systems manifest)",
+                "description": "Action parameters — fields depend on connector and action (see Connected Connectors manifest)",
             },
         },
-        "required": ["system", "action", "params"],
+        "required": ["connector", "action", "params"],
     },
     category=ToolCategory.EXTERNAL_WRITE,
     default_requires_approval=False,
@@ -478,7 +478,7 @@ Use this for any batch operation: enriching contacts, researching companies, sen
 Provide EITHER tool (to call a tool per item) OR workflow_id (to run a workflow per item).
 
 **Tool mode** — each item renders params_template ({{field}} placeholders filled from item), then the tool is called. Results stored in bulk_operation_results (queryable via run_sql_query). Uses distributed Celery workers.
-  Example: foreach(tool="query_system", items_query="SELECT id, name FROM contacts", params_template={"system": "web_search", "query": "Current role of {{name}}?"})
+  Example: foreach(tool="query_system", items_query="SELECT id, name FROM contacts", params_template={"connector": "web_search", "query": "Current role of {{name}}?"})
 
 **Workflow mode** — each item dict is passed as input_data to the workflow. Uses async in-process execution with context propagation.
   Example: foreach(workflow_id="uuid-...", items=[{"email": "a@b.com"}, {"email": "c@d.com"}])

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -362,6 +362,8 @@ def _log_tool_execution_result(
         logger.info("[Tools] search_cloud_files returned %d results", len(result.get("files", [])))
     elif executed_tool_name == "read_cloud_file":
         logger.info("[Tools] read_cloud_file completed: %s", result.get("file_name", "unknown"))
+    elif executed_tool_name == "edit_cloud_file":
+        logger.info("[Tools] edit_cloud_file completed: %s", result.get("status", result.get("error", "unknown")))
     elif executed_tool_name == "create_artifact":
         logger.info("[Tools] create_artifact completed: %s", result.get("artifact_id"))
     elif executed_tool_name == "keep_notes":
@@ -535,7 +537,7 @@ async def _get_connector_instance(
     registry = discover_connectors()
     connector_cls: type[BaseConnector] | None = registry.get(slug)
     if connector_cls is None:
-        return None, f"Unknown system '{slug}'. Use list_connected_systems to see available systems."
+        return None, f"Unknown connector '{slug}'. Use list_connected_systems to see available connectors."
 
     meta: ConnectorMeta = connector_cls.meta  # type: ignore[attr-defined]
 
@@ -551,7 +553,7 @@ async def _get_connector_instance(
             result = await session.execute(
                 select(Integration).where(
                     Integration.organization_id == UUID(organization_id),
-                    Integration.provider == slug,
+                    Integration.connector == slug,
                     Integration.user_id == UUID(user_id),
                     Integration.is_active == True,  # noqa: E712
                 )
@@ -571,7 +573,7 @@ async def _get_connector_instance(
                 result = await session.execute(
                     select(Integration).where(
                         Integration.organization_id == UUID(organization_id),
-                        Integration.provider == slug,
+                        Integration.connector == slug,
                         Integration.is_active == True,  # noqa: E712
                         share_flag == True,  # noqa: E712
                     )
@@ -582,7 +584,7 @@ async def _get_connector_instance(
                 result = await session.execute(
                     select(Integration).where(
                         Integration.organization_id == UUID(organization_id),
-                        Integration.provider == slug,
+                        Integration.connector == slug,
                         Integration.is_active == True,  # noqa: E712
                     )
                 )
@@ -605,13 +607,13 @@ async def _get_connector_instance(
 
 
 async def _list_connected_systems(organization_id: str) -> dict[str, Any]:
-    """Return the systems manifest for all connected connectors."""
+    """Return the connectors manifest for all connected connectors."""
     from connectors.registry import Capability, ConnectorMeta, discover_connectors
     from models.integration import Integration
 
     async with get_session(organization_id=organization_id) as session:
         result = await session.execute(
-            select(Integration.provider).where(
+            select(Integration.connector).where(
                 Integration.organization_id == UUID(organization_id),
                 Integration.is_active == True,  # noqa: E712
             )
@@ -620,7 +622,7 @@ async def _list_connected_systems(organization_id: str) -> dict[str, Any]:
 
     registry = discover_connectors()
 
-    systems: list[dict[str, Any]] = []
+    connectors: list[dict[str, Any]] = []
     for slug, connector_cls in sorted(registry.items()):
         if slug not in active_providers:
             continue
@@ -642,33 +644,33 @@ async def _list_connected_systems(organization_id: str) -> dict[str, Any]:
                 {"name": act.name, "description": act.description, "parameters": act.parameters}
                 for act in meta.actions
             ]
-        systems.append(entry)
+        connectors.append(entry)
 
-    return {"systems": systems, "count": len(systems)}
+    return {"connectors": connectors, "count": len(connectors)}
 
 
 async def _query_system(
     params: dict[str, Any], organization_id: str, user_id: str | None
 ) -> dict[str, Any]:
     """Dispatch a query to a QUERY-capable connector."""
-    system: str = (params.get("system") or "").strip()
+    connector: str = (params.get("connector") or "").strip()
     query: str = (params.get("query") or "").strip()
-    if not system:
-        return {"error": "system is required"}
+    if not connector:
+        return {"error": "connector is required"}
     if not query:
         return {"error": "query is required"}
 
     dp_ctx = ConnectorContext(
         organization_id=organization_id,
         user_id=user_id,
-        provider=system,
+        provider=connector,
         operation="query",
     )
-    dp_result = await check_connector_call(dp_ctx, {"system": system, "query": query})
+    dp_result = await check_connector_call(dp_ctx, {"connector": connector, "query": query})
     if not dp_result.allowed:
         return {"error": dp_result.deny_reason or "Connector query not allowed"}
 
-    instance, error = await _get_connector_instance(system, organization_id, user_id, required_capability="query")
+    instance, error = await _get_connector_instance(connector, organization_id, user_id, required_capability="query")
     if error:
         return {"error": error}
     assert instance is not None
@@ -676,8 +678,8 @@ async def _query_system(
     try:
         return await instance.query(query)
     except Exception as exc:
-        logger.error("[Tools] query_system(%s) failed: %s", system, exc, exc_info=True)
-        return {"error": f"Query to {system} failed: {exc}"}
+        logger.error("[Tools] query_system(%s) failed: %s", connector, exc, exc_info=True)
+        return {"error": f"Query to {connector} failed: {exc}"}
 
 
 async def _write_to_system(
@@ -688,26 +690,26 @@ async def _write_to_system(
     conversation_id: str | None,
 ) -> dict[str, Any]:
     """Dispatch a write to a WRITE-capable connector."""
-    system: str = (params.get("system") or "").strip()
+    connector: str = (params.get("connector") or "").strip()
     operation: str = (params.get("operation") or "").strip()
     data: dict[str, Any] = params.get("data") or {}
 
-    if not system:
-        return {"error": "system is required"}
+    if not connector:
+        return {"error": "connector is required"}
     if not operation:
         return {"error": "operation is required"}
 
     dp_ctx = ConnectorContext(
         organization_id=organization_id,
         user_id=user_id,
-        provider=system,
+        provider=connector,
         operation="write",
     )
-    dp_result = await check_connector_call(dp_ctx, {"system": system, "operation": operation, "data": data})
+    dp_result = await check_connector_call(dp_ctx, {"connector": connector, "operation": operation, "data": data})
     if not dp_result.allowed:
         return {"error": dp_result.deny_reason or "Connector write not allowed"}
 
-    instance, error = await _get_connector_instance(system, organization_id, user_id, required_capability="write")
+    instance, error = await _get_connector_instance(connector, organization_id, user_id, required_capability="write")
     if error:
         return {"error": error}
     assert instance is not None
@@ -715,8 +717,8 @@ async def _write_to_system(
     try:
         return await instance.write(operation, data)
     except Exception as exc:
-        logger.error("[Tools] write_to_system(%s, %s) failed: %s", system, operation, exc, exc_info=True)
-        return {"error": f"Write to {system}.{operation} failed: {exc}"}
+        logger.error("[Tools] write_to_system(%s, %s) failed: %s", connector, operation, exc, exc_info=True)
+        return {"error": f"Write to {connector}.{operation} failed: {exc}"}
 
 
 async def _run_action(
@@ -727,17 +729,17 @@ async def _run_action(
     context: dict[str, Any] | None,
 ) -> dict[str, Any]:
     """Dispatch an action to an ACTION-capable connector."""
-    system: str = (params.get("system") or "").strip()
+    connector: str = (params.get("connector") or "").strip()
     action: str = (params.get("action") or "").strip()
     action_params: dict[str, Any] = params.get("params") or {}
 
-    if not system:
-        return {"error": "system is required"}
+    if not connector:
+        return {"error": "connector is required"}
     if not action:
         return {"error": "action is required"}
 
     # Inject conversation_id for code_sandbox execute_command
-    if system == "code_sandbox" and action == "execute_command":
+    if connector == "code_sandbox" and action == "execute_command":
         conversation_id: str | None = (context or {}).get("conversation_id")
         if conversation_id:
             action_params["conversation_id"] = conversation_id
@@ -745,14 +747,14 @@ async def _run_action(
     dp_ctx = ConnectorContext(
         organization_id=organization_id,
         user_id=user_id,
-        provider=system,
+        provider=connector,
         operation="action",
     )
-    dp_result = await check_connector_call(dp_ctx, {"system": system, "action": action, "params": action_params})
+    dp_result = await check_connector_call(dp_ctx, {"connector": connector, "action": action, "params": action_params})
     if not dp_result.allowed:
         return {"error": dp_result.deny_reason or "Connector action not allowed"}
 
-    instance, error = await _get_connector_instance(system, organization_id, user_id, required_capability="action")
+    instance, error = await _get_connector_instance(connector, organization_id, user_id, required_capability="action")
     if error:
         return {"error": error}
     assert instance is not None
@@ -760,8 +762,8 @@ async def _run_action(
     try:
         return await instance.execute_action(action, action_params)
     except Exception as exc:
-        logger.error("[Tools] run_action(%s, %s) failed: %s", system, action, exc, exc_info=True)
-        return {"error": f"Action {system}.{action} failed: {exc}"}
+        logger.error("[Tools] run_action(%s, %s) failed: %s", connector, action, exc, exc_info=True)
+        return {"error": f"Action {connector}.{action} failed: {exc}"}
 
 
 # =============================================================================
@@ -2155,7 +2157,7 @@ async def _handle_tracker_write(
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == UUID(organization_id),
-                Integration.provider == target_system,
+                Integration.connector == target_system,
                 Integration.is_active == True,
             )
         )
@@ -2288,7 +2290,7 @@ async def _handle_code_repo_write(
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == UUID(organization_id),
-                Integration.provider == target_system,
+                Integration.connector == target_system,
                 Integration.is_active == True,
             )
         )
@@ -2407,7 +2409,7 @@ async def _crm_write(
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == UUID(organization_id),
-                Integration.provider == target_system,
+                Integration.connector == target_system,
                 Integration.is_active == True,
             )
         )
@@ -4199,7 +4201,7 @@ async def _enrich_contacts_with_apollo(
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == UUID(organization_id),
-                Integration.provider == "apollo",
+                Integration.connector == "apollo",
                 Integration.is_active == True,
             )
         )
@@ -4329,7 +4331,7 @@ async def _enrich_company_with_apollo(
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == UUID(organization_id),
-                Integration.provider == "apollo",
+                Integration.connector == "apollo",
                 Integration.is_active == True,
             )
         )
@@ -4412,7 +4414,7 @@ async def _send_email_from(
             select(Integration).where(
                 Integration.organization_id == UUID(organization_id),
                 Integration.user_id == UUID(user_id),
-                Integration.provider.in_(["gmail", "microsoft_mail"]),
+                Integration.connector.in_(["gmail", "microsoft_mail"]),
                 Integration.is_active == True,
             )
         )
@@ -4447,7 +4449,7 @@ async def _send_email_from(
         "operation_id": operation_id,
         "tool_name": "send_email_from",
         "preview": {
-            "provider": integration.provider,
+            "connector": integration.connector,
             "to": to,
             "subject": subject,
             "body": body[:500] + ("..." if len(body) > 500 else ""),
@@ -4487,7 +4489,7 @@ async def execute_send_email_from(
             select(Integration).where(
                 Integration.organization_id == UUID(organization_id),
                 Integration.user_id == UUID(user_id),
-                Integration.provider.in_(["gmail", "microsoft_mail"]),
+                Integration.connector.in_(["gmail", "microsoft_mail"]),
                 Integration.is_active == True,
             )
         )
@@ -4501,7 +4503,7 @@ async def execute_send_email_from(
     
     try:
         # Create appropriate connector with user_id for per-user integrations
-        if integration.provider == "gmail":
+        if integration.connector == "gmail":
             connector = GmailConnector(
                 organization_id=organization_id,
                 user_id=user_id,
@@ -4522,11 +4524,11 @@ async def execute_send_email_from(
         )
         
         if result.get("success"):
-            logger.info(f"[Tools] Email sent via {integration.provider} to {to}")
+            logger.info(f"[Tools] Email sent via {integration.connector} to {to}")
             return {
                 "status": "completed",
                 "message": f"Email sent successfully to {to}",
-                "provider": integration.provider,
+                "connector": integration.connector,
                 "to": to,
                 "subject": subject,
             }
@@ -4584,12 +4586,12 @@ async def _send_slack(
         all_int_list = all_integrations.scalars().all()
         logger.info(f"[send_slack] Found {len(all_int_list)} integrations for org {organization_id}")
         for i in all_int_list:
-            logger.info(f"[send_slack]   - provider={i.provider}, is_active={i.is_active}")
+            logger.info(f"[send_slack]   - provider={i.connector}, is_active={i.is_active}")
         
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == UUID(organization_id),
-                Integration.provider == "slack",
+                Integration.connector == "slack",
                 Integration.is_active == True,
             )
         )
@@ -4656,7 +4658,7 @@ async def execute_send_slack(
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == UUID(organization_id),
-                Integration.provider == "slack",
+                Integration.connector == "slack",
                 Integration.is_active == True,
             )
         )
@@ -4762,7 +4764,7 @@ async def _trigger_sync(
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == UUID(organization_id),
-                Integration.provider == provider,
+                Integration.connector == provider,
                 Integration.is_active == True,
             )
         )
@@ -4838,7 +4840,7 @@ async def _initiate_connector(
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == UUID(organization_id),
-                Integration.provider == provider,
+                Integration.connector == provider,
                 Integration.user_id == UUID(user_id),
                 Integration.is_active == True,  # noqa: E712
             )
@@ -5808,6 +5810,79 @@ async def execute_create_cloud_file(
     except Exception as e:
         logger.error("[Tools._create_cloud_file] Failed: %s", e)
         return {"error": f"Failed to create cloud file: {str(e)}"}
+
+
+async def _edit_cloud_file(
+    params: dict[str, Any],
+    organization_id: str,
+    user_id: str | None,
+    skip_approval: bool = False,
+) -> dict[str, Any]:
+    """
+    Edit an existing Google Workspace file (Doc, Sheet, or Slides).
+
+    Routes to GoogleDriveConnector.edit_file() for the actual API calls.
+    """
+    external_id: str = params.get("external_id", "").strip()
+    content: Any = params.get("content")
+    mode: str = params.get("mode", "replace").strip()
+
+    if not external_id:
+        return {"error": "external_id is required."}
+    if not content:
+        return {"error": "content is required."}
+    if not user_id:
+        return {"error": "Google Drive file editing requires an authenticated user."}
+
+    if not skip_approval:
+        operation_id: str = str(uuid4())
+        store_pending_operation(
+            operation_id=operation_id,
+            tool_name="edit_cloud_file",
+            params=params,
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        return {
+            "type": "pending_approval",
+            "status": "pending_approval",
+            "operation_id": operation_id,
+            "tool_name": "edit_cloud_file",
+            "preview": {
+                "external_id": external_id,
+                "mode": mode,
+            },
+            "message": f"Ready to edit Google Drive file {external_id} (mode: {mode}). Please approve to proceed.",
+        }
+
+    return await execute_edit_cloud_file(params, organization_id, user_id)
+
+
+async def execute_edit_cloud_file(
+    params: dict[str, Any],
+    organization_id: str,
+    user_id: str,
+) -> dict[str, Any]:
+    """Execute the actual Google Drive file edit (called after approval)."""
+    external_id: str = params.get("external_id", "").strip()
+    content: Any = params.get("content")
+    mode: str = params.get("mode", "replace").strip()
+
+    try:
+        from connectors.google_drive import GoogleDriveConnector
+
+        connector = GoogleDriveConnector(organization_id, user_id)
+        result: dict[str, Any] = await connector.edit_file(
+            external_id=external_id,
+            content=content,
+            mode=mode,
+        )
+        return result
+    except ValueError as e:
+        return {"error": str(e)}
+    except Exception as e:
+        logger.error("[Tools._edit_cloud_file] Failed: %s", e)
+        return {"error": f"Failed to edit cloud file: {str(e)}"}
 
 
 # =============================================================================

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -759,7 +759,7 @@ async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
                 drive_integration_result = await session.execute(
                     select(Integration).where(
                         Integration.organization_id == existing.organization_id,
-                        Integration.provider == "google_drive",
+                        Integration.connector == "google_drive",
                         Integration.user_id == existing.id,
                         Integration.is_active == True,
                     )
@@ -1083,7 +1083,7 @@ async def create_organization(
             session.add(
                 Integration(
                     organization_id=org_uuid,
-                    provider="web_search",
+                    connector="web_search",
                     user_id=creator_user_id,
                     scope="organization",
                     nango_connection_id="builtin",
@@ -1801,7 +1801,7 @@ async def invite_missing_slack_users_to_organization(
         slack_integration_result = await session.execute(
             select(Integration.id).where(
                 Integration.organization_id == org_uuid,
-                Integration.provider == "slack",
+                Integration.connector == "slack",
                 Integration.is_active == True,
             )
         )
@@ -2777,7 +2777,7 @@ async def confirm_integration(
                     _existing_slack_rows = await _check_session.execute(
                         select(Integration.extra_data).where(
                             Integration.organization_id == org_uuid,
-                            Integration.provider == "slack",
+                            Integration.connector == "slack",
                             Integration.is_active.is_(True),
                         )
                     )
@@ -2859,7 +2859,7 @@ async def confirm_integration(
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == org_uuid,
-                Integration.provider == request.provider,
+                Integration.connector == request.provider,
                 Integration.user_id == user_uuid,
             )
         )
@@ -2881,7 +2881,7 @@ async def confirm_integration(
         else:
             new_integration = Integration(
                 organization_id=org_uuid,
-                provider=request.provider,
+                connector=request.provider,
                 user_id=user_uuid,
                 scope="user",  # Satisfy DB NOT NULL; column deprecated, all integrations are user-scoped
                 nango_connection_id=nango_connection_id,
@@ -2992,7 +2992,7 @@ async def update_integration_sharing(
 
         org_id_str = str(integration.organization_id)
         user_id_str = str(integration.user_id) if integration.user_id else ""
-        provider = integration.provider
+        provider = integration.connector
 
     # Propagate share_synced_data to activity visibility
     new_visibility: str = "team" if request.share_synced_data else "owner_only"
@@ -3131,7 +3131,7 @@ async def connect_builtin(request: ConnectBuiltinRequest) -> dict[str, Any]:
             result = await session.execute(
                 select(Integration).where(
                     Integration.organization_id == org_uuid,
-                    Integration.provider == request.provider,
+                    Integration.connector == request.provider,
                     Integration.user_id == user_uuid,
                 )
             )
@@ -3143,7 +3143,7 @@ async def connect_builtin(request: ConnectBuiltinRequest) -> dict[str, Any]:
             else:
                 new_integration = Integration(
                     organization_id=org_uuid,
-                    provider=request.provider,
+                    connector=request.provider,
                     user_id=user_uuid,
                     scope="user",  # Satisfy DB NOT NULL; column deprecated, all integrations are user-scoped
                     nango_connection_id="builtin",
@@ -3286,7 +3286,7 @@ async def nango_callback(
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == org_uuid,
-                Integration.provider == provider,
+                Integration.connector == provider,
                 Integration.user_id == user_uuid,
             )
         )
@@ -3302,7 +3302,7 @@ async def nango_callback(
         else:
             new_integration = Integration(
                 organization_id=org_uuid,
-                provider=provider,
+                connector=provider,
                 user_id=user_uuid,
                 scope="user",  # Satisfy DB NOT NULL; column deprecated, all integrations are user-scoped
                 nango_connection_id=connection_id,
@@ -3378,9 +3378,9 @@ async def list_integrations(
         # Group integrations by provider
         integrations_by_provider: dict[str, list[Integration]] = {}
         for i in all_integrations:
-            if i.provider not in integrations_by_provider:
-                integrations_by_provider[i.provider] = []
-            integrations_by_provider[i.provider].append(i)
+            if i.connector not in integrations_by_provider:
+                integrations_by_provider[i.connector] = []
+            integrations_by_provider[i.connector].append(i)
 
         # Get team members
         team_result = await db_session.execute(
@@ -3413,10 +3413,17 @@ async def list_integrations(
                         user_name=user_obj.name or user_obj.email,
                     ))
 
-            # Use current user's integration for display, or first available
-            ref_integration = current_user_integration or (
-                integrations_for_provider[0] if integrations_for_provider else None
-            )
+            # Use current user's integration for display, or the one with most recent sync
+            # (sync may update a different integration when multiple exist)
+            if current_user_integration:
+                ref_integration = current_user_integration
+            elif integrations_for_provider:
+                ref_integration = max(
+                    integrations_for_provider,
+                    key=lambda i: (i.last_sync_at or datetime.min),
+                )
+            else:
+                ref_integration = None
 
             # Get owner name
             connected_by_name: str | None = None
@@ -3517,7 +3524,7 @@ async def disconnect_integration(
         result = await db_session.execute(
             select(Integration).where(
                 Integration.organization_id == org_uuid,
-                Integration.provider == provider,
+                Integration.connector == provider,
                 Integration.user_id == current_user_uuid,
             )
         )
@@ -3529,7 +3536,7 @@ async def disconnect_integration(
             result = await db_session.execute(
                 select(Integration).where(
                     Integration.organization_id == org_uuid,
-                    Integration.provider == provider,
+                    Integration.connector == provider,
                     Integration.nango_connection_id == expected_conn_id,
                 )
             )
@@ -3542,7 +3549,7 @@ async def disconnect_integration(
                 result = await db_session.execute(
                     select(Integration).where(
                         Integration.organization_id == org_uuid,
-                        Integration.provider == provider,
+                        Integration.connector == provider,
                     )
                 )
                 integration = result.scalar_one_or_none()
@@ -4038,7 +4045,7 @@ async def _run_initial_drive_sync(organization_id: str, user_id: Optional[str]) 
             result = await session.execute(
                 select(Integration).where(
                     Integration.organization_id == UUID(organization_id),
-                    Integration.provider == "google_drive",
+                    Integration.connector == "google_drive",
                     Integration.user_id == UUID(user_id),
                 )
             )

--- a/backend/api/routes/connectors.py
+++ b/backend/api/routes/connectors.py
@@ -98,7 +98,7 @@ async def handle_connector_webhook(
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == org_uuid,
-                Integration.provider == provider,
+                Integration.connector == provider,
                 Integration.is_active == True,
             )
         )

--- a/backend/api/routes/drive.py
+++ b/backend/api/routes/drive.py
@@ -230,7 +230,7 @@ async def _run_sync(org_id: str, user_id: str) -> None:
             result = await session.execute(
                 sa_select(Integration).where(
                     Integration.organization_id == UUID(org_id),
-                    Integration.provider == "google_drive",
+                    Integration.connector == "google_drive",
                     Integration.user_id == UUID(user_id),
                 )
             )

--- a/backend/api/routes/slack_user_mappings.py
+++ b/backend/api/routes/slack_user_mappings.py
@@ -95,7 +95,7 @@ async def _require_slack_integration(organization_id: UUID) -> Integration:
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == organization_id,
-                Integration.provider == "slack",
+                Integration.connector == "slack",
                 Integration.is_active == True,
             )
         )

--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -345,7 +345,7 @@ async def list_admin_integrations(user_id: str) -> AdminIntegrationsResponse:
         result = await session.execute(
             select(Integration, Organization.name.label("org_name"))
             .join(Organization, Integration.organization_id == Organization.id)
-            .order_by(Organization.name, Integration.provider)
+            .order_by(Organization.name, Integration.connector)
         )
         rows = result.all()
     
@@ -357,7 +357,7 @@ async def list_admin_integrations(user_id: str) -> AdminIntegrationsResponse:
             id=str(integration.id),
             organization_id=str(integration.organization_id),
             organization_name=org_name,
-            provider=integration.provider,
+            provider=integration.connector,
             is_active=integration.is_active,
             last_sync_at=integration.last_sync_at.isoformat() if integration.last_sync_at else None,
             last_error=integration.last_error,
@@ -686,7 +686,7 @@ async def trigger_sync(
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == customer_uuid,
-                Integration.provider == provider,
+                Integration.connector == provider,
                 Integration.is_active == True,
             )
         )
@@ -737,7 +737,7 @@ async def get_sync_status(organization_id: str, provider: str) -> SyncStatusResp
             result = await session.execute(
                 select(Integration).where(
                     Integration.organization_id == UUID(organization_id),
-                    Integration.provider == provider,
+                    Integration.connector == provider,
                 )
             )
             integration = result.scalar_one_or_none()
@@ -801,11 +801,11 @@ async def trigger_sync_all(
     if not integrations:
         raise HTTPException(status_code=404, detail="No active integrations found")
 
-    providers: list[str] = list({i.provider for i in integrations})
+    providers: list[str] = list({i.connector for i in integrations})
 
     # Trigger sync for each integration (including per-user variants)
     for integration in integrations:
-        prov: str = integration.provider
+        prov: str = integration.connector
         if prov in CONNECTORS:
             status_key: str = _get_status_key(organization_id, prov)
             _sync_status[status_key] = {
@@ -984,7 +984,7 @@ async def match_hubspot_owners(organization_id: str) -> OwnerMatchResponse:
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == UUID(organization_id),
-                Integration.provider == "hubspot",
+                Integration.connector == "hubspot",
                 Integration.is_active == True,
             )
         )
@@ -1089,7 +1089,7 @@ async def list_github_repos(organization_id: str) -> GitHubAvailableReposRespons
             select(Integration)
             .where(
                 Integration.organization_id == UUID(organization_id),
-                Integration.provider == "github",
+                Integration.connector == "github",
                 Integration.is_active == True,
             )
             .limit(1)
@@ -1256,7 +1256,7 @@ async def queue_sync(organization_id: str, provider: str) -> QueuedSyncResponse:
         result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == customer_uuid,
-                Integration.provider == provider,
+                Integration.connector == provider,
                 Integration.is_active == True,
             )
         )

--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -479,6 +479,7 @@ async def _execute_tool_approval(
         execute_save_memory,
         execute_keep_notes,
         execute_create_cloud_file,
+        execute_edit_cloud_file,
     )
     
     # First check if this is in our in-memory pending operations store
@@ -521,6 +522,10 @@ async def _execute_tool_approval(
             return result
         elif tool_name == "create_cloud_file":
             result = await execute_create_cloud_file(params, op_org_id, op_user_id)
+            result["tool_name"] = tool_name
+            return result
+        elif tool_name == "edit_cloud_file":
+            result = await execute_edit_cloud_file(params, op_org_id, op_user_id)
             result["tool_name"] = tool_name
             return result
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -38,6 +38,8 @@ class Settings(BaseSettings):
 
     # Database
     DATABASE_URL: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/revenue_copilot"
+    # Optional: use direct connection for migrations (avoids "must be owner" with pooler)
+    MIGRATION_DATABASE_URL: Optional[str] = None
     DB_POOL_SIZE: int = 1
     DB_MAX_OVERFLOW: int = 2
     DB_POOL_TIMEOUT_SECONDS: int = 10

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -265,7 +265,7 @@ class BaseConnector(ABC):
         """
         conditions = [
             Integration.organization_id == UUID(self.organization_id),
-            Integration.provider == self.source_system,
+            Integration.connector == self.source_system,
         ]
         if require_active:
             conditions.append(Integration.is_active == True)  # noqa: E712

--- a/backend/connectors/github.py
+++ b/backend/connectors/github.py
@@ -89,7 +89,7 @@ class GitHubConnector(BaseConnector):
     ) -> Any:
         """GET from the GitHub REST API. Returns parsed JSON."""
         headers: dict[str, str] = await self._get_headers()
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
             resp: httpx.Response = await client.get(
                 f"{GITHUB_API_BASE}{path}",
                 headers=headers,
@@ -105,7 +105,7 @@ class GitHubConnector(BaseConnector):
     ) -> Any:
         """POST to the GitHub REST API. Returns parsed JSON."""
         headers: dict[str, str] = await self._get_headers()
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
             resp: httpx.Response = await client.post(
                 f"{GITHUB_API_BASE}{path}",
                 headers=headers,
@@ -130,7 +130,7 @@ class GitHubConnector(BaseConnector):
         request_params: dict[str, Any] = {"per_page": 100, **(params or {})}
         url: str = f"{GITHUB_API_BASE}{path}"
 
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
             for _ in range(max_pages):
                 resp: httpx.Response = await client.get(
                     url, headers=headers, params=request_params
@@ -184,14 +184,17 @@ class GitHubConnector(BaseConnector):
 
         org_uuid: UUID = UUID(self.organization_id)
 
-        # 1. Check existing mapping
+        # 1. Check existing mapping (prefer rows with user_id; tolerate duplicates)
         async with get_session(organization_id=self.organization_id) as session:
             result = await session.execute(
-                select(SlackUserMapping.user_id).where(
+                select(SlackUserMapping.user_id)
+                .where(
                     SlackUserMapping.organization_id == org_uuid,
                     SlackUserMapping.external_userid == login,
                     SlackUserMapping.source == "github",
                 )
+                .order_by(SlackUserMapping.user_id.desc().nulls_last())
+                .limit(1)
             )
             mapping_user_id: UUID | None = result.scalar_one_or_none()
 
@@ -199,14 +202,16 @@ class GitHubConnector(BaseConnector):
             self._login_cache[login] = mapping_user_id
             return mapping_user_id
 
-        # 2. Try email match against users table
+        # 2. Try email match against users table (tolerate duplicate emails)
         if email:
             async with get_session(organization_id=self.organization_id) as session:
                 result = await session.execute(
-                    select(User.id).where(
+                    select(User.id)
+                    .where(
                         User.organization_id == org_uuid,
                         User.email == email,
                     )
+                    .limit(1)
                 )
                 matched_user_id: UUID | None = result.scalar_one_or_none()
 
@@ -236,11 +241,14 @@ class GitHubConnector(BaseConnector):
         """
         org_uuid: UUID = UUID(self.organization_id)
         existing = await session.execute(
-            select(SlackUserMapping).where(
+            select(SlackUserMapping)
+            .where(
                 SlackUserMapping.organization_id == org_uuid,
                 SlackUserMapping.external_userid == github_login,
                 SlackUserMapping.source == "github",
             )
+            .order_by(SlackUserMapping.user_id.desc().nulls_last())
+            .limit(1)
         )
         mapping: SlackUserMapping | None = existing.scalar_one_or_none()
 

--- a/backend/connectors/google_drive.py
+++ b/backend/connectors/google_drive.py
@@ -1,16 +1,18 @@
 """
-Google Drive connector for syncing file metadata, reading, and creating files.
+Google Drive connector for syncing file metadata, reading, creating, and editing files.
 
 1. Syncs all file metadata (folders, docs, sheets, slides) from a user's Drive
 2. Supports searching files by name
 3. Exports text representations of Docs, Sheets, and Slides on demand
 4. Creates new Google Docs, Sheets, and Slides with content
+5. Edits existing Google Docs, Sheets, and Slides (replaces or appends content)
 
 Flow:
 1. User connects Google account via OAuth (Nango)
 2. Sync crawls Drive and stores file metadata in shared_files table (source='google_drive')
 3. Agent can search files by name and read their text content
 4. Agent can create new files in the user's Drive and populate them with content
+5. Agent can edit existing files (user must have edit permission on the file)
 """
 
 import json
@@ -261,9 +263,18 @@ class GoogleDriveConnector(BaseConnector):
                     {"name": "folder_id", "type": "string", "required": False, "description": "Google Drive folder ID to place the file in"},
                 ],
             ),
+            ConnectorAction(
+                name="edit_file",
+                description="Edit an existing Google Doc, Sheet, or Slides presentation. Requires edit permission on the file.",
+                parameters=[
+                    {"name": "external_id", "type": "string", "required": True, "description": "Google Drive file ID of the file to edit"},
+                    {"name": "content", "type": "string", "required": True, "description": "New content. For documents: Markdown. For sheets/slides: JSON. Same format as create_file."},
+                    {"name": "mode", "type": "string", "required": False, "description": "Edit mode: 'replace' (default) replaces all content, 'append' adds to end (documents only)"},
+                ],
+            ),
         ],
         nango_integration_id="google-drive",
-        description="Google Drive – file metadata sync, search, read, and create",
+        description="Google Drive – file metadata sync, search, read, create, and edit",
     )
 
     def __init__(self, organization_id: str, user_id: str) -> None:
@@ -283,7 +294,7 @@ class GoogleDriveConnector(BaseConnector):
             result = await session.execute(
                 select(Integration).where(
                     Integration.organization_id == UUID(self.organization_id),
-                    Integration.provider == "google_drive",
+                    Integration.connector == "google_drive",
                     Integration.user_id == UUID(self.user_id),
                 )
             )
@@ -811,6 +822,394 @@ class GoogleDriveConnector(BaseConnector):
             result["populate_warning"] = populate_error
         return result
 
+    # -------------------------------------------------------------------------
+    # File Editing
+    # -------------------------------------------------------------------------
+
+    async def edit_file(
+        self,
+        external_id: str,
+        content: Any,
+        mode: str = "replace",
+    ) -> dict[str, Any]:
+        """
+        Edit an existing Google Workspace file by replacing or appending content.
+
+        Args:
+            external_id: Google Drive file ID.
+            content: New content (same format as create_file).
+            mode: 'replace' (clear & rewrite) or 'append' (documents only).
+
+        Returns:
+            Dict with edit result metadata.
+        """
+        if mode not in ("replace", "append"):
+            return {"error": f"Unsupported mode '{mode}'. Use: replace, append."}
+
+        await self.get_oauth_token()
+
+        org_uuid: UUID = UUID(self.organization_id)
+        user_uuid: UUID = UUID(self.user_id)
+
+        file_record: Optional[SharedFile] = None
+        async with get_session(organization_id=self.organization_id) as session:
+            result = await session.execute(
+                select(SharedFile).where(
+                    and_(
+                        SharedFile.organization_id == org_uuid,
+                        SharedFile.user_id == user_uuid,
+                        SharedFile.source == "google_drive",
+                        SharedFile.external_id == external_id,
+                    )
+                )
+            )
+            file_record = result.scalar_one_or_none()
+
+        if not file_record:
+            return {"error": f"File not found in synced metadata: {external_id}"}
+
+        mime_type: str = file_record.mime_type or ""
+        file_name: str = file_record.name or ""
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            edit_error: Optional[str] = None
+
+            if mime_type == GOOGLE_DOC_MIME:
+                edit_error = await self._edit_document(client, external_id, content, mode)
+            elif mime_type == GOOGLE_SHEET_MIME:
+                if mode == "append":
+                    return {"error": "Append mode is not supported for spreadsheets. Use 'replace'."}
+                edit_error = await self._edit_spreadsheet(client, external_id, content)
+            elif mime_type == GOOGLE_SLIDES_MIME:
+                if mode == "append":
+                    return {"error": "Append mode is not supported for presentations. Use 'replace'."}
+                edit_error = await self._edit_presentation(client, external_id, content)
+            else:
+                return {"error": f"Editing is not supported for files of type '{mime_type}'. Only Google Docs, Sheets, and Slides can be edited."}
+
+        if edit_error:
+            return {"error": edit_error}
+
+        web_link: str = file_record.web_view_link or f"https://docs.google.com/open?id={external_id}"
+
+        return {
+            "status": "edited",
+            "external_id": external_id,
+            "name": file_name,
+            "mime_type": mime_type,
+            "mode": mode,
+            "web_view_link": web_link,
+        }
+
+    async def _edit_document(
+        self, client: httpx.AsyncClient, doc_id: str, content: Any, mode: str
+    ) -> Optional[str]:
+        """Edit a Google Doc: replace all content or append to end."""
+        text_content: str = str(content) if content else ""
+        if not text_content:
+            return "Content is empty — nothing to write."
+
+        if mode == "replace":
+            # Fetch current doc to get the end-of-body index
+            doc_resp = await client.get(
+                f"{DOCS_API_BASE}/documents/{doc_id}",
+                headers=self._get_headers(),
+                params={"fields": "body.content"},
+            )
+            if doc_resp.status_code == 403:
+                return f"Permission denied: you don't have edit access to this document. (HTTP 403)"
+            if doc_resp.status_code != 200:
+                return f"Failed to fetch document structure: {doc_resp.status_code} — {doc_resp.text[:200]}"
+
+            doc_data: dict[str, Any] = doc_resp.json()
+            body_content: list[dict[str, Any]] = doc_data.get("body", {}).get("content", [])
+
+            end_index: int = 1
+            for element in body_content:
+                ei: int = element.get("endIndex", 0)
+                if ei > end_index:
+                    end_index = ei
+
+            # Delete existing body content (index 1 to end_index - 1)
+            requests: list[dict[str, Any]] = []
+            if end_index > 2:
+                requests.append({
+                    "deleteContentRange": {
+                        "range": {"startIndex": 1, "endIndex": end_index - 1},
+                    }
+                })
+
+            if requests:
+                del_resp = await client.post(
+                    f"{DOCS_API_BASE}/documents/{doc_id}:batchUpdate",
+                    headers={**self._get_headers(), "Content-Type": "application/json"},
+                    json={"requests": requests},
+                )
+                if del_resp.status_code == 403:
+                    return f"Permission denied: you don't have edit access to this document. (HTTP 403)"
+                if del_resp.status_code != 200:
+                    return f"Failed to clear document: {del_resp.status_code} — {del_resp.text[:200]}"
+
+            # Insert new content from index 1
+            insert_requests: list[dict[str, Any]] = _markdown_to_docs_requests(text_content)
+            if insert_requests:
+                ins_resp = await client.post(
+                    f"{DOCS_API_BASE}/documents/{doc_id}:batchUpdate",
+                    headers={**self._get_headers(), "Content-Type": "application/json"},
+                    json={"requests": insert_requests},
+                )
+                if ins_resp.status_code != 200:
+                    return f"Failed to insert new content: {ins_resp.status_code} — {ins_resp.text[:200]}"
+
+            return None
+
+        # mode == "append"
+        doc_resp = await client.get(
+            f"{DOCS_API_BASE}/documents/{doc_id}",
+            headers=self._get_headers(),
+            params={"fields": "body.content"},
+        )
+        if doc_resp.status_code == 403:
+            return f"Permission denied: you don't have edit access to this document. (HTTP 403)"
+        if doc_resp.status_code != 200:
+            return f"Failed to fetch document structure: {doc_resp.status_code} — {doc_resp.text[:200]}"
+
+        doc_data = doc_resp.json()
+        body_content = doc_data.get("body", {}).get("content", [])
+
+        end_index = 1
+        for element in body_content:
+            ei = element.get("endIndex", 0)
+            if ei > end_index:
+                end_index = ei
+
+        # Build insert requests starting at current end (before the trailing newline)
+        append_idx: int = max(end_index - 1, 1)
+        raw_requests: list[dict[str, Any]] = _markdown_to_docs_requests(text_content)
+
+        # Shift all indices in the requests to start at append_idx instead of 1
+        offset: int = append_idx - 1
+        shifted_requests: list[dict[str, Any]] = []
+        for req in raw_requests:
+            shifted_req: dict[str, Any] = {}
+            for key, val in req.items():
+                if isinstance(val, dict):
+                    new_val: dict[str, Any] = dict(val)
+                    if "location" in new_val and "index" in new_val["location"]:
+                        new_val["location"] = dict(new_val["location"])
+                        new_val["location"]["index"] += offset
+                    if "range" in new_val:
+                        new_range: dict[str, Any] = dict(new_val["range"])
+                        if "startIndex" in new_range:
+                            new_range["startIndex"] += offset
+                        if "endIndex" in new_range:
+                            new_range["endIndex"] += offset
+                        new_val["range"] = new_range
+                    shifted_req[key] = new_val
+                else:
+                    shifted_req[key] = val
+            shifted_requests.append(shifted_req)
+
+        if shifted_requests:
+            ins_resp = await client.post(
+                f"{DOCS_API_BASE}/documents/{doc_id}:batchUpdate",
+                headers={**self._get_headers(), "Content-Type": "application/json"},
+                json={"requests": shifted_requests},
+            )
+            if ins_resp.status_code == 403:
+                return f"Permission denied: you don't have edit access to this document. (HTTP 403)"
+            if ins_resp.status_code != 200:
+                return f"Failed to append content: {ins_resp.status_code} — {ins_resp.text[:200]}"
+
+        return None
+
+    async def _edit_spreadsheet(
+        self, client: httpx.AsyncClient, spreadsheet_id: str, content: Any
+    ) -> Optional[str]:
+        """Replace all content in a Google Sheet."""
+        if isinstance(content, str):
+            try:
+                content = json.loads(content)
+            except (json.JSONDecodeError, TypeError):
+                content = {"sheets": [{"title": "Sheet1", "data": [[content]]}]}
+
+        if not isinstance(content, dict):
+            return "Spreadsheet content must be a JSON object with a 'sheets' key."
+
+        sheets: list[dict[str, Any]] = content.get("sheets", [])
+        if not sheets:
+            flat_data: Any = content.get("data")
+            if flat_data and isinstance(flat_data, list):
+                sheets = [{"title": "Sheet1", "data": flat_data}]
+
+        if not sheets:
+            return "No sheet data provided."
+
+        errors: list[str] = []
+        for sheet in sheets:
+            sheet_title: str = sheet.get("title", "Sheet1")
+            rows: Any = sheet.get("data", [])
+            if not isinstance(rows, list) or not rows:
+                continue
+
+            # Clear existing data in this sheet
+            clear_range: str = f"'{sheet_title}'"
+            clear_resp = await client.post(
+                f"{SHEETS_API_BASE}/spreadsheets/{spreadsheet_id}/values/{clear_range}:clear",
+                headers={**self._get_headers(), "Content-Type": "application/json"},
+                json={},
+            )
+            if clear_resp.status_code == 403:
+                return f"Permission denied: you don't have edit access to this spreadsheet. (HTTP 403)"
+            if clear_resp.status_code != 200:
+                errors.append(f"Sheet '{sheet_title}' clear failed: {clear_resp.status_code} — {clear_resp.text[:200]}")
+                continue
+
+            # Write new data
+            range_notation: str = f"'{sheet_title}'!A1"
+            write_resp = await client.put(
+                f"{SHEETS_API_BASE}/spreadsheets/{spreadsheet_id}/values/{range_notation}",
+                headers={**self._get_headers(), "Content-Type": "application/json"},
+                params={"valueInputOption": "USER_ENTERED"},
+                json={"range": range_notation, "majorDimension": "ROWS", "values": rows},
+            )
+            if write_resp.status_code == 403:
+                return f"Permission denied: you don't have edit access to this spreadsheet. (HTTP 403)"
+            if write_resp.status_code != 200:
+                errors.append(f"Sheet '{sheet_title}' write failed: {write_resp.status_code} — {write_resp.text[:200]}")
+
+        return "; ".join(errors) if errors else None
+
+    async def _edit_presentation(
+        self, client: httpx.AsyncClient, presentation_id: str, content: Any
+    ) -> Optional[str]:
+        """Replace all slides in a Google Slides presentation."""
+        if isinstance(content, str):
+            try:
+                content = json.loads(content)
+            except (json.JSONDecodeError, TypeError):
+                content = {"slides": [{"title": content}]}
+
+        if not isinstance(content, dict):
+            return "Presentation content must be a JSON object with a 'slides' key."
+
+        new_slides: list[dict[str, Any]] = content.get("slides", [])
+        if not new_slides:
+            return "No slide data provided."
+
+        # Get existing slides
+        get_resp = await client.get(
+            f"{SLIDES_API_BASE}/presentations/{presentation_id}",
+            headers=self._get_headers(),
+            params={"fields": "slides.objectId"},
+        )
+        if get_resp.status_code == 403:
+            return f"Permission denied: you don't have edit access to this presentation. (HTTP 403)"
+        if get_resp.status_code != 200:
+            return f"Failed to fetch presentation: {get_resp.status_code} — {get_resp.text[:200]}"
+
+        existing_slide_ids: list[str] = [
+            s["objectId"] for s in get_resp.json().get("slides", [])
+        ]
+
+        # Create new slides
+        create_requests: list[dict[str, Any]] = []
+        slide_object_ids: list[str] = []
+        for idx, _slide_def in enumerate(new_slides):
+            slide_obj_id: str = f"edit_slide_{idx}"
+            slide_object_ids.append(slide_obj_id)
+            create_requests.append({
+                "createSlide": {
+                    "objectId": slide_obj_id,
+                    "insertionIndex": idx,
+                    "slideLayoutReference": {"predefinedLayout": "TITLE_AND_BODY"},
+                }
+            })
+
+        batch_resp = await client.post(
+            f"{SLIDES_API_BASE}/presentations/{presentation_id}:batchUpdate",
+            headers={**self._get_headers(), "Content-Type": "application/json"},
+            json={"requests": create_requests},
+        )
+        if batch_resp.status_code == 403:
+            return f"Permission denied: you don't have edit access to this presentation. (HTTP 403)"
+        if batch_resp.status_code != 200:
+            return f"Slides create failed: {batch_resp.status_code} — {batch_resp.text[:200]}"
+
+        # Delete old slides
+        if existing_slide_ids:
+            delete_requests: list[dict[str, Any]] = [
+                {"deleteObject": {"objectId": sid}} for sid in existing_slide_ids
+            ]
+            del_resp = await client.post(
+                f"{SLIDES_API_BASE}/presentations/{presentation_id}:batchUpdate",
+                headers={**self._get_headers(), "Content-Type": "application/json"},
+                json={"requests": delete_requests},
+            )
+            if del_resp.status_code != 200:
+                logger.warning("[GoogleDrive] Failed to delete old slides: %s", del_resp.status_code)
+
+        # Populate new slides with content (re-fetch to get placeholder IDs)
+        full_resp = await client.get(
+            f"{SLIDES_API_BASE}/presentations/{presentation_id}",
+            headers=self._get_headers(),
+        )
+        if full_resp.status_code != 200:
+            return f"Could not fetch presentation after creating slides: {full_resp.status_code}"
+
+        text_requests: list[dict[str, Any]] = []
+        all_slides: list[dict[str, Any]] = full_resp.json().get("slides", [])
+
+        for slide_data in all_slides:
+            obj_id: str = slide_data.get("objectId", "")
+            if obj_id not in slide_object_ids:
+                continue
+            idx = slide_object_ids.index(obj_id)
+            slide_def: dict[str, Any] = new_slides[idx]
+
+            for element in slide_data.get("pageElements", []):
+                shape: Optional[dict[str, Any]] = element.get("shape")
+                if not shape:
+                    continue
+                placeholder: Optional[dict[str, Any]] = shape.get("placeholder")
+                if not placeholder:
+                    continue
+
+                ph_type: str = placeholder.get("type", "")
+                element_id: str = element.get("objectId", "")
+
+                if ph_type in ("TITLE", "CENTERED_TITLE") and slide_def.get("title"):
+                    text_requests.append({
+                        "insertText": {
+                            "objectId": element_id,
+                            "text": slide_def["title"],
+                            "insertionIndex": 0,
+                        }
+                    })
+                elif ph_type == "BODY" and slide_def.get("body"):
+                    text_requests.append({
+                        "insertText": {
+                            "objectId": element_id,
+                            "text": slide_def["body"],
+                            "insertionIndex": 0,
+                        }
+                    })
+
+        if text_requests:
+            text_resp = await client.post(
+                f"{SLIDES_API_BASE}/presentations/{presentation_id}:batchUpdate",
+                headers={**self._get_headers(), "Content-Type": "application/json"},
+                json={"requests": text_requests},
+            )
+            if text_resp.status_code != 200:
+                return f"Slides text insert failed: {text_resp.status_code} — {text_resp.text[:200]}"
+
+        return None
+
+    # -------------------------------------------------------------------------
+    # File Creation – Content Population Helpers
+    # -------------------------------------------------------------------------
+
     async def _populate_document(
         self, client: httpx.AsyncClient, doc_id: str, content: Any
     ) -> Optional[str]:
@@ -1105,5 +1504,11 @@ class GoogleDriveConnector(BaseConnector):
                 title=params.get("title", ""),
                 content=params.get("content", ""),
                 folder_id=params.get("folder_id"),
+            )
+        if action == "edit_file":
+            return await self.edit_file(
+                external_id=params.get("external_id", ""),
+                content=params.get("content", ""),
+                mode=params.get("mode", "replace"),
             )
         raise ValueError(f"Unknown action: {action}")

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -135,7 +135,7 @@ class SlackConnector(BaseConnector):
 
         conditions = [
             Integration.organization_id == uuid.UUID(self.organization_id),
-            Integration.provider == self.source_system,
+            Integration.connector == self.source_system,
             Integration.extra_data["team_id"].astext == self.team_id,
         ]
         if require_active:

--- a/backend/db/migrations/env.py
+++ b/backend/db/migrations/env.py
@@ -1,9 +1,15 @@
 """Alembic migration environment configuration."""
 
 from logging.config import fileConfig
+from pathlib import Path
 
+from dotenv import load_dotenv
 from alembic import context
 from sqlalchemy import pool, create_engine
+
+# Load .env from project root before config (alembic cwd may differ)
+_root: Path = Path(__file__).resolve().parent.parent.parent
+load_dotenv(_root / ".env")
 
 from config import settings
 from models.database import Base
@@ -23,9 +29,14 @@ from models.credit_transaction import CreditTransaction
 
 config = context.config
 
-# Convert async URL to sync URL for alembic migrations
-# postgresql+asyncpg:// -> postgresql://
-sync_url = settings.DATABASE_URL.replace("+asyncpg", "")
+# Use MIGRATION_DATABASE_URL for DDL (direct connection, table owner) when set;
+# otherwise DATABASE_URL (pooler can cause "must be owner" errors).
+migration_url: str = (
+    settings.MIGRATION_DATABASE_URL
+    if settings.MIGRATION_DATABASE_URL
+    else settings.DATABASE_URL
+)
+sync_url: str = migration_url.replace("+asyncpg", "")
 config.set_main_option("sqlalchemy.url", sync_url)
 
 if config.config_file_name is not None:

--- a/backend/db/migrations/versions/095_rename_integrations_provider_to_connector.py
+++ b/backend/db/migrations/versions/095_rename_integrations_provider_to_connector.py
@@ -1,0 +1,51 @@
+"""Rename integrations.provider to integrations.connector.
+
+Aligns DB terminology with agent-facing 'connector' (connector slug).
+
+Revision ID: 095_rename_provider_to_connector
+Revises: 094_remove_org_scoped_memories
+Create Date: 2026-03-07
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import Column, String, text
+
+
+revision: str = "095_rename_provider_to_connector"
+down_revision: Union[str, None] = "094_remove_org_scoped_memories"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Phase 1: Add connector column, copy from provider, keep provider for now.
+    # A future migration will drop provider after all code is deployed.
+    op.add_column("integrations", Column("connector", String(50), nullable=True))
+    op.execute(text("UPDATE integrations SET connector = provider"))
+    op.alter_column(
+        "integrations",
+        "connector",
+        existing_type=String(50),
+        nullable=False,
+    )
+    op.drop_constraint("uq_integration_org_provider_user", "integrations", type_="unique")
+    op.create_unique_constraint(
+        "uq_integration_org_connector_user",
+        "integrations",
+        ["organization_id", "connector", "user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_integration_org_connector_user", "integrations", type_="unique")
+    op.create_unique_constraint(
+        "uq_integration_org_provider_user",
+        "integrations",
+        ["organization_id", "provider", "user_id"],
+    )
+    op.drop_column("integrations", "connector")
+

--- a/backend/db/migrations/versions/096_github_pr_id_bigint.py
+++ b/backend/db/migrations/versions/096_github_pr_id_bigint.py
@@ -1,0 +1,40 @@
+"""Change github_pull_requests.github_pr_id to BIGINT.
+
+GitHub PR IDs can exceed int32 range (2^31-1); use BIGINT to avoid overflow.
+
+Revision ID: 096_github_pr_id_bigint
+Revises: 095_rename_provider_to_connector
+Create Date: 2026-03-07
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text
+
+
+revision: str = "096_github_pr_id_bigint"
+down_revision: Union[str, None] = "095_rename_provider_to_connector"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        text(
+            "ALTER TABLE github_pull_requests "
+            "ALTER COLUMN github_pr_id TYPE BIGINT USING github_pr_id::BIGINT"
+        )
+    )
+
+
+def downgrade() -> None:
+    # Only safe if all values fit in int32
+    op.execute(
+        text(
+            "ALTER TABLE github_pull_requests "
+            "ALTER COLUMN github_pr_id TYPE INTEGER USING github_pr_id::INTEGER"
+        )
+    )

--- a/backend/models/github_pull_request.py
+++ b/backend/models/github_pull_request.py
@@ -9,7 +9,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional
 
-from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -49,8 +49,8 @@ class GitHubPullRequest(Base):
         UUID(as_uuid=True), ForeignKey("github_repositories.id"), nullable=False
     )
 
-    # PR identification
-    github_pr_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    # PR identification (BIGINT: GitHub IDs can exceed int32)
+    github_pr_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     number: Mapped[int] = mapped_column(Integer, nullable=False)
 
     # Content

--- a/backend/models/integration.py
+++ b/backend/models/integration.py
@@ -39,8 +39,8 @@ class Integration(Base):
     __tablename__ = "integrations"
     __table_args__ = (
         UniqueConstraint(
-            "organization_id", "provider", "user_id",
-            name="uq_integration_org_provider_user"
+            "organization_id", "connector", "user_id",
+            name="uq_integration_org_connector_user"
         ),
     )
 
@@ -51,8 +51,8 @@ class Integration(Base):
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
     )
 
-    # Integration type: 'hubspot', 'slack', 'google_calendar', 'salesforce', 'gmail', etc.
-    provider: Mapped[str] = mapped_column(String(50), nullable=False)
+    # Connector slug: 'hubspot', 'slack', 'google_calendar', 'salesforce', 'gmail', etc.
+    connector: Mapped[str] = mapped_column(String(50), nullable=False)
 
     # Owner of this integration (who authenticated)
     # NOTE: nullable=True for backwards compatibility during migration.
@@ -107,7 +107,8 @@ class Integration(Base):
         result: dict[str, Any] = {
             "id": str(self.id),
             "organization_id": str(self.organization_id),
-            "provider": self.provider,
+            "connector": self.connector,
+            "provider": self.connector,  # Deprecated alias for connector; remove after frontend migration
             "user_id": str(self.user_id),
             "is_active": self.is_active,
             "last_sync_at": f"{self.last_sync_at.isoformat()}Z" if self.last_sync_at else None,

--- a/backend/scripts/test_nango_worker_auth.py
+++ b/backend/scripts/test_nango_worker_auth.py
@@ -75,7 +75,7 @@ async def _resolve_connection_id_from_db(
     async with get_session(organization_id=organization_id, user_id=user_id) as session:
         stmt = select(Integration).where(
             Integration.organization_id == organization_id,
-            Integration.provider == provider,
+            Integration.connector == provider,
         )
         if user_id:
             stmt = stmt.where(Integration.user_id == user_id)

--- a/backend/services/slack_conversations.py
+++ b/backend/services/slack_conversations.py
@@ -296,7 +296,7 @@ async def find_organization_by_slack_team(team_id: str) -> str | None:
     integrations: list[Integration] = []
     query = (
         select(Integration)
-        .where(Integration.provider == "slack")
+        .where(Integration.connector == "slack")
         .where(Integration.is_active == True)
     )
     for attempt in (1, 2):
@@ -539,7 +539,7 @@ async def refresh_slack_user_mappings_for_org(organization_id: str) -> int:
         integrations_query = (
             select(Integration)
             .where(Integration.organization_id == UUID(organization_id))
-            .where(Integration.provider == "slack")
+            .where(Integration.connector == "slack")
             .where(Integration.is_active == True)
         )
         integrations_result = await session.execute(integrations_query)
@@ -903,7 +903,7 @@ async def get_slack_user_ids_for_revtops_user(
         integrations_query = (
             select(Integration)
             .where(Integration.organization_id == UUID(organization_id))
-            .where(Integration.provider == "slack")
+            .where(Integration.connector == "slack")
             .where(Integration.is_active == True)
         )
         integrations_result = await sess.execute(integrations_query)
@@ -1484,7 +1484,7 @@ async def resolve_revtops_user_for_slack_actor(
         integrations_query = (
             select(Integration)
             .where(Integration.organization_id == UUID(organization_id))
-            .where(Integration.provider == "slack")
+            .where(Integration.connector == "slack")
             .where(Integration.is_active == True)
         )
         integrations_result = await session.execute(integrations_query)

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -193,7 +193,7 @@ async def _get_all_active_integrations() -> list[dict[str, str | None]]:
         return [
             {
                 "organization_id": str(i.organization_id),
-                "provider": i.provider,
+                "connector": i.connector,
                 "user_id": str(i.user_id) if i.user_id else None,
                 "last_sync_at": i.last_sync_at.isoformat() if i.last_sync_at else None,
             }
@@ -203,7 +203,7 @@ async def _get_all_active_integrations() -> list[dict[str, str | None]]:
 
 def _should_sync_in_periodic_run(integration: dict[str, str | None], now: datetime) -> bool:
     """Return whether an integration is due for sync in the periodic global run."""
-    provider: str = integration["provider"]  # type: ignore[assignment]
+    provider: str = integration["connector"]  # type: ignore[assignment]
     cadence: timedelta = PROVIDER_SYNC_INTERVALS.get(provider, DEFAULT_SYNC_INTERVAL)
     raw_last_sync_at: str | None = integration.get("last_sync_at")
 
@@ -258,7 +258,7 @@ async def _get_org_integrations(organization_id: str) -> list[dict[str, str | No
         integrations = result.scalars().all()
         return [
             {
-                "provider": i.provider,
+                "connector": i.connector,
                 "user_id": str(i.user_id) if i.user_id else None,
             }
             for i in integrations
@@ -306,7 +306,7 @@ def sync_organization(self: Any, organization_id: str) -> dict[str, Any]:
         results: dict[str, Any] = {}
         
         for entry in integration_entries:
-            provider: str = entry["provider"]  # type: ignore[assignment]
+            provider: str = entry["connector"]  # type: ignore[assignment]
             uid: str | None = entry["user_id"]
             key: str = f"{provider}:{uid}" if uid else provider
             results[key] = await _sync_integration(organization_id, provider, user_id=uid)
@@ -353,7 +353,7 @@ def sync_all_organizations(self: Any) -> dict[str, Any]:
             for entry in entries:
                 if not _should_sync_in_periodic_run(entry, now):
                     continue
-                provider: str = entry["provider"]  # type: ignore[assignment]
+                provider: str = entry["connector"]  # type: ignore[assignment]
                 uid: str | None = entry["user_id"]
                 key: str = f"{provider}:{uid}" if uid else provider
                 result = await _sync_integration(org_id, provider, user_id=uid)

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -1387,7 +1387,7 @@ async def _action_send_slack(
                 select(Integration).where(
                     and_(
                         Integration.organization_id == UUID(org_id),
-                        Integration.provider == "slack",
+                        Integration.connector == "slack",
                         Integration.is_active == True,
                     )
                 )
@@ -1627,7 +1627,7 @@ async def _action_send_email_from(
             query = select(Integration).where(
                 and_(
                     Integration.organization_id == UUID(org_id),
-                    Integration.provider == provider,
+                    Integration.connector == provider,
                     Integration.is_active == True,
                 )
             )

--- a/env.example
+++ b/env.example
@@ -1,5 +1,8 @@
 # Database
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/revenue_copilot
+# Optional: direct connection for migrations (avoids "must be owner" with Supabase pooler)
+# Use port 5432, not 6543; omit ?pgbouncer=true
+# MIGRATION_DATABASE_URL=postgresql://postgres:password@host:5432/postgres
 DB_TCP_KEEPALIVES_IDLE_SECONDS=60
 DB_TCP_KEEPALIVES_INTERVAL_SECONDS=30
 DB_TCP_KEEPALIVES_COUNT=5

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -883,26 +883,29 @@ export function DataSources(): JSX.Element {
 
       if (!response.ok) throw new Error('Sync failed');
 
-      // Poll for completion
+      // Poll for completion (GitHub sync can take 1–2 min; allow 2.5 min)
       let attempts = 0;
+      const maxAttempts = 150;
       const checkStatus = async (): Promise<void> => {
         const statusRes = await fetch(`${API_BASE}/sync/${organizationId}/${provider}/status`);
         const status = await statusRes.json();
 
-        if (status.status === 'completed' || status.status === 'failed' || attempts >= 30) {
+        if (status.status === 'completed' || status.status === 'failed' || attempts >= maxAttempts) {
           setSyncingProviders((prev) => {
             const next = new Set(prev);
             next.delete(provider);
             return next;
           });
 
-          // Invalidate cache to get updated sync status
-          if (status.status === 'completed' || status.status === 'failed') {
-            void fetchIntegrations();
+          // Always refetch: on completion, failure, or timeout (slow syncs like GitHub can exceed 30s)
+          void fetchIntegrations();
+          // If we timed out, sync may still be running; refetch again after delay to pick up result
+          if (attempts >= maxAttempts) {
+            setTimeout(() => void fetchIntegrations(), 60000);
           }
         } else {
           attempts++;
-          setTimeout(() => void checkStatus(), 1000);
+          setTimeout(() => void checkStatus(), 2000);
         }
       };
 

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -619,16 +619,31 @@ export const useChatStore = create<ChatState>()(
       const hasStreamingMessages = current.messages.some(
         (msg) => msg.isStreaming,
       );
-      if (!hasStreamingMessages && !current.streamingMessageId) return;
+      const hasInProgressTools = current.messages.some((msg) =>
+        msg.contentBlocks.some(
+          (block) => block.type === "tool_use" && block.status !== "complete",
+        ),
+      );
+      if (!hasStreamingMessages && !current.streamingMessageId && !hasInProgressTools) return;
 
       console.log(
         "[Store] Marking complete for conversation:",
         conversationId,
       );
 
-      const updated = current.messages.map((msg) =>
-        msg.isStreaming ? { ...msg, isStreaming: false } : msg,
-      );
+      const updated = current.messages.map((msg) => {
+        const finalizedBlocks = msg.contentBlocks.map((block) =>
+          block.type === "tool_use" &&
+          block.status !== "complete"
+            ? { ...block, status: "complete" as const }
+            : block,
+        );
+        const blocksChanged = finalizedBlocks !== msg.contentBlocks;
+        if (msg.isStreaming || blocksChanged) {
+          return { ...msg, isStreaming: false, contentBlocks: finalizedBlocks };
+        }
+        return msg;
+      });
       set({
         conversations: {
           ...conversations,


### PR DESCRIPTION
## Summary

- **GitHub PR sync**: Fix int32 overflow for `github_pr_id` (BigInteger), handle 301 redirects for renamed repos, fix multiple-rows in identity mapping
- **Last synced UI**: Extend poll timeout (2.5 min), always refetch on completion/timeout, pick integration with most recent `last_sync_at` when multiple exist
- **Migrations**: 095 (provider→connector rename), 096 (`github_pr_id` BIGINT)

## Changes
- `backend/connectors/github.py`: `follow_redirects=True`, scalar_one_or_none→limit(1) for duplicate mappings
- `backend/models/github_pull_request.py`: `BigInteger` for `github_pr_id`
- `frontend/src/components/DataSources.tsx`: Poll up to 150 attempts (2s interval), refetch on timeout + delayed refetch
- `backend/api/routes/auth.py`: Use integration with max `last_sync_at` for display when multiple exist
- `backend/config.py`, `backend/db/migrations/env.py`: Optional `MIGRATION_DATABASE_URL`
- Migrations 095, 096

Made with [Cursor](https://cursor.com)