### PR TITLE
Gate PagerDuty incident creation behind explicit env flag

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -141,6 +141,7 @@ class Settings(BaseSettings):
         validation_alias=AliasChoices("PAGERDUTY_KEY", "PagerDuty_Key"),
     )
     PAGERDUTY_SERVICE_ID: Optional[str] = None
+    PAGERDUTY_INCIDENTS_ENABLED: bool = False
 
     # Credits
     NUM_GRACE_CREDITS: int = 5
@@ -194,6 +195,7 @@ EXPECTED_ENV_VARS: tuple[str, ...] = (
     "PAGERDUTY_FROM_EMAIL",
     "PagerDuty_Key",
     "PAGERDUTY_SERVICE_ID",
+    "PAGERDUTY_INCIDENTS_ENABLED",
 )
 
 

--- a/backend/services/pagerduty.py
+++ b/backend/services/pagerduty.py
@@ -3,16 +3,11 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from urllib.parse import urlparse
-
 import httpx
 
 from config import settings
 
 logger = logging.getLogger(__name__)
-
-_LOCALHOST_HOSTNAMES = {"localhost", "127.0.0.1", "::1"}
-
 
 @dataclass(frozen=True)
 class PagerDutyIncidentResult:
@@ -24,33 +19,20 @@ class PagerDutyIncidentResult:
     response_body: str | None = None
 
 
-def _is_localhost_runtime() -> bool:
-    """Return True when runtime URLs indicate a localhost/developer environment."""
-    candidate_urls = [
-        settings.BACKEND_PUBLIC_URL,
-        settings.FRONTEND_URL,
-    ]
+def _pagerduty_incidents_enabled() -> bool:
+    """Return True when PagerDuty incident creation is explicitly enabled."""
+    if settings.PAGERDUTY_INCIDENTS_ENABLED:
+        return True
 
-    for value in candidate_urls:
-        if not value:
-            continue
-
-        parsed = urlparse(value)
-        hostname = parsed.hostname
-        if hostname and hostname.lower() in _LOCALHOST_HOSTNAMES:
-            logger.info(
-                "PagerDuty incidents disabled for localhost runtime (url=%s)",
-                value,
-            )
-            return True
-
+    logger.info(
+        "PagerDuty incident skipped: incidenting disabled (PAGERDUTY_INCIDENTS_ENABLED=false)"
+    )
     return False
 
 
 def get_pagerduty_config() -> tuple[str, str, str] | None:
     """Return PagerDuty settings if complete, else log and skip."""
-    if _is_localhost_runtime():
-        logger.info("PagerDuty incident skipped: localhost runtime detected")
+    if not _pagerduty_incidents_enabled():
         return None
 
     from_email = settings.PAGERDUTY_FROM_EMAIL

--- a/backend/tests/test_pagerduty_service.py
+++ b/backend/tests/test_pagerduty_service.py
@@ -36,6 +36,7 @@ def test_create_pagerduty_incident_with_details_missing_config(monkeypatch: Any)
     monkeypatch.delenv("PAGERDUTY_KEY", raising=False)
     monkeypatch.delenv("PagerDuty_Key", raising=False)
     monkeypatch.delenv("PAGERDUTY_SERVICE_ID", raising=False)
+    monkeypatch.setenv("PAGERDUTY_INCIDENTS_ENABLED", "true")
     monkeypatch.setattr(pagerduty, "settings", settings.__class__())
 
     import asyncio
@@ -58,6 +59,7 @@ def test_create_pagerduty_incident_with_details_http_error(monkeypatch: Any) -> 
     monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
     monkeypatch.setenv("FRONTEND_URL", "https://app.basebase.com")
     monkeypatch.delenv("BACKEND_PUBLIC_URL", raising=False)
+    monkeypatch.setenv("PAGERDUTY_INCIDENTS_ENABLED", "true")
     monkeypatch.setattr(pagerduty, "settings", settings.__class__())
 
     import asyncio
@@ -81,6 +83,7 @@ def test_create_pagerduty_incident_with_details_success(monkeypatch: Any) -> Non
     monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
     monkeypatch.setenv("FRONTEND_URL", "https://app.basebase.com")
     monkeypatch.delenv("BACKEND_PUBLIC_URL", raising=False)
+    monkeypatch.setenv("PAGERDUTY_INCIDENTS_ENABLED", "true")
     monkeypatch.setattr(pagerduty, "settings", settings.__class__())
 
     import asyncio
@@ -97,12 +100,11 @@ def test_create_pagerduty_incident_with_details_success(monkeypatch: Any) -> Non
     assert result.status_code == 201
 
 
-def test_get_pagerduty_config_skips_when_frontend_url_is_localhost(monkeypatch: Any) -> None:
+def test_get_pagerduty_config_skips_when_incidents_disabled(monkeypatch: Any) -> None:
     monkeypatch.setenv("PAGERDUTY_FROM_EMAIL", "alerts@revtops.com")
     monkeypatch.setenv("PagerDuty_Key", "pd_test_key")
     monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
-    monkeypatch.setenv("FRONTEND_URL", "http://localhost:5173")
-    monkeypatch.delenv("BACKEND_PUBLIC_URL", raising=False)
+    monkeypatch.setenv("PAGERDUTY_INCIDENTS_ENABLED", "false")
     monkeypatch.setattr(pagerduty, "settings", settings.__class__())
 
     config = pagerduty.get_pagerduty_config()
@@ -110,14 +112,13 @@ def test_get_pagerduty_config_skips_when_frontend_url_is_localhost(monkeypatch: 
     assert config is None
 
 
-def test_get_pagerduty_config_skips_when_backend_public_url_is_localhost(monkeypatch: Any) -> None:
+def test_get_pagerduty_config_returns_config_when_incidents_enabled(monkeypatch: Any) -> None:
     monkeypatch.setenv("PAGERDUTY_FROM_EMAIL", "alerts@revtops.com")
     monkeypatch.setenv("PagerDuty_Key", "pd_test_key")
     monkeypatch.setenv("PAGERDUTY_SERVICE_ID", "svc_123")
-    monkeypatch.setenv("FRONTEND_URL", "https://app.basebase.com")
-    monkeypatch.setenv("BACKEND_PUBLIC_URL", "http://127.0.0.1:8000")
+    monkeypatch.setenv("PAGERDUTY_INCIDENTS_ENABLED", "true")
     monkeypatch.setattr(pagerduty, "settings", settings.__class__())
 
     config = pagerduty.get_pagerduty_config()
 
-    assert config is None
+    assert config == ("alerts@revtops.com", "pd_test_key", "svc_123")


### PR DESCRIPTION
### Motivation

- Replace the previous runtime hostname-based suppression for PagerDuty incidents with an explicit opt-in toggle so incidents are only raised when intentionally enabled.
- Prevent accidental incident firing from local/dev environments by making incident creation default to disabled via configuration.

### Description

- Add `PAGERDUTY_INCIDENTS_ENABLED: bool = False` to `backend/config.py` and include it in `EXPECTED_ENV_VARS` for diagnostics.
- Replace the `_is_localhost_runtime()` check in `backend/services/pagerduty.py` with a `_pagerduty_incidents_enabled()` gate that returns early unless `settings.PAGERDUTY_INCIDENTS_ENABLED` is true.
- Update `create_pagerduty_incident_with_details()`/`get_pagerduty_config()` behavior to skip when the new flag is not enabled and keep existing config validation for `PAGERDUTY_FROM_EMAIL`, `PAGERDUTY_KEY`, and `PAGERDUTY_SERVICE_ID`.
- Rewrite PagerDuty unit tests in `backend/tests/test_pagerduty_service.py` to assert the new gating behavior and to explicitly set `PAGERDUTY_INCIDENTS_ENABLED` for enabled paths.

### Testing

- Ran `pytest -q backend/tests/test_pagerduty_service.py` and all tests passed with `5 passed`.
- Verified the new unit tests cover both disabled (`PAGERDUTY_INCIDENTS_ENABLED=false`) and enabled (`PAGERDUTY_INCIDENTS_ENABLED=true`) code paths for config resolution and HTTP request handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acc5b0262c8321a0b8573e9ffb2a6f)