### PR TITLE
Rename agent tools: system -> connector with consistent *_on_connector pattern

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -203,13 +203,13 @@ All external connectors (HubSpot, Linear, Gmail, Slack, etc.) are **user-scoped*
 
 ### Reading & Analyzing Data
 - **run_sql_query**: Execute SELECT queries against the database. Use for structured analysis, filtering, joins, aggregations, exact text matching (ILIKE). Always prefer this for questions that can be answered with SQL. **Includes GitHub data**: query github_repositories, github_commits, github_pull_requests for repo activity, who's committing, recent PRs, etc. **Do NOT add organization_id to WHERE clauses** — data is automatically scoped to the user's organization via row-level security. **Semantic search**: Use `semantic_embed('text')` inline to search activities by meaning (e.g. `ORDER BY embedding <=> semantic_embed('pricing discussion') LIMIT 10`).
-- **run_action** with connector=code_sandbox (Code Sandbox): Run shell commands in a persistent Linux sandbox. Use for complex multi-step data analysis, Python/bash/Node scripts, CLI tools, or computation beyond SQL. Only use if **code_sandbox** is listed under Connected Connectors (enabled) below. If not enabled, offer to connect it using `initiate_connector`.
-- **query_system** with connector=web_search (Web Search): Search the web for external information. Only use if **web_search** is listed under Connected Connectors below; if not enabled, offer to connect it using `initiate_connector`.
+- **run_on_connector** with connector=code_sandbox (Code Sandbox): Run shell commands in a persistent Linux sandbox. Use for complex multi-step data analysis, Python/bash/Node scripts, CLI tools, or computation beyond SQL. Only use if **code_sandbox** is listed under Connected Connectors (enabled) below. If not enabled, offer to connect it using `initiate_connector`.
+- **query_on_connector** with connector=web_search (Web Search): Search the web for external information. Only use if **web_search** is listed under Connected Connectors below; if not enabled, offer to connect it using `initiate_connector`.
 
 
 ### Writing & Modifying Data
-- **write_to_system_of_record**: Universal tool for creating or updating records in ANY connected external system — CRMs (HubSpot, Salesforce), issue trackers (Linear, Jira, Asana), code repos (GitHub, GitLab), and more. Accepts target_system, record_type, operation, and records array. Single-record writes execute immediately; bulk CRM writes go through the Pending Changes panel.
-- **run_sql_write**: Execute INSERT/UPDATE/DELETE SQL. Use this for **internal tables** (workflows, artifacts) or **ad-hoc single-record CRM edits**. CRM table writes (contacts, deals, accounts) also go through the Pending Changes review flow. Prefer write_to_system_of_record for external system operations.
+- **write_to_system_of_record**: Universal tool for creating or updating records in ANY connected external connector — CRMs (HubSpot, Salesforce), issue trackers (Linear, Jira, Asana), code repos (GitHub, GitLab), and more. Accepts target_system, record_type, operation, and records array. Single-record writes execute immediately; bulk CRM writes go through the Pending Changes panel.
+- **run_sql_write**: Execute INSERT/UPDATE/DELETE SQL. Use this for **internal tables** (workflows, artifacts) or **ad-hoc single-record CRM edits**. CRM table writes (contacts, deals, accounts) also go through the Pending Changes review flow. Prefer write_to_system_of_record for external connector operations.
 
 ### Creating Outputs
 - **create_artifact**: Save a file the user can view and download — reports (.md/.pdf), charts (.html with Plotly), or data exports (.txt).
@@ -275,11 +275,11 @@ When the user provides a CSV or file for import, include ALL available fields fr
 | File a GitHub issue | **write_to_system_of_record** (target_system="github", record_type="issue") |
 | Create a report or chart | **run_sql_query** → **create_artifact** |
 | Create an interactive dashboard or chart with filters | **run_sql_query** (inspect data) → **write_app** (create) → **write_app** (test_query to verify) |
-| Complex multi-step data analysis, statistical modeling, or ML | **run_action** (connector=code_sandbox, action=execute_command) — only if code_sandbox is enabled in Connected Connectors |
-| Generate a chart programmatically (matplotlib, seaborn) | **run_action** (code_sandbox, execute_command) — only if enabled |
-| Transform or combine data in ways SQL can't handle | **run_action** (code_sandbox, execute_command) — only if enabled |
+| Complex multi-step data analysis, statistical modeling, or ML | **run_on_connector** (connector=code_sandbox, action=execute_command) — only if code_sandbox is enabled in Connected Connectors |
+| Generate a chart programmatically (matplotlib, seaborn) | **run_on_connector** (code_sandbox, execute_command) — only if enabled |
+| Transform or combine data in ways SQL can't handle | **run_on_connector** (code_sandbox, execute_command) — only if enabled |
 | Set up a recurring task | **run_sql_write** (INSERT INTO workflows) |
-| Research a company externally | **query_system** (connector=web_search) — only if web_search is enabled in Connected Connectors |
+| Research a company externally | **query_on_connector** (connector=web_search) — only if web_search is enabled in Connected Connectors |
 
 ### Workflow Automations
 
@@ -842,7 +842,7 @@ class ChatOrchestrator:
     async def _build_systems_manifest(self) -> str | None:
         """Build a compact manifest of connected systems (names, capabilities, action names only).
 
-        Full parameter docs are fetched on demand via get_system_docs(system).
+        Full parameter docs are fetched on demand via get_connector_docs(connector).
         """
         from connectors.registry import ConnectorMeta, discover_connectors
         from models.integration import Integration
@@ -873,7 +873,7 @@ class ChatOrchestrator:
             registry = discover_connectors()
 
             lines: list[str] = [
-                "Call `get_system_docs(system)` to get detailed usage instructions and parameter reference before using a system for the first time.",
+                "Call `get_connector_docs(connector)` to get detailed usage instructions and parameter reference before using a connector for the first time.",
                 "",
             ]
             for slug, connector_cls in sorted(registry.items()):
@@ -918,14 +918,14 @@ class ChatOrchestrator:
                 not_enabled_block = (
                     "\n\n## Connectors not currently enabled\n"
                     + "\n".join(not_enabled_lines)
-                    + "\n\nDo **not** call query_system, write_to_system, or run_action for any of these — they are not connected. "
+                    + "\n\nDo **not** call query_on_connector, write_on_connector, or run_on_connector for any of these — they are not connected. "
                     "If the user asks for something that would need one of them, offer to help them connect it using "
                     "`initiate_connector` which will open the OAuth authorization flow in their browser."
                 )
 
             return (connected_block + not_enabled_block) if (connected_block or not_enabled_block) else None
         except Exception:
-            logger.warning("Failed to build systems manifest", exc_info=True)
+            logger.warning("Failed to build connectors manifest", exc_info=True)
             return None
 
     async def _load_context_profile(self) -> dict[str, Any]:
@@ -1267,14 +1267,14 @@ WHERE scheduled_start >= '2026-01-27'::date AND scheduled_start < '2026-01-28'::
 5. **Displaying Results**: Convert UTC times to the user's timezone when presenting results. Use relative references when helpful (e.g., "in 30 minutes", "3 hours ago")."""
         system_prompt += time_context
 
-        # Inject connected systems manifest (capabilities, operations, parameters)
+        # Inject connected connectors manifest (capabilities, operations, parameters)
         if self.organization_id:
             systems_manifest: str | None = await self._build_systems_manifest()
             if systems_manifest:
                 system_prompt += "\n\n## Connected Connectors\n"
                 system_prompt += (
-                    "Use `query_system`, `write_to_system`, and `run_action` only for connectors listed **above** under the enabled connectors. "
-                    "Use `list_connected_systems` to refresh this list mid-conversation.\n\n"
+                    "Use `query_on_connector`, `write_on_connector`, and `run_on_connector` only for connectors listed **above** under the enabled connectors. "
+                    "Use `list_connected_connectors` to refresh this list mid-conversation.\n\n"
                     "**IMPORTANT**: Before calling any of these tools, check that the target connector (e.g. code_sandbox, web_search, google_drive) "
                     "appears in the **enabled** list above, not under \"Connectors not currently enabled\". "
                     "If the user's request needs a connector that is only in the not-enabled list, do **not** call the tool — "

--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -118,7 +118,7 @@ Available tables:
 - tracker_teams: Issue tracker teams/workspaces (source_system, source_id, name, key, description). Filter by source_system ('linear', 'jira', 'asana'). Join to issues via team_id.
 - tracker_projects: Issue tracker projects (source_system, source_id, name, description, state, progress, target_date, start_date, lead_name, team_ids JSONB). Filter by source_system.
 - tracker_issues: Issue tracker issues/tasks (source_system, source_id, team_id, identifier e.g. "ENG-123", title, description, state_name, state_type, priority 0-4, priority_label, issue_type, assignee_name, assignee_email, creator_name, project_id, labels JSONB, estimate, url, due_date, created_date, updated_date, completed_date, cancelled_date, user_id). Filter by source_system.
-- shared_files: Synced file metadata from cloud sources like Google Drive (external_id, source, name, mime_type, folder_path, web_view_link, file_size, source_modified_at). Filter by source (e.g. 'google_drive'). Use query_system(system='google_drive', query='search:...') for name-based searches.
+- shared_files: Synced file metadata from cloud sources like Google Drive (external_id, source, name, mime_type, folder_path, web_view_link, file_size, source_modified_at). Filter by source (e.g. 'google_drive'). Use query_on_connector(connector='google_drive', query='search:...') for name-based searches.
 - temp_data: Agent-generated results and computed metrics. Flexible JSONB storage linked to entities. Columns: entity_type, entity_id, namespace, key, value (JSONB), metadata (JSONB), created_by_user_id, created_at, expires_at. Example: SELECT td.value->>'score' as confidence, d.name FROM temp_data td JOIN deals d ON d.id = td.entity_id WHERE td.namespace = 'deal_confidence'
 
 SEMANTIC SEARCH on activities: Use semantic_embed('natural language query') as an inline function to generate an embedding vector. Combine with the <=> cosine distance operator to rank by similarity.
@@ -144,7 +144,7 @@ IMPORTANT: Only SELECT queries are allowed. No INSERT, UPDATE, DELETE, DROP, etc
 
 
 register_tool(
-    name="list_connected_systems",
+    name="list_connected_connectors",
     description="""Refresh and return the capabilities manifest for all connected connectors.
 
 Use this to get an up-to-date list of connected integrations and their capabilities
@@ -162,22 +162,22 @@ need to verify a connector is connected before using it.""",
 
 
 register_tool(
-    name="get_system_docs",
-    description="""Get detailed usage documentation for a connected system (connector).
+    name="get_connector_docs",
+    description="""Get detailed usage documentation for a connected connector.
 
-Call this before using query_system, write_to_system, or run_action for a connector
+Call this before using query_on_connector, write_on_connector, or run_on_connector for a connector
 you haven't used yet. Returns rich usage guides (query formats, action parameters,
-examples) written by the connector author. Use the system slug (e.g. 'google_drive',
+examples) written by the connector author. Use the connector slug (e.g. 'google_drive',
 'hubspot', 'slack') from the Connected Connectors manifest.""",
     input_schema={
         "type": "object",
         "properties": {
-            "system": {
+            "connector": {
                 "type": "string",
                 "description": "Connector slug (e.g. 'google_drive', 'hubspot', 'slack')",
             },
         },
-        "required": ["system"],
+        "required": ["connector"],
     },
     category=ToolCategory.LOCAL_READ,
     default_requires_approval=False,
@@ -185,13 +185,13 @@ examples) written by the connector author. Use the system slug (e.g. 'google_dri
 
 
 register_tool(
-    name="query_system",
+    name="query_on_connector",
     description="""Query a connected connector for on-demand data retrieval.
 
 Use this for any QUERY-capable connector: web search (web_search), Apollo enrichment,
 Google Drive file search/read, or any future connector with query capability.
 
-The query string format depends on the connector. Call `get_system_docs(system)` for
+The query string format depends on the connector. Call `get_connector_docs(connector)` for
 detailed query formats, parameters, and examples before using a connector.""",
     input_schema={
         "type": "object",
@@ -213,7 +213,7 @@ detailed query formats, parameters, and examples before using a connector.""",
 
 
 register_tool(
-    name="write_to_system",
+    name="write_on_connector",
     description="""Create or update records in a connected connector.
 
 Use this for any WRITE-capable connector: HubSpot (deals, contacts, companies),
@@ -244,7 +244,7 @@ Check the Connected Connectors manifest for available operations and their requi
 
 
 register_tool(
-    name="run_action",
+    name="run_on_connector",
     description="""Execute a side-effect action on a connected connector.
 
 Use this for any ACTION-capable connector: sending Slack messages, sending emails
@@ -308,7 +308,7 @@ Workflows are prompts sent to the agent on a schedule. Use these columns:
 - prompt: Natural language instructions for what the agent should do
 - trigger_type: 'schedule', 'event', or 'manual'
 - trigger_config: JSON with cron expression, e.g. '{"cron": "0 9 * * *"}'
-- auto_approve_tools: JSON array of tools that run without approval, e.g. '["run_sql_query", "run_action"]'
+- auto_approve_tools: JSON array of tools that run without approval, e.g. '["run_sql_query", "run_on_connector"]'
 
 DO NOT use the 'steps' column - it's deprecated. Use 'prompt' instead.
 
@@ -319,7 +319,7 @@ VALUES (
   'Query deals to get a summary of open opportunities. Include total count, value by stage, and top 5 deals by amount. Format a nice summary with emojis and post to #sales on Slack.',
   'schedule',
   '{"cron": "0 9 * * *"}',
-  '["run_sql_query", "run_action"]'
+  '["run_sql_query", "run_on_connector"]'
 )
 
 Auto-managed columns (don't include):
@@ -501,7 +501,7 @@ Use this for any batch operation: enriching contacts, researching companies, sen
 Provide EITHER tool (to call a tool per item) OR workflow_id (to run a workflow per item).
 
 **Tool mode** — each item renders params_template ({{field}} placeholders filled from item), then the tool is called. Results stored in bulk_operation_results (queryable via run_sql_query). Uses distributed Celery workers.
-  Example: foreach(tool="query_system", items_query="SELECT id, name FROM contacts", params_template={"connector": "web_search", "query": "Current role of {{name}}?"})
+  Example: foreach(tool="query_on_connector", items_query="SELECT id, name FROM contacts", params_template={"connector": "web_search", "query": "Current role of {{name}}?"})
 
 **Workflow mode** — each item dict is passed as input_data to the workflow. Uses async in-process execution with context propagation.
   Example: foreach(workflow_id="uuid-...", items=[{"email": "a@b.com"}, {"email": "c@d.com"}])
@@ -512,7 +512,7 @@ Set max_concurrent=1 for sequential execution, higher for parallel. Blocks until
         "properties": {
             "tool": {
                 "type": "string",
-                "description": "Name of the tool to run per item (e.g., 'query_system', 'run_action'). Mutually exclusive with workflow_id.",
+                "description": "Name of the tool to run per item (e.g., 'query_on_connector', 'run_on_connector'). Mutually exclusive with workflow_id.",
             },
             "workflow_id": {
                 "type": "string",

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -4,11 +4,11 @@ Tool definitions and execution for Claude.
 Tools are organized by category (see registry.py):
 - LOCAL_READ: run_sql_query
 - LOCAL_WRITE: create_artifact, run_sql_write, run_workflow, write_app, keep_notes, manage_memory, foreach, initiate_connector
-- EXTERNAL_READ: query_system, list_connected_systems
-- EXTERNAL_WRITE: write_to_system, run_action, trigger_sync
+- EXTERNAL_READ: query_on_connector, list_connected_connectors
+- EXTERNAL_WRITE: write_on_connector, run_on_connector, trigger_sync
 
-All external interactions go through generic connector tools (query_system,
-write_to_system, run_action) which dispatch to the appropriate connector.
+All external interactions go through generic connector tools (query_on_connector,
+write_on_connector, run_on_connector) which dispatch to the appropriate connector.
 """
 
 from __future__ import annotations
@@ -315,11 +315,11 @@ async def execute_tool(
         "trigger_sync": lambda: _trigger_sync(tool_input, organization_id),
         "initiate_connector": lambda: _initiate_connector(tool_input, organization_id, user_id),
         # Connector-driven generic tools
-        "list_connected_systems": lambda: _list_connected_systems(organization_id),
-        "get_system_docs": lambda: _get_system_docs(tool_input, organization_id),
-        "query_system": lambda: _query_system(tool_input, organization_id, user_id),
-        "write_to_system": lambda: _write_to_system(tool_input, organization_id, user_id, skip_approval, conversation_id),
-        "run_action": lambda: _run_action(tool_input, organization_id, user_id, skip_approval, context),
+        "list_connected_connectors": lambda: _list_connected_connectors(organization_id),
+        "get_connector_docs": lambda: _get_connector_docs(tool_input, organization_id),
+        "query_on_connector": lambda: _query_on_connector(tool_input, organization_id, user_id),
+        "write_on_connector": lambda: _write_on_connector(tool_input, organization_id, user_id, skip_approval, conversation_id),
+        "run_on_connector": lambda: _run_on_connector(tool_input, organization_id, user_id, skip_approval, context),
     }
 
     handler = tool_handlers.get(tool_name)
@@ -355,10 +355,10 @@ def _log_tool_execution_result(
         )
     elif executed_tool_name == "trigger_sync":
         logger.info("[Tools] trigger_sync completed: %s", result.get("status"))
-    elif executed_tool_name in ("query_system", "write_to_system", "run_action"):
+    elif executed_tool_name in ("query_on_connector", "write_on_connector", "run_on_connector"):
         logger.info("[Tools] %s completed: %s", executed_tool_name, result.get("status", result.get("error", "ok")))
-    elif executed_tool_name == "list_connected_systems":
-        logger.info("[Tools] list_connected_systems returned manifest")
+    elif executed_tool_name == "list_connected_connectors":
+        logger.info("[Tools] list_connected_connectors returned manifest")
     elif executed_tool_name == "search_cloud_files":
         logger.info("[Tools] search_cloud_files returned %d results", len(result.get("files", [])))
     elif executed_tool_name == "read_cloud_file":
@@ -538,14 +538,14 @@ async def _get_connector_instance(
     registry = discover_connectors()
     connector_cls: type[BaseConnector] | None = registry.get(slug)
     if connector_cls is None:
-        return None, f"Unknown connector '{slug}'. Use list_connected_systems to see available connectors."
+        return None, f"Unknown connector '{slug}'. Use list_connected_connectors to see available connectors."
 
     meta: ConnectorMeta = connector_cls.meta  # type: ignore[attr-defined]
 
     if required_capability:
         cap = Capability(required_capability)
         if cap not in meta.capabilities:
-            return None, f"System '{slug}' does not support {required_capability}. Capabilities: {[c.value for c in meta.capabilities]}"
+            return None, f"Connector '{slug}' does not support {required_capability}. Capabilities: {[c.value for c in meta.capabilities]}"
 
     # Find an integration the user can access
     async with get_session(organization_id=organization_id) as session:
@@ -596,7 +596,7 @@ async def _get_connector_instance(
                 return None, f"No {slug} integration with query access. Connect your own or ask a teammate to enable query sharing."
             elif required_capability == "write":
                 return None, f"No {slug} integration with write access. Connect your own or ask a teammate to enable write sharing."
-            return None, f"System '{slug}' is not connected. Ask the user to connect it in the Connectors page."
+            return None, f"Connector '{slug}' is not connected. Ask the user to connect it in the Connectors page."
 
         # Store integration owner's user_id for the connector
         integration_user_id = str(integration.user_id)
@@ -607,7 +607,7 @@ async def _get_connector_instance(
     return instance, None
 
 
-async def _list_connected_systems(organization_id: str) -> dict[str, Any]:
+async def _list_connected_connectors(organization_id: str) -> dict[str, Any]:
     """Return the connectors manifest for all connected connectors."""
     from connectors.registry import Capability, ConnectorMeta, discover_connectors
     from models.integration import Integration
@@ -650,7 +650,7 @@ async def _list_connected_systems(organization_id: str) -> dict[str, Any]:
     return {"connectors": connectors, "count": len(connectors)}
 
 
-async def _get_system_docs(
+async def _get_connector_docs(
     params: dict[str, Any], organization_id: str
 ) -> dict[str, Any]:
     """Return detailed usage documentation for a connected connector.
@@ -661,9 +661,9 @@ async def _get_system_docs(
     from connectors.registry import Capability, ConnectorMeta, discover_connectors
     from models.integration import Integration
 
-    system: str = (params.get("system") or "").strip().lower()
-    if not system:
-        return {"error": "system is required (connector slug, e.g. 'google_drive', 'hubspot')"}
+    slug: str = (params.get("connector") or "").strip().lower()
+    if not slug:
+        return {"error": "connector is required (e.g. 'google_drive', 'hubspot')"}
 
     async with get_session(organization_id=organization_id) as session:
         result = await session.execute(
@@ -674,15 +674,15 @@ async def _get_system_docs(
         )
         active_providers: set[str] = {row[0] for row in result.all()}
 
-    if system not in active_providers:
+    if slug not in active_providers:
         return {
-            "error": f"'{system}' is not connected. Use list_connected_systems to see available connectors.",
+            "error": f"'{slug}' is not connected. Use list_connected_connectors to see available connectors.",
         }
 
     registry = discover_connectors()
-    connector_cls = registry.get(system)
+    connector_cls = registry.get(slug)
     if not connector_cls:
-        return {"error": f"Unknown connector: {system}"}
+        return {"error": f"Unknown connector: {slug}"}
 
     meta: ConnectorMeta = connector_cls.meta  # type: ignore[attr-defined]
     sections: list[str] = []
@@ -690,7 +690,6 @@ async def _get_system_docs(
     if meta.usage_guide:
         sections.append(meta.usage_guide)
 
-    # Auto-generated parameter reference as fallback/supplement
     param_lines: list[str] = []
 
     if Capability.QUERY in meta.capabilities and meta.query_description:
@@ -712,10 +711,10 @@ async def _get_system_docs(
         sections.append("\n\n---\n\n# Parameter reference\n\n" + "\n\n".join(param_lines))
 
     docs: str = "\n\n".join(sections) if sections else f"No documentation available for {meta.name}."
-    return {"system": system, "name": meta.name, "docs": docs}
+    return {"connector": slug, "name": meta.name, "docs": docs}
 
 
-async def _query_system(
+async def _query_on_connector(
     params: dict[str, Any], organization_id: str, user_id: str | None
 ) -> dict[str, Any]:
     """Dispatch a query to a QUERY-capable connector."""
@@ -744,11 +743,11 @@ async def _query_system(
     try:
         return await instance.query(query)
     except Exception as exc:
-        logger.error("[Tools] query_system(%s) failed: %s", connector, exc, exc_info=True)
+        logger.error("[Tools] query_on_connector(%s) failed: %s", connector, exc, exc_info=True)
         return {"error": f"Query to {connector} failed: {exc}"}
 
 
-async def _write_to_system(
+async def _write_on_connector(
     params: dict[str, Any],
     organization_id: str,
     user_id: str | None,
@@ -783,11 +782,11 @@ async def _write_to_system(
     try:
         return await instance.write(operation, data)
     except Exception as exc:
-        logger.error("[Tools] write_to_system(%s, %s) failed: %s", connector, operation, exc, exc_info=True)
+        logger.error("[Tools] write_on_connector(%s, %s) failed: %s", connector, operation, exc, exc_info=True)
         return {"error": f"Write to {connector}.{operation} failed: {exc}"}
 
 
-async def _run_action(
+async def _run_on_connector(
     params: dict[str, Any],
     organization_id: str,
     user_id: str | None,
@@ -828,7 +827,7 @@ async def _run_action(
     try:
         return await instance.execute_action(action, action_params)
     except Exception as exc:
-        logger.error("[Tools] run_action(%s, %s) failed: %s", connector, action, exc, exc_info=True)
+        logger.error("[Tools] run_on_connector(%s, %s) failed: %s", connector, action, exc, exc_info=True)
         return {"error": f"Action {connector}.{action} failed: {exc}"}
 
 

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1118,7 +1118,7 @@ async def create_organization(
                 "3. Write a concise 2–3 sentence summary of what the company does, its industry, and notable aspects.\n"
                 "4. Call run_sql_write with: UPDATE organizations SET company_summary = '<your summary>' WHERE id = '<organization_id>'"
             ),
-            auto_approve_tools=["run_action", "query_system", "run_sql_write"],
+            auto_approve_tools=["run_on_connector", "query_on_connector", "run_sql_write"],
             input_schema={
                 "type": "object",
                 "properties": {

--- a/backend/connectors/github.py
+++ b/backend/connectors/github.py
@@ -65,7 +65,7 @@ class GitHubConnector(BaseConnector):
 
 ## create_issue write operation
 
-Create a new issue in a GitHub repository. Use `write_to_system` with `operation: "create_issue"`.
+Create a new issue in a GitHub repository. Use `write_on_connector(connector='github', operation='create_issue', data={...})`.
 
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|

--- a/backend/connectors/google_drive.py
+++ b/backend/connectors/google_drive.py
@@ -277,9 +277,9 @@ class GoogleDriveConnector(BaseConnector):
         description="Google Drive – file metadata sync, search, read, create, and edit",
         usage_guide="""# Google Drive Usage Guide
 
-## Query format (query_system)
+## Query format (query_on_connector)
 
-Use the `query` parameter with one of these prefixes:
+Use `query_on_connector(connector='google_drive', query='...')` with one of these prefixes:
 
 | Prefix | Example | Description |
 |--------|---------|-------------|
@@ -295,7 +295,9 @@ Use the `query` parameter with one of these prefixes:
 
 ---
 
-## create_file action
+## Action: create_file
+
+Call via `run_on_connector(connector='google_drive', action='create_file', params={...})`.
 
 Creates a new Google Doc, Sheet, or Slides presentation.
 
@@ -326,7 +328,9 @@ Each row is an array of cell values. Use `{"data": [[...]]}` as shorthand for a 
 
 ---
 
-## edit_file action
+## Action: edit_file
+
+Call via `run_on_connector(connector='google_drive', action='edit_file', params={...})`.
 
 Edits an existing Google Doc, Sheet, or Slides. Requires edit permission on the file.
 
@@ -346,19 +350,13 @@ Edits an existing Google Doc, Sheet, or Slides. Requires edit permission on the 
 ## Examples
 
 **Create a meeting notes doc:**
-```json
-{"file_type": "document", "title": "Q1 Planning Notes", "content": "# Q1 Planning\\n\\n## Attendees\\n- Alice\\n- Bob\\n\\n## Action items\\n1. Review budget\\n2. Schedule follow-up"}
-```
+`run_on_connector(connector='google_drive', action='create_file', params={"file_type": "document", "title": "Q1 Planning Notes", "content": "# Q1 Planning\\n\\n## Attendees\\n- Alice\\n- Bob\\n\\n## Action items\\n1. Review budget\\n2. Schedule follow-up"})`
 
 **Create a simple spreadsheet:**
-```json
-{"file_type": "spreadsheet", "title": "Sales Pipeline", "content": "{\\\"sheets\\\": [{\\\"title\\\": \\\"Deals\\\", \\\"data\\\": [[\\\"Company\\\", \\\"Amount\\\", \\\"Stage\\\"], [\\\"Acme\\\", 5000, \\\"Proposal\\\"]]}]}"}
-```
+`run_on_connector(connector='google_drive', action='create_file', params={"file_type": "spreadsheet", "title": "Sales Pipeline", "content": "{\\\"sheets\\\": [{\\\"title\\\": \\\"Deals\\\", \\\"data\\\": [[\\\"Company\\\", \\\"Amount\\\", \\\"Stage\\\"], [\\\"Acme\\\", 5000, \\\"Proposal\\\"]]}]}"})`
 
 **Edit a doc (append):**
-```json
-{"external_id": "1abc...", "content": "\\n## Additional notes\\n- New item", "mode": "append"}
-```
+`run_on_connector(connector='google_drive', action='edit_file', params={"external_id": "1abc...", "content": "\\n## Additional notes\\n- New item", "mode": "append"})`
 """,
     )
 

--- a/backend/connectors/hubspot.py
+++ b/backend/connectors/hubspot.py
@@ -125,9 +125,9 @@ class HubSpotConnector(BaseConnector):
         description="HubSpot CRM – deals, contacts, companies, and activities",
         usage_guide="""# HubSpot Usage Guide
 
-## Write operations (write_to_system)
+## Write operations (write_on_connector)
 
-Use `write_to_system` with `operation` set to one of: `create_deal`, `update_deal`, `create_contact`, `update_contact`, `create_company`, `update_company`.
+Use `write_on_connector(connector='hubspot', operation='...', data={...})` with one of: `create_deal`, `update_deal`, `create_contact`, `update_contact`, `create_company`, `update_company`.
 
 ### Deals
 

--- a/backend/connectors/linear.py
+++ b/backend/connectors/linear.py
@@ -93,9 +93,9 @@ class LinearConnector(BaseConnector):
         webhook_secret_extra_data_key="linear_webhook_secret",
         usage_guide="""# Linear Usage Guide
 
-## Write operations (write_to_system)
+## Write operations (write_on_connector)
 
-Use `write_to_system` with `operation` set to `create_issue` or `update_issue`.
+Use `write_on_connector(connector='linear', operation='...', data={...})` with `create_issue` or `update_issue`.
 
 ### create_issue
 

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -99,7 +99,9 @@ class SlackConnector(BaseConnector):
         description="Slack workspace – messages, channels, and real-time events",
         usage_guide="""# Slack Usage Guide
 
-## send_message action
+## Action: send_message
+
+Call via `run_on_connector(connector='slack', action='send_message', params={...})`.
 
 Send a message to a Slack channel, DM, or user.
 

--- a/backend/services/credits.py
+++ b/backend/services/credits.py
@@ -220,19 +220,19 @@ def credits_for_tool(
     write-back 2, artifact 5-10, bulk ~1 per record, etc.).
     """
     # Simple read-only / list
-    if tool_name in ("run_sql_query", "list_connected_systems"):
+    if tool_name in ("run_sql_query", "list_connected_connectors"):
         return 1
-    # CRM/system write-back
-    if tool_name == "write_to_system":
+    # Connector write-back
+    if tool_name == "write_on_connector":
         return 2
-    # Query system often crosses sources
-    if tool_name == "query_system":
+    # Connector queries often cross sources
+    if tool_name == "query_on_connector":
         return 2
     # Artifacts / reports
     if tool_name == "create_artifact":
         return 5
-    # Run action (enrichment, etc.)
-    if tool_name == "run_action":
+    # Run on connector (enrichment, etc.)
+    if tool_name == "run_on_connector":
         return 3
     # Workflow run
     if tool_name == "run_workflow":

--- a/backend/tests/test_tools_credit_grace.py
+++ b/backend/tests/test_tools_credit_grace.py
@@ -16,7 +16,7 @@ def test_execute_tool_returns_credit_error_when_grace_exhausted(monkeypatch) -> 
 
     result = asyncio.run(
         tools.execute_tool(
-            tool_name="list_connected_systems",
+            tool_name="list_connected_connectors",
             tool_input={},
             organization_id="00000000-0000-0000-0000-000000000001",
             user_id="00000000-0000-0000-0000-000000000002",
@@ -35,16 +35,16 @@ def test_execute_tool_marks_turn_for_credit_closeout_when_grace_used(monkeypatch
     async def _fake_should_skip_approval(*args, **kwargs) -> bool:
         return True
 
-    async def _fake_list_connected_systems(_organization_id: str):
-        return {"connected_systems": []}
+    async def _fake_list_connected_connectors(_organization_id: str):
+        return {"connectors": []}
 
     monkeypatch.setattr(credits, "deduct_with_grace", _fake_deduct_with_grace)
     monkeypatch.setattr(tools, "_should_skip_approval", _fake_should_skip_approval)
-    monkeypatch.setattr(tools, "_list_connected_systems", _fake_list_connected_systems)
+    monkeypatch.setattr(tools, "_list_connected_connectors", _fake_list_connected_connectors)
 
     result = asyncio.run(
         tools.execute_tool(
-            tool_name="list_connected_systems",
+            tool_name="list_connected_connectors",
             tool_input={},
             organization_id="00000000-0000-0000-0000-000000000001",
             user_id="00000000-0000-0000-0000-000000000002",
@@ -52,5 +52,5 @@ def test_execute_tool_marks_turn_for_credit_closeout_when_grace_used(monkeypatch
         )
     )
 
-    assert result.get("connected_systems") == []
+    assert result.get("connectors") == []
     assert result.get("_out_of_credits_after_turn") is True

--- a/backend/tests/test_tools_write_to_system_of_record.py
+++ b/backend/tests/test_tools_write_to_system_of_record.py
@@ -4,8 +4,8 @@ from agents import tools
 from services import credits
 
 
-def test_write_to_system_routes_to_dispatcher(monkeypatch) -> None:
-    """write_to_system is the generic connector write tool; test that it routes and approval is applied."""
+def test_write_on_connector_routes_to_dispatcher(monkeypatch) -> None:
+    """write_on_connector is the generic connector write tool; test that it routes and approval is applied."""
     called: dict[str, object] = {}
 
     async def _fake_should_skip_approval(
@@ -18,7 +18,7 @@ def test_write_to_system_routes_to_dispatcher(monkeypatch) -> None:
         called["skip_context"] = context
         return True
 
-    async def _fake_write_to_system(
+    async def _fake_write_on_connector(
         params: dict[str, object],
         organization_id: str,
         user_id: str | None,
@@ -36,14 +36,14 @@ def test_write_to_system_routes_to_dispatcher(monkeypatch) -> None:
         return True, False
 
     monkeypatch.setattr(tools, "_should_skip_approval", _fake_should_skip_approval)
-    monkeypatch.setattr(tools, "_write_to_system", _fake_write_to_system)
+    monkeypatch.setattr(tools, "_write_on_connector", _fake_write_on_connector)
     monkeypatch.setattr(credits, "deduct_with_grace", _fake_deduct_with_grace)
 
     result = asyncio.run(
         tools.execute_tool(
-            tool_name="write_to_system",
+            tool_name="write_on_connector",
             tool_input={
-                "system": "hubspot",
+                "connector": "hubspot",
                 "operation": "create_contact",
                 "data": {"email": "a@b.com"},
             },
@@ -54,7 +54,7 @@ def test_write_to_system_routes_to_dispatcher(monkeypatch) -> None:
     )
 
     assert result.get("status") == "created"
-    assert called["skip_tool_name"] == "write_to_system"
+    assert called["skip_tool_name"] == "write_on_connector"
     assert called["organization_id"] == "00000000-0000-0000-0000-000000000001"
     assert called["user_id"] == "00000000-0000-0000-0000-000000000002"
     assert called["skip_approval"] is True

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2357,45 +2357,44 @@ function getToolStatusText(
       }
       return `Running ${workflowName}...`;
     }
-    case 'query_system': {
-      const systemSlug = typeof input?.system === 'string' ? input.system : '';
-      const systemLabel = systemSlug
-        ? systemSlug.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
-        : 'connected system';
+    case 'query_on_connector': {
+      const connectorSlug: string = typeof input?.connector === 'string' ? input.connector : '';
+      const connectorLabel: string = connectorSlug
+        ? connectorSlug.replace(/_/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase())
+        : 'connector';
       if (isComplete) {
-        if (result?.error) return `Query to ${systemLabel} failed`;
+        if (result?.error) return `Query to ${connectorLabel} failed`;
         const count = typeof result?.count === 'number' ? result.count : (Array.isArray(result?.files) ? result.files.length : undefined);
-        const isSingleFileRead = systemSlug === 'google_drive' && result?.file_name != null && result?.content != null;
-        if (count !== undefined && systemSlug === 'google_drive') {
-          return count === 1 ? `Read 1 file from ${systemLabel}` : `Read ${count} files from ${systemLabel}`;
+        const isSingleFileRead: boolean = connectorSlug === 'google_drive' && result?.file_name != null && result?.content != null;
+        if (count !== undefined && connectorSlug === 'google_drive') {
+          return count === 1 ? `Read 1 file from ${connectorLabel}` : `Read ${count} files from ${connectorLabel}`;
         }
-        if (isSingleFileRead) return `Read 1 file from ${systemLabel}`;
-        return `Queried ${systemLabel}`;
+        if (isSingleFileRead) return `Read 1 file from ${connectorLabel}`;
+        return `Queried ${connectorLabel}`;
       }
-      return `Querying ${systemLabel}...`;
+      return `Querying ${connectorLabel}...`;
     }
-    case 'write_to_system': {
-      const writeSystem = typeof input?.system === 'string' ? input.system : '';
-      const writeOp = typeof input?.operation === 'string' ? input.operation : 'write';
-      const systemLabel = writeSystem ? writeSystem.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()) : 'system';
-      const opLabel = writeOp.replace(/_/g, ' ');
+    case 'write_on_connector': {
+      const writeConnector: string = typeof input?.connector === 'string' ? input.connector : '';
+      const writeOp: string = typeof input?.operation === 'string' ? input.operation : 'write';
+      const connectorLabel: string = writeConnector ? writeConnector.replace(/_/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase()) : 'connector';
+      const opLabel: string = writeOp.replace(/_/g, ' ');
       if (isComplete) {
-        return result?.error ? `Write to ${systemLabel} failed` : `Wrote to ${systemLabel} (${opLabel})`;
+        return result?.error ? `Write to ${connectorLabel} failed` : `Wrote to ${connectorLabel} (${opLabel})`;
       }
-      return `Writing to ${systemLabel} (${opLabel})...`;
+      return `Writing to ${connectorLabel} (${opLabel})...`;
     }
-    case 'run_action': {
-      const actionSystem: string = typeof input?.system === 'string' ? input.system : '';
+    case 'run_on_connector': {
+      const actionConnector: string = typeof input?.connector === 'string' ? input.connector : '';
       const actionName: string = typeof input?.action === 'string' ? input.action : '';
-      const systemLabel: string = actionSystem ? actionSystem.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()) : '';
+      const connectorLabel: string = actionConnector ? actionConnector.replace(/_/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase()) : '';
       const actionLabel: string = actionName ? actionName.replace(/_/g, ' ') : '';
-      if (systemLabel && actionLabel) {
+      if (connectorLabel && actionLabel) {
         if (isComplete) {
-          return result?.error ? `Action on ${systemLabel} failed` : `Ran ${actionLabel} on ${systemLabel}`;
+          return result?.error ? `Action on ${connectorLabel} failed` : `Ran ${actionLabel} on ${connectorLabel}`;
         }
-        return `Running ${actionLabel} on ${systemLabel}...`;
+        return `Running ${actionLabel} on ${connectorLabel}...`;
       }
-      // No system/action yet (e.g. still streaming) — show tool name so it's clear what's running
       if (isComplete) {
         return result?.error ? 'Connector action failed' : 'Completed connector action';
       }


### PR DESCRIPTION
## Summary
- Renames all agent-facing connector tools to a consistent `*_on_connector` pattern: `query_on_connector`, `write_on_connector`, `run_on_connector`, `list_connected_connectors`, `get_connector_docs`
- Removes all agent-visible uses of "system" (tool names, params, descriptions, prompt text, error messages)
- Updates connector usage guides (Google Drive, HubSpot, Linear, GitHub, Slack) to reference correct tool names and clarify that actions like `create_file`/`edit_file` are called via `run_on_connector`
- Updates frontend tool status text, credit costs, auth routes, and tests

## Test plan
- [x] `pytest -q tests/` — 145 passed
- [ ] Ask the agent "what tools do you have?" — should show new names
- [ ] Ask "how would you edit a Google Doc?" — should reference `run_on_connector` not `edit_file` as a standalone tool
- [ ] Verify connector actions (Slack send, Drive create/edit) still work end-to-end


Made with [Cursor](https://cursor.com)