### PR TITLE
Fix NOT NULL violation when connecting builtin integrations

### DIFF
--- a/backend/models/integration.py
+++ b/backend/models/integration.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from models.database import Base
 
 
-class Integration(Base):
+class Integration(Base):  # type: ignore[misc]
     """
     Integration model for tracking connected integrations.
 
@@ -35,6 +35,13 @@ class Integration(Base):
     - share_query_access: Others can query live data via this connection
     - share_write_access: Others can write via this connection (almost always false)
     """
+
+    def __init__(self, **kwargs: Any) -> None:
+        if "provider" not in kwargs and "connector" in kwargs:
+            kwargs["provider"] = kwargs["connector"]
+        elif "connector" not in kwargs and "provider" in kwargs:
+            kwargs["connector"] = kwargs["provider"]
+        super().__init__(**kwargs)
 
     __tablename__ = "integrations"
     __table_args__ = (
@@ -53,6 +60,9 @@ class Integration(Base):
 
     # Connector slug: 'hubspot', 'slack', 'google_calendar', 'salesforce', 'gmail', etc.
     connector: Mapped[str] = mapped_column(String(50), nullable=False)
+
+    # Legacy column kept for DB NOT-NULL constraint; always mirrors `connector`.
+    provider: Mapped[str] = mapped_column(String(50), nullable=False)
 
     # Owner of this integration (who authenticated)
     # NOTE: nullable=True for backwards compatibility during migration.


### PR DESCRIPTION
## Summary
- The `integrations` DB table has a legacy `provider` NOT NULL column that wasn't mapped in the SQLAlchemy model, causing all new integration inserts (e.g. enabling code_sandbox) to fail with an IntegrityError.
- Adds the `provider` column to the model and auto-syncs it with `connector` in `__init__` so all existing call sites work without changes.

## Test plan
- [ ] Toggle code_sandbox connector on/off in the UI — should succeed without 500 errors
- [ ] Create a new organization (waitlist flow) — web_search integration should auto-create successfully


Made with [Cursor](https://cursor.com)