### PR TITLE
Fix blank error display in app SDK

### DIFF
--- a/frontend/src/components/apps/appSdkSource.ts
+++ b/frontend/src/components/apps/appSdkSource.ts
@@ -64,7 +64,7 @@ export function useAppQuery(queryName, params) {
       setColumns(json.columns ?? []);
     } catch (err) {
       if (err.name !== "AbortError") {
-        setError(err.message || "Unknown error");
+        setError(err instanceof Error ? err : new Error(err.message || "Unknown error"));
       }
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- App SDK `useAppQuery` stored errors as plain strings, but generated app code (e.g. Dark Deal Alerts) accesses `error.message` expecting an Error object
- This caused a blank "Error:" display when queries failed — the error text was invisible to users
- Now wraps caught errors in `new Error()` so `.message` always works

## Test plan
- [ ] Trigger a query failure in an app (e.g. invalid query name, network error) and verify the error message displays correctly
- [ ] Verify working apps still load and render data normally
- [ ] `npm run build` and `npm run lint` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)