### PR TITLE
Fix pending changes badge not refreshing on org switch

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -229,13 +229,15 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
     }
   }, [user?.id]);
 
-  // Fetch on mount + listen for updates
+  // Fetch on mount, on org switch, + listen for updates
+  const orgId = organization?.id;
   useEffect(() => {
+    setPendingChangesCount(0);
     void fetchPendingCount();
     const handle = (): void => { void fetchPendingCount(); };
     window.addEventListener('pending-changes-updated', handle);
     return () => window.removeEventListener('pending-changes-updated', handle);
-  }, [fetchPendingCount]);
+  }, [fetchPendingCount, orgId]);
 
   // React Query: Get team members for member count (single source of truth)
   const { data: teamData } = useTeamMembers(


### PR DESCRIPTION
## Summary
- Sidebar "Changes" badge showed stale count after switching organizations
- `fetchPendingCount` callback only depended on `user.id`, so switching orgs didn't trigger a re-fetch
- Now resets count to 0 and re-fetches when `organization.id` changes

## Test plan
- [ ] Switch between orgs with different pending change counts — badge should update immediately
- [ ] Badge should still update when changes are committed/discarded within the same org

🤖 Generated with [Claude Code](https://claude.com/claude-code)