### PR TITLE
Fix Celery worker DB connection timeouts

### DIFF
--- a/backend/workers/tasks/bulk_operations.py
+++ b/backend/workers/tasks/bulk_operations.py
@@ -50,17 +50,24 @@ def _redis_key(operation_id: str, field: str) -> str:
     return f"bulk_op:{operation_id}:{field}"
 
 
-def run_async(coro: Any) -> Any:
-    """Run an async function in a sync Celery task context."""
-    from models.database import dispose_engine
+_worker_loop: asyncio.AbstractEventLoop | None = None
 
-    dispose_engine()
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        return loop.run_until_complete(coro)
-    finally:
-        loop.close()
+
+def run_async(coro: Any) -> Any:
+    """Run an async function in a sync Celery task context.
+
+    Reuses a single event loop per worker process so that asyncpg connections
+    remain valid across task invocations.
+    """
+    global _worker_loop
+
+    if _worker_loop is None or _worker_loop.is_closed():
+        from models.database import dispose_engine
+        dispose_engine()
+        _worker_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(_worker_loop)
+
+    return _worker_loop.run_until_complete(coro)
 
 
 async def _mark_operation_failed(operation_id: str, organization_id: str, error: str) -> None:

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -32,24 +32,24 @@ PROVIDER_SYNC_INTERVALS: dict[str, timedelta] = {
 DEFAULT_SYNC_INTERVAL: timedelta = timedelta(hours=1)
 
 
+_worker_loop: asyncio.AbstractEventLoop | None = None
+
+
 def run_async(coro: Any) -> Any:
     """Run an async function in a sync context (for Celery tasks).
-    
-    Creates a fresh event loop and disposes any existing database connections
-    to avoid 'Future attached to different loop' errors with asyncpg.
+
+    Reuses a single event loop per worker process so that asyncpg connections
+    remain valid across task invocations.
     """
-    from models.database import dispose_engine
-    
-    # Dispose existing connections - they're tied to a previous (closed) event loop
-    # and will cause "Future attached to different loop" errors if reused
-    dispose_engine()
-    
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        return loop.run_until_complete(coro)
-    finally:
-        loop.close()
+    global _worker_loop
+
+    if _worker_loop is None or _worker_loop.is_closed():
+        from models.database import dispose_engine
+        dispose_engine()
+        _worker_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(_worker_loop)
+
+    return _worker_loop.run_until_complete(coro)
 
 
 async def _sync_integration(

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -481,24 +481,27 @@ def format_workflow_runtime_context_for_prompt(
     )
 
 
+_worker_loop: asyncio.AbstractEventLoop | None = None
+
+
 def run_async(coro: Any) -> Any:
     """Run an async function in a sync context (for Celery tasks).
-    
-    Creates a fresh event loop and disposes any existing database connections
-    to avoid 'Future attached to different loop' errors with asyncpg.
+
+    Reuses a single event loop per worker process so that asyncpg connections
+    (which are bound to a specific loop) remain valid across task invocations.
+    This avoids the costly dispose-and-reconnect cycle that was causing
+    TimeoutError on every check_scheduled_workflows call.
     """
-    from models.database import dispose_engine
-    
-    # Dispose existing connections - they're tied to a previous (closed) event loop
-    # and will cause "Future attached to different loop" errors if reused
-    dispose_engine()
-    
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        return loop.run_until_complete(coro)
-    finally:
-        loop.close()
+    global _worker_loop
+
+    if _worker_loop is None or _worker_loop.is_closed():
+        from models.database import dispose_engine
+        # Only dispose when we truly need a new loop (first call or after a crash)
+        dispose_engine()
+        _worker_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(_worker_loop)
+
+    return _worker_loop.run_until_complete(coro)
 
 
 async def _check_scheduled_workflows() -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- `run_async()` in Celery workers was disposing the SQLAlchemy engine and creating a new asyncio event loop on **every task invocation**
- Since `process_pending_events` runs every 10s, this destroyed the connection pool constantly
- When `check_scheduled_workflows` (every 60s) tried to connect right after, `asyncpg` timed out trying to establish a fresh Postgres connection — visible as `TimeoutError` in production logs
- Fix: reuse a single event loop per worker process so the engine and its pooled connections stay valid
- Applied to all three task modules: `workflows.py`, `bulk_operations.py`, `sync.py`

## Test plan
- [ ] Deploy to staging, verify `check_scheduled_workflows` no longer raises `TimeoutError`
- [ ] Verify `process_pending_events` continues succeeding every 10s
- [ ] Verify data sync tasks still work correctly
- [ ] Monitor connection pool metrics — should see stable connection count instead of churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)