### PR TITLE
Rename agent from Penny to Basebase

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -109,9 +109,9 @@ VITE_NANGO_PUBLIC_KEY=...
 
 OAuth redirect stays as `api.nango.dev/oauth/callback`; no change needed when you change app/API domain. Ensure **VITE_NANGO_PUBLIC_KEY** is set when building the frontend (required for the Connect UI popup); if it’s missing, connecting GitHub or other Nango integrations can fail.
 
-### Slack: Add-to-Slack (Penny bot) and Nango Connect
+### Slack: Add-to-Slack (Basebase bot) and Nango Connect
 
-To support both (1) **Connect** (Nango OAuth) and (2) **Add Penny to Slack** (other workspaces installing the bot), use a single Slack OAuth callback on your backend:
+To support both (1) **Connect** (Nango OAuth) and (2) **Add Basebase to Slack** (other workspaces installing the bot), use a single Slack OAuth callback on your backend:
 
 1. **Slack app** (api.slack.com → Your App → OAuth & Permissions): set **Redirect URL** to:
    ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Basebase: Agentic Intelligence for Companies
 
-Basebase is an **agentic intelligence framework** that connects to the siloed tools and data sources your business already uses — CRM, email, calendars, Slack, issue trackers, code repos, meeting transcripts, and more — and exposes a unified AI agent (called "**Penny**") in Slack and in a web app that helps team members work faster, smarter, and with full context.
+Basebase is an **agentic intelligence framework** that connects to the siloed tools and data sources your business already uses — CRM, email, calendars, Slack, issue trackers, code repos, meeting transcripts, and more — and exposes a unified AI agent (called "**Basebase**") in Slack and in a web app that helps team members work faster, smarter, and with full context.
 
-Instead of switching between a dozen tabs, employees ask **Penny** questions in natural language — via the **web app** or **Slack** — and get instant, data-backed answers, reports, and actions across every connected system.
+Instead of switching between a dozen tabs, employees ask **Basebase** questions in natural language — via the **web app** or **Slack** — and get instant, data-backed answers, reports, and actions across every connected system.
 
 ## Architecture
 
@@ -39,13 +39,13 @@ All integrations connect via OAuth through [Nango](https://nango.dev) — tokens
 ### How Users Interact
 
 - **Web App** — Full-featured React interface with real-time chat (WebSocket-streamed), a data browser, semantic search, workflow manager, and a pending-changes approval panel for CRM writes.
-- **Slack** — DM the bot or @mention it in any channel. Penny reads the thread context and responds inline. Conversations sync between Slack and the web app.
+- **Slack** — DM the bot or @mention it in any channel. Basebase reads the thread context and responds inline. Conversations sync between Slack and the web app.
 
 ### Synchronous and Asynchronous Agent Operation
 
 Basebase supports multiple execution modes:
 
-- **Synchronous (real-time)** — Users chat with Penny via WebSocket. Tool calls execute inline and results stream back token-by-token.
+- **Synchronous (real-time)** — Users chat with Basebase via WebSocket. Tool calls execute inline and results stream back token-by-token.
 - **Asynchronous (background)** — Workflows run on a Celery task queue. Scheduled (cron), event-driven (e.g. "after every data sync"), or manually triggered.
 - **Agent Swarms** — Complex tasks can be decomposed into prompt-based workflows that spawn child agents, each tackling a sub-problem. Workflows can trigger other workflows, enabling multi-agent coordination to solve problems no single agent pass could handle.
 

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -172,7 +172,7 @@ async def update_tool_result(
         logger.error(f"[update_tool_result] Error: {e}")
         return False
 
-SYSTEM_PROMPT = """You are Penny, an AI assistant created by Basebase that helps business teams to work across their siloed tools and data sources.
+SYSTEM_PROMPT = """You are Basebase, an AI assistant created by Basebase that helps business teams to work across their siloed tools and data sources.
 
 You help team members quickly gather and summarize information and also complete tasks using the tools from the Basebase platform.
 
@@ -376,7 +376,7 @@ WHERE d.organization_id = :org_id
 ```
 
 ### apps
-Interactive mini-apps created by Penny (dashboards, charts with filters, etc.).
+Interactive mini-apps created by Basebase (dashboards, charts with filters, etc.).
 ```
 id, organization_id, user_id, title, description, queries (JSONB), frontend_code (TEXT), created_at
 ```

--- a/backend/api/routes/apps.py
+++ b/backend/api/routes/apps.py
@@ -1,5 +1,5 @@
 """
-Penny Apps API routes.
+Basebase Apps API routes.
 
 Provides endpoints to:
 - Execute named queries from an app's server-side spec

--- a/backend/config.py
+++ b/backend/config.py
@@ -119,7 +119,7 @@ class Settings(BaseSettings):
     
     # Slack Events API (for receiving DMs)
     SLACK_SIGNING_SECRET: Optional[str] = None
-    # Slack OAuth app (same app as Nango uses) — for "Add Penny to Slack" bot-install flow
+    # Slack OAuth app (same app as Nango uses) — for "Add Basebase to Slack" bot-install flow
     SLACK_CLIENT_ID: Optional[str] = None
     SLACK_CLIENT_SECRET: Optional[str] = None
     # Public backend URL (for Slack OAuth redirect_uri). Default from FRONTEND_URL for local.

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -89,7 +89,7 @@ class SlackConnector(BaseConnector):
                 description="Send a message to Slack. Provide `channel` for channels/DM IDs, or `user_id` to open a DM and send directly to that user. Uses Slack mrkdwn: *bold*, _italic_, ~strike~.",
                 parameters=[
                     {"name": "channel", "type": "string", "required": False, "description": "Channel/DM/MPIM ID (e.g. 'C123', 'D123', 'G123') or channel name"},
-                    {"name": "user_id", "type": "string", "required": False, "description": "Slack user ID (e.g. 'U123'). If provided without channel, Penny opens a DM to this user and sends the message."},
+                    {"name": "user_id", "type": "string", "required": False, "description": "Slack user ID (e.g. 'U123'). If provided without channel, Basebase opens a DM to this user and sends the message."},
                     {"name": "text", "type": "string", "required": True, "description": "Message text in Slack mrkdwn format"},
                     {"name": "thread_ts", "type": "string", "required": False, "description": "Thread timestamp to reply in-thread (when channel is provided)"},
                 ],

--- a/backend/db/migrations/versions/065_create_apps_table.py
+++ b/backend/db/migrations/versions/065_create_apps_table.py
@@ -1,4 +1,4 @@
-"""Create apps table for interactive Penny mini-apps.
+"""Create apps table for interactive Basebase mini-apps.
 
 Separates apps from the artifacts table. Apps have dedicated columns
 for queries (JSONB) and frontend_code (Text) instead of overloading

--- a/backend/db/migrations/versions/078_slack_bot_installs.py
+++ b/backend/db/migrations/versions/078_slack_bot_installs.py
@@ -1,6 +1,6 @@
 """Add slack_bot_installs table for Add-to-Slack (bot install) OAuth flow.
 
-Stores bot tokens for workspaces that add Penny via the public "Add to Slack"
+Stores bot tokens for workspaces that add Basebase via the public "Add to Slack"
 link, so we can route events to the correct org without going through Nango.
 
 Revision ID: 078_slack_bot_installs

--- a/backend/db/migrations/versions/093_activity_visibility_scoping.py
+++ b/backend/db/migrations/versions/093_activity_visibility_scoping.py
@@ -1,6 +1,6 @@
 """Add activity visibility scoping (integration_id, owner_user_id, visibility).
 
-Enables per-connector "others can read" enforcement so Penny respects
+Enables per-connector "others can read" enforcement so Basebase respects
 share_synced_data when querying activities (e.g., private emails).
 
 Revision ID: 093_activity_visibility_scoping

--- a/backend/models/app.py
+++ b/backend/models/app.py
@@ -1,5 +1,5 @@
 """
-App model - interactive mini-apps created by Penny.
+App model - interactive mini-apps created by Basebase.
 
 Each app has server-side SQL queries and client-side React code.
 Separate from Artifact which handles static files (text, markdown, PDF, charts).

--- a/backend/models/slack_bot_install.py
+++ b/backend/models/slack_bot_install.py
@@ -12,7 +12,7 @@ from models.database import Base
 
 
 class SlackBotInstall(Base):
-    """Stores bot token for a workspace that added Penny via the public Add-to-Slack link."""
+    """Stores bot token for a workspace that added Basebase via the public Add-to-Slack link."""
 
     __tablename__ = "slack_bot_installs"
 

--- a/backend/services/conversation_summary.py
+++ b/backend/services/conversation_summary.py
@@ -30,7 +30,7 @@ _MAX_MESSAGES_FOR_PROMPT = 50
 _MODEL = "claude-3-5-haiku-20241022"
 
 _SYSTEM_PROMPT = (
-    "You summarize conversations between a user and an AI assistant called Penny. "
+    "You summarize conversations between a user and an AI assistant called Basebase. "
     "Return ONLY valid JSON with two keys:\n"
     '- "overall": A 1-2 sentence summary of the entire conversation so far.\n'
     '- "recent": A 1-2 sentence summary of the most recent exchange(s).\n'

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -348,7 +348,7 @@ async def send_invitation_email(to_email: str, name: str) -> bool:
                 <tr>
                   <td style="padding:20px 24px;">
                     <p style="margin:0 0 12px;font-size:14px;font-weight:600;color:#111;">One AI for your whole team</p>
-                    <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.6;">Penny lives in your Slack workspace. Ask her anything &mdash; deal updates, meeting prep, customer research &mdash; and she answers right in the thread. When one person learns something, the whole team benefits.</p>
+                    <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.6;">Basebase lives in your Slack workspace. Ask it anything &mdash; deal updates, meeting prep, customer research &mdash; and it answers right in the thread. When one person learns something, the whole team benefits.</p>
                   </td>
                 </tr>
               </table>
@@ -368,11 +368,11 @@ async def send_invitation_email(to_email: str, name: str) -> bool:
     """
 
     text_content: str = f"""
-{name}, you're invited to use Penny in your Slack workspace.
+{name}, you're invited to use Basebase in your Slack workspace.
 
 Sign up for Basebase to get started.
 
-Penny lives in your Slack workspace. Ask her anything -- deal updates, meeting prep, customer research -- and she answers right in the thread. When one person learns something, the whole team benefits.
+Basebase lives in your Slack workspace. Ask it anything -- deal updates, meeting prep, customer research -- and it answers right in the thread. When one person learns something, the whole team benefits.
 
 Get started: {invite_url}
 
@@ -447,15 +447,15 @@ async def send_org_invitation_email(
     invite_url: str = f"{settings.FRONTEND_URL}?{'&'.join(params)}"
 
     headline: str = (
-        f"{invited_by_name} invited you to use Penny in {org_name}&apos;s Slack workspace"
+        f"{invited_by_name} invited you to use Basebase in {org_name}&apos;s Slack workspace"
         if invited_by_name
-        else f"You&apos;ve been invited to use Penny in {org_name}&apos;s Slack workspace"
+        else f"You&apos;ve been invited to use Basebase in {org_name}&apos;s Slack workspace"
     )
 
     subject: str = (
-        f"{invited_by_name} invited you to use Penny"
+        f"{invited_by_name} invited you to use Basebase"
         if invited_by_name
-        else f"You're invited to use Penny in {org_name}'s Slack"
+        else f"You're invited to use Basebase in {org_name}'s Slack"
     )
 
     html_content: str = f"""
@@ -499,7 +499,7 @@ async def send_org_invitation_email(
                 <tr>
                   <td style="padding:20px 24px;">
                     <p style="margin:0 0 12px;font-size:14px;font-weight:600;color:#111;">One AI for your whole team</p>
-                    <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.6;">Penny lives in your Slack workspace. Ask her anything &mdash; deal updates, meeting prep, customer research &mdash; and she answers right in the thread. When one person learns something, the whole team benefits.</p>
+                    <p style="margin:0;color:#6b7280;font-size:13px;line-height:1.6;">Basebase lives in your Slack workspace. Ask it anything &mdash; deal updates, meeting prep, customer research &mdash; and it answers right in the thread. When one person learns something, the whole team benefits.</p>
                   </td>
                 </tr>
               </table>
@@ -507,7 +507,7 @@ async def send_org_invitation_email(
           </tr>
           <tr>
             <td style="padding:28px 36px;text-align:center;">
-              <p style="margin:0;color:#9ca3af;font-size:12px;line-height:1.6;">You received this email because someone at {org_name} invited you to use Penny.<br/>If this wasn&apos;t expected, you can safely ignore it.</p>
+              <p style="margin:0;color:#9ca3af;font-size:12px;line-height:1.6;">You received this email because someone at {org_name} invited you to use Basebase.<br/>If this wasn&apos;t expected, you can safely ignore it.</p>
             </td>
           </tr>
         </table>
@@ -519,9 +519,9 @@ async def send_org_invitation_email(
     """
 
     headline_text: str = (
-        f"{invited_by_name} invited you to use Penny in {org_name}'s Slack workspace."
+        f"{invited_by_name} invited you to use Basebase in {org_name}'s Slack workspace."
         if invited_by_name
-        else f"You've been invited to use Penny in {org_name}'s Slack workspace."
+        else f"You've been invited to use Basebase in {org_name}'s Slack workspace."
     )
 
     text_content: str = f"""
@@ -529,7 +529,7 @@ async def send_org_invitation_email(
 
 Sign up for Basebase to accept.
 
-Penny lives in your Slack workspace. Ask her anything -- deal updates, meeting prep, customer research -- and she answers right in the thread. When one person learns something, the whole team benefits.
+Basebase lives in your Slack workspace. Ask it anything -- deal updates, meeting prep, customer research -- and it answers right in the thread. When one person learns something, the whole team benefits.
 
 Get started: {invite_url}
 

--- a/backend/services/slack_bot_install.py
+++ b/backend/services/slack_bot_install.py
@@ -1,7 +1,7 @@
 """
 Slack "Add to Slack" (bot install) flow — token storage and lookup.
 
-When another workspace adds the Penny bot via the public link, we exchange
+When another workspace adds the Basebase bot via the public link, we exchange
 the OAuth code ourselves and store the bot token here (not in Nango).
 Events from that workspace are then routed to the correct org via
 find_organization_by_slack_team + get_slack_bot_token.

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -18,12 +18,12 @@ def test_execute_action_send_message_can_initiate_dm_with_user_id(monkeypatch) -
     result = asyncio.run(
         connector.execute_action(
             "send_message",
-            {"user_id": "U123", "text": "Hi from Penny"},
+            {"user_id": "U123", "text": "Hi from Basebase"},
         )
     )
 
     assert result == {"ok": True}
-    assert captured == {"slack_user_id": "U123", "text": "Hi from Penny"}
+    assert captured == {"slack_user_id": "U123", "text": "Hi from Basebase"}
 
 
 def test_execute_action_send_message_accepts_legacy_message_param(monkeypatch) -> None:

--- a/backend/tests/test_slack_events_direct_messages.py
+++ b/backend/tests/test_slack_events_direct_messages.py
@@ -29,7 +29,7 @@ def test_process_event_callback_routes_mpim_messages_to_direct_message_handler(m
             "channel_type": "mpim",
             "channel": "G123",
             "user": "U123",
-            "text": "hey penny",
+            "text": "hey basebase",
             "ts": "1700000000.001",
         },
     }
@@ -40,7 +40,7 @@ def test_process_event_callback_routes_mpim_messages_to_direct_message_handler(m
         "team_id": "T123",
         "channel_id": "G123",
         "user_id": "U123",
-        "message_text": "hey penny",
+        "message_text": "hey basebase",
         "event_ts": "1700000000.001",
         "thread_ts": None,
     }

--- a/backend/utils/transpile_jsx.py
+++ b/backend/utils/transpile_jsx.py
@@ -55,7 +55,7 @@ def _extract_component_name(code: str) -> str:
 
 def transpile_jsx(source: str) -> tuple[str, str] | None:
     """
-    Transpile Penny app JSX source into plain JS.
+    Transpile Basebase app JSX source into plain JS.
 
     1. Extract the component name from the raw source.
     2. Strip imports/exports (same transforms as the frontend).

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -1179,8 +1179,8 @@ export function DataSources(): JSX.Element {
       return (
         <div className="mt-4 pt-4 border-t border-surface-700/50 space-y-3">
           <div className="text-xs text-surface-400 space-y-1">
-            <p><strong className="text-surface-300">To sync:</strong> Invite @Penny to channels—type <code className="text-surface-300">/invite @Penny</code> or add her from channel details.</p>
-            <p><strong className="text-surface-300">To chat:</strong> Mention @Penny in any channel she’s in; she’ll reply in the thread.</p>
+            <p><strong className="text-surface-300">To sync:</strong> Invite @Basebase to channels—type <code className="text-surface-300">/invite @Basebase</code> or add it from channel details.</p>
+            <p><strong className="text-surface-300">To chat:</strong> Mention @Basebase in any channel it's in; it'll reply in the thread.</p>
           </div>
           <div className="flex items-center justify-between">
             <div>
@@ -1721,7 +1721,7 @@ export function DataSources(): JSX.Element {
               From your team ({fromTeamConnectors.length})
             </h2>
             <p className="text-sm text-surface-400 mb-4">
-              Teammates have connected these personal integrations. Connect your own for Penny to access your data.
+              Teammates have connected these personal integrations. Connect your own for Basebase to access your data.
             </p>
             <div className="grid gap-4">
               {fromTeamConnectors.map((integration) => renderIntegrationTile(integration, 'team-only'))}
@@ -1980,7 +1980,7 @@ export function DataSources(): JSX.Element {
                       Others can read
                     </div>
                     <div className="text-xs text-surface-500 mt-0.5">
-                      When on: teammates and Penny can see synced records (emails, meetings, etc.). When off: only you can see it.
+                      When on: teammates and Basebase can see synced records (emails, meetings, etc.). When off: only you can see it.
                     </div>
                   </div>
                 </label>

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -371,7 +371,7 @@ export function Home(): JSX.Element {
       </header>
 
       <div className="flex-1 overflow-auto p-4 md:p-6">
-        {/* Banner: "Choose App" when org has apps, "Ask Penny" when none */}
+        {/* Banner: "Choose App" when org has apps, "Ask Basebase" when none */}
         {orgAppCount > 0 ? (
           <div className="mb-4 md:mb-6 bg-surface-800/60 border border-surface-700 rounded-xl p-4">
             <div className="flex items-center gap-3">
@@ -405,7 +405,7 @@ export function Home(): JSX.Element {
               <div className="flex-1 min-w-0">
                 <p className="text-surface-300 text-sm">
                   <span className="font-medium text-surface-200">Make this Home tab your own</span>
-                  {' '}— ask Penny to build a custom dashboard and it will appear here for your whole team.
+                  {' '}— ask Basebase to build a custom dashboard and it will appear here for your whole team.
                 </p>
               </div>
               <button
@@ -417,7 +417,7 @@ export function Home(): JSX.Element {
                 }}
                 className="flex-shrink-0 px-3 py-1.5 bg-primary-600 hover:bg-primary-500 text-white text-xs font-medium rounded-lg transition-colors"
               >
-                Ask Penny
+                Ask Basebase
               </button>
             </div>
           </div>

--- a/frontend/src/components/OnboardingWizard.tsx
+++ b/frontend/src/components/OnboardingWizard.tsx
@@ -90,8 +90,8 @@ function generateUUID(): string {
 }
 
 const SKIP_MESSAGES: Record<number, string> = {
-  2: "Without Slack, Penny won't respond in your workspace. You can connect Slack later from Connectors. Skip for now?",
-  3: "Fewer connections mean Penny has less context. You can add sources anytime from Connectors. Skip?",
+  2: "Without Slack, Basebase won't respond in your workspace. You can connect Slack later from Connectors. Skip for now?",
+  3: "Fewer connections mean Basebase has less context. You can add sources anytime from Connectors. Skip?",
   4: "You can invite teammates later from Team settings. Skip?",
 };
 
@@ -515,10 +515,10 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
                   <span className="text-3xl">&#x1F44B;</span>
                 </div>
                 <h1 className="text-2xl font-bold text-white leading-tight">
-                  Meet Penny, your new<br />AI teammate
+                  Meet Basebase, your new<br />AI teammate
                 </h1>
                 <p className="text-surface-300 mt-3 text-[15px] leading-relaxed max-w-sm mx-auto">
-                  She finds data across all your tools, manages tasks, runs workflows,
+                  It finds data across all your tools, manages tasks, runs workflows,
                   and keeps your whole team in the loop — so nobody has to sign into
                   five different apps to get one answer.
                 </p>
@@ -541,7 +541,7 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
                 <div>
                   <label htmlFor="websiteUrl" className="block text-sm font-medium text-surface-300 mb-1.5">
                     Company website
-                    <span className="text-surface-500 font-normal ml-1">(so Penny can learn about you)</span>
+                    <span className="text-surface-500 font-normal ml-1">(so Basebase can learn about you)</span>
                   </label>
                   <input
                     id="websiteUrl"
@@ -604,7 +604,7 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
                   Welcome to {organization?.name ?? 'your team'}!
                 </h1>
                 <p className="text-surface-300 mt-3 text-[15px] leading-relaxed max-w-sm mx-auto">
-                  You&apos;re all set as a member. Let&apos;s connect your tools so Penny
+                  You&apos;re all set as a member. Let&apos;s connect your tools so Basebase
                   can help you alongside your team.
                 </p>
               </div>
@@ -687,12 +687,12 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
                 <h2 className="text-xl font-bold text-white">
                   {slackSatisfied && !slackConnected
                     ? 'Slack is ready'
-                    : isInvitedMode ? 'Connect your Slack account' : 'Bring Penny where your team already works'}
+                    : isInvitedMode ? 'Connect your Slack account' : 'Bring Basebase where your team already works'}
                 </h2>
                 <p className="text-surface-300 mt-3 text-sm leading-relaxed">
                   {slackSatisfied && !slackConnected
-                    ? 'Your team already connected Slack for this team. Penny is available in any channel the bot has been invited to.'
-                    : <>Connect Slack and your team can ask Penny anything right from the channels they&apos;re
+                    ? 'Your team already connected Slack for this team. Basebase is available in any channel the bot has been invited to.'
+                    : <>Connect Slack and your team can ask Basebase anything right from the channels they&apos;re
                       already in &mdash; deal updates, meeting prep, customer research &mdash; no tab-switching required.</>
                   }
                 </p>
@@ -714,7 +714,7 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
                   <svg className="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
-                  <span className="font-medium">Slack connected &mdash; Penny is in your workspace!</span>
+                  <span className="font-medium">Slack connected &mdash; Basebase is in your workspace!</span>
                 </div>
               ) : (
                 <button
@@ -740,12 +740,12 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
             <>
               <div className="mb-6">
                 <h2 className="text-xl font-bold text-white">
-                  {isInvitedMode ? 'Connect your data sources' : 'Give Penny superpowers'}
+                  {isInvitedMode ? 'Connect your data sources' : 'Give Basebase superpowers'}
                 </h2>
                 <p className="text-surface-300 mt-2 text-sm leading-relaxed">
                   {isInvitedMode
-                    ? 'Team-wide sources are already set up. Connect your personal accounts (email, calendar) so Penny has full context.'
-                    : 'Now that you can ask Penny questions directly in Slack, what data sources do you want her to be able to read/write?'
+                    ? 'Team-wide sources are already set up. Connect your personal accounts (email, calendar) so Basebase has full context.'
+                    : 'Now that you can ask Basebase questions directly in Slack, what data sources do you want it to be able to read/write?'
                   }
                 </p>
               </div>
@@ -830,7 +830,7 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
                 </div>
                 <h2 className="text-xl font-bold text-white">Better together</h2>
                 <p className="text-surface-300 mt-3 text-sm leading-relaxed">
-                  Invite your teammates and watch the magic happen! Penny gets smarter with
+                  Invite your teammates and watch the magic happen! Basebase gets smarter with
                   every person who joins. Meeting briefs, deal updates, customer insights
                   &mdash; all synced and accessible. Less chasing, more celebrating together.
                 </p>
@@ -879,11 +879,11 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
                 <h2 className="text-2xl font-bold text-white">You&apos;re ready to roll</h2>
                 <p className="text-surface-300 mt-3 text-sm leading-relaxed max-w-sm mx-auto">
                   Your free plan includes <span className="text-white font-semibold">100 credits/month</span> &mdash;
-                  enough to explore everything Penny can do. Upgrade anytime if you want more.
+                  enough to explore everything Basebase can do. Upgrade anytime if you want more.
                 </p>
               </div>
               <div className="space-y-2 mb-2 p-4 rounded-xl bg-surface-800/50 border border-surface-700/50">
-                <p className="text-surface-400 text-xs font-medium mb-3">Try asking Penny:</p>
+                <p className="text-surface-400 text-xs font-medium mb-3">Try asking Basebase:</p>
                 <div className="flex flex-col gap-2">
                   <div className="self-start rounded-2xl rounded-bl-sm px-4 py-2.5 bg-primary-500/15 border border-primary-500/25 text-sm text-surface-100 max-w-[92%]">
                     &ldquo;Catch me up on what I missed this week&rdquo;
@@ -903,7 +903,7 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
             </>
           )}
 
-          {/* Step 6: Success — Penny's research + launch */}
+          {/* Step 6: Success — Basebase's research + launch */}
           {contentStep === 6 && (
             <>
               <div className="text-center mb-6">
@@ -912,7 +912,7 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
                 </div>
                 <h2 className="text-2xl font-bold text-white">Setup complete!</h2>
                 <p className="text-surface-300 mt-2 text-sm">
-                  While you were setting up, Penny got a head start.
+                  While you were setting up, Basebase got a head start.
                 </p>
               </div>
               {companySummary ? (
@@ -924,13 +924,13 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
               ) : companySummaryLoading ? (
                 <div className="mb-6 p-5 rounded-xl bg-surface-800/50 border border-surface-700 animate-pulse">
                   <p className="text-surface-400 text-sm">
-                    Penny is researching your company&hellip;
+                    Basebase is researching your company&hellip;
                   </p>
                 </div>
               ) : (
                 <div className="mb-6 p-5 rounded-xl bg-surface-800/50 border border-surface-700">
                   <p className="text-surface-300 text-sm">
-                    Penny is ready to learn about your business. Start a conversation and she&apos;ll
+                    Basebase is ready to learn about your business. Start a conversation and it&apos;ll
                     get up to speed fast.
                   </p>
                 </div>
@@ -940,7 +940,7 @@ export function OnboardingWizard({ emailDomain, isInvitedMode = false, isCreatin
                 onClick={onComplete}
                 className="w-full btn-primary py-3.5 text-base font-semibold"
               >
-                Start chatting with Penny
+                Start chatting with Basebase
               </button>
               <div className="flex justify-center gap-1.5 pt-6">
                 {Array.from({ length: TOTAL_STEPS }, (_, i) => (

--- a/frontend/src/components/apps/AppPreviewPanel.tsx
+++ b/frontend/src/components/apps/AppPreviewPanel.tsx
@@ -1,7 +1,7 @@
 /**
  * Persistent app preview panel shown above the chat messages.
  *
- * Displays the active Penny App with a header bar containing:
+ * Displays the active Basebase App with a header bar containing:
  * - App title + switcher dropdown (when multiple apps exist)
  * - Collapse toggle (hides/shows the renderer)
  * - Close (X) button to dismiss the preview

--- a/frontend/src/components/apps/AppViewer.tsx
+++ b/frontend/src/components/apps/AppViewer.tsx
@@ -1,10 +1,10 @@
 /**
- * App viewer component for displaying an interactive Penny App in the side panel.
+ * App viewer component for displaying an interactive Basebase App in the side panel.
  *
  * Wraps SandpackAppRenderer with:
  * - Header showing title and type badge
  * - Share / Embed action buttons
- * - Error feedback ("Fix it" prompt sent back to Penny)
+ * - Error feedback ("Fix it" prompt sent back to Basebase)
  */
 
 import { useState, useCallback } from "react";

--- a/frontend/src/components/apps/AppsGallery.tsx
+++ b/frontend/src/components/apps/AppsGallery.tsx
@@ -1,5 +1,5 @@
 /**
- * Apps gallery page – lists all Penny apps for the current org.
+ * Apps gallery page – lists all Basebase apps for the current org.
  *
  * Accessible via the "Apps" nav item in the sidebar.
  */
@@ -226,7 +226,7 @@ export function AppsGallery(): JSX.Element {
         <div>
           <h1 className="text-xl font-bold text-surface-100">Apps</h1>
           <p className="text-sm text-surface-400 mt-1">
-            Interactive dashboards and data views created by Penny
+            Interactive dashboards and data views created by Basebase
           </p>
         </div>
         <span className="text-sm text-surface-500">
@@ -251,7 +251,7 @@ export function AppsGallery(): JSX.Element {
           </svg>
           <p className="text-surface-400 mb-2">No apps yet</p>
           <p className="text-surface-500 text-sm">
-            Ask Penny to create an interactive chart or dashboard in chat
+            Ask Basebase to create an interactive chart or dashboard in chat
           </p>
         </div>
       ) : (

--- a/frontend/src/components/apps/HomeAppPicker.tsx
+++ b/frontend/src/components/apps/HomeAppPicker.tsx
@@ -133,7 +133,7 @@ export function HomeAppPicker({
 
               {apps.length === 0 && (
                 <div className="text-center py-6 text-surface-500 text-sm">
-                  No apps yet. Ask Penny to create one!
+                  No apps yet. Ask Basebase to create one!
                 </div>
               )}
             </div>

--- a/frontend/src/components/apps/SandpackAppRenderer.tsx
+++ b/frontend/src/components/apps/SandpackAppRenderer.tsx
@@ -1,11 +1,11 @@
 /**
- * Renders a Penny App inside a sandboxed srcdoc iframe.
+ * Renders a Basebase App inside a sandboxed srcdoc iframe.
  *
  * Replaces the Sandpack-based approach with a simpler, more reliable method:
  * 1. React + ReactDOM + Plotly loaded from CDN as UMD globals
  * 2. Babel standalone transpiles JSX in-browser
  * 3. SDK + Plot shim inlined (no module bundler needed)
- * 4. Penny's code has imports stripped (everything is already in scope)
+ * 4. Basebase's code has imports stripped (everything is already in scope)
  *
  * The iframe uses sandbox="allow-scripts" for security isolation.
  */
@@ -49,7 +49,7 @@ function stripModuleSyntax(code: string): string {
 }
 
 /**
- * Transform Penny's code for the srcdoc environment:
+ * Transform Basebase's code for the srcdoc environment:
  * - Strip imports (everything is in global scope)
  * - Capture the default-exported component name
  */
@@ -291,7 +291,7 @@ export function SandpackAppRenderer({
           borderRadius: 8,
           background: "#18181b",
         }}
-        title="Penny App"
+        title="Basebase App"
       />
     </div>
   );

--- a/frontend/src/components/apps/appSdkSource.ts
+++ b/frontend/src/components/apps/appSdkSource.ts
@@ -4,7 +4,7 @@
  * This is shipped as a string constant so SandpackAppRenderer can place it
  * at /node_modules/@revtops/app-sdk/index.js inside the sandbox filesystem.
  *
- * Penny's generated React code imports from "@revtops/app-sdk".
+ * Basebase's generated React code imports from "@revtops/app-sdk".
  */
 
 export const APP_SDK_SOURCE: string = `


### PR DESCRIPTION
Renames the agent from Penny to Basebase across the codebase:

- **Agent identity:** System prompt, conversation summary, orchestrator
- **User-facing UI:** OnboardingWizard, Home, DataSources, app components
- **Emails:** Invitation templates (her/she → it)
- **Docs:** README, DEPLOY
- **Code:** Comments, docstrings, migrations, tests

**Manual step:** Update Slack App display name to "Basebase" in [Slack API App Settings](https://api.slack.com/apps) so `@Basebase` matches in-app instructions.

Made with [Cursor](https://cursor.com)