### PR TITLE
Rate-limit useAppQuery to prevent DB connection exhaustion

### DIFF
--- a/frontend/src/components/apps/appSdkSource.ts
+++ b/frontend/src/components/apps/appSdkSource.ts
@@ -29,13 +29,15 @@ export function useAppQuery(queryName, params, options) {
   const [error, setError]     = useState(null);
   const abortRef = useRef(null);
   const lastFetchedAt = useRef(0);
+  const lastParamKey = useRef("");
 
   // Stable serialisation of params for the dependency array
   const paramKey = JSON.stringify(params ?? {});
 
   const refetch = useCallback(async () => {
-    // Throttle: skip if last successful fetch was less than MIN_REFETCH_MS ago
-    if (Date.now() - lastFetchedAt.current < MIN_REFETCH_MS) return;
+    // Throttle: skip if same params and last fetch was recent
+    const paramsChanged = paramKey !== lastParamKey.current;
+    if (!paramsChanged && Date.now() - lastFetchedAt.current < MIN_REFETCH_MS) return;
 
     // Abort any in-flight request
     if (abortRef.current) abortRef.current.abort();
@@ -69,6 +71,7 @@ export function useAppQuery(queryName, params, options) {
       setData(json.data ?? []);
       setColumns(json.columns ?? []);
       lastFetchedAt.current = Date.now();
+      lastParamKey.current = paramKey;
     } catch (err) {
       if (err.name !== "AbortError") {
         setError(err instanceof Error ? err : new Error(err.message || "Unknown error"));


### PR DESCRIPTION
## Summary
- Add 5-second throttle (`MIN_REFETCH_MS`) on `useAppQuery.refetch()` in the App SDK — if called within 5s of the last successful fetch, the call is a no-op
- Add optional `refetchInterval` option to `useAppQuery(queryName, params, { refetchInterval: 30000 })` for built-in polling with cleanup, replacing the `setInterval` + epoch cache-bust hack pattern
- Protects all Penny apps automatically without requiring app code changes

## Context
The System Performance Dashboard fires 6 SQL queries every 30s per open tab (12 queries/min) with no throttle. Multiple tabs compound this, contributing to DB connection exhaustion. This SDK-level fix caps refetch frequency across all apps.

## Test plan
- [ ] `npm run build && npm run lint` pass
- [ ] Open an existing Penny app with auto-refresh — still refreshes on its normal interval (30s > 5s cooldown)
- [ ] Rapidly spam a manual refresh — only one query fires per 5s window
- [ ] Verify new `refetchInterval` option works when provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)