### PR TITLE
Add live Drive API fallback for file search

### DIFF
--- a/backend/connectors/google_drive.py
+++ b/backend/connectors/google_drive.py
@@ -15,6 +15,7 @@ Flow:
 5. Agent can edit existing files (user must have edit permission on the file)
 """
 
+import asyncio
 import json
 import logging
 import re
@@ -776,7 +777,11 @@ Call via `run_on_connector(connector='google_drive', action='edit_file', params=
         await self.get_oauth_token()
 
         escaped_term: str = cleaned_query.replace("'", "\\'")
-        drive_query: str = f"name contains '{escaped_term}' and trashed=false"
+        drive_query: str = (
+            f"name contains '{escaped_term}'"
+            f" and mimeType != '{GOOGLE_FOLDER_MIME}'"
+            f" and trashed=false"
+        )
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(
@@ -801,18 +806,15 @@ Call via `run_on_connector(connector='google_drive', action='edit_file', params=
 
             api_files: list[dict[str, Any]] = resp.json().get("files", [])
 
-        # Filter out folders
-        api_files = [
-            f for f in api_files if f.get("mimeType") != GOOGLE_FOLDER_MIME
-        ]
-
         # Filter by requested MIME types if specified
         if mime_types:
             api_files = [f for f in api_files if f.get("mimeType") in mime_types]
 
         # Upsert into shared_files so subsequent queries hit the fast DB path
-        for file_meta in api_files:
-            await self._upsert_created_file(file_meta)
+        if api_files:
+            await asyncio.gather(
+                *(self._upsert_created_file(f) for f in api_files)
+            )
 
         now_iso: str = f"{datetime.utcnow().isoformat()}Z"
         return [
@@ -823,7 +825,7 @@ Call via `run_on_connector(connector='google_drive', action='edit_file', params=
                 "mime_type": f.get("mimeType", ""),
                 "folder_path": "/",
                 "web_view_link": f.get("webViewLink"),
-                "file_size": f.get("size"),
+                "file_size": None,
                 "source_modified_at": (
                     f.get("modifiedTime") if f.get("modifiedTime") else None
                 ),


### PR DESCRIPTION
## Summary
- When `search_files()` returns no results from the local DB and a search term is provided, falls back to the live Google Drive API (`files.list` with `name contains '<term>'`)
- Filters out folders server-side in the Drive API query and respects `mime_types` filter
- Upserts discovered files into `shared_files` (in parallel via `asyncio.gather`) so subsequent queries use the fast DB path

## Review feedback addressed

**Result starvation (not fixing):** The suggestion was to always merge live API + DB results. We intentionally skip the API when the DB has results — the DB is the authoritative synced view (refreshed every 30 min) and those results are valid files, not stale. This fallback exists for the specific case where a file was *just added* to Drive and hasn't been synced yet (DB returns 0 results). Merging both sources would introduce deduplication complexity, inconsistent ordering, and mixed data freshness for no real user benefit.

**Sequential upsert bottleneck (fixed):** Replaced sequential `await` loop with `asyncio.gather` so all upserts run concurrently.

**MIME type exclusions (fixed):** Moved folder exclusion (`mimeType != folder`) into the Drive API query string so folders don't consume `pageSize` slots.

**File size mismatch (fixed):** The return dict now uses `file_size: None` to match what `_upsert_created_file` stores and what `SharedFile.to_dict()` returns on subsequent DB queries.

## Test plan
- [ ] Add a new file to Google Drive, immediately search for it via the agent — should find it
- [ ] Search for the same file again — should return from DB (verify via logs)
- [ ] Wildcard/browse queries (no search term) should not trigger the API fallback
- [ ] Verify `py_compile` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)