### PR TITLE
fix: tolerate duplicate integrations in data protection layer

### DIFF
--- a/backend/access_control/data_protection.py
+++ b/backend/access_control/data_protection.py
@@ -91,13 +91,16 @@ async def check_connector_call(
 
         if is_org_scoped:
             result = await session.execute(
-                select(Integration).where(
+                select(Integration)
+                .where(
                     Integration.organization_id == UUID(context.organization_id),
                     Integration.connector == context.provider,
                     Integration.is_active == True,  # noqa: E712
                 )
+                .order_by(Integration.updated_at.desc().nullslast())
+                .limit(1)
             )
-            shared_integration = result.scalar_one_or_none()
+            shared_integration: Integration | None = result.scalars().first()
             if shared_integration:
                 return DataProtectionResult(
                     allowed=True,
@@ -114,14 +117,17 @@ async def check_connector_call(
 
             if share_flag is not None:
                 result = await session.execute(
-                    select(Integration).where(
+                    select(Integration)
+                    .where(
                         Integration.organization_id == UUID(context.organization_id),
                         Integration.connector == context.provider,
                         Integration.is_active == True,  # noqa: E712
                         share_flag == True,  # noqa: E712
                     )
+                    .order_by(Integration.updated_at.desc().nullslast())
+                    .limit(1)
                 )
-                shared_integration = result.scalar_one_or_none()
+                shared_integration: Integration | None = result.scalars().first()
                 if shared_integration:
                     return DataProtectionResult(
                         allowed=True,

--- a/backend/api/routes/connectors.py
+++ b/backend/api/routes/connectors.py
@@ -96,13 +96,16 @@ async def handle_connector_webhook(
 
     async with get_session(organization_id=organization_id) as session:
         result = await session.execute(
-            select(Integration).where(
+            select(Integration)
+            .where(
                 Integration.organization_id == org_uuid,
                 Integration.connector == provider,
-                Integration.is_active == True,
+                Integration.is_active == True,  # noqa: E712
             )
+            .order_by(Integration.updated_at.desc().nullslast())
+            .limit(1)
         )
-        integration: Integration | None = result.scalar_one_or_none()
+        integration: Integration | None = result.scalars().first()
 
     if not integration:
         logger.warning(


### PR DESCRIPTION
## Summary
- PR #588 fixed `_get_connector_instance` in `tools.py` but the `MultipleResultsFound` exception was actually thrown **earlier** in `check_connector_call()` (`data_protection.py`), which runs before `_get_connector_instance` is reached
- Applied the same `order_by(updated_at.desc()).limit(1).first()` pattern to the org-scoped and shared-integration queries in `data_protection.py` (2 sites) and the webhook handler in `connectors.py` (1 site)

## Test plan
- [ ] Verify web_search works for orgs with multiple active `web_search` integrations
- [ ] Verify webhook delivery still works for connectors with LISTEN capability

Made with [Cursor](https://cursor.com)