### PR TITLE
perf: speed up chat loading — defer Slack lookup, skeleton UI, paginated sidebar

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -26,7 +26,7 @@ import redis.asyncio as aioredis
 
 
 from pydantic import BaseModel
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.auth_middleware import AuthContext, get_current_auth
@@ -102,8 +102,13 @@ async def _get_slack_user_ids(
 
 def _build_conversation_access_filter(
     auth: AuthContext,
-    slack_user_ids: set[str],
+    slack_user_ids: set[str] | None = None,
 ):
+    """Build an OR filter for conversations the user may access.
+
+    When *slack_user_ids* is ``None`` (or empty) the Slack branch is omitted,
+    making the query cheaper for the common non-Slack path.
+    """
     # User's own conversations (private or shared)
     user_filter = or_(
         Conversation.user_id == auth.user_id,
@@ -247,38 +252,61 @@ async def list_conversations(
     org_id = auth.organization_id_str
 
     async with get_session(organization_id=org_id) as session:
-        slack_user_ids = await _get_slack_user_ids(auth, session=session)
-        # Simple query - message_count and last_message_preview are cached on the conversation
-        # Filter out workflow conversations - they're accessed via Automations tab, not chat list
+        # Fast path: query without Slack filter first
         query = (
-            select(Conversation, func.count(Conversation.id).over().label("total_count"))
+            select(Conversation)
             .where(Conversation.type != "workflow")
+            .where(_build_conversation_access_filter(auth))
         )
-        query = query.where(_build_conversation_access_filter(auth, slack_user_ids))
-        
-        # Optional scope filter
+
         if scope in ("shared", "private"):
             query = query.where(Conversation.scope == scope)
-        if slack_user_ids:
-            logger.info(
-                "[chat] Listing conversations for user=%s with Slack IDs %s",
-                auth.user_id_str,
-                sorted(slack_user_ids),
-            )
+
         result = await session.execute(
             query.order_by(Conversation.updated_at.desc())
             .offset(offset)
             .limit(limit)
         )
-        rows = result.all()
+        conversations: list[Conversation] = list(result.scalars().all())
 
-        # Extract total from first row (window function returns same value for all rows)
-        total: int = rows[0][1] if rows else 0
+        # Slow path: if we got fewer rows than limit, Slack conversations may
+        # be missing. Resolve Slack IDs and merge any additional results.
+        if len(conversations) < limit:
+            slack_user_ids = await _get_slack_user_ids(auth, session=session)
+            if slack_user_ids:
+                logger.info(
+                    "[chat] Listing conversations for user=%s with Slack IDs %s",
+                    auth.user_id_str,
+                    sorted(slack_user_ids),
+                )
+                seen_ids = {c.id for c in conversations}
+                slack_query = (
+                    select(Conversation)
+                    .where(Conversation.type != "workflow")
+                    .where(Conversation.source == "slack")
+                    .where(Conversation.source_user_id.in_(slack_user_ids))
+                )
+                if auth.organization_id:
+                    slack_query = slack_query.where(
+                        Conversation.organization_id == auth.organization_id
+                    )
+                if scope in ("shared", "private"):
+                    slack_query = slack_query.where(Conversation.scope == scope)
+
+                slack_result = await session.execute(
+                    slack_query.order_by(Conversation.updated_at.desc()).limit(limit)
+                )
+                for conv in slack_result.scalars().all():
+                    if conv.id not in seen_ids:
+                        conversations.append(conv)
+                        seen_ids.add(conv.id)
+
+                conversations.sort(key=lambda c: c.updated_at, reverse=True)
+                conversations = conversations[:limit]
 
         # Collect all participant user IDs to fetch in one query
         all_participant_ids: set[UUID] = set()
-        for row in rows:
-            conv: Conversation = row[0]
+        for conv in conversations:
             for uid in (conv.participating_user_ids or []):
                 all_participant_ids.add(uid)
 
@@ -293,9 +321,7 @@ async def list_conversations(
 
         # Build response using cached fields
         response_items: list[ConversationResponse] = []
-        for row in rows:
-            conv: Conversation = row[0]
-
+        for conv in conversations:
             if conv.source == "slack":
                 preview_length = len(conv.last_message_preview or "")
                 logger.debug(
@@ -339,7 +365,7 @@ async def list_conversations(
 
         return ConversationListResponse(
             conversations=response_items,
-            total=total,
+            total=len(response_items),
         )
 
 
@@ -410,13 +436,13 @@ async def create_conversation(
 async def get_conversation(
     conversation_id: str,
     auth: AuthContext = Depends(get_current_auth),
-    limit: int = 30,
+    limit: int = 15,
     before: Optional[str] = None,
 ) -> ConversationDetailResponse:
     """Get a conversation with its messages (paginated).
 
     Args:
-        limit: Number of messages to return (default 30).
+        limit: Number of messages to return (default 15).
         before: ISO timestamp cursor — return messages created before this time
                 (pass the oldest loaded message's ``created_at`` to page backwards).
     """
@@ -438,13 +464,24 @@ async def get_conversation(
     org_id = auth.organization_id_str
 
     async with get_session(organization_id=org_id) as session:
-        slack_user_ids = await _get_slack_user_ids(auth, session=session)
+        # Fast path: try without Slack lookup (covers web chats + shared org chats)
         result = await session.execute(
             select(Conversation)
             .where(Conversation.id == conv_uuid)
-            .where(_build_conversation_access_filter(auth, slack_user_ids))
+            .where(_build_conversation_access_filter(auth))
         )
         conversation = result.scalar_one_or_none()
+
+        # Slow path: conversation not found — may be a Slack DM visible only via source_user_id
+        if not conversation:
+            slack_user_ids = await _get_slack_user_ids(auth, session=session)
+            if slack_user_ids:
+                result = await session.execute(
+                    select(Conversation)
+                    .where(Conversation.id == conv_uuid)
+                    .where(_build_conversation_access_filter(auth, slack_user_ids))
+                )
+                conversation = result.scalar_one_or_none()
 
         if not conversation:
             raise HTTPException(status_code=404, detail="Conversation not found")

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -52,6 +52,8 @@ export interface ConversationSummary {
   updated_at: string;
   message_count: number;
   last_message_preview: string | null;
+  scope?: "private" | "shared";
+  participants?: Array<{ id: string; name: string | null; email: string; avatar_url?: string | null }>;
 }
 
 export interface ConversationListResponse {

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -25,6 +25,7 @@ import { Home } from './Home';
 import { DataSources } from './DataSources';
 import { Data } from './Data';
 import { Chat } from './Chat';
+import { ChatsList } from './ChatsList';
 import { Workflows } from './Workflows';
 import { Memories } from './Memories';
 import { AdminPanel } from './AdminPanel';
@@ -398,6 +399,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
         return;
       }
       const viewMap: Record<string, typeof currentView> = {
+        chats: "chats",
         sources: "data-sources",
         data: "data",
         workflows: "workflows",
@@ -436,6 +438,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
     const viewPaths: Record<string, typeof currentView> = {
       "/": "home",
       "/chat": "chat",
+      "/chats": "chats",
       "/sources": "data-sources",
       "/data": "data",
       "/workflows": "workflows",
@@ -501,6 +504,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       const viewPaths: Record<typeof currentView, string> = {
         home: "/",
         chat: "/chat",
+        chats: "/chats",
         "data-sources": "/sources",
         data: "/data",
         workflows: "/workflows",
@@ -1251,6 +1255,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
   const viewTitles: Record<string, string> = {
     home: 'Home',
     chat: 'Chat',
+    chats: 'All Chats',
     'data-sources': 'Connectors',
     workflows: 'Workflows',
     memory: 'Memory',
@@ -1408,6 +1413,13 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
             crmApprovalResults={crmApprovalResults}
             onConversationNotFound={handleConversationNotFound}
             creditsInfo={billingStatus ? { balance: billingStatus.credits_balance, included: billingStatus.credits_included } : null}
+          />
+        )}
+        {currentView === 'chats' && (
+          <ChatsList
+            chats={recentChats}
+            onSelectChat={handleSelectChat}
+            onNewChat={startNewChat}
           />
         )}
         {currentView === 'data-sources' && (

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1222,11 +1222,39 @@ export function Chat({
   }, [chatId]);
 
   if (isLoading) {
+    const skeletonTitle: string =
+      useAppStore.getState().recentChats.find((c) => c.id === chatId)?.title ?? 'Loading…';
+
     return (
-      <div className="flex-1 flex items-center justify-center min-h-0 overflow-hidden">
-        <div className="flex flex-col items-center gap-4">
-          <div className="w-8 h-8 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
-          <p className="text-surface-400">Loading...</p>
+      <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+        {/* Header skeleton */}
+        <header className="hidden md:flex h-14 border-b border-surface-800 items-center px-4 md:px-6 flex-shrink-0">
+          <h1 className="text-lg font-semibold text-surface-100 truncate max-w-md">{skeletonTitle}</h1>
+        </header>
+
+        {/* Message skeletons */}
+        <div className="flex-1 overflow-hidden p-3 md:p-6">
+          <div className="max-w-3xl mx-auto space-y-4">
+            {Array.from({ length: 6 }, (_, i) => (
+              <div key={i} className={`flex gap-3 ${i % 2 === 0 ? '' : 'justify-end'}`}>
+                <div className={`flex gap-2 ${i % 2 === 0 ? 'max-w-[70%]' : 'max-w-[60%] flex-row-reverse'}`}>
+                  <div className="w-6 h-6 rounded-md bg-surface-800 animate-pulse flex-shrink-0" />
+                  <div className="space-y-1.5 flex-1">
+                    <div className={`h-3.5 rounded bg-surface-800 animate-pulse ${i % 3 === 0 ? 'w-3/4' : 'w-full'}`} />
+                    <div className={`h-3.5 rounded bg-surface-800 animate-pulse ${i % 2 === 0 ? 'w-5/6' : 'w-2/3'}`} />
+                    {i % 3 === 0 && <div className="h-3.5 rounded bg-surface-800 animate-pulse w-1/2" />}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Input skeleton */}
+        <div className="flex-shrink-0 border-t border-surface-800 p-3 md:p-4">
+          <div className="max-w-3xl mx-auto">
+            <div className="h-11 rounded-xl bg-surface-800/50 animate-pulse" />
+          </div>
         </div>
       </div>
     );

--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -1,17 +1,14 @@
 /**
- * Chats list view showing all historical conversations.
- * 
- * Features:
- * - Search/filter chats
- * - Sort by date
- * - Delete chats
- * - Click to resume conversation
- * - Visual indicators for chats with active background tasks
+ * Full-page chats list view with search, infinite scroll, and paginated API loading.
+ *
+ * Accessible via "View all" in the sidebar chat sections.
  */
 
-import { useMemo, useState } from 'react';
-import type { ChatSummary } from './AppLayout';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ChatSummary } from '../store/types';
 import { useActiveTasksByConversation, useAppStore } from '../store';
+import { listConversations, type ConversationSummary } from '../api/client';
+import { Avatar } from './Avatar';
 
 interface ChatsListProps {
   chats: ChatSummary[];
@@ -19,49 +16,136 @@ interface ChatsListProps {
   onNewChat: () => void;
 }
 
-export function ChatsList({ chats, onSelectChat, onNewChat }: ChatsListProps): JSX.Element {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState<'recent' | 'oldest'>('recent');
+const PAGE_SIZE = 30;
+
+function apiConvToChatSummary(conv: ConversationSummary): ChatSummary {
+  return {
+    id: conv.id,
+    title: conv.title ?? 'New Chat',
+    lastMessageAt: new Date(conv.updated_at),
+    previewText: conv.last_message_preview ?? '',
+    scope: conv.scope ?? 'shared',
+    userId: conv.user_id ?? undefined,
+    participants: conv.participants?.map((p) => ({
+      id: p.id,
+      name: p.name,
+      email: p.email,
+      avatarUrl: p.avatar_url,
+    })),
+  };
+}
+
+export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: ChatsListProps): JSX.Element {
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const [allChats, setAllChats] = useState<ChatSummary[]>([]);
+  const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false);
+  const [hasMore, setHasMore] = useState<boolean>(true);
+  const [initialLoaded, setInitialLoaded] = useState<boolean>(false);
+  const offsetRef = useRef<number>(0);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+
   const activeTasksByConversation = useActiveTasksByConversation();
   const pinnedChatIds = useAppStore((state) => state.pinnedChatIds);
   const togglePinChat = useAppStore((state) => state.togglePinChat);
 
-  const filteredChats = useMemo(() => {
-    const sortedChats = chats
-      .filter((chat) =>
-        chat.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        chat.previewText.toLowerCase().includes(searchQuery.toLowerCase())
-      )
-      .sort((a, b) => {
-        if (sortBy === 'recent') {
-          return b.lastMessageAt.getTime() - a.lastMessageAt.getTime();
-        }
-        return a.lastMessageAt.getTime() - b.lastMessageAt.getTime();
-      });
-    if (pinnedChatIds.length === 0) {
-      return sortedChats;
+  const loadPage = useCallback(async (reset: boolean = false): Promise<void> => {
+    if (isLoadingMore) return;
+    setIsLoadingMore(true);
+    const offset = reset ? 0 : offsetRef.current;
+    try {
+      const { data, error } = await listConversations(PAGE_SIZE, offset);
+      if (error || !data) {
+        setHasMore(false);
+        return;
+      }
+      const mapped: ChatSummary[] = data.conversations.map(apiConvToChatSummary);
+      if (reset) {
+        setAllChats(mapped);
+        offsetRef.current = mapped.length;
+      } else {
+        setAllChats((prev) => {
+          const existingIds = new Set(prev.map((c) => c.id));
+          const deduped = mapped.filter((c) => !existingIds.has(c.id));
+          return [...prev, ...deduped];
+        });
+        offsetRef.current = offset + mapped.length;
+      }
+      setHasMore(mapped.length >= PAGE_SIZE);
+    } finally {
+      setIsLoadingMore(false);
+      setInitialLoaded(true);
     }
+  }, [isLoadingMore]);
+
+  // Initial load
+  useEffect(() => {
+    void loadPage(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Infinite scroll via IntersectionObserver
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && hasMore && !isLoadingMore) {
+          void loadPage(false);
+        }
+      },
+      { rootMargin: '200px' },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, isLoadingMore, loadPage]);
+
+  // Merge sidebar chats (may have more recent data) with loaded chats
+  const mergedChats = useMemo((): ChatSummary[] => {
+    const byId = new Map<string, ChatSummary>();
+    for (const c of allChats) byId.set(c.id, c);
+    for (const c of sidebarChats) byId.set(c.id, c);
+    return Array.from(byId.values()).sort(
+      (a, b) => b.lastMessageAt.getTime() - a.lastMessageAt.getTime(),
+    );
+  }, [allChats, sidebarChats]);
+
+  // Client-side title search
+  const filteredChats = useMemo((): ChatSummary[] => {
+    if (!searchQuery.trim()) return mergedChats;
+    const q = searchQuery.toLowerCase();
+    return mergedChats.filter(
+      (c) =>
+        c.title.toLowerCase().includes(q) ||
+        c.previewText.toLowerCase().includes(q),
+    );
+  }, [mergedChats, searchQuery]);
+
+  // Pinned first
+  const orderedChats = useMemo((): ChatSummary[] => {
+    if (pinnedChatIds.length === 0) return filteredChats;
     const pinnedSet = new Set(pinnedChatIds);
-    const pinned = sortedChats.filter((chat) => pinnedSet.has(chat.id));
-    const unpinned = sortedChats.filter((chat) => !pinnedSet.has(chat.id));
+    const pinned = filteredChats.filter((c) => pinnedSet.has(c.id));
+    const unpinned = filteredChats.filter((c) => !pinnedSet.has(c.id));
     return [...pinned, ...unpinned];
-  }, [chats, pinnedChatIds, searchQuery, sortBy]);
+  }, [filteredChats, pinnedChatIds]);
 
   return (
-    <div className="flex-1 overflow-y-auto">
+    <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
       {/* Header */}
-      <header className="sticky top-0 bg-surface-950 border-b border-surface-800 px-8 py-6">
-        <div className="flex items-center justify-between">
+      <header className="flex-shrink-0 border-b border-surface-800 px-6 md:px-8 py-5">
+        <div className="flex items-center justify-between max-w-4xl mx-auto">
           <div>
-            <h1 className="text-2xl font-bold text-surface-50">Chats</h1>
-            <p className="text-surface-400 mt-1">
-              {chats.length} conversation{chats.length !== 1 ? 's' : ''}
-            </p>
+            <h1 className="text-2xl font-bold text-surface-50">All Chats</h1>
+            {initialLoaded && (
+              <p className="text-surface-400 text-sm mt-0.5">
+                {mergedChats.length} conversation{mergedChats.length !== 1 ? 's' : ''}
+                {hasMore ? '+' : ''}
+              </p>
+            )}
           </div>
-          <button
-            onClick={onNewChat}
-            className="btn-primary flex items-center gap-2"
-          >
+          <button onClick={onNewChat} className="btn-primary flex items-center gap-2">
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
             </svg>
@@ -69,9 +153,9 @@ export function ChatsList({ chats, onSelectChat, onNewChat }: ChatsListProps): J
           </button>
         </div>
 
-        {/* Search & Filter */}
-        <div className="flex items-center gap-4 mt-4">
-          <div className="relative flex-1">
+        {/* Search */}
+        <div className="max-w-4xl mx-auto mt-4">
+          <div className="relative">
             <svg
               className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-surface-500"
               fill="none"
@@ -85,147 +169,188 @@ export function ChatsList({ chats, onSelectChat, onNewChat }: ChatsListProps): J
               placeholder="Search conversations..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="input-field pl-10"
+              className="input-field pl-10 w-full"
+              autoFocus
             />
           </div>
-          <select
-            value={sortBy}
-            onChange={(e) => setSortBy(e.target.value as 'recent' | 'oldest')}
-            className="input-field w-auto"
-          >
-            <option value="recent">Most Recent</option>
-            <option value="oldest">Oldest First</option>
-          </select>
         </div>
       </header>
 
-      {/* Chats List */}
-      <div className="max-w-4xl mx-auto px-8 py-6">
-        {filteredChats.length === 0 ? (
-          <div className="text-center py-16">
-            {searchQuery ? (
-              <>
-                <div className="w-16 h-16 rounded-full bg-surface-800 flex items-center justify-center mx-auto mb-4">
-                  <svg className="w-8 h-8 text-surface-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                  </svg>
-                </div>
-                <h3 className="text-surface-200 font-medium mb-2">No matching chats</h3>
-                <p className="text-surface-400 text-sm">
-                  Try a different search term
-                </p>
-              </>
-            ) : (
-              <>
-                <div className="w-16 h-16 rounded-full bg-surface-800 flex items-center justify-center mx-auto mb-4">
-                  <svg className="w-8 h-8 text-surface-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-                  </svg>
-                </div>
-                <h3 className="text-surface-200 font-medium mb-2">No conversations yet</h3>
-                <p className="text-surface-400 text-sm mb-4">
-                  Start your first conversation to get insights from your data
-                </p>
-                <button onClick={onNewChat} className="btn-primary">
-                  Start a conversation
-                </button>
-              </>
-            )}
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {filteredChats.map((chat) => {
-              const hasActiveTask = chat.id in activeTasksByConversation;
-              const isPinned = pinnedChatIds.includes(chat.id);
-              return (
-                <button
-                  key={chat.id}
-                  onClick={() => onSelectChat(chat.id)}
-                  className="relative w-full text-left p-4 rounded-xl bg-surface-900 hover:bg-surface-800 border border-surface-800 hover:border-surface-700 transition-colors group"
-                >
-                  <div className="flex items-start justify-between gap-4">
-                    {/* Icon - different for workflow vs chat */}
-                    <div className="flex-shrink-0 mt-0.5">
-                      {chat.type === 'workflow' ? (
-                        <svg className="w-5 h-5 text-amber-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                        </svg>
-                      ) : (
-                        <svg className="w-5 h-5 text-surface-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-                        </svg>
-                      )}
+      {/* Scrollable list */}
+      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto">
+        <div className="max-w-4xl mx-auto px-6 md:px-8 py-4">
+          {!initialLoaded ? (
+            <div className="space-y-3">
+              {Array.from({ length: 8 }, (_, i) => (
+                <div key={i} className="p-4 rounded-xl bg-surface-900 border border-surface-800 animate-pulse">
+                  <div className="flex items-start gap-4">
+                    <div className="w-5 h-5 rounded bg-surface-800 flex-shrink-0" />
+                    <div className="flex-1 space-y-2">
+                      <div className="h-4 rounded bg-surface-800 w-2/3" />
+                      <div className="h-3 rounded bg-surface-800 w-1/2" />
                     </div>
-                    
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <h3 className="font-medium text-surface-100 truncate group-hover:text-white transition-colors">
-                          {chat.title}
-                        </h3>
-                        {isPinned && (
-                          <svg className="w-4 h-4 text-primary-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M12 21v-6m0 0l-3-3m3 3l3-3m-6.364-2.364L6 8m0 0l3.636-3.636a3 3 0 014.243 0L18 8m-12 0h12"
-                            />
-                          </svg>
-                        )}
-                        {chat.type === 'workflow' && (
-                          <span className="flex-shrink-0 px-1.5 py-0.5 rounded text-xs bg-amber-500/20 text-amber-400">
-                            Workflow
-                          </span>
-                        )}
-                        {hasActiveTask && (
-                          <span className="flex-shrink-0 flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-primary-500/20 text-primary-400 text-xs">
-                            <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
-                              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                            </svg>
-                            Active
-                          </span>
-                        )}
-                      </div>
-                      <p className="text-sm text-surface-400 truncate mt-1">
-                        {chat.previewText}
-                      </p>
-                    </div>
-                    <div className="text-xs text-surface-500 whitespace-nowrap">
-                      {formatDate(chat.lastMessageAt)}
-                    </div>
+                    <div className="h-3 rounded bg-surface-800 w-16" />
                   </div>
-                  <button
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      togglePinChat(chat.id);
-                    }}
-                    className="absolute right-3 top-3 p-1.5 rounded opacity-0 group-hover:opacity-100 hover:bg-surface-700 text-surface-500 hover:text-surface-200 transition-all"
-                    title={isPinned ? "Unpin conversation" : "Pin conversation"}
-                  >
-                    <svg
-                      className={`w-4 h-4 ${isPinned ? "text-primary-400" : ""}`}
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M12 21v-6m0 0l-3-3m3 3l3-3m-6.364-2.364L6 8m0 0l3.636-3.636a3 3 0 014.243 0L18 8m-12 0h12"
-                      />
+                </div>
+              ))}
+            </div>
+          ) : orderedChats.length === 0 ? (
+            <div className="text-center py-16">
+              {searchQuery ? (
+                <>
+                  <div className="w-16 h-16 rounded-full bg-surface-800 flex items-center justify-center mx-auto mb-4">
+                    <svg className="w-8 h-8 text-surface-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
                     </svg>
-                  </button>
-                </button>
-              );
-            })}
-          </div>
-        )}
+                  </div>
+                  <h3 className="text-surface-200 font-medium mb-2">No matching chats</h3>
+                  <p className="text-surface-400 text-sm">Try a different search term</p>
+                </>
+              ) : (
+                <>
+                  <div className="w-16 h-16 rounded-full bg-surface-800 flex items-center justify-center mx-auto mb-4">
+                    <svg className="w-8 h-8 text-surface-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                    </svg>
+                  </div>
+                  <h3 className="text-surface-200 font-medium mb-2">No conversations yet</h3>
+                  <p className="text-surface-400 text-sm mb-4">Start your first conversation</p>
+                  <button onClick={onNewChat} className="btn-primary">Start a conversation</button>
+                </>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {orderedChats.map((chat) => (
+                <ChatRow
+                  key={chat.id}
+                  chat={chat}
+                  hasActiveTask={chat.id in activeTasksByConversation}
+                  isPinned={pinnedChatIds.includes(chat.id)}
+                  onSelect={onSelectChat}
+                  onTogglePin={togglePinChat}
+                />
+              ))}
+
+              {/* Infinite scroll sentinel */}
+              <div ref={sentinelRef} className="h-1" />
+
+              {isLoadingMore && (
+                <div className="flex justify-center py-4">
+                  <div className="w-6 h-6 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Chat row
+// ---------------------------------------------------------------------------
+
+function ChatRow({
+  chat,
+  hasActiveTask,
+  isPinned,
+  onSelect,
+  onTogglePin,
+}: {
+  chat: ChatSummary;
+  hasActiveTask: boolean;
+  isPinned: boolean;
+  onSelect: (id: string) => void;
+  onTogglePin: (id: string) => void;
+}): JSX.Element {
+  return (
+    <button
+      onClick={() => onSelect(chat.id)}
+      className="relative w-full text-left p-4 rounded-xl bg-surface-900 hover:bg-surface-800 border border-surface-800 hover:border-surface-700 transition-colors group"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-shrink-0 mt-0.5">
+          {chat.scope === 'private' ? (
+            <svg className="w-5 h-5 text-surface-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+          ) : (
+            <svg className="w-5 h-5 text-surface-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+            </svg>
+          )}
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="font-medium text-surface-100 truncate group-hover:text-white transition-colors">
+              {chat.title}
+            </h3>
+            {isPinned && (
+              <svg className="w-4 h-4 text-primary-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+              </svg>
+            )}
+            {chat.type === 'workflow' && (
+              <span className="flex-shrink-0 px-1.5 py-0.5 rounded text-xs bg-amber-500/20 text-amber-400">Workflow</span>
+            )}
+            {hasActiveTask && (
+              <span className="flex-shrink-0 flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-primary-500/20 text-primary-400 text-xs">
+                <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                </svg>
+                Active
+              </span>
+            )}
+            <span className={`flex-shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide ${
+              chat.scope === 'shared'
+                ? 'bg-primary-500/20 text-primary-400'
+                : 'bg-surface-700 text-surface-400'
+            }`}>
+              {chat.scope}
+            </span>
+          </div>
+          <div className="flex items-center gap-2 mt-1">
+            {chat.participants && chat.participants.length > 0 && (
+              <div className="flex -space-x-1.5">
+                {chat.participants.slice(0, 3).map((p, idx) => (
+                  <Avatar key={p.id} user={p} size="xs" bordered style={{ zIndex: 3 - idx }} />
+                ))}
+                {chat.participants.length > 3 && (
+                  <div className="w-5 h-5 rounded-full border border-surface-800 bg-surface-700 flex items-center justify-center text-[10px] font-medium text-surface-300">
+                    +{chat.participants.length - 3}
+                  </div>
+                )}
+              </div>
+            )}
+            <p className="text-sm text-surface-400 truncate">{chat.previewText}</p>
+          </div>
+        </div>
+
+        <div className="text-xs text-surface-500 whitespace-nowrap">{formatDate(chat.lastMessageAt)}</div>
+      </div>
+
+      <button
+        onClick={(e) => { e.stopPropagation(); onTogglePin(chat.id); }}
+        className={`absolute right-3 top-3 p-1.5 rounded ${
+          isPinned ? 'opacity-100 text-primary-400' : 'opacity-0 text-surface-500'
+        } group-hover:opacity-100 hover:bg-surface-700 hover:text-surface-200 transition-all`}
+        title={isPinned ? 'Unpin conversation' : 'Pin conversation'}
+      >
+        <svg className={`w-4 h-4 ${isPinned ? 'text-primary-400' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+        </svg>
+      </button>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function formatDate(date: Date): string {
   const now = new Date();

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -627,6 +627,7 @@ export function Sidebar({
         onSelectChat={onSelectChat}
         onDeleteChat={onDeleteChat}
         togglePinChat={togglePinChat}
+        onViewAll={() => onViewChange('chats')}
       />
 
       {collapsed && <div className="flex-1" />}
@@ -684,6 +685,7 @@ function ChatAccordion({
   onSelectChat,
   onDeleteChat,
   togglePinChat,
+  onViewAll,
 }: {
   collapsed: boolean;
   orderedChats: ChatSummary[];
@@ -694,6 +696,7 @@ function ChatAccordion({
   onSelectChat: (id: string) => void;
   onDeleteChat: (id: string) => void;
   togglePinChat: (id: string) => void;
+  onViewAll: () => void;
 }): JSX.Element | null {
   const [expandedSection, setExpandedSection] = useState<'shared' | 'private'>('shared');
   const [editingChatId, setEditingChatId] = useState<string | null>(null);
@@ -744,8 +747,8 @@ function ChatAccordion({
 
   if (collapsed) return null;
 
-  const sharedChats = orderedChats.filter(c => c.scope === 'shared').slice(0, 50);
-  const privateChats = orderedChats.filter(c => c.scope === 'private').slice(0, 50);
+  const sharedChats = orderedChats.filter(c => c.scope === 'shared').slice(0, 10);
+  const privateChats = orderedChats.filter(c => c.scope === 'private').slice(0, 10);
 
   const renderChatItem = (chat: ChatSummary, showLockIcon: boolean) => {
     const hasActiveTask = chat.id in activeTasksByConversation;
@@ -884,7 +887,18 @@ function ChatAccordion({
   
   return (
     <div className="flex-1 flex flex-col min-h-0 px-2">
-      {/* Shared Section Header - always visible */}
+      {/* Chat History header with View All link */}
+      <div className="flex-shrink-0 flex items-center justify-between px-3 py-2">
+        <span className="text-xs font-semibold text-surface-200 uppercase tracking-wider">Chat History</span>
+        <button
+          onClick={onViewAll}
+          className="text-xs font-medium text-amber-400 hover:text-amber-300 transition-colors"
+        >
+          View All
+        </button>
+      </div>
+
+      {/* Shared Section Header */}
       <button
         onClick={() => setExpandedSection(expandedSection === 'shared' ? 'private' : 'shared')}
         className="flex-shrink-0 w-full flex items-center justify-between px-3 py-2 text-xs font-medium text-surface-400 hover:text-surface-200 transition-colors"
@@ -913,7 +927,7 @@ function ChatAccordion({
         </div>
       )}
       
-      {/* Private Section Header - always visible */}
+      {/* Private Section Header */}
       <button
         onClick={() => setExpandedSection(expandedSection === 'private' ? 'shared' : 'private')}
         className="flex-shrink-0 w-full flex items-center justify-between px-3 py-2 text-xs font-medium text-surface-400 hover:text-surface-200 transition-colors border-t border-surface-800 mt-1"

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -291,7 +291,7 @@ export const useChatStore = create<ChatState>()(
 
         const requestStart = performance.now();
         const { data, error } = await apiRequest<ConversationApiResponse>(
-          `/chat/conversations?limit=40`,
+          `/chat/conversations?limit=20`,
         );
 
         if (error) {

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -245,6 +245,7 @@ export interface ActiveTask {
 export type View =
   | "home"
   | "chat"
+  | "chats"
   | "data-sources"
   | "data"
   | "workflows"


### PR DESCRIPTION
## Summary

- **Defer Slack user ID resolution** in `get_conversation` and `list_conversations` — tries the non-Slack access filter first and only resolves Slack IDs when the conversation isn't found or fewer rows than expected are returned. Saves 1–2 DB queries + Redis lookup per request for non-Slack chats.
- **Remove `COUNT(*) OVER()` window function** from `list_conversations` — this forced Postgres to scan all matching rows before applying LIMIT. The `total` value was never used by the frontend. This was the primary cause of 5–7s sidebar load times.
- **Reduce default message page size** from 30 to 15 in `get_conversation` for faster initial chat loads.
- **Skeleton loading UI** — replace full-screen spinner with an instant chat shell (header with title from sidebar cache, message placeholder bars, input skeleton).
- **Reduce sidebar fetch** from 40 to 20 conversations (10 shared + 10 private shown).
- **Add "View All" chats page** — full-page view with search, infinite scroll (30 per page via `IntersectionObserver`), accessible via "View All" link in the sidebar chat history header.

## Test plan

- [ ] Click a chat in the sidebar — should show skeleton UI briefly, then messages (no full-screen spinner)
- [ ] Sidebar should load in <1s (was 5–7s before the window function removal)
- [ ] "View All" link in sidebar opens `/chats` with full chat list, search, and infinite scroll
- [ ] Slack DM conversations still appear correctly in sidebar and are accessible
- [ ] "Load earlier messages" button works in chat (now loads from message 15 instead of 30)
- [ ] Back/forward browser navigation works for `/chats` route


Made with [Cursor](https://cursor.com)