### PR TITLE
fix: record sync errors to database for user-scoped integrations

### DIFF
--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -925,7 +925,7 @@ async def sync_integration_data(
 
         # Record error in database
         try:
-            connector = connector_class(organization_id)
+            connector = connector_class(organization_id, user_id=user_id)
             await connector.record_error(error_msg)
         except Exception as record_err:
             print(f"[Sync] Failed to record error to DB: {record_err}")

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -496,6 +496,14 @@ class BaseConnector(ABC):
     async def record_error(self, error: str) -> None:
         """Record an error for this integration."""
         if not self._integration:
+            await self._load_integration()
+        if not self._integration:
+            logger.warning(
+                "record_error: no integration found for %s org=%s user=%s; error not persisted",
+                self.source_system,
+                self.organization_id,
+                self.user_id,
+            )
             return
 
         async with get_session(organization_id=self.organization_id) as session:

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -153,7 +153,7 @@ async def _sync_integration(
 
         # Record error in database
         try:
-            connector = connector_class(organization_id)
+            connector = connector_class(organization_id, user_id=user_id)
             await connector.record_error(error_msg)
         except Exception:
             pass


### PR DESCRIPTION
## Problem

11 integrations (5 gmail, 4 google_calendar, 2 fireflies) haven't synced since Mar 5. Errors were silently lost because when sync failed, the error handler created a new connector without passing `user_id`, causing `record_error` to receive a connector with `_integration = None` and return without persisting anything.

## Changes

1. **sync.py & workers/tasks/sync.py**: Pass `user_id` to `connector_class()` in the error handler so the connector can resolve the integration for `record_error`.

2. **base.py record_error**: When `_integration` is None, attempt `_load_integration()` before giving up. Log a warning if still not found (instead of silent return).

## Result

Sync failures will now populate `integrations.last_error`, enabling debugging of stale integrations (e.g. expired Nango tokens) via the database and logs.

Made with [Cursor](https://cursor.com)