### PR TITLE
Fix hourly sync crash: unify worker event loop across all task modules

### DIFF
--- a/backend/workers/celery_app.py
+++ b/backend/workers/celery_app.py
@@ -170,8 +170,8 @@ def setup_backend_path(**kwargs) -> None:
         pass
 
     try:
-        from workers.tasks import sync as sync_module
-        sync_module._worker_loop = None
+        from workers.run_async import reset_worker_loop
+        reset_worker_loop()
     except Exception:
         pass
 

--- a/backend/workers/run_async.py
+++ b/backend/workers/run_async.py
@@ -1,0 +1,51 @@
+"""
+Shared async-to-sync bridge for all Celery task modules.
+
+Every task module MUST use the single `run_async` from here instead of
+maintaining its own `_worker_loop` global.  Having multiple event loops
+in the same worker process causes asyncpg connections created on one loop
+to be used by another, producing:
+
+    RuntimeError: ... got Future ... attached to a different loop
+
+A single loop per worker process guarantees the SQLAlchemy engine's
+connection pool only ever sees one event loop.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_worker_loop: asyncio.AbstractEventLoop | None = None
+
+
+def run_async(coro: Any) -> Any:
+    """Run an async coroutine synchronously inside a Celery worker process.
+
+    Reuses a single event loop per worker process so that asyncpg connections
+    remain valid across task invocations.
+    """
+    global _worker_loop
+
+    if _worker_loop is None or _worker_loop.is_closed():
+        from models.database import dispose_engine
+
+        dispose_engine()
+        _worker_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(_worker_loop)
+        logger.debug("Created new worker event loop id=%s", id(_worker_loop))
+
+    return _worker_loop.run_until_complete(coro)
+
+
+def reset_worker_loop() -> None:
+    """Reset the shared event loop after fork.
+
+    Called from the ``worker_process_init`` signal handler so the first
+    task in a freshly-forked process creates a brand-new loop.
+    """
+    global _worker_loop
+    _worker_loop = None

--- a/backend/workers/tasks/bulk_operations.py
+++ b/backend/workers/tasks/bulk_operations.py
@@ -32,6 +32,7 @@ from celery import group as celery_group
 from sqlalchemy import select, func as sa_func, text
 
 from workers.celery_app import celery_app
+from workers.run_async import run_async
 
 logger = logging.getLogger(__name__)
 
@@ -48,26 +49,6 @@ MAX_BULK_ITEMS: int = 50_000
 # Redis key helpers
 def _redis_key(operation_id: str, field: str) -> str:
     return f"bulk_op:{operation_id}:{field}"
-
-
-_worker_loop: asyncio.AbstractEventLoop | None = None
-
-
-def run_async(coro: Any) -> Any:
-    """Run an async function in a sync Celery task context.
-
-    Reuses a single event loop per worker process so that asyncpg connections
-    remain valid across task invocations.
-    """
-    global _worker_loop
-
-    if _worker_loop is None or _worker_loop.is_closed():
-        from models.database import dispose_engine
-        dispose_engine()
-        _worker_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(_worker_loop)
-
-    return _worker_loop.run_until_complete(coro)
 
 
 async def _mark_operation_failed(operation_id: str, organization_id: str, error: str) -> None:

--- a/backend/workers/tasks/monitoring.py
+++ b/backend/workers/tasks/monitoring.py
@@ -179,7 +179,7 @@ async def _heartbeat_age_seconds() -> int | None:
 @celery_app.task(bind=True, name="workers.tasks.monitoring.monitor_dependencies")
 def monitor_dependencies(self: Any) -> dict[str, Any]:
     """Periodic task: monitor key dependencies and open PagerDuty incidents if down."""
-    import asyncio
+    from workers.run_async import run_async
 
     logger.info("Task %s: Starting dependency monitoring run", self.request.id)
 
@@ -245,13 +245,13 @@ def monitor_dependencies(self: Any) -> dict[str, Any]:
             "down_services": [result.name for result in down],
         }
 
-    return asyncio.run(_run())
+    return run_async(_run())
 
 
 @celery_app.task(bind=True, name="workers.tasks.monitoring.monitoring_heartbeat_watchdog")
 def monitoring_heartbeat_watchdog(self: Any) -> dict[str, Any]:
     """Ensure dependency checks are executing regularly and incident on stale runs."""
-    import asyncio
+    from workers.run_async import run_async
 
     logger.info("Task %s: Starting dependency monitor heartbeat watchdog", self.request.id)
 
@@ -303,4 +303,4 @@ def monitoring_heartbeat_watchdog(self: Any) -> dict[str, Any]:
         )
         return {"status": "ok", "age_seconds": age_seconds}
 
-    return asyncio.run(_run())
+    return run_async(_run())

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -14,13 +14,13 @@ _backend_dir = Path(__file__).resolve().parent.parent.parent
 if str(_backend_dir) not in sys.path:
     sys.path.insert(0, str(_backend_dir))
 
-import asyncio
 import logging
 from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID
 
 from workers.celery_app import celery_app
+from workers.run_async import run_async
 
 logger = logging.getLogger(__name__)
 
@@ -30,26 +30,6 @@ PROVIDER_SYNC_INTERVALS: dict[str, timedelta] = {
     "google_drive": timedelta(minutes=30),
 }
 DEFAULT_SYNC_INTERVAL: timedelta = timedelta(hours=1)
-
-
-_worker_loop: asyncio.AbstractEventLoop | None = None
-
-
-def run_async(coro: Any) -> Any:
-    """Run an async function in a sync context (for Celery tasks).
-
-    Reuses a single event loop per worker process so that asyncpg connections
-    remain valid across task invocations.
-    """
-    global _worker_loop
-
-    if _worker_loop is None or _worker_loop.is_closed():
-        from models.database import dispose_engine
-        dispose_engine()
-        _worker_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(_worker_loop)
-
-    return _worker_loop.run_until_complete(coro)
 
 
 async def _sync_integration(

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -17,7 +17,7 @@ _backend_dir = Path(__file__).resolve().parent.parent.parent
 if str(_backend_dir) not in sys.path:
     sys.path.insert(0, str(_backend_dir))
 
-import asyncio
+
 import json
 import logging
 from datetime import UTC, datetime
@@ -481,27 +481,7 @@ def format_workflow_runtime_context_for_prompt(
     )
 
 
-_worker_loop: asyncio.AbstractEventLoop | None = None
-
-
-def run_async(coro: Any) -> Any:
-    """Run an async function in a sync context (for Celery tasks).
-
-    Reuses a single event loop per worker process so that asyncpg connections
-    (which are bound to a specific loop) remain valid across task invocations.
-    This avoids the costly dispose-and-reconnect cycle that was causing
-    TimeoutError on every check_scheduled_workflows call.
-    """
-    global _worker_loop
-
-    if _worker_loop is None or _worker_loop.is_closed():
-        from models.database import dispose_engine
-        # Only dispose when we truly need a new loop (first call or after a crash)
-        dispose_engine()
-        _worker_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(_worker_loop)
-
-    return _worker_loop.run_until_complete(coro)
+from workers.run_async import run_async
 
 
 async def _check_scheduled_workflows() -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- Four Celery task modules (`sync`, `workflows`, `monitoring`, `bulk_operations`) each maintained their own `_worker_loop` / `asyncio.run()`, creating multiple event loops in the same worker process
- When asyncpg connections created on one loop were checked out by a task running on another loop, the worker crashed with `RuntimeError: Future attached to a different loop` — silently killing hourly syncs for hours at a time
- Extracts a single shared `run_async()` into `workers/run_async.py` so all task modules share one event loop per worker process, and updates `worker_process_init` to reset the single shared loop after fork

## Test plan
- [x] Started local Celery worker with `--concurrency=1` (forces all tasks into one process)
- [x] Fired `process_pending_events`, `monitoring_heartbeat_watchdog`, then `process_pending_events` again sequentially — all succeeded without `Future attached to a different loop`
- [ ] Deploy and verify hourly `sync_all_organizations` runs successfully on the next `:00` mark
- [ ] Check Worker logs for absence of `attached to a different loop` errors over 2+ hours

Made with [Cursor](https://cursor.com)