### PR TITLE
Add Granola connector — meeting notes, transcripts & on-demand query via MCP

### DIFF
--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -189,7 +189,7 @@ register_tool(
     description="""Query a connected connector for on-demand data retrieval.
 
 Use this for any QUERY-capable connector: web search (web_search), Apollo enrichment,
-Google Drive file search/read, or any future connector with query capability.
+Google Drive file search/read, Granola meeting search (granola), or any other connector with query capability.
 
 The query string format depends on the connector. Call `get_connector_docs(connector)` for
 detailed query formats, parameters, and examples before using a connector.""",

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -2707,11 +2707,19 @@ async def get_connect_session(
     # All connections are user-scoped
     connection_id = f"{org_id_str}:user:{user_id_str}"
 
+    org_name: str | None = None
+    async with get_session() as db_session:
+        from models.organization import Organization
+        org_row = await db_session.get(Organization, UUID(org_id_str))
+        if org_row:
+            org_name = org_row.name
+
     nango = get_nango_client()
     try:
         session_data = await nango.create_connect_session(
             integration_id=nango_integration_id,
             connection_id=connection_id,
+            organization_name=org_name or "Basebase",
         )
     except ValueError as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/connectors/granola.py
+++ b/backend/connectors/granola.py
@@ -190,6 +190,14 @@ class GranolaMcpClient:
                 return None
             raise
 
+    async def query_meetings(self, query: str) -> str:
+        """Call query_granola_meetings — semantic search across meetings."""
+        result: Any = await self.call_tool(
+            "query_granola_meetings",
+            {"query": query},
+        )
+        return _extract_text(result) or ""
+
 
 def _extract_content_list(result: Any) -> list[dict[str, Any]]:
     """Parse MCP tool result into a list of content dicts.
@@ -313,8 +321,15 @@ class GranolaConnector(BaseConnector):
         auth_type=AuthType.OAUTH2,
         scope=ConnectorScope.USER,
         entity_types=["activities"],
-        capabilities=[Capability.SYNC],
+        capabilities=[Capability.SYNC, Capability.QUERY],
         nango_integration_id="granola-mcp",
+        query_description=(
+            "Query Granola meetings on demand. Supported formats:\n"
+            "- Natural language search: 'What did we discuss about pricing?'\n"
+            "- Get notes for a specific meeting: 'meeting:<granola_meeting_id>'\n"
+            "- Get transcript for a specific meeting: 'transcript:<granola_meeting_id>'\n"
+            "Natural language queries use Granola's semantic search across all meetings."
+        ),
         description="Granola – meeting notes and transcript sync via MCP",
     )
 
@@ -339,6 +354,45 @@ class GranolaConnector(BaseConnector):
 
     async def fetch_deal(self, deal_id: str) -> dict[str, Any]:
         return {"error": "Granola does not support deals"}
+
+    # -- QUERY capability --------------------------------------------------------
+
+    async def query(self, request: str) -> dict[str, Any]:
+        """Execute an on-demand query against Granola meetings.
+
+        Supports:
+          - ``meeting:<id>``  — fetch notes for a specific meeting
+          - ``transcript:<id>`` — fetch transcript for a specific meeting
+          - bare text — semantic search via query_granola_meetings
+        """
+        stripped: str = request.strip()
+        if not stripped:
+            return {"error": "Empty query"}
+
+        mcp: GranolaMcpClient = await self._get_mcp_client()
+        lower: str = stripped.lower()
+
+        if lower.startswith("meeting:"):
+            meeting_id: str = stripped[len("meeting:"):].strip()
+            if not meeting_id:
+                return {"error": "meeting_id is required after 'meeting:'"}
+            notes: str = await mcp.get_meetings(meeting_ids=[meeting_id])
+            return {"meeting_id": meeting_id, "notes": notes}
+
+        if lower.startswith("transcript:"):
+            meeting_id = stripped[len("transcript:"):].strip()
+            if not meeting_id:
+                return {"error": "meeting_id is required after 'transcript:'"}
+            transcript: str | None = await mcp.get_meeting_transcript(meeting_id)
+            if transcript is None:
+                return {
+                    "meeting_id": meeting_id,
+                    "error": "Transcript not available (may require a paid Granola tier)",
+                }
+            return {"meeting_id": meeting_id, "transcript": transcript}
+
+        result_text: str = await mcp.query_meetings(stripped)
+        return {"query": stripped, "results": result_text}
 
     # -- Main sync ---------------------------------------------------------------
 

--- a/backend/services/nango.py
+++ b/backend/services/nango.py
@@ -447,6 +447,7 @@ class NangoClient:
         connection_id: str,
         organization_id: Optional[str] = None,
         user_id: Optional[str] = None,
+        organization_name: Optional[str] = None,
     ) -> dict[str, Any]:
         """
         Create a Nango Connect session for OAuth.
@@ -476,7 +477,10 @@ class NangoClient:
             elif not org_id:
                 org_id = connection_id
             
-            payload["organization"] = {"id": org_id}
+            org_payload: dict[str, str] = {"id": org_id}
+            if organization_name:
+                org_payload["display_name"] = organization_name
+            payload["organization"] = org_payload
             
             # Set end_user for user-scoped connections
             end_user_id = user_id


### PR DESCRIPTION
## Summary
- New Granola connector that syncs meeting notes and transcripts via the Granola MCP server (Streamable HTTP / JSON-RPC), with OAuth managed through Nango
- Adds on-demand QUERY capability so the agent can semantically search meetings, fetch specific meeting notes, or retrieve transcripts without a full sync
- Passes organization display name to Nango connect sessions so the OAuth consent screen shows "Basebase" instead of the default Nango team name
- Adds Granola to the frontend DataSources UI with a custom logo icon

## Test plan
- [ ] Connect Granola from the DataSources page and verify OAuth flow shows "Basebase"
- [ ] Trigger a sync and confirm meeting notes + transcripts are stored
- [ ] Ask the agent to query Granola meetings (e.g. "What did we discuss about X?") and verify it uses `query_on_connector`
- [ ] Verify `meeting:<id>` and `transcript:<id>` query modes return correct data

Made with [Cursor](https://cursor.com)