### PR TITLE
Add incremental sync to all connectors

### DIFF
--- a/backend/connectors/asana.py
+++ b/backend/connectors/asana.py
@@ -420,9 +420,14 @@ class AsanaConnector(BaseConnector):
                     else:
                         continue  # No teams synced yet
 
+                task_params: dict[str, Any] = {"limit": 100, "opt_fields": task_fields}
+                if self.sync_since:
+                    task_params["modified_since"] = self.sync_since.strftime(
+                        "%Y-%m-%dT%H:%M:%S.000Z"
+                    )
                 tasks: list[dict[str, Any]] = await self._get_paginated(
                     f"/projects/{project_source_id}/tasks",
-                    {"limit": 100, "opt_fields": task_fields},
+                    task_params,
                 )
 
                 for task in tasks:

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -44,6 +44,10 @@ class BaseConnector(ABC):
     # Not required yet (backward compat) but needed for auto-discovery.
     meta: ConnectorMeta
 
+    # Safety buffer subtracted from last_sync_at to avoid missing items
+    # due to clock skew or eventual consistency in upstream APIs.
+    _SYNC_SINCE_BUFFER: timedelta = timedelta(minutes=5)
+
     def __init__(self, organization_id: str, user_id: str | None = None) -> None:
         """
         Initialize the connector.
@@ -57,6 +61,18 @@ class BaseConnector(ABC):
         self._token: str | None = None
         self._credentials: dict[str, Any] | None = None
         self._integration: Integration | None = None
+
+    @property
+    def sync_since(self) -> datetime | None:
+        """Return the cutoff time for incremental sync, or None for first sync.
+
+        When a previous successful sync timestamp exists, returns that time
+        minus a small safety buffer. Connectors should fall back to their
+        default window (e.g. 30 days) when this returns None.
+        """
+        if self._integration and self._integration.last_sync_at:
+            return self._integration.last_sync_at - self._SYNC_SINCE_BUFFER
+        return None
 
     async def ensure_sync_active(self, stage: str) -> None:
         """Stop in-flight syncs when integration has been disconnected or pending config."""

--- a/backend/connectors/fireflies.py
+++ b/backend/connectors/fireflies.py
@@ -199,8 +199,16 @@ class FirefliesConnector(BaseConnector):
         )
         
         print(f"[Fireflies] Fetching transcripts for org {self.organization_id}")
-        transcripts = await self.get_transcripts(limit=50)  # Fireflies max is 50
+        transcripts: list[dict[str, Any]] = await self.get_transcripts(limit=50)
         print(f"[Fireflies] Got {len(transcripts)} transcripts")
+
+        if self.sync_since:
+            cutoff_ms: float = self.sync_since.timestamp() * 1000
+            transcripts = [
+                t for t in transcripts
+                if (t.get("date") or 0) >= cutoff_ms
+            ]
+            print(f"[Fireflies] After incremental filter: {len(transcripts)} transcripts since {self.sync_since}")
 
         count = 0
         # Pass user_id for RLS: activities with owner_only visibility require

--- a/backend/connectors/github.py
+++ b/backend/connectors/github.py
@@ -1387,9 +1387,12 @@ Use `run_sql_query` on `github_repositories`, `github_commits`, `github_pull_req
     async def _sync_commits_for_repo(self, repo: GitHubRepository) -> int:
         """Fetch and upsert commits for a single repo."""
         org_uuid: UUID = UUID(self.organization_id)
+        commit_params: dict[str, Any] = {"sha": repo.default_branch}
+        if self.sync_since:
+            commit_params["since"] = self.sync_since.strftime("%Y-%m-%dT%H:%M:%SZ")
         raw_commits: list[dict[str, Any]] = await self._gh_get_paginated(
             f"/repos/{repo.full_name}/commits",
-            params={"sha": repo.default_branch},
+            params=commit_params,
         )
 
         count: int = 0
@@ -1494,6 +1497,10 @@ Use `run_sql_query` on `github_repositories`, `github_commits`, `github_pull_req
         count: int = 0
         async with get_session(organization_id=self.organization_id) as session:
             for pr in raw_prs:
+                if self.sync_since and pr.get("updated_at"):
+                    updated_at: datetime | None = self._parse_gh_date_optional(pr["updated_at"])
+                    if updated_at and updated_at < self.sync_since:
+                        break
                 user_info: dict[str, Any] = pr.get("user", {})
                 author_login: str = user_info.get("login", "unknown")
                 merged_by: dict[str, Any] | None = pr.get("merged_by")

--- a/backend/connectors/gmail.py
+++ b/backend/connectors/gmail.py
@@ -219,8 +219,7 @@ Send an email via the user's connected Gmail account. Emails are sent from the a
         from sqlalchemy import select
         from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-        # Get emails from the last 30 days
-        after: datetime = datetime.utcnow() - timedelta(days=30)
+        after: datetime = self.sync_since or (datetime.utcnow() - timedelta(days=30))
         before: datetime = datetime.utcnow()
 
         messages: list[dict[str, Any]] = await self.get_messages(

--- a/backend/connectors/google_calendar.py
+++ b/backend/connectors/google_calendar.py
@@ -206,8 +206,7 @@ class GoogleCalendarConnector(BaseConnector):
         await self.ensure_sync_active("sync_activities:start")
         from connectors.resolution import build_activity_resolver
 
-        # Get events from primary calendar for the last 30 days and next 30 days
-        time_min: datetime = datetime.utcnow() - timedelta(days=30)
+        time_min: datetime = self.sync_since or (datetime.utcnow() - timedelta(days=30))
         time_max: datetime = datetime.utcnow() + timedelta(days=30)
 
         # Import broadcast function for real-time progress updates

--- a/backend/connectors/google_drive.py
+++ b/backend/connectors/google_drive.py
@@ -544,10 +544,14 @@ Call via `run_on_connector(connector='google_drive', action='edit_file', params=
         all_files: list[dict[str, Any]] = []
         page_token: Optional[str] = None
 
+        drive_query: str = "trashed=false"
+        if self.sync_since:
+            drive_query += f" and modifiedTime > '{self.sync_since.isoformat()}Z'"
+
         async with httpx.AsyncClient(timeout=60.0) as client:
             while True:
                 params: dict[str, Any] = {
-                    "q": "trashed=false",
+                    "q": drive_query,
                     "fields": LIST_FIELDS,
                     "pageSize": 1000,
                     "supportsAllDrives": "true",

--- a/backend/connectors/granola.py
+++ b/backend/connectors/granola.py
@@ -421,6 +421,20 @@ class GranolaConnector(BaseConnector):
         )
         meetings_list: list[dict[str, Any]] = await mcp.list_meetings()
         logger.info("Got %d meetings from Granola", len(meetings_list))
+
+        if self.sync_since:
+            filtered: list[dict[str, Any]] = []
+            for stub in meetings_list:
+                raw_date: Any = stub.get("date") or stub.get("start_time")
+                meeting_dt: datetime = _parse_datetime(raw_date)
+                if meeting_dt >= self.sync_since:
+                    filtered.append(stub)
+            logger.info(
+                "Granola incremental filter: %d → %d meetings since %s",
+                len(meetings_list), len(filtered), self.sync_since,
+            )
+            meetings_list = filtered
+
         for i, stub in enumerate(meetings_list):
             print(f"[Granola] Meeting stub {i}: {json.dumps(stub, default=str)[:2000]}")
 

--- a/backend/connectors/hubspot.py
+++ b/backend/connectors/hubspot.py
@@ -343,6 +343,77 @@ Use `m.external_userid` when setting `hubspot_owner_id`. If no mapping exists, t
 
         return all_results
 
+    async def _search_results_since(
+        self,
+        object_type: str,
+        properties: list[str],
+        since: datetime,
+        associations: Optional[list[str]] = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Paginate through HubSpot Search API filtered by hs_lastmodifieddate.
+
+        The search API supports POST ``/crm/v3/objects/{type}/search`` with
+        ``filterGroups`` for date-based incremental fetching.
+        """
+        all_results: list[dict[str, Any]] = []
+        after: int = 0
+        iso_ms: str = since.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+        while True:
+            body: dict[str, Any] = {
+                "filterGroups": [
+                    {
+                        "filters": [
+                            {
+                                "propertyName": "hs_lastmodifieddate",
+                                "operator": "GTE",
+                                "value": iso_ms,
+                            }
+                        ]
+                    }
+                ],
+                "properties": properties,
+                "limit": limit,
+            }
+            if after:
+                body["after"] = after
+            if associations:
+                body["associations"] = associations
+
+            data: dict[str, Any] = await self._make_request(
+                "POST",
+                f"/crm/v3/objects/{object_type}/search",
+                json_data=body,
+            )
+            results: list[dict[str, Any]] = data.get("results", [])
+            all_results.extend(results)
+
+            paging: dict[str, Any] = data.get("paging", {})
+            next_link: dict[str, Any] = paging.get("next", {})
+            after_val: str | None = next_link.get("after")
+            if not after_val:
+                break
+            after = int(after_val)
+
+        return all_results
+
+    async def _paginate_or_search(
+        self,
+        endpoint: str,
+        object_type: str,
+        properties: list[str],
+        associations: Optional[list[str]] = None,
+    ) -> list[dict[str, Any]]:
+        """Use incremental search when sync_since is available, otherwise full list."""
+        if self.sync_since:
+            return await self._search_results_since(
+                object_type, properties, self.sync_since, associations=associations,
+            )
+        return await self._paginate_results(
+            endpoint, properties, associations=associations,
+        )
+
     async def sync_pipelines(self) -> int:
         """
         Sync all deal pipelines and stages from HubSpot.
@@ -468,8 +539,9 @@ Use `m.external_userid` when setting `hubspot_owner_id`. If no mapping exists, t
             "pipeline",
         ]
 
-        raw_deals = await self._paginate_results(
+        raw_deals = await self._paginate_or_search(
             "/crm/v3/objects/deals",
+            "deals",
             properties=properties,
             associations=["companies"],
         )
@@ -665,8 +737,8 @@ Use `m.external_userid` when setting `hubspot_owner_id`. If no mapping exists, t
             "hs_lastmodifieddate",
         ]
 
-        raw_companies = await self._paginate_results(
-            "/crm/v3/objects/companies", properties=properties
+        raw_companies = await self._paginate_or_search(
+            "/crm/v3/objects/companies", "companies", properties=properties,
         )
 
         # Pre-load owner email cache so _normalize_account doesn't trigger per-row fetches
@@ -797,8 +869,9 @@ Use `m.external_userid` when setting `hubspot_owner_id`. If no mapping exists, t
         # Fetch contacts with company associations
         print(f"[HubSpot] Fetching contacts for org {self.organization_id}...")
         try:
-            raw_contacts = await self._paginate_results(
+            raw_contacts = await self._paginate_or_search(
                 "/crm/v3/objects/contacts",
+                "contacts",
                 properties=properties,
                 associations=["companies"],
             )
@@ -998,8 +1071,9 @@ Use `m.external_userid` when setting `hubspot_owner_id`. If no mapping exists, t
                 properties = ["hs_timestamp", "hs_note_body"]
 
             try:
-                raw_engagements: list[dict[str, Any]] = await self._paginate_results(
+                raw_engagements: list[dict[str, Any]] = await self._paginate_or_search(
                     f"/crm/v3/objects/{engagement_type}",
+                    engagement_type,
                     properties=properties,
                     associations=["deals", "contacts", "companies"],
                 )

--- a/backend/connectors/jira.py
+++ b/backend/connectors/jira.py
@@ -338,8 +338,10 @@ class JiraConnector(BaseConnector):
             for row in result.all():
                 project_map[row[0]] = row[1]
 
-        # Fetch issues using JQL search
-        jql: str = "ORDER BY updated DESC"
+        jql: str = ""
+        if self.sync_since:
+            jql = f"updated >= '{self.sync_since.strftime('%Y-%m-%d %H:%M')}' "
+        jql += "ORDER BY updated DESC"
         issues: list[dict[str, Any]] = await self._get_paginated(
             "/search",
             {

--- a/backend/connectors/linear.py
+++ b/backend/connectors/linear.py
@@ -455,6 +455,16 @@ Use `write_on_connector(connector='linear', operation='...', data={...})` with `
         count: int = 0
         async with get_session(organization_id=self.organization_id) as session:
             for issue in issues:
+                if self.sync_since and issue.get("updatedAt"):
+                    try:
+                        updated_at: datetime = datetime.fromisoformat(
+                            issue["updatedAt"].replace("Z", "+00:00")
+                        ).replace(tzinfo=None)
+                        if updated_at < self.sync_since:
+                            break
+                    except (ValueError, TypeError):
+                        pass
+
                 team_data: dict[str, Any] | None = issue.get("team")
                 if not team_data:
                     continue  # Skip issues without a team

--- a/backend/connectors/microsoft_calendar.py
+++ b/backend/connectors/microsoft_calendar.py
@@ -171,9 +171,8 @@ class MicrosoftCalendarConnector(BaseConnector):
         3. Link the Activity to the Meeting
         """
         await self.ensure_sync_active("sync_activities:start")
-        # Get events from default calendar for the last 30 days and next 30 days
-        time_min = datetime.utcnow() - timedelta(days=30)
-        time_max = datetime.utcnow() + timedelta(days=30)
+        time_min: datetime = self.sync_since or (datetime.utcnow() - timedelta(days=30))
+        time_max: datetime = datetime.utcnow() + timedelta(days=30)
 
         events = await self.get_events(
             time_min=time_min,

--- a/backend/connectors/microsoft_mail.py
+++ b/backend/connectors/microsoft_mail.py
@@ -177,9 +177,8 @@ class MicrosoftMailConnector(BaseConnector):
         with deals and accounts.
         """
         await self.ensure_sync_active("sync_activities:start")
-        # Get emails from the last 30 days
-        received_after = datetime.utcnow() - timedelta(days=30)
-        received_before = datetime.utcnow()
+        received_after: datetime = self.sync_since or (datetime.utcnow() - timedelta(days=30))
+        received_before: datetime = datetime.utcnow()
 
         emails = await self.get_emails(
             received_after=received_after,

--- a/backend/connectors/salesforce.py
+++ b/backend/connectors/salesforce.py
@@ -137,6 +137,13 @@ class SalesforceConnector(BaseConnector):
 
         return all_records
 
+    def _soql_incremental_filter(self) -> str:
+        """Return a SOQL WHERE clause fragment for incremental sync, or empty string."""
+        if self.sync_since:
+            iso: str = self.sync_since.strftime("%Y-%m-%dT%H:%M:%SZ")
+            return f" WHERE LastModifiedDate > {iso}"
+        return ""
+
     async def sync_deals(self) -> int:
         """
         Sync all opportunities from Salesforce.
@@ -145,11 +152,12 @@ class SalesforceConnector(BaseConnector):
         - Id, Name, AccountId, OwnerId, Amount, StageName
         - Probability, CloseDate, CreatedDate, LastModifiedDate
         """
-        soql = """
-            SELECT Id, Name, AccountId, OwnerId, Amount, StageName,
-                   Probability, CloseDate, CreatedDate, LastModifiedDate
-            FROM Opportunity
-        """
+        soql: str = (
+            "SELECT Id, Name, AccountId, OwnerId, Amount, StageName,"
+            " Probability, CloseDate, CreatedDate, LastModifiedDate"
+            " FROM Opportunity"
+            + self._soql_incremental_filter()
+        )
 
         raw_opportunities = await self._query_soql(soql)
 
@@ -248,11 +256,12 @@ class SalesforceConnector(BaseConnector):
 
     async def sync_accounts(self) -> int:
         """Sync all accounts from Salesforce."""
-        soql = """
-            SELECT Id, Name, Website, Industry, NumberOfEmployees,
-                   AnnualRevenue, OwnerId, CreatedDate, LastModifiedDate
-            FROM Account
-        """
+        soql: str = (
+            "SELECT Id, Name, Website, Industry, NumberOfEmployees,"
+            " AnnualRevenue, OwnerId, CreatedDate, LastModifiedDate"
+            " FROM Account"
+            + self._soql_incremental_filter()
+        )
 
         raw_accounts = await self._query_soql(soql)
 
@@ -333,11 +342,12 @@ class SalesforceConnector(BaseConnector):
 
     async def sync_contacts(self) -> int:
         """Sync all contacts from Salesforce."""
-        soql = """
-            SELECT Id, AccountId, FirstName, LastName, Name, Email,
-                   Title, Phone, CreatedDate, LastModifiedDate
-            FROM Contact
-        """
+        soql: str = (
+            "SELECT Id, AccountId, FirstName, LastName, Name, Email,"
+            " Title, Phone, CreatedDate, LastModifiedDate"
+            " FROM Contact"
+            + self._soql_incremental_filter()
+        )
 
         raw_contacts = await self._query_soql(soql)
 
@@ -405,11 +415,12 @@ class SalesforceConnector(BaseConnector):
         count: int = 0
 
         # Sync Tasks
-        task_soql = """
-            SELECT Id, WhatId, WhoId, Subject, Description,
-                   ActivityDate, OwnerId, CreatedDate, LastModifiedDate
-            FROM Task
-        """
+        task_soql: str = (
+            "SELECT Id, WhatId, WhoId, Subject, Description,"
+            " ActivityDate, OwnerId, CreatedDate, LastModifiedDate"
+            " FROM Task"
+            + self._soql_incremental_filter()
+        )
 
         try:
             raw_tasks = await self._query_soql(task_soql)
@@ -439,11 +450,12 @@ class SalesforceConnector(BaseConnector):
             pass
 
         # Sync Events
-        event_soql = """
-            SELECT Id, WhatId, WhoId, Subject, Description,
-                   StartDateTime, EndDateTime, OwnerId, CreatedDate, LastModifiedDate
-            FROM Event
-        """
+        event_soql: str = (
+            "SELECT Id, WhatId, WhoId, Subject, Description,"
+            " StartDateTime, EndDateTime, OwnerId, CreatedDate, LastModifiedDate"
+            " FROM Event"
+            + self._soql_incremental_filter()
+        )
 
         try:
             raw_events = await self._query_soql(event_soql)

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -512,8 +512,7 @@ Send a message to a Slack channel, DM, or user.
             self.organization_id,
         )
 
-        # Calculate timestamp for last 7 days
-        oldest = (datetime.utcnow().timestamp()) - (7 * 24 * 60 * 60)
+        oldest: float = self.sync_since.timestamp() if self.sync_since else (datetime.utcnow().timestamp() - 7 * 24 * 60 * 60)
 
         count = 0
         channels_with_messages = 0

--- a/backend/connectors/zoom.py
+++ b/backend/connectors/zoom.py
@@ -160,9 +160,9 @@ class ZoomConnector(BaseConnector):
     async def sync_activities(self) -> int:
         """Sync Zoom meeting transcripts as activities."""
         await self.ensure_sync_active("sync_activities:start")
-        now = datetime.utcnow()
-        start_date = (now - timedelta(days=7)).date()
-        end_date = now.date()
+        now: datetime = datetime.utcnow()
+        start_date: date = self.sync_since.date() if self.sync_since else (now - timedelta(days=7)).date()
+        end_date: date = now.date()
 
         meetings = await self._fetch_recordings(start_date, end_date)
         logger.info("Processing Zoom recordings", extra={"count": len(meetings)})

--- a/backend/tests/test_sync_since.py
+++ b/backend/tests/test_sync_since.py
@@ -1,0 +1,97 @@
+"""Tests for the BaseConnector.sync_since incremental-sync property."""
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+from connectors.base import BaseConnector
+
+
+class _StubConnector(BaseConnector):
+    """Minimal concrete connector for testing base-class behaviour."""
+
+    source_system = "test"
+
+    async def sync_deals(self) -> int:
+        return 0
+
+    async def sync_accounts(self) -> int:
+        return 0
+
+    async def sync_contacts(self) -> int:
+        return 0
+
+    async def sync_activities(self) -> int:
+        return 0
+
+    async def fetch_deal(self, deal_id: str) -> dict[str, Any]:
+        return {"id": deal_id}
+
+
+_ORG_ID: str = "00000000-0000-0000-0000-000000000000"
+
+
+def _make_connector(last_sync_at: datetime | None = None) -> _StubConnector:
+    """Create a _StubConnector with a fake integration attached."""
+    connector = _StubConnector(organization_id=_ORG_ID)
+    if last_sync_at is not None:
+        connector._integration = SimpleNamespace(last_sync_at=last_sync_at, is_active=True)  # type: ignore[assignment]
+    return connector
+
+
+class TestSyncSinceProperty:
+    """sync_since should return a buffered cutoff or None."""
+
+    def test_returns_none_when_no_integration(self) -> None:
+        connector = _StubConnector(organization_id=_ORG_ID)
+        assert connector.sync_since is None
+
+    def test_returns_none_when_last_sync_at_is_none(self) -> None:
+        connector = _make_connector()
+        connector._integration = SimpleNamespace(last_sync_at=None, is_active=True)  # type: ignore[assignment]
+        assert connector.sync_since is None
+
+    def test_returns_buffered_timestamp(self) -> None:
+        now: datetime = datetime(2025, 6, 15, 12, 0, 0)
+        connector = _make_connector(last_sync_at=now)
+        expected: datetime = now - timedelta(minutes=5)
+
+        result: datetime | None = connector.sync_since
+        assert result is not None
+        assert result == expected
+
+    def test_buffer_equals_five_minutes(self) -> None:
+        assert BaseConnector._SYNC_SINCE_BUFFER == timedelta(minutes=5)
+
+    def test_sync_since_is_before_last_sync_at(self) -> None:
+        now: datetime = datetime.utcnow()
+        connector = _make_connector(last_sync_at=now)
+
+        result: datetime | None = connector.sync_since
+        assert result is not None
+        assert result < now
+
+    def test_different_last_sync_at_values(self) -> None:
+        timestamps: list[datetime] = [
+            datetime(2024, 1, 1, 0, 0, 0),
+            datetime(2025, 6, 15, 23, 59, 59),
+            datetime(2025, 12, 31, 0, 5, 0),
+        ]
+        buffer: timedelta = timedelta(minutes=5)
+        for ts in timestamps:
+            connector = _make_connector(last_sync_at=ts)
+            assert connector.sync_since == ts - buffer
+
+    def test_last_sync_at_very_recent(self) -> None:
+        """Buffer should push the cutoff into the past even for a just-now timestamp."""
+        now: datetime = datetime.utcnow()
+        connector = _make_connector(last_sync_at=now)
+        result: datetime | None = connector.sync_since
+        assert result is not None
+        assert (now - result).total_seconds() == 300.0
+
+    def test_last_sync_at_exactly_at_buffer_boundary(self) -> None:
+        """When last_sync_at is exactly 5 min after epoch, sync_since should equal epoch."""
+        epoch_plus_five: datetime = datetime(1970, 1, 1, 0, 5, 0)
+        connector = _make_connector(last_sync_at=epoch_plus_five)
+        assert connector.sync_since == datetime(1970, 1, 1, 0, 0, 0)


### PR DESCRIPTION
## Summary
- Adds a `sync_since` property to `BaseConnector` that returns `last_sync_at - 5min safety buffer` (or `None` on first sync), giving every connector an incremental cutoff timestamp
- Updates all 15 connectors to use `sync_since` — native API date filters for Gmail, Slack, Google/Microsoft Calendar, Google Drive, Salesforce, HubSpot, Jira, GitHub, Zoom, and Asana; client-side filtering for Fireflies, Granola, and Linear
- First syncs remain unchanged (full historical window); subsequent syncs only fetch new/updated data

## Test plan
- [x] Unit tests for `sync_since` property (8 tests in `backend/tests/test_sync_since.py`, all passing)
- [ ] Trigger a sync for each connector type and verify only recent data is fetched
- [ ] Verify first sync (no `last_sync_at`) still pulls the full default window

Made with [Cursor](https://cursor.com)