### PR TITLE
Fix Slack user identity resolution via messenger_user_mappings

### DIFF
--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -160,6 +160,10 @@ class WorkspaceMessenger(BaseMessenger):
         """
         user: User | None = await super().resolve_user(message)
         if user is not None:
+            logger.info(
+                "[%s] Resolved user via mapping: user=%s ext=%s",
+                self.meta.slug, user.id, message.external_user_id,
+            )
             return user
 
         workspace_id: str | None = message.messenger_context.get("workspace_id")
@@ -174,6 +178,10 @@ class WorkspaceMessenger(BaseMessenger):
             workspace_id, message.external_user_id,
         )
         if profile is None:
+            logger.warning(
+                "[%s] No profile for ext=%s ws=%s — falling back to guest",
+                self.meta.slug, message.external_user_id, workspace_id,
+            )
             return await self._resolve_guest_user(organization_id)
 
         email: str | None = self._extract_email_from_profile(profile)
@@ -191,7 +199,20 @@ class WorkspaceMessenger(BaseMessenger):
                     external_email=email,
                     match_source="email",
                 )
+                logger.info(
+                    "[%s] Resolved user via email match: user=%s email=%s",
+                    self.meta.slug, matched_user.id, email,
+                )
                 return matched_user
+            logger.warning(
+                "[%s] Email %s from profile did not match any org member (org=%s)",
+                self.meta.slug, email, organization_id,
+            )
+        else:
+            logger.warning(
+                "[%s] No email in profile for ext=%s ws=%s — falling back to guest",
+                self.meta.slug, message.external_user_id, workspace_id,
+            )
 
         return await self._resolve_guest_user(organization_id)
 

--- a/backend/messengers/base.py
+++ b/backend/messengers/base.py
@@ -113,12 +113,15 @@ class BaseMessenger(ABC):
         """Map an external messenger identity to a RevTops :class:`User`.
 
         Default implementation queries ``messenger_user_mappings`` by
-        ``(platform=self.meta.slug, external_user_id)``.  Subclasses may
-        override to add fallback strategies (e.g. phone-number lookup).
+        ``(platform, external_user_id)``.  When a ``workspace_id`` is
+        present in the message context, an exact match is preferred but
+        rows with ``workspace_id IS NULL`` (legacy data) are accepted as
+        a fallback.  Subclasses may override to add strategies such as
+        phone-number lookup.
         """
         from models.messenger_user_mapping import MessengerUserMapping
         from models.database import get_admin_session
-        from sqlalchemy import select
+        from sqlalchemy import case, or_, select
 
         platform: str = self.meta.slug
         external_id: str = message.external_user_id
@@ -126,7 +129,7 @@ class BaseMessenger(ABC):
 
         async with get_admin_session() as session:
             stmt = (
-                select(User)
+                select(User, MessengerUserMapping.workspace_id)
                 .join(
                     MessengerUserMapping,
                     MessengerUserMapping.user_id == User.id,
@@ -136,10 +139,18 @@ class BaseMessenger(ABC):
             )
             if workspace_id is not None:
                 stmt = stmt.where(
-                    MessengerUserMapping.workspace_id == workspace_id
+                    or_(
+                        MessengerUserMapping.workspace_id == workspace_id,
+                        MessengerUserMapping.workspace_id.is_(None),
+                    )
+                ).order_by(
+                    case(
+                        (MessengerUserMapping.workspace_id == workspace_id, 0),
+                        else_=1,
+                    )
                 )
-            result = await session.execute(stmt)
-            return result.scalar_one_or_none()
+            rows = (await session.execute(stmt)).first()
+            return rows[0] if rows else None
 
     # ------------------------------------------------------------------
     # Organisation resolution


### PR DESCRIPTION
## Summary
- Migration 101 copied existing Slack identity mappings with `workspace_id=NULL`, but `BaseMessenger.resolve_user()` filtered on exact `workspace_id` match — causing all lookups to miss and falling through to the guest user.
- Now accepts `NULL workspace_id` as a fallback (preferring exact match via `ORDER BY CASE`).
- Adds debug logging to the email-matching fallback path in `WorkspaceMessenger` for easier future diagnosis.

## Test plan
- [x] All 133 backend tests pass
- [ ] Deploy and send a Slack DM/@mention — bot should recognize the sender's identity instead of responding as "Guest user"

Made with [Cursor](https://cursor.com)