### PR TITLE
feat(agent): add adaptive thinking for Claude Opus 4.6

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1059,6 +1059,7 @@ class ChatOrchestrator:
             tool_uses: list[dict[str, Any]] = []
             current_tool: dict[str, Any] | None = None
             current_tool_input_json = ""
+            is_thinking_block: bool = False
             final_message = None
             context_retry_needed = False
 
@@ -1071,31 +1072,32 @@ class ChatOrchestrator:
                     tool_uses = []
                     current_tool = None
                     current_tool_input_json = ""
+                    is_thinking_block = False
                     
                     # Stream the response
                     async with self.client.messages.stream(
                         model="claude-opus-4-6",
-                        max_tokens=16384,
+                        max_tokens=32768,
                         system=system_prompt,
                         tools=get_tools(self.workflow_context),
                         messages=messages,
+                        thinking={"type": "adaptive"},
                     ) as stream:
                         async for event in stream:
                             # Handle different event types
                             if event.type == "content_block_start":
-                                if event.content_block.type == "text":
-                                    # Text block starting - nothing to do yet
+                                if event.content_block.type == "thinking":
+                                    is_thinking_block = True
+                                    yield json.dumps({"type": "thinking_start"})
+                                elif event.content_block.type == "text":
                                     pass
                                 elif event.content_block.type == "tool_use":
-                                    # Tool use block starting - capture id and name
                                     current_tool = {
                                         "id": event.content_block.id,
                                         "name": event.content_block.name,
                                         "input": {},
                                     }
                                     current_tool_input_json = ""
-                                    # Immediately notify frontend that a tool call is starting
-                                    # so it can show a spinner while the input JSON streams
                                     yield json.dumps({
                                         "type": "tool_call_start",
                                         "tool_name": event.content_block.name,
@@ -1103,18 +1105,25 @@ class ChatOrchestrator:
                                     })
                             
                             elif event.type == "content_block_delta":
-                                if event.delta.type == "text_delta":
-                                    # Stream text immediately!
-                                    text = event.delta.text
+                                if event.delta.type == "thinking_delta":
+                                    yield json.dumps({
+                                        "type": "thinking_delta",
+                                        "text": event.delta.thinking,
+                                    })
+                                elif event.delta.type == "signature_delta":
+                                    pass
+                                elif event.delta.type == "text_delta":
+                                    text: str = event.delta.text
                                     current_text += text
                                     yield text
                                 elif event.delta.type == "input_json_delta":
-                                    # Accumulate tool input JSON
                                     current_tool_input_json += event.delta.partial_json
                             
                             elif event.type == "content_block_stop":
-                                if current_tool is not None:
-                                    # Parse the accumulated JSON for tool input
+                                if is_thinking_block:
+                                    is_thinking_block = False
+                                    yield json.dumps({"type": "thinking_stop"})
+                                elif current_tool is not None:
                                     try:
                                         current_tool["input"] = json.loads(current_tool_input_json) if current_tool_input_json else {}
                                     except json.JSONDecodeError:
@@ -1122,7 +1131,6 @@ class ChatOrchestrator:
                                         current_tool["input"] = {}
                                     
                                     tool_uses.append(current_tool)
-                                    # Send tool_call with input immediately so the UI can show "Running X on Y" instead of "Running connector action..."
                                     yield json.dumps({
                                         "type": "tool_call",
                                         "tool_name": current_tool["name"],
@@ -1412,11 +1420,17 @@ class ChatOrchestrator:
                 yield out_of_credits_message
                 break
 
-            # Add assistant message with all tool uses, then user message with all results
-            # Convert content blocks to plain dicts to avoid Pydantic serialization issues
+            # Add assistant message with all tool uses, then user message with all results.
+            # Thinking blocks must be preserved for the API to maintain reasoning continuity.
             assistant_content: list[dict[str, Any]] = []
             for block in final_message.content:
-                if block.type == "text":
+                if block.type == "thinking":
+                    assistant_content.append({
+                        "type": "thinking",
+                        "thinking": block.thinking,
+                        "signature": block.signature,
+                    })
+                elif block.type == "text":
                     assistant_content.append({"type": "text", "text": block.text})
                 elif block.type == "tool_use":
                     assistant_content.append({

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -616,10 +616,86 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
             }
           } else if (typeof chunkData === 'object' && chunkData !== null) {
             const data = chunkData as Record<string, unknown>;
-            
-            if (data.type === 'tool_call_start') {
-              // Tool call STARTING — LLM is still streaming the input JSON.
-              // Show a placeholder block immediately so the user sees activity.
+
+            if (data.type === 'thinking_start') {
+              const state = useAppStore.getState();
+              const convState = state.conversations[conversation_id];
+              const thinkingBlock = { type: 'thinking' as const, text: '', isStreaming: true };
+              if (convState?.streamingMessageId) {
+                const updated = convState.messages.map((msg) => {
+                  if (msg.id !== convState.streamingMessageId) return msg;
+                  return { ...msg, contentBlocks: [...msg.contentBlocks, thinkingBlock] };
+                });
+                useAppStore.setState({
+                  conversations: {
+                    ...state.conversations,
+                    [conversation_id]: { ...convState, messages: updated },
+                  },
+                });
+              } else {
+                const msgId = `assistant-${Date.now()}`;
+                startConversationStreaming(conversation_id, msgId, '', chunkIndex);
+                const state2 = useAppStore.getState();
+                const convState2 = state2.conversations[conversation_id];
+                if (convState2?.streamingMessageId) {
+                  const updated = convState2.messages.map((msg) => {
+                    if (msg.id !== convState2.streamingMessageId) return msg;
+                    return { ...msg, contentBlocks: [thinkingBlock] };
+                  });
+                  useAppStore.setState({
+                    conversations: {
+                      ...state2.conversations,
+                      [conversation_id]: { ...convState2, messages: updated },
+                    },
+                  });
+                }
+              }
+            } else if (data.type === 'thinking_delta') {
+              const state = useAppStore.getState();
+              const convState = state.conversations[conversation_id];
+              const streamingId = convState?.streamingMessageId;
+              if (convState && streamingId) {
+                const updated = convState.messages.map((msg) => {
+                  if (msg.id !== streamingId) return msg;
+                  const blocks = [...msg.contentBlocks];
+                  const lastBlock = blocks[blocks.length - 1];
+                  if (lastBlock && lastBlock.type === 'thinking') {
+                    blocks[blocks.length - 1] = {
+                      ...lastBlock,
+                      text: lastBlock.text + (data.text as string),
+                    };
+                  }
+                  return { ...msg, contentBlocks: blocks };
+                });
+                useAppStore.setState({
+                  conversations: {
+                    ...state.conversations,
+                    [conversation_id]: { ...convState, messages: updated },
+                  },
+                });
+              }
+            } else if (data.type === 'thinking_stop') {
+              const state = useAppStore.getState();
+              const convState = state.conversations[conversation_id];
+              const streamingId = convState?.streamingMessageId;
+              if (convState && streamingId) {
+                const updated = convState.messages.map((msg) => {
+                  if (msg.id !== streamingId) return msg;
+                  const blocks = msg.contentBlocks.map((block) =>
+                    block.type === 'thinking' && block.isStreaming
+                      ? { ...block, isStreaming: false }
+                      : block,
+                  );
+                  return { ...msg, contentBlocks: blocks };
+                });
+                useAppStore.setState({
+                  conversations: {
+                    ...state.conversations,
+                    [conversation_id]: { ...convState, messages: updated },
+                  },
+                });
+              }
+            } else if (data.type === 'tool_call_start') {
               const toolBlock = {
                 type: 'tool_use' as const,
                 id: data.tool_id as string,
@@ -970,7 +1046,87 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
                 }
               } else if (typeof chunkData === 'object' && chunkData !== null) {
                 const data = chunkData as Record<string, unknown>;
-                if (data.type === 'tool_call_start') {
+                if (data.type === 'thinking_start') {
+                  const state = useAppStore.getState();
+                  const convState = state.conversations[conversationId];
+                  const thinkingBlock = { type: 'thinking' as const, text: '', isStreaming: true };
+                  if (convState?.streamingMessageId) {
+                    const updated = convState.messages.map((msg) =>
+                      msg.id === convState.streamingMessageId
+                        ? { ...msg, contentBlocks: [...msg.contentBlocks, thinkingBlock] }
+                        : msg,
+                    );
+                    useAppStore.setState({
+                      conversations: {
+                        ...state.conversations,
+                        [conversationId]: { ...convState, messages: updated },
+                      },
+                    });
+                  } else {
+                    const msgId = `assistant-${Date.now()}`;
+                    startConversationStreaming(conversationId, msgId, '', chunkIndex);
+                    const state2 = useAppStore.getState();
+                    const convState2 = state2.conversations[conversationId];
+                    if (convState2?.streamingMessageId) {
+                      const updated = convState2.messages.map((msg) =>
+                        msg.id === convState2.streamingMessageId
+                          ? { ...msg, contentBlocks: [thinkingBlock] }
+                          : msg,
+                      );
+                      useAppStore.setState({
+                        conversations: {
+                          ...state2.conversations,
+                          [conversationId]: { ...convState2, messages: updated },
+                        },
+                      });
+                    }
+                  }
+                } else if (data.type === 'thinking_delta') {
+                  const state = useAppStore.getState();
+                  const convState = state.conversations[conversationId];
+                  const streamingId = convState?.streamingMessageId;
+                  if (convState && streamingId) {
+                    const updated = convState.messages.map((msg) => {
+                      if (msg.id !== streamingId) return msg;
+                      const blocks = [...msg.contentBlocks];
+                      const lastBlock = blocks[blocks.length - 1];
+                      if (lastBlock && lastBlock.type === 'thinking') {
+                        blocks[blocks.length - 1] = {
+                          ...lastBlock,
+                          text: lastBlock.text + (data.text as string),
+                        };
+                      }
+                      return { ...msg, contentBlocks: blocks };
+                    });
+                    useAppStore.setState({
+                      conversations: {
+                        ...state.conversations,
+                        [conversationId]: { ...convState, messages: updated },
+                      },
+                    });
+                  }
+                } else if (data.type === 'thinking_stop') {
+                  const state = useAppStore.getState();
+                  const convState = state.conversations[conversationId];
+                  const streamingId = convState?.streamingMessageId;
+                  if (convState && streamingId) {
+                    const updated = convState.messages.map((msg) => {
+                      if (msg.id !== streamingId) return msg;
+                      const blocks = msg.contentBlocks.map((block) =>
+                        block.type === 'thinking' && block.isStreaming
+                          ? { ...block, isStreaming: false }
+                          : block,
+                      );
+                      return { ...msg, contentBlocks: blocks };
+                    });
+                    useAppStore.setState({
+                      conversations: {
+                        ...state.conversations,
+                        [conversationId]: { ...convState, messages: updated },
+                      },
+                    });
+                  }
+                } else if (data.type === 'tool_call_start') {
                   const toolBlock = {
                     type: 'tool_use' as const,
                     id: data.tool_id as string,

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -33,6 +33,7 @@ import {
   type ChatMessage,
   type ConversationSummaryData,
   type Integration,
+  type ThinkingBlock as ThinkingBlockType,
   type ToolCallData,
   type ToolUseBlock,
   type ErrorBlock,
@@ -2091,6 +2092,14 @@ function MessageWithBlocks({
       {/* Content blocks in order */}
       <div className="flex-1 max-w-[85%] overflow-hidden">
         {blocks.map((block, index) => {
+          if (block.type === 'thinking') {
+            if (!block.text && !block.isStreaming) return null;
+            return (
+              <div key={`thinking-${index}`} className={index > 0 ? 'mt-1' : ''}>
+                <ThinkingBlockIndicator block={block} />
+              </div>
+            );
+          }
           if (block.type === 'text') {
             const isLast = index === lastTextIndex;
             return (
@@ -2154,6 +2163,58 @@ function MessageWithBlocks({
           </span>
         </div>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Collapsible thinking block — shows Claude's reasoning process.
+ * Open (expanded) while streaming with capped height and internal scroll;
+ * auto-collapses when thinking completes and the next content appears.
+ */
+function ThinkingBlockIndicator({
+  block,
+}: {
+  block: ThinkingBlockType;
+}): JSX.Element {
+  const [collapsed, setCollapsed] = useState<boolean>(!block.isStreaming);
+
+  // Auto-close when thinking finishes so the next message takes focus
+  useEffect(() => {
+    if (!block.isStreaming) {
+      setCollapsed(true);
+    }
+  }, [block.isStreaming]);
+
+  // While streaming, keep expanded so the user sees the thinking box open
+  const isExpanded: boolean = block.isStreaming || !collapsed;
+
+  return (
+    <div className="my-1">
+      <button
+        onClick={() => setCollapsed((prev) => !prev)}
+        className="flex items-center gap-1 text-xs text-surface-500 hover:text-surface-300 transition-colors cursor-pointer"
+      >
+        <svg
+          className={`w-3 h-3 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+        <span>
+          {block.isStreaming ? 'Thinking…' : 'Thought process'}
+        </span>
+        {block.isStreaming && (
+          <span className="inline-block w-1 h-1 rounded-full bg-primary-400 animate-pulse" />
+        )}
+      </button>
+      {isExpanded && (
+        <div className="mt-1 ml-4 pl-2 border-l border-surface-700 text-xs text-surface-500 whitespace-pre-wrap leading-relaxed max-h-48 overflow-y-auto">
+          {block.text || (block.isStreaming ? '' : null)}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -36,6 +36,7 @@ export type {
   ErrorBlock,
   ArtifactBlock,
   AppBlock,
+  ThinkingBlock,
   AttachmentBlock,
   ContentBlock,
   ToolCallData,

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -161,6 +161,12 @@ export interface AppBlock {
   };
 }
 
+export interface ThinkingBlock {
+  type: "thinking";
+  text: string;
+  isStreaming?: boolean;
+}
+
 export interface AttachmentBlock {
   type: "attachment";
   filename: string;
@@ -174,6 +180,7 @@ export type ContentBlock =
   | ErrorBlock
   | ArtifactBlock
   | AppBlock
+  | ThinkingBlock
   | AttachmentBlock;
 
 // Legacy type for streaming compatibility


### PR DESCRIPTION
## Summary
Enables Claude's adaptive extended thinking for the Opus 4.6 agent and streams thinking content to the chat UI.

## Backend
- **Orchestrator**: `thinking: { type: "adaptive" }` on `messages.stream()`, `max_tokens` increased to 32768
- Stream events: `thinking_start`, `thinking_delta`, `thinking_stop` (and `signature_delta` absorbed)
- Tool-loop history: assistant content now includes thinking blocks with `thinking` + `signature` for API continuity

## Frontend
- **Types**: `ThinkingBlock` (`type", "text", `isStreaming?`) added to `ContentBlock` union
- **AppLayout**: `task_chunk` and `catchup` handle `thinking_start` / `thinking_delta` / `thinking_stop`
- **Chat**: Collapsible thinking block — open while streaming (capped height + internal scroll), auto-closes when thinking completes

## Notes
- Adaptive mode gives interleaved thinking between tool calls (better for agentic workflows)
- Thinking tokens are billed as output; use `output_config: { effort: "medium" }` later if cost-tuning is needed

Made with [Cursor](https://cursor.com)