### PR TITLE
Improve safe streaming sentence breaks for Slack-style formatting

### DIFF
--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import time
 import uuid as _uuid
 from datetime import UTC, datetime
@@ -67,6 +68,8 @@ _WORKSPACE_ORG_CACHE_TTL_SECONDS: int = 300
 _workspace_org_cache: dict[tuple[str, str], tuple[str | None, float]] = {}
 _workspace_org_cache_lock: asyncio.Lock = asyncio.Lock()
 
+_SENTENCE_BREAK_RE: re.Pattern[str] = re.compile(r"[.!?](?:\s|$)")
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -83,6 +86,38 @@ def _merge_participating_user_ids(
         if uid not in current:
             current.append(uid)
     return current
+
+
+def _find_safe_stream_break(text: str) -> int:
+    """Find the best character index to break a streamed response.
+
+    Prefer sentence boundaries (``.``, ``!``, ``?`` followed by whitespace or
+    end-of-string), while avoiding split points that sit inside Slack or
+    Markdown formatting markers (``**`` and ``~``) and apostrophe contractions
+    (e.g. ``user's``).
+    """
+    if not text:
+        return 0
+
+    break_idx: int = 0
+    for match in _SENTENCE_BREAK_RE.finditer(text):
+        candidate: int = match.end()
+
+        punct_idx: int = match.start()
+
+        # Avoid breaks after apostrophe contractions/possessives (e.g., "user's.").
+        if punct_idx >= 2 and text[punct_idx - 2:punct_idx] in {"'s", "'S"}:
+            continue
+
+        # Don't split right after formatting marks (e.g., "**.", "~.").
+        if punct_idx >= 2 and text[punct_idx - 2:punct_idx] == "**":
+            continue
+        if punct_idx >= 1 and text[punct_idx - 1:punct_idx] == "~":
+            continue
+
+        break_idx = candidate
+
+    return break_idx
 
 
 # ===========================================================================
@@ -525,10 +560,16 @@ class WorkspaceMessenger(BaseMessenger):
 
         async def _flush(*, reason: str, force: bool = False) -> None:
             nonlocal current_text, total_length, last_flush_at
-            text_to_send: str = current_text.strip() if force else current_text.strip()
-            if not force:
+            text_to_send: str = ""
+            if force:
                 text_to_send = current_text.strip()
-            current_text = "" if force else ""
+                current_text = ""
+            else:
+                break_idx: int = _find_safe_stream_break(current_text)
+                if break_idx <= 0:
+                    return
+                text_to_send = current_text[:break_idx].strip()
+                current_text = current_text[break_idx:]
 
             if not text_to_send:
                 return

--- a/backend/tests/test_workspace_stream_breaks.py
+++ b/backend/tests/test_workspace_stream_breaks.py
@@ -1,0 +1,16 @@
+from messengers._workspace import _find_safe_stream_break
+
+
+def test_find_safe_stream_break_prefers_sentence_boundary() -> None:
+    text = "First sentence. Second sentence"
+    assert _find_safe_stream_break(text) == len("First sentence. ")
+
+
+def test_find_safe_stream_break_skips_apostrophe_s_boundary() -> None:
+    text = "The user's. request is queued"
+    assert _find_safe_stream_break(text) == 0
+
+
+def test_find_safe_stream_break_skips_formatting_mark_boundaries() -> None:
+    assert _find_safe_stream_break("Wrapped in **. bold") == 0
+    assert _find_safe_stream_break("Wrapped in ~. strike") == 0


### PR DESCRIPTION
### Motivation
- Avoid streaming partial responses that break sentences at punctuation which is part of apostrophe-s contractions or Slack/Markdown formatting markers, reducing awkward mid-sentence flushes in Slack and similar messengers.

### Description
- Add `_find_safe_stream_break` to detect sentence boundaries using a sentence-regex and skip breakpoints that follow apostrophe-s (e.g. `'s`) or formatting markers like `**` and `~`.
- Change non-forced flush behavior in `WorkspaceMessenger.stream_and_post_responses` so it only emits up to a safe break and keeps the remainder buffered, while forced/tool-boundary flushes continue to send the full buffer.
- Add unit tests in `backend/tests/test_workspace_stream_breaks.py` covering normal sentence breaks and the new apostrophe/formatting guard cases.

### Testing
- Ran `pytest -q backend/tests/test_workspace_stream_breaks.py` during development (initial run showed failures), and after fixes the final run succeeded with `3 passed`.
- No database migrations were changed and no other automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4779504a88321b1785e52d07c63d9)