### PR TITLE
Unify safe text breaking for Slack streaming and Twilio segmentation

### DIFF
--- a/backend/messengers/_text_breaks.py
+++ b/backend/messengers/_text_breaks.py
@@ -1,0 +1,63 @@
+"""Shared helpers for safely breaking streamed and segmented text."""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+BreakPreference = Literal["best", "quickest_safe"]
+
+_SENTENCE_BREAK_RE: re.Pattern[str] = re.compile(r"[.!?](?:\s|$)")
+
+
+def _is_disallowed_punctuation_break(text: str, punct_idx: int) -> bool:
+    """Return True when punctuation at ``punct_idx`` should not be used as a break."""
+    if punct_idx >= 2 and text[punct_idx - 2:punct_idx] in {"'s", "'S"}:
+        return True
+    if punct_idx >= 2 and text[punct_idx - 2:punct_idx] == "**":
+        return True
+    if punct_idx >= 1 and text[punct_idx - 1:punct_idx] == "~":
+        return True
+    return False
+
+
+def find_safe_text_break(
+    text: str,
+    *,
+    preference: BreakPreference,
+    max_index: int | None = None,
+) -> int:
+    """Find a safe index for splitting text.
+
+    - ``quickest_safe`` returns the earliest safe sentence boundary.
+    - ``best`` returns the latest safe boundary up to ``max_index``.
+    """
+    if not text:
+        return 0
+
+    limit: int = min(max_index, len(text)) if max_index is not None else len(text)
+    if limit <= 0:
+        return 0
+
+    sentence_candidates: list[int] = []
+    for match in _SENTENCE_BREAK_RE.finditer(text[:limit]):
+        punct_idx: int = match.start()
+        if _is_disallowed_punctuation_break(text, punct_idx):
+            continue
+        sentence_candidates.append(match.end())
+
+    if sentence_candidates:
+        return sentence_candidates[0] if preference == "quickest_safe" else sentence_candidates[-1]
+
+    # Fallbacks for bounded chunking use-cases (e.g., SMS segmentation).
+    if max_index is not None:
+        for char in ("\n", " "):
+            cut: int = text.rfind(char, 0, limit)
+            if cut > 0:
+                return cut
+        if len(text) > limit:
+            return limit
+
+    return 0

--- a/backend/messengers/_twilio_phone.py
+++ b/backend/messengers/_twilio_phone.py
@@ -29,6 +29,7 @@ import httpx
 from sqlalchemy import select
 
 from config import settings
+from messengers._text_breaks import find_safe_text_break
 from messengers.base import (
     BaseMessenger,
     InboundMessage,
@@ -99,18 +100,22 @@ _TWILIO_MAX_LENGTH: int = 1600
 
 
 def _split_text(text: str, max_len: int) -> list[str]:
-    """Split *text* into chunks of at most *max_len* chars, preferring newlines."""
+    """Split *text* into chunks of at most *max_len* chars using best safe breaks."""
     segments: list[str] = []
     remaining: str = text
     while remaining:
         if len(remaining) <= max_len:
             segments.append(remaining)
             break
-        cut: int = remaining.rfind("\n", 0, max_len)
-        if cut <= 0:
-            cut = remaining.rfind(" ", 0, max_len)
+
+        cut: int = find_safe_text_break(
+            remaining,
+            preference="best",
+            max_index=max_len,
+        )
         if cut <= 0:
             cut = max_len
+
         segments.append(remaining[:cut].rstrip())
         remaining = remaining[cut:].lstrip()
     return segments

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import re
 import time
 import uuid as _uuid
 from datetime import UTC, datetime
@@ -43,6 +42,7 @@ from models.messenger_user_mapping import MessengerUserMapping
 from models.org_member import OrgMember
 from models.organization import Organization
 from models.user import User
+from messengers._text_breaks import find_safe_text_break
 
 logger = logging.getLogger(__name__)
 
@@ -68,8 +68,6 @@ _WORKSPACE_ORG_CACHE_TTL_SECONDS: int = 300
 _workspace_org_cache: dict[tuple[str, str], tuple[str | None, float]] = {}
 _workspace_org_cache_lock: asyncio.Lock = asyncio.Lock()
 
-_SENTENCE_BREAK_RE: re.Pattern[str] = re.compile(r"[.!?](?:\s|$)")
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -89,35 +87,8 @@ def _merge_participating_user_ids(
 
 
 def _find_safe_stream_break(text: str) -> int:
-    """Find the best character index to break a streamed response.
-
-    Prefer sentence boundaries (``.``, ``!``, ``?`` followed by whitespace or
-    end-of-string), while avoiding split points that sit inside Slack or
-    Markdown formatting markers (``**`` and ``~``) and apostrophe contractions
-    (e.g. ``user's``).
-    """
-    if not text:
-        return 0
-
-    break_idx: int = 0
-    for match in _SENTENCE_BREAK_RE.finditer(text):
-        candidate: int = match.end()
-
-        punct_idx: int = match.start()
-
-        # Avoid breaks after apostrophe contractions/possessives (e.g., "user's.").
-        if punct_idx >= 2 and text[punct_idx - 2:punct_idx] in {"'s", "'S"}:
-            continue
-
-        # Don't split right after formatting marks (e.g., "**.", "~.").
-        if punct_idx >= 2 and text[punct_idx - 2:punct_idx] == "**":
-            continue
-        if punct_idx >= 1 and text[punct_idx - 1:punct_idx] == "~":
-            continue
-
-        break_idx = candidate
-
-    return break_idx
+    """Find the quickest safe break for workspace streaming updates."""
+    return find_safe_text_break(text, preference="quickest_safe")
 
 
 # ===========================================================================

--- a/backend/tests/test_text_breaks.py
+++ b/backend/tests/test_text_breaks.py
@@ -1,0 +1,27 @@
+from messengers._text_breaks import find_safe_text_break
+from messengers._twilio_phone import _split_text
+from messengers._workspace import _find_safe_stream_break
+
+
+def test_workspace_uses_quickest_safe_sentence_break() -> None:
+    text = "First sentence. Second sentence."
+    assert _find_safe_stream_break(text) == len("First sentence. ")
+
+
+def test_safe_break_skips_disallowed_boundaries() -> None:
+    assert find_safe_text_break("The user's. request", preference="quickest_safe") == 0
+    assert find_safe_text_break("Wrapped in **. bold", preference="quickest_safe") == 0
+    assert find_safe_text_break("Wrapped in ~. strike", preference="quickest_safe") == 0
+
+
+def test_twilio_split_prefers_best_sentence_break_within_limit() -> None:
+    text = "First short sentence. Second sentence is long enough to split here"
+    segments = _split_text(text, max_len=35)
+    assert segments[0] == "First short sentence."
+    assert "Second sentence" in segments[1]
+
+
+def test_twilio_split_falls_back_to_whitespace_when_no_sentence_boundary() -> None:
+    text = "word " * 20
+    segments = _split_text(text.strip(), max_len=20)
+    assert all(len(segment) <= 20 for segment in segments)


### PR DESCRIPTION
### Motivation
- Centralize punctuation-aware text-splitting logic used by workspace streaming and Twilio SMS/WhatsApp segmentation to avoid duplicated heuristics and inconsistent behavior.
- Ensure workspace-style streams flush at the earliest safe sentence boundary while Twilio segments prefer the best safe break within a length bound.

### Description
- Added `backend/messengers/_text_breaks.py` with `find_safe_text_break(text, *, preference, max_index)` implementing shared sentence-boundary detection and guards against apostrophe/formatting breaks.
- Updated `backend/messengers/_workspace.py` to make `_find_safe_stream_break` call `find_safe_text_break(..., preference="quickest_safe")` so streaming uses the earliest safe break.
- Updated `backend/messengers/_twilio_phone.py` to make `_split_text` call `find_safe_text_break(..., preference="best", max_index=max_len)` and fall back to a hard cutoff, so Twilio segmentation picks the best safe split within limits.
- Added `backend/tests/test_text_breaks.py` with unit tests for workspace quickest-safe behavior, disallowed boundaries, Twilio best-break selection, and fallback splitting.

### Testing
- Ran `pytest -q tests/test_workspace_stream_breaks.py tests/test_text_breaks.py` which completed successfully with all tests passing (`7 passed`).
- Verified that the original `tests/test_workspace_stream_breaks.py` still passes after the refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4822ec6648321909910cbcbb18962)