### PR TITLE
Unify safe stream break logic for Slack and Twilio

### DIFF
--- a/backend/messengers/_stream_breaks.py
+++ b/backend/messengers/_stream_breaks.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+StreamBreakStrategy = Literal["best", "quickest_safe"]
+
+_SENTENCE_BREAK_RE: re.Pattern[str] = re.compile(r"[.!?](?:\s|$)")
+
+
+def _is_valid_sentence_break(text: str, punct_idx: int) -> bool:
+    """Return whether punctuation index is safe to break on."""
+    if punct_idx >= 2 and text[punct_idx - 2:punct_idx] in {"'s", "'S"}:
+        return False
+    if punct_idx >= 2 and text[punct_idx - 2:punct_idx] == "**":
+        return False
+    if punct_idx >= 1 and text[punct_idx - 1:punct_idx] == "~":
+        return False
+    return True
+
+
+def find_safe_break(
+    text: str,
+    *,
+    strategy: StreamBreakStrategy = "best",
+    limit: int | None = None,
+) -> int:
+    """Find a safe break index for streamed/segmented text.
+
+    - ``best``: choose the farthest safe sentence break within ``limit``.
+    - ``quickest_safe``: choose the first safe sentence break within ``limit``.
+    """
+    if not text:
+        return 0
+
+    max_index: int = len(text) if limit is None else min(limit, len(text))
+    if max_index <= 0:
+        return 0
+
+    selected_break: int = 0
+    for match in _SENTENCE_BREAK_RE.finditer(text):
+        candidate: int = match.end()
+        if candidate > max_index:
+            break
+        punct_idx: int = match.start()
+        if not _is_valid_sentence_break(text, punct_idx):
+            continue
+        if strategy == "quickest_safe":
+            return candidate
+        selected_break = candidate
+
+    if selected_break > 0:
+        return selected_break
+
+    # For unbounded streaming buffers, only sentence-safe boundaries are used.
+    if limit is None:
+        return 0
+
+    # Fallback when no sentence boundary is available in the bounded window.
+    newline_break: int = text.rfind("\n", 0, max_index)
+    if newline_break > 0:
+        return newline_break
+
+    space_break: int = text.rfind(" ", 0, max_index)
+    if space_break > 0:
+        return space_break
+
+    return max_index if max_index < len(text) else 0
+

--- a/backend/messengers/_twilio_phone.py
+++ b/backend/messengers/_twilio_phone.py
@@ -29,6 +29,7 @@ import httpx
 from sqlalchemy import select
 
 from config import settings
+from messengers._stream_breaks import find_safe_break
 from messengers.base import (
     BaseMessenger,
     InboundMessage,
@@ -99,16 +100,18 @@ _TWILIO_MAX_LENGTH: int = 1600
 
 
 def _split_text(text: str, max_len: int) -> list[str]:
-    """Split *text* into chunks of at most *max_len* chars, preferring newlines."""
+    """Split *text* into chunks of at most *max_len* chars.
+
+    Uses the shared safe-break routine with the ``best`` strategy so Twilio
+    segments prefer the farthest safe break before hard-cutting.
+    """
     segments: list[str] = []
     remaining: str = text
     while remaining:
         if len(remaining) <= max_len:
             segments.append(remaining)
             break
-        cut: int = remaining.rfind("\n", 0, max_len)
-        if cut <= 0:
-            cut = remaining.rfind(" ", 0, max_len)
+        cut: int = find_safe_break(remaining, strategy="best", limit=max_len)
         if cut <= 0:
             cut = max_len
         segments.append(remaining[:cut].rstrip())

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import re
 import time
 import uuid as _uuid
 from datetime import UTC, datetime
@@ -28,6 +27,7 @@ from sqlalchemy import select, or_, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from config import settings
+from messengers._stream_breaks import find_safe_break
 from messengers.base import (
     BaseMessenger,
     InboundMessage,
@@ -68,7 +68,6 @@ _WORKSPACE_ORG_CACHE_TTL_SECONDS: int = 300
 _workspace_org_cache: dict[tuple[str, str], tuple[str | None, float]] = {}
 _workspace_org_cache_lock: asyncio.Lock = asyncio.Lock()
 
-_SENTENCE_BREAK_RE: re.Pattern[str] = re.compile(r"[.!?](?:\s|$)")
 
 
 # ---------------------------------------------------------------------------
@@ -87,37 +86,6 @@ def _merge_participating_user_ids(
             current.append(uid)
     return current
 
-
-def _find_safe_stream_break(text: str) -> int:
-    """Find the best character index to break a streamed response.
-
-    Prefer sentence boundaries (``.``, ``!``, ``?`` followed by whitespace or
-    end-of-string), while avoiding split points that sit inside Slack or
-    Markdown formatting markers (``**`` and ``~``) and apostrophe contractions
-    (e.g. ``user's``).
-    """
-    if not text:
-        return 0
-
-    break_idx: int = 0
-    for match in _SENTENCE_BREAK_RE.finditer(text):
-        candidate: int = match.end()
-
-        punct_idx: int = match.start()
-
-        # Avoid breaks after apostrophe contractions/possessives (e.g., "user's.").
-        if punct_idx >= 2 and text[punct_idx - 2:punct_idx] in {"'s", "'S"}:
-            continue
-
-        # Don't split right after formatting marks (e.g., "**.", "~.").
-        if punct_idx >= 2 and text[punct_idx - 2:punct_idx] == "**":
-            continue
-        if punct_idx >= 1 and text[punct_idx - 1:punct_idx] == "~":
-            continue
-
-        break_idx = candidate
-
-    return break_idx
 
 
 # ===========================================================================
@@ -565,7 +533,7 @@ class WorkspaceMessenger(BaseMessenger):
                 text_to_send = current_text.strip()
                 current_text = ""
             else:
-                break_idx: int = _find_safe_stream_break(current_text)
+                break_idx: int = find_safe_break(current_text, strategy="quickest_safe")
                 if break_idx <= 0:
                     return
                 text_to_send = current_text[:break_idx].strip()

--- a/backend/tests/test_twilio_stream_breaks.py
+++ b/backend/tests/test_twilio_stream_breaks.py
@@ -1,0 +1,7 @@
+from messengers._twilio_phone import _split_text
+
+
+def test_twilio_split_text_uses_best_safe_breaks() -> None:
+    text = "One short sentence. Two short sentence. Three"
+    segments = _split_text(text, max_len=len("One short sentence. Two short sentence. T"))
+    assert segments == ["One short sentence. Two short sentence.", "Three"]

--- a/backend/tests/test_workspace_stream_breaks.py
+++ b/backend/tests/test_workspace_stream_breaks.py
@@ -1,16 +1,21 @@
-from messengers._workspace import _find_safe_stream_break
+from messengers._stream_breaks import find_safe_break
 
 
-def test_find_safe_stream_break_prefers_sentence_boundary() -> None:
-    text = "First sentence. Second sentence"
-    assert _find_safe_stream_break(text) == len("First sentence. ")
+def test_find_safe_stream_break_best_prefers_farthest_sentence_boundary() -> None:
+    text = "First sentence. Second sentence? Third sentence"
+    assert find_safe_break(text, strategy="best") == len("First sentence. Second sentence? ")
+
+
+def test_find_safe_stream_break_quickest_safe_returns_earliest_boundary() -> None:
+    text = "First sentence. Second sentence? Third sentence"
+    assert find_safe_break(text, strategy="quickest_safe") == len("First sentence. ")
 
 
 def test_find_safe_stream_break_skips_apostrophe_s_boundary() -> None:
     text = "The user's. request is queued"
-    assert _find_safe_stream_break(text) == 0
+    assert find_safe_break(text, strategy="best") == 0
 
 
 def test_find_safe_stream_break_skips_formatting_mark_boundaries() -> None:
-    assert _find_safe_stream_break("Wrapped in **. bold") == 0
-    assert _find_safe_stream_break("Wrapped in ~. strike") == 0
+    assert find_safe_break("Wrapped in **. bold", strategy="best") == 0
+    assert find_safe_break("Wrapped in ~. strike", strategy="best") == 0


### PR DESCRIPTION
### Motivation
- Remove duplicated stream-break heuristics and centralize safe-break selection to avoid inconsistent behavior across workspace (Slack) and Twilio messengers.
- Allow different default break strategies per channel: workspace/Slack should favor the earliest safe break for snappier streaming and Twilio should prefer the farthest safe break when segmenting SMS/MMS.

### Description
- Add a shared helper `find_safe_break` in `backend/messengers/_stream_breaks.py` that implements `best` and `quickest_safe` strategies and the same apostrophe/formatting safety checks.
- Switch workspace streaming flush logic in `backend/messengers/_workspace.py` to call `find_safe_break(..., strategy="quickest_safe")` for streaming flushes.
- Switch Twilio segmentation in `backend/messengers/_twilio_phone.py` to call `find_safe_break(..., strategy="best", limit=max_len)` so Twilio prefers the farthest safe break within the segment window.
- Update and add unit tests: replace workspace tests to exercise both strategies and add `backend/tests/test_twilio_stream_breaks.py` to cover Twilio segmentation behavior.

### Testing
- Ran `pytest -q backend/tests/test_workspace_stream_breaks.py backend/tests/test_twilio_stream_breaks.py` and the suite passed with `5 passed`.
- The new and updated tests verify both `quickest_safe` and `best` strategies and Twilio split behavior using the shared routine.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4822ec6648321909910cbcbb18962)