### PR TITLE
Add invariant test to enforce central stream-break handling for messengers

### DIFF
--- a/backend/tests/test_messenger_stream_break_invariants.py
+++ b/backend/tests/test_messenger_stream_break_invariants.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from messengers._twilio_phone import TwilioPhoneMessenger
+from messengers._workspace import WorkspaceMessenger
+from messengers.registry import discover_messengers
+
+
+_ALLOWED_BASES: tuple[type, ...] = (TwilioPhoneMessenger, WorkspaceMessenger)
+
+
+def test_all_message_delivery_messengers_inherit_stream_break_aware_base() -> None:
+    """Guardrail: delivery messengers must inherit a base that uses central safe breaks.
+
+    Current stream break behavior is centralized in:
+    - ``TwilioPhoneMessenger`` (batch delivery via ``_split_text``)
+    - ``WorkspaceMessenger`` (streaming flush boundaries)
+
+    Any newly added messenger type that delivers responses should inherit one
+    of these bases; otherwise this test fails and prompts explicit adoption.
+    """
+
+    registry = discover_messengers()
+
+    for slug, messenger_cls in registry.items():
+        if slug == "web":
+            # Web chat uses a separate websocket path (no messenger chunking).
+            continue
+
+        assert issubclass(messenger_cls, _ALLOWED_BASES), (
+            f"Messenger '{slug}' must inherit TwilioPhoneMessenger or "
+            "WorkspaceMessenger so it uses central stream break handling."
+        )


### PR DESCRIPTION
### Motivation
- Ensure all current and future response-delivering messenger implementations use the centralized stream-break logic so message chunking/streaming behavior remains consistent and future additions fail fast if they bypass the central tools.

### Description
- Add `backend/tests/test_messenger_stream_break_invariants.py` which discovers messengers via `discover_messengers()` and asserts each messenger (except `web`) is a subclass of either `TwilioPhoneMessenger` or `WorkspaceMessenger` so they use the shared `find_safe_break`/streaming flush behavior.

### Testing
- Ran `pytest -q backend/tests/test_messenger_stream_break_invariants.py backend/tests/test_workspace_stream_breaks.py backend/tests/test_twilio_stream_breaks.py` and all tests passed (`6 passed in 8.11s`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4834bd648832199c695016260b963)