### PR TITLE
Tighten stream break logic to sentence punctuation only

### DIFF
--- a/backend/messengers/_stream_breaks.py
+++ b/backend/messengers/_stream_breaks.py
@@ -16,6 +16,15 @@ def _is_valid_sentence_break(text: str, punct_idx: int) -> bool:
         return False
     if punct_idx >= 1 and text[punct_idx - 1:punct_idx] == "~":
         return False
+
+    line_start: int = text.rfind("\n", 0, punct_idx) + 1
+    line_prefix: str = text[line_start:punct_idx].strip()
+
+    if line_prefix.startswith(("-", "*", "+")):
+        return False
+    if re.fullmatch(r"\d+", line_prefix):
+        return False
+
     return True
 
 
@@ -56,14 +65,5 @@ def find_safe_break(
     if limit is None:
         return 0
 
-    # Fallback when no sentence boundary is available in the bounded window.
-    newline_break: int = text.rfind("\n", 0, max_index)
-    if newline_break > 0:
-        return newline_break
-
-    space_break: int = text.rfind(" ", 0, max_index)
-    if space_break > 0:
-        return space_break
-
-    return max_index if max_index < len(text) else 0
-
+    # Bounded windows still require sentence boundaries.
+    return 0

--- a/backend/tests/test_workspace_stream_breaks.py
+++ b/backend/tests/test_workspace_stream_breaks.py
@@ -19,3 +19,17 @@ def test_find_safe_stream_break_skips_apostrophe_s_boundary() -> None:
 def test_find_safe_stream_break_skips_formatting_mark_boundaries() -> None:
     assert find_safe_break("Wrapped in **. bold", strategy="best") == 0
     assert find_safe_break("Wrapped in ~. strike", strategy="best") == 0
+
+
+def test_find_safe_stream_break_skips_bullet_boundaries() -> None:
+    assert find_safe_break("- Item one. Item two", strategy="best") == 0
+    assert find_safe_break("* Item one. Item two", strategy="best") == 0
+    assert find_safe_break("+ Item one. Item two", strategy="best") == 0
+
+
+def test_find_safe_stream_break_skips_numbered_list_boundaries() -> None:
+    assert find_safe_break("1. First item", strategy="best") == 0
+
+
+def test_find_safe_stream_break_never_uses_space_fallback_with_limit() -> None:
+    assert find_safe_break("no sentence break here", strategy="best", limit=10) == 0


### PR DESCRIPTION
### Motivation
- Ensure streaming only breaks at true sentence-ending punctuation and not on spaces, list markers, or inline formatting, matching the desired streaming behavior.
- Prevent awkward mid-list or formatting splits that produce noisy partial messages in real-time streams.

### Description
- Updated `_is_valid_sentence_break` to reject punctuation that follows bullet markers (`-`, `*`, `+`) or a numeric list prefix using a `rfind("\n")`-based line prefix check and `re.fullmatch(r"\d+", ...)`.
- Preserved existing protections for apostrophe-s (`'s`), bold markers (`**`), and strike (`~`) edge cases.
- Removed the bounded-window fallback that previously returned newline/space/hard-limit positions so that bounded windows also require valid sentence-ending punctuation.
- Added tests covering bullet list boundaries, numbered-list boundaries, and bounded-window behavior to prevent regressions.

### Testing
- Ran `pytest -q backend/tests/test_workspace_stream_breaks.py` and all tests passed.
- Test result: `7 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b485079ff88321b9261f2927672aae)