### PR TITLE
Add dedicated global command memory support and 400-char enforcement

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -616,6 +616,7 @@ class ChatOrchestrator:
             "reports_to_name": None,
             "phone_number": getattr(self, "_phone_number", None),
             "participant_job_memories": [],
+            "global_command_memory": None,
         }
 
         try:
@@ -681,6 +682,9 @@ class ChatOrchestrator:
                 for mem in all_memories:
                     entry: dict[str, str] = {"id": str(mem.id), "content": mem.content}
                     if mem.entity_type == "user" and user_uuid and mem.entity_id == user_uuid:
+                        if mem.category == "global_commands":
+                            profile["global_command_memory"] = entry
+                            continue
                         profile["user_memories"].append(entry)
                     elif (
                         mem.entity_type == "organization_member"
@@ -916,9 +920,10 @@ class ChatOrchestrator:
             membership_title: str | None = profile["membership_title"]
             reports_to_name: str | None = profile["reports_to_name"]
             phone_number: str | None = profile["phone_number"]
+            global_command_memory: dict[str, str] | None = profile.get("global_command_memory")
 
             has_any_context: bool = bool(
-                user_memories or job_memories
+                user_memories or job_memories or global_command_memory
                 or membership_title or reports_to_name or phone_number
             )
 
@@ -926,6 +931,10 @@ class ChatOrchestrator:
                 system_prompt += "\n\n# Context Profile"
                 system_prompt += "\nThese are persisted facts about the user and their role."
                 system_prompt += " Follow preferences. Use manage_memory with action=\"update\" or action=\"delete\" and the [memory_id] shown in brackets to manage entries.\n"
+
+            if global_command_memory:
+                system_prompt += "\n## Global Command (Always Apply)\n"
+                system_prompt += f"- [{global_command_memory['id']}] {global_command_memory['content']}\n"
 
             # -- User profile section --
             if user_memories or phone_number:

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -5558,6 +5558,25 @@ async def execute_keep_notes(
     return {"note_id": f"{run_id}:{len(notes) - 1}", "content": content, "status": "saved"}
 
 
+
+GLOBAL_COMMAND_CATEGORY = "global_commands"
+GLOBAL_COMMAND_MAX_LENGTH = 400
+
+
+def _normalize_memory_category(category: str | None) -> str | None:
+    if not category:
+        return None
+    normalized = category.strip().lower()
+    if not normalized:
+        return None
+    return GLOBAL_COMMAND_CATEGORY if normalized in {"global_command", "global_commands"} else normalized
+
+
+def _validate_memory_content_for_category(content: str, category: str | None) -> str | None:
+    if category == GLOBAL_COMMAND_CATEGORY and len(content) > GLOBAL_COMMAND_MAX_LENGTH:
+        return f"Global command memories must be {GLOBAL_COMMAND_MAX_LENGTH} characters or fewer."
+    return None
+
 async def _manage_memory(
     params: dict[str, Any], organization_id: str, user_id: str | None, skip_approval: bool = False
 ) -> dict[str, Any]:
@@ -5624,9 +5643,10 @@ async def execute_save_memory(
         return {"status": "failed", "error": "content is required."}
 
     entity_type: str = params.get("entity_type", "user").strip()
-    category: str | None = params.get("category")
-    if category:
-        category = category.strip() or None
+    category: str | None = _normalize_memory_category(params.get("category"))
+    content_error = _validate_memory_content_for_category(content, category)
+    if content_error:
+        return {"status": "failed", "error": content_error}
 
     from models.memory import Memory
     from models.org_member import OrgMember
@@ -5736,6 +5756,10 @@ async def _update_memory(
 
         if memory.created_by_user_id and str(memory.created_by_user_id) != user_id:
             return {"error": f"Memory {memory_id} does not belong to this user."}
+
+        content_error = _validate_memory_content_for_category(new_content, _normalize_memory_category(memory.category))
+        if content_error:
+            return {"error": content_error}
 
         memory.content = new_content
         await session.commit()

--- a/backend/api/routes/memories.py
+++ b/backend/api/routes/memories.py
@@ -14,6 +14,29 @@ from models.memory import Memory
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+GLOBAL_COMMAND_CATEGORY = "global_commands"
+GLOBAL_COMMAND_CATEGORY_ALIASES = {"global_command", "global_commands"}
+GLOBAL_COMMAND_MAX_LENGTH = 400
+
+
+def normalize_memory_category(category: str | None) -> str | None:
+    if not category:
+        return None
+    normalized = category.strip().lower()
+    if not normalized:
+        return None
+    if normalized in GLOBAL_COMMAND_CATEGORY_ALIASES:
+        return GLOBAL_COMMAND_CATEGORY
+    return normalized
+
+
+def validate_memory_content(content: str, category: str | None) -> None:
+    if category == GLOBAL_COMMAND_CATEGORY and len(content) > GLOBAL_COMMAND_MAX_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Global command memories must be {GLOBAL_COMMAND_MAX_LENGTH} characters or fewer",
+        )
+
 
 class MemoryResponse(BaseModel):
     id: str
@@ -90,13 +113,15 @@ async def create_user_memory(
     content = request.content.strip()
     if not content:
         raise HTTPException(status_code=400, detail="content is required")
+    category = normalize_memory_category(request.category)
+    validate_memory_content(content, category)
 
     async with get_session(organization_id=organization_id) as session:
         memory = Memory(
             entity_type="user",
             entity_id=user_uuid,
             organization_id=org_uuid,
-            category=(request.category.strip() or None) if request.category else None,
+            category=category,
             content=content,
             created_by_user_id=user_uuid,
         )
@@ -119,7 +144,8 @@ async def create_user_memory(
 @router.patch("/{organization_id}/user/{memory_id}", response_model=MemoryResponse)
 async def update_user_memory(organization_id: str, memory_id: str, user_id: str, request: UpdateMemoryRequest) -> MemoryResponse:
     """Update a user-stored memory's content."""
-    if not request.content.strip():
+    content = request.content.strip()
+    if not content:
         raise HTTPException(status_code=400, detail="content is required")
 
     try:
@@ -143,7 +169,9 @@ async def update_user_memory(organization_id: str, memory_id: str, user_id: str,
         if not memory:
             raise HTTPException(status_code=404, detail="Memory not found")
 
-        memory.content = request.content.strip()
+        validate_memory_content(content, normalize_memory_category(memory.category))
+
+        memory.content = content
         await session.commit()
         await session.refresh(memory)
 

--- a/frontend/src/components/Memories.tsx
+++ b/frontend/src/components/Memories.tsx
@@ -17,6 +17,9 @@ interface MemoryDashboardResponse {
   memories: StoredMemory[];
 }
 
+const GLOBAL_COMMAND_CATEGORY = 'global_commands';
+const GLOBAL_COMMAND_MAX_LENGTH = 400;
+
 function formatTime(value: string | null): string {
   if (!value) return 'Unknown time';
   return new Date(value).toLocaleString();
@@ -28,6 +31,7 @@ export function Memories(): JSX.Element {
   const [editingMemoryId, setEditingMemoryId] = useState<string | null>(null);
   const [memoryDraft, setMemoryDraft] = useState<string>('');
   const [newMemoryContent, setNewMemoryContent] = useState<string>('');
+  const [newGlobalCommand, setNewGlobalCommand] = useState<string>('');
   const [showAddForm, setShowAddForm] = useState<boolean>(false);
 
   const orgId = organization?.id;
@@ -45,6 +49,8 @@ export function Memories(): JSX.Element {
   });
 
   const memories: StoredMemory[] = data?.memories ?? [];
+  const globalCommandMemory = memories.find((memory) => memory.category === GLOBAL_COMMAND_CATEGORY) ?? null;
+  const otherMemories = memories.filter((memory) => memory.category !== GLOBAL_COMMAND_CATEGORY);
 
   const updateMemory = useMutation({
     mutationFn: async ({ memoryId, content }: { memoryId: string; content: string }) => {
@@ -74,16 +80,17 @@ export function Memories(): JSX.Element {
   });
 
   const createMemory = useMutation({
-    mutationFn: async (content: string) => {
+    mutationFn: async ({ content, category }: { content: string; category?: string }) => {
       const { error: err } = await apiRequest(`/memories/${orgId}/user?user_id=${userId}`, {
         method: 'POST',
-        body: JSON.stringify({ content: content.trim() }),
+        body: JSON.stringify({ content: content.trim(), category }),
       });
       if (err) throw new Error(err);
     },
     onSuccess: () => {
       setNewMemoryContent('');
       setShowAddForm(false);
+      setNewGlobalCommand('');
       void queryClient.invalidateQueries({ queryKey });
     },
   });
@@ -91,7 +98,13 @@ export function Memories(): JSX.Element {
   const handleAddMemory = (): void => {
     const trimmed = newMemoryContent.trim();
     if (!trimmed) return;
-    createMemory.mutate(trimmed);
+    createMemory.mutate({ content: trimmed });
+  };
+
+  const handleSaveGlobalCommand = (): void => {
+    const trimmed = newGlobalCommand.trim();
+    if (!trimmed || trimmed.length > GLOBAL_COMMAND_MAX_LENGTH) return;
+    createMemory.mutate({ content: trimmed, category: GLOBAL_COMMAND_CATEGORY });
   };
 
   return (
@@ -102,6 +115,91 @@ export function Memories(): JSX.Element {
 
         {!isLoading && !isError && (
           <>
+            <div className="rounded-lg border border-primary-700/40 bg-primary-950/20 p-3">
+              <div className="text-xs uppercase tracking-wide text-primary-300 mb-2">Global command</div>
+              <p className="text-xs text-surface-400 mb-2">Sent on every message. Maximum 400 characters.</p>
+              <textarea
+                className="w-full min-h-20 rounded-lg bg-surface-800 border border-surface-700 px-3 py-2 text-sm text-surface-100"
+                value={editingMemoryId === globalCommandMemory?.id ? memoryDraft : (globalCommandMemory?.content ?? newGlobalCommand)}
+                onChange={(e) => {
+                  if (editingMemoryId === globalCommandMemory?.id) {
+                    setMemoryDraft(e.target.value);
+                    return;
+                  }
+                  setNewGlobalCommand(e.target.value);
+                }}
+                placeholder="e.g. Always start with a short summary before details"
+                maxLength={GLOBAL_COMMAND_MAX_LENGTH}
+                readOnly={Boolean(globalCommandMemory && editingMemoryId !== globalCommandMemory.id)}
+              />
+              <div className="mt-2 flex items-center justify-between gap-2">
+                <span className="text-xs text-surface-500">
+                  {(editingMemoryId === globalCommandMemory?.id ? memoryDraft : (globalCommandMemory?.content ?? newGlobalCommand)).length}/{GLOBAL_COMMAND_MAX_LENGTH}
+                </span>
+                <div className="flex items-center gap-2">
+                  {globalCommandMemory && (
+                    <button
+                      type="button"
+                      className="px-3 py-1.5 text-xs rounded-md bg-red-600/20 hover:bg-red-600/30 text-red-300"
+                      onClick={() => deleteMemory.mutate(globalCommandMemory.id)}
+                    >
+                      Delete
+                    </button>
+                  )}
+                  {editingMemoryId === globalCommandMemory?.id ? (
+                    <>
+                      <button
+                        type="button"
+                        className="px-3 py-1.5 text-xs rounded-md bg-primary-600 hover:bg-primary-700 text-white disabled:opacity-60"
+                        disabled={!memoryDraft.trim() || memoryDraft.length > GLOBAL_COMMAND_MAX_LENGTH}
+                        onClick={() => {
+                          updateMemory.mutate({ memoryId: globalCommandMemory.id, content: memoryDraft });
+                          setEditingMemoryId(null);
+                        }}
+                      >
+                        Save
+                      </button>
+                      <button
+                        type="button"
+                        className="px-3 py-1.5 text-xs rounded-md bg-surface-800 hover:bg-surface-700 text-surface-200"
+                        onClick={() => {
+                          setEditingMemoryId(null);
+                          setMemoryDraft(globalCommandMemory.content);
+                        }}
+                      >
+                        Cancel
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      {globalCommandMemory && (
+                        <button
+                          type="button"
+                          className="px-3 py-1.5 text-xs rounded-md bg-surface-800 hover:bg-surface-700 text-surface-200"
+                          onClick={() => {
+                            setEditingMemoryId(globalCommandMemory.id);
+                            setMemoryDraft(globalCommandMemory.content);
+                          }}
+                        >
+                          Edit
+                        </button>
+                      )}
+                      {!globalCommandMemory && (
+                        <button
+                          type="button"
+                          className="px-3 py-1.5 text-xs rounded-md bg-primary-600 hover:bg-primary-700 text-white disabled:opacity-60"
+                          disabled={!newGlobalCommand.trim() || newGlobalCommand.length > GLOBAL_COMMAND_MAX_LENGTH || createMemory.isPending}
+                          onClick={handleSaveGlobalCommand}
+                        >
+                          Save
+                        </button>
+                      )}
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+
             <div className="flex justify-end">
               {!showAddForm && (
                 <button
@@ -144,7 +242,7 @@ export function Memories(): JSX.Element {
             )}
 
             <div className="space-y-3">
-              {memories.length ? memories.map((memory) => (
+              {otherMemories.length ? otherMemories.map((memory) => (
                 <div key={memory.id} className="rounded-lg border border-surface-800 bg-surface-900 p-3">
                   <div className="flex flex-col gap-3">
                     <div className="w-full">


### PR DESCRIPTION
### Motivation
- Provide a first-class, always-applied per-user instruction (“Global command”) in the memory sidebar so agents receive a short global instruction on every message. 
- Ensure global commands are stored consistently and kept short to avoid overly long injected system prompts by enforcing a 400-character limit. 

### Description
- UI: add a top-level “Global command” block to `frontend/src/components/Memories.tsx` that displays/edits/deletes a single memory with `category='global_commands'` and enforces a 400-character limit, while listing other memories below. 
- API: normalize category aliases (`global_command` / `global_commands`) and validate content length in `backend/api/routes/memories.py` on create and update paths (returns 400 on violation). 
- Tools: apply the same category normalization and 400-char validation in the `manage_memory` persistence path in `backend/agents/tools.py` so tool-based saves/updates are consistent with the UI. 
- Orchestrator: separate global command from regular user/job memories and inject it into the prompt under a `Global Command (Always Apply)` section in `backend/agents/orchestrator.py`. 

### Testing
- Ran frontend lint with `npm --prefix frontend run lint` and it completed successfully. 
- Verified Python compilation for modified backend modules with `python -m py_compile backend/api/routes/memories.py backend/agents/orchestrator.py backend/agents/tools.py` and it succeeded. 
- Executed unit tests `pytest -q backend/tests/test_workflow_permissions.py` which passed (`6 passed`). 
- Rendered the frontend and captured a headless screenshot via a Playwright script to validate the sidebar UI (screenshot artifact generated successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b488d401508321810631f5533f0d09)