### PR TITLE
Adjust 'Get Immediate Help' button size and right-edge spacing

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -59,10 +59,10 @@ function HelpButton(): JSX.Element {
       <button
         onClick={() => setShowModal(true)}
         title="Get Immediate Help"
-        className="p-2 rounded-lg text-amber-400 hover:text-amber-300 hover:bg-amber-500/15 transition-colors"
+        className="mr-0.5 p-2 rounded-lg text-amber-400 hover:text-amber-300 hover:bg-amber-500/15 transition-colors"
         aria-label="Get Immediate Help"
       >
-        <FaLifeRing className="w-5 h-5" />
+        <FaLifeRing className="w-[18px] h-[18px]" />
       </button>
       {showModal && (
         <div


### PR DESCRIPTION
### Motivation
- Improve visual balance in the sidebar by creating a small grey buffer on the right edge and reducing the help icon size by ~10% so it reads lighter and less cramped.

### Description
- In `frontend/src/components/Sidebar.tsx` added `mr-0.5` to the help button and changed the `<FaLifeRing>` icon from `w-5 h-5` to `w-[18px] h-[18px]` to implement the spacing and size adjustments.

### Testing
- Ran `cd frontend && npx eslint src/components/Sidebar.tsx` which passed, and executed an automated Playwright screenshot against the local dev server to visually validate the change, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b48675bb548321a37be47cd467353f)