### PR TITLE
Route short yes/no/thanks turns to configurable cheap model

### DIFF
--- a/backend/agents/model_routing.py
+++ b/backend/agents/model_routing.py
@@ -1,0 +1,42 @@
+"""Utilities for selecting LLM models based on message characteristics."""
+
+import re
+from typing import Any
+
+_SHORT_PHRASE_CANONICAL_RESPONSES: set[str] = {
+    "yes", "yep", "yeah", "yup", "sure", "ok", "okay", "affirmative",
+    "no", "nope", "nah", "negative",
+    "thanks", "thank you", "thx", "ty", "thankyou",
+}
+
+
+def _normalize_short_phrase(text: str) -> str:
+    """Normalize short text for semantic short-phrase checks."""
+    collapsed = re.sub(r"[^a-z0-9\s]", " ", text.lower())
+    return " ".join(collapsed.split())
+
+
+def is_short_phrase_for_cheap_model(content: str | list[dict[str, Any]]) -> bool:
+    """Return True if this turn is a 1-2 word yes/no/thanks-style phrase."""
+    if isinstance(content, list):
+        text_parts = [
+            str(block.get("text", ""))
+            for block in content
+            if isinstance(block, dict) and block.get("type") == "text"
+        ]
+        text = " ".join(part for part in text_parts if part).strip()
+    else:
+        text = str(content).strip()
+
+    if not text:
+        return False
+
+    normalized = _normalize_short_phrase(text)
+    if not normalized:
+        return False
+
+    word_count = len(normalized.split())
+    if word_count < 1 or word_count > 2:
+        return False
+
+    return normalized in _SHORT_PHRASE_CANONICAL_RESPONSES

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -21,6 +21,7 @@ from uuid import UUID, uuid4
 from anthropic import APIStatusError, AsyncAnthropic
 from sqlalchemy import select, update
 
+from agents.model_routing import is_short_phrase_for_cheap_model
 from agents.tools import execute_tool, get_tools
 from config import settings
 from models.chat_message import ChatMessage
@@ -841,6 +842,20 @@ class ChatOrchestrator:
             {"role": "user", "content": user_content}
         ]
 
+        selected_model: str = settings.ANTHROPIC_PRIMARY_MODEL
+        if (
+            settings.USE_CHEAP_MODEL_FOR_SHORT_PHRASE
+            and is_short_phrase_for_cheap_model(user_content)
+        ):
+            selected_model = settings.CHEAP_SHORT_PHRASE_MODEL
+
+        logger.info(
+            "[Orchestrator] conversation_id=%s selected_model=%s short_phrase_cheap_enabled=%s",
+            self.conversation_id,
+            selected_model,
+            settings.USE_CHEAP_MODEL_FOR_SHORT_PHRASE,
+        )
+
         # Keep track of content blocks for saving (preserves interleaving order)
         content_blocks: list[dict[str, Any]] = []
 
@@ -1009,7 +1024,7 @@ class ChatOrchestrator:
 
 
         # Stream responses with tool handling loop
-        async for chunk in self._stream_with_tools(messages, system_prompt, content_blocks):
+        async for chunk in self._stream_with_tools(messages, system_prompt, content_blocks, selected_model):
             yield chunk
         
         # Save conversation (user message was already saved at the start)
@@ -1034,6 +1049,7 @@ class ChatOrchestrator:
         messages: list[dict[str, Any]],
         system_prompt: str,
         content_blocks: list[dict[str, Any]],
+        model_name: str,
     ) -> AsyncGenerator[str, None]:
         """
         Stream Claude's response, handling tool calls in a loop.
@@ -1075,8 +1091,15 @@ class ChatOrchestrator:
                     is_thinking_block = False
                     
                     # Stream the response
+                    logger.info(
+                        "[Orchestrator] Sending message batch to Anthropic conversation_id=%s model=%s message_count=%d attempt=%d",
+                        self.conversation_id,
+                        model_name,
+                        len(messages),
+                        attempt + 1,
+                    )
                     async with self.client.messages.stream(
-                        model="claude-opus-4-6",
+                        model=model_name,
                         max_tokens=32768,
                         system=system_prompt,
                         tools=get_tools(self.workflow_context),

--- a/backend/config.py
+++ b/backend/config.py
@@ -58,6 +58,9 @@ class Settings(BaseSettings):
 
     # Anthropic
     ANTHROPIC_API_KEY: Optional[str] = None
+    ANTHROPIC_PRIMARY_MODEL: str = "claude-opus-4-6"
+    USE_CHEAP_MODEL_FOR_SHORT_PHRASE: bool = True
+    CHEAP_SHORT_PHRASE_MODEL: str = "claude-haiku-4-5"
     
     # OpenAI (for embeddings + research fallback)
     OPENAI_API_KEY: Optional[str] = None

--- a/backend/tests/test_orchestrator_short_phrase_model.py
+++ b/backend/tests/test_orchestrator_short_phrase_model.py
@@ -1,0 +1,23 @@
+from agents.model_routing import is_short_phrase_for_cheap_model
+
+
+def test_short_phrase_detector_accepts_yes_no_and_thanks_semantics() -> None:
+    assert is_short_phrase_for_cheap_model("yes") is True
+    assert is_short_phrase_for_cheap_model("Nope") is True
+    assert is_short_phrase_for_cheap_model("thank you") is True
+    assert is_short_phrase_for_cheap_model("thx!") is True
+
+
+def test_short_phrase_detector_rejects_longer_or_non_target_content() -> None:
+    assert is_short_phrase_for_cheap_model("sounds good") is False
+    assert is_short_phrase_for_cheap_model("yes please") is False
+    assert is_short_phrase_for_cheap_model("this is definitely longer") is False
+
+
+def test_short_phrase_detector_handles_content_blocks() -> None:
+    assert is_short_phrase_for_cheap_model([
+        {"type": "text", "text": "Thanks"},
+    ]) is True
+    assert is_short_phrase_for_cheap_model([
+        {"type": "tool_result", "content": "ignored"},
+    ]) is False


### PR DESCRIPTION
### Motivation
- Reduce cost for trivial 1–2 word replies (yes/no/thank-you variants) by routing them to a cheaper model and make that behavior configurable.
- Ensure we log which model is selected for each incoming message so model usage is auditable.

### Description
- Added three new settings in `backend/config.py`: `ANTHROPIC_PRIMARY_MODEL`, `USE_CHEAP_MODEL_FOR_SHORT_PHRASE` (default `True`), and `CHEAP_SHORT_PHRASE_MODEL` (default `claude-haiku-4-5`).
- Introduced `backend/agents/model_routing.py` which implements short-phrase detection for 1–2 word semantic variants of yes/no/thanks and normalizes both plain strings and content-blocks.
- Updated `ChatOrchestrator` in `backend/agents/orchestrator.py` to pick `selected_model` per incoming turn using the detector and new settings, pass `model_name` into the streaming call, and log the selected model on message receipt and when sending batches to Anthropic.
- Added unit tests `backend/tests/test_orchestrator_short_phrase_model.py` covering positive/negative and content-block cases for the detector.

### Testing
- Ran the new unit tests with `cd backend && pytest -q tests/test_orchestrator_short_phrase_model.py`, which passed (tests covering detection of yes/no/thanks variants and content-block handling).
- Attempted to run a larger orchestrator test set (`tests/test_orchestrator_short_phrase_model.py tests/test_orchestrator_context_window.py tests/test_orchestrator_identity.py`), but collection failed due to an existing circular import in this environment involving `agents.orchestrator` ↔ `api.websockets`; this is unrelated to the short-phrase routing logic itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b48e0003208321a02336635f9edc65)