### PR TITLE
Update global command wording, increase limit to 800 chars, and autosize textarea

### DIFF
--- a/frontend/src/components/Memories.tsx
+++ b/frontend/src/components/Memories.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiRequest } from '../lib/api';
 import { useAppStore } from '../store';
@@ -18,7 +18,7 @@ interface MemoryDashboardResponse {
 }
 
 const GLOBAL_COMMAND_CATEGORY = 'global_commands';
-const GLOBAL_COMMAND_MAX_LENGTH = 400;
+const GLOBAL_COMMAND_MAX_LENGTH = 800;
 
 function formatTime(value: string | null): string {
   if (!value) return 'Unknown time';
@@ -33,6 +33,7 @@ export function Memories(): JSX.Element {
   const [newMemoryContent, setNewMemoryContent] = useState<string>('');
   const [newGlobalCommand, setNewGlobalCommand] = useState<string>('');
   const [showAddForm, setShowAddForm] = useState<boolean>(false);
+  const globalCommandTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const orgId = organization?.id;
   const userId = user?.id;
@@ -107,6 +108,18 @@ export function Memories(): JSX.Element {
     createMemory.mutate({ content: trimmed, category: GLOBAL_COMMAND_CATEGORY });
   };
 
+  const globalCommandValue = editingMemoryId === globalCommandMemory?.id
+    ? memoryDraft
+    : (globalCommandMemory?.content ?? newGlobalCommand);
+
+  useLayoutEffect(() => {
+    const textarea = globalCommandTextareaRef.current;
+    if (!textarea) return;
+
+    textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }, [globalCommandValue]);
+
   return (
     <div className="flex-1 overflow-hidden flex flex-col">
       <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
@@ -117,10 +130,12 @@ export function Memories(): JSX.Element {
           <>
             <div className="rounded-lg border border-primary-700/40 bg-primary-950/20 p-3">
               <div className="text-xs uppercase tracking-wide text-primary-300 mb-2">Global command</div>
-              <p className="text-xs text-surface-400 mb-2">Sent on every message. Maximum 400 characters.</p>
+              <p className="text-xs text-surface-400 mb-2">Applied on every message. Maximum 800 characters.</p>
               <textarea
-                className="w-full min-h-20 rounded-lg bg-surface-800 border border-surface-700 px-3 py-2 text-sm text-surface-100"
-                value={editingMemoryId === globalCommandMemory?.id ? memoryDraft : (globalCommandMemory?.content ?? newGlobalCommand)}
+                ref={globalCommandTextareaRef}
+                className="w-full rounded-lg bg-surface-800 border border-surface-700 px-3 py-2 text-sm text-surface-100 overflow-y-auto"
+                style={{ minHeight: '5rem', resize: 'none' }}
+                value={globalCommandValue}
                 onChange={(e) => {
                   if (editingMemoryId === globalCommandMemory?.id) {
                     setMemoryDraft(e.target.value);
@@ -134,7 +149,7 @@ export function Memories(): JSX.Element {
               />
               <div className="mt-2 flex items-center justify-between gap-2">
                 <span className="text-xs text-surface-500">
-                  {(editingMemoryId === globalCommandMemory?.id ? memoryDraft : (globalCommandMemory?.content ?? newGlobalCommand)).length}/{GLOBAL_COMMAND_MAX_LENGTH}
+                  {globalCommandValue.length}/{GLOBAL_COMMAND_MAX_LENGTH}
                 </span>
                 <div className="flex items-center gap-2">
                   {globalCommandMemory && (


### PR DESCRIPTION
### Motivation
- Clarify the helper copy to better describe how the global command is applied to messages.
- Give users more room to express global commands by increasing the maximum allowed length.
- Improve UX by making the global command input box grow with its content so users can see what they are typing.

### Description
- Changed the helper text from "Sent on every message. Maximum 400 characters." to "Applied on every message. Maximum 800 characters." in `frontend/src/components/Memories.tsx`.
- Increased `GLOBAL_COMMAND_MAX_LENGTH` from `400` to `800` and updated the UI character counter to reference the new limit.
- Added a `ref` plus `useLayoutEffect` autosize routine so the global command `<textarea>` grows to fit its content, and enforced a minimum height with `style={{ minHeight: '5rem', resize: 'none' }}`.
- Introduced a derived `globalCommandValue` to consolidate the displayed textarea value and character count logic.

### Testing
- Ran `npm run build` in `frontend/` and the build completed successfully.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and captured a screenshot of the updated UI to validate visual behavior.
- No automated test failures were observed during the build and dev validation steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b490b5389c8321b9bb56324faa9c81)