### PR TITLE
Fix private alpha banner dismiss icon alignment

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1541,17 +1541,15 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
                 </span>
                 <span>{RELEASE_STAGE.description}</span>
               </p>
-              <div className="self-start">
-                <button
-                  onClick={dismissReleaseBanner}
-                  className="flex-shrink-0 text-surface-400 hover:text-surface-200 transition-colors px-1"
-                  aria-label="Dismiss"
-                >
-                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              </div>
+              <button
+                onClick={dismissReleaseBanner}
+                className="flex-shrink-0 self-center text-surface-400 hover:text-surface-200 transition-colors px-1"
+                aria-label="Dismiss"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
             </div>
           </div>
         )}


### PR DESCRIPTION
### Motivation
- The dismiss (X) icon in the release/private-alpha banner was vertically misaligned (too high) and needed to sit on the same baseline/line as the banner text for visual consistency.

### Description
- Adjusted the banner markup in `frontend/src/components/AppLayout.tsx` by removing the extra wrapper `div` that enforced top alignment and applying `self-center` to the dismiss `button` so the icon vertically centers with the message.
- Preserved existing behavior and accessibility by keeping the `onClick` handler, `aria-label`, and SVG icon unchanged.

### Testing
- Ran `cd frontend && npx eslint src/components/AppLayout.tsx` and it completed without errors.
- Started the local dev server via `npm run dev` (Vite reported ready) to visually validate the change.
- Captured a UI screenshot with Playwright to confirm the alignment: `browser:/tmp/codex_browser_invocations/0b79d33fbda5886e/artifacts/artifacts/release-banner-alignment.png` (screenshot generated successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b492954cdc83219da8da917cd784fc)