### PR TITLE
Fix dismiss icon alignment in private alpha banner

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1541,7 +1541,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
                 </span>
                 <span>{RELEASE_STAGE.description}</span>
               </p>
-              <div className="self-start">
+              <div>
                 <button
                   onClick={dismissReleaseBanner}
                   className="flex-shrink-0 text-surface-400 hover:text-surface-200 transition-colors px-1"


### PR DESCRIPTION
### Motivation
- The dismiss (X) button in the release-stage/private-alpha banner was vertically misaligned relative to the banner text and needed to sit on the same baseline as the content.

### Description
- Updated `frontend/src/components/AppLayout.tsx` to remove the `self-start` wrapper class around the dismiss button so the close icon aligns properly with the banner text in the flex row.

### Testing
- Ran frontend lint with `npm --prefix frontend run lint` which completed successfully.
- Started the dev server with `npm --prefix frontend run dev -- --host 0.0.0.0 --port 4173` for visual verification and it started successfully.
- Captured a Playwright screenshot of the page to validate the UI change; the screenshot artifact was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b492954cdc83219da8da917cd784fc)