### PR TITLE
Move all-chats pin icon below timestamp

### DIFF
--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -330,20 +330,21 @@ function ChatRow({
           </div>
         </div>
 
-        <div className="text-xs text-surface-500 whitespace-nowrap">{formatDate(chat.lastMessageAt)}</div>
+        <div className="flex flex-col items-end gap-2 flex-shrink-0">
+          <div className="text-xs text-surface-500 whitespace-nowrap">{formatDate(chat.lastMessageAt)}</div>
+          <button
+            onClick={(e) => { e.stopPropagation(); onTogglePin(chat.id); }}
+            className={`p-1.5 rounded ${
+              isPinned ? 'opacity-100 text-primary-400' : 'opacity-0 text-surface-500'
+            } group-hover:opacity-100 hover:bg-surface-700 hover:text-surface-200 transition-all`}
+            title={isPinned ? 'Unpin conversation' : 'Pin conversation'}
+          >
+            <svg className={`w-4 h-4 ${isPinned ? 'text-primary-400' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+            </svg>
+          </button>
+        </div>
       </div>
-
-      <button
-        onClick={(e) => { e.stopPropagation(); onTogglePin(chat.id); }}
-        className={`absolute right-3 top-3 p-1.5 rounded ${
-          isPinned ? 'opacity-100 text-primary-400' : 'opacity-0 text-surface-500'
-        } group-hover:opacity-100 hover:bg-surface-700 hover:text-surface-200 transition-all`}
-        title={isPinned ? 'Unpin conversation' : 'Pin conversation'}
-      >
-        <svg className={`w-4 h-4 ${isPinned ? 'text-primary-400' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-        </svg>
-      </button>
     </button>
   );
 }


### PR DESCRIPTION
### Motivation
- The pin/bookmark icon in the All Chats view was overlaying the timestamp, which obscures the time and feels visually cluttered. 
- The intent is to place the pin control below the timestamp to improve readability while keeping the same interaction and visibility behavior.

### Description
- Updated the All Chats row layout in `frontend/src/components/ChatsList.tsx` to make the right-side metadata a vertical stack with the timestamp above the pin button. 
- Moved the pin/bookmark action from an absolutely positioned top-right overlay into the timestamp column so the icon sits directly under the time. 
- Preserved the existing hover visibility, pinned-state styling, and the `onTogglePin` interaction.

### Testing
- Ran `npm run lint` in `frontend/` and it completed successfully. 
- Launched the dev frontend and captured a Playwright-driven screenshot of the updated UI to validate the pin position, which ran successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b494796c7883218c57ff8b8cd372d3)