### PR TITLE
Add Microsoft Teams messenger integration

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -20,7 +20,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from api.websockets import websocket_endpoint
-from api.routes import apps, artifacts, auth, billing, change_sessions, chat, connectors, data, deals, drive, memories, search, slack_events, slack_user_mappings, support, sync, tool_settings, twilio_events, whatsapp_events, waitlist, workflows
+from api.routes import apps, artifacts, auth, billing, change_sessions, chat, connectors, data, deals, drive, memories, search, slack_events, slack_user_mappings, support, sync, teams_events, tool_settings, twilio_events, whatsapp_events, waitlist, workflows
 from models.database import close_db, get_pool_status
 from services.task_manager import task_manager
 from config import log_missing_env_vars, settings
@@ -176,6 +176,7 @@ app.include_router(slack_events.router, prefix="/api/slack", tags=["slack"])
 app.include_router(slack_user_mappings.router, prefix="/api/slack", tags=["slack-user-mappings"])
 app.include_router(twilio_events.router, prefix="/api/twilio", tags=["twilio"])
 app.include_router(whatsapp_events.router, prefix="/api/whatsapp", tags=["whatsapp"])
+app.include_router(teams_events.router, prefix="/api/teams", tags=["teams"])
 
 # WebSocket - authenticated via JWT token in query parameter
 app.add_api_websocket_route("/ws/chat", websocket_endpoint)

--- a/backend/api/routes/teams_events.py
+++ b/backend/api/routes/teams_events.py
@@ -1,0 +1,414 @@
+"""
+Microsoft Teams Bot Framework webhook endpoint.
+
+Handles incoming activities from the Bot Framework (Teams channel):
+- message: 1:1 chat, channel @mentions, thread replies
+- conversationUpdate / installationUpdate: acknowledge only
+
+Security: Requests are validated using the Bot Framework JWT Bearer token.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import redis.asyncio as redis
+from fastapi import APIRouter, HTTPException, Request
+from jose import JWTError, jwk, jwt
+
+from config import get_redis_connection_kwargs, settings
+from messengers.base import InboundMessage, MessageType
+from messengers.teams import TeamsMessenger
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+BOT_OPENID_URL: str = "https://login.botframework.com/v1/.well-known/openidconfiguration"
+JWKS_CACHE_TTL_SECONDS: int = 3600
+
+# Merged key set from Bot Framework + tenant-specific OpenID endpoints
+_merged_jwks_keys: list[dict[str, Any]] = []
+_jwks_fetched_at: float = 0.0
+
+_redis_client: redis.Redis | None = None
+
+
+class TeamsThreadLockManager:
+    """Per-thread lock for Teams conversation to serialize replies."""
+
+    def __init__(self) -> None:
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._lock_refs: dict[str, int] = {}
+        self._manager_lock = asyncio.Lock()
+
+    @staticmethod
+    def build_lock_key(tenant_id: str, conversation_id: str, thread_id: str | None) -> str:
+        if thread_id:
+            return f"{tenant_id}:{conversation_id}:{thread_id}"
+        return f"{tenant_id}:{conversation_id}"
+
+    @asynccontextmanager
+    async def thread_lock(self, lock_key: str):
+        async with self._manager_lock:
+            lock = self._locks.get(lock_key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[lock_key] = lock
+                self._lock_refs[lock_key] = 0
+            self._lock_refs[lock_key] = self._lock_refs.get(lock_key, 0) + 1
+        await lock.acquire()
+        try:
+            yield
+        finally:
+            lock.release()
+            async with self._manager_lock:
+                remaining = max(self._lock_refs.get(lock_key, 1) - 1, 0)
+                if remaining == 0:
+                    self._lock_refs.pop(lock_key, None)
+                    self._locks.pop(lock_key, None)
+                else:
+                    self._lock_refs[lock_key] = remaining
+
+
+_thread_lock_manager: TeamsThreadLockManager = TeamsThreadLockManager()
+
+
+async def get_redis() -> redis.Redis:
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = redis.from_url(
+            settings.REDIS_URL, **get_redis_connection_kwargs()
+        )
+    return _redis_client
+
+
+async def _fetch_jwks_from_openid(client: httpx.AsyncClient, openid_url: str) -> list[dict[str, Any]]:
+    """Fetch JWKS keys from an OpenID configuration endpoint."""
+    resp = await client.get(openid_url, timeout=10.0)
+    resp.raise_for_status()
+    openid: dict[str, Any] = resp.json()
+    jwks_uri: str | None = openid.get("jwks_uri")
+    if not jwks_uri:
+        return []
+    resp2 = await client.get(jwks_uri, timeout=10.0)
+    resp2.raise_for_status()
+    return resp2.json().get("keys", [])
+
+
+async def _refresh_jwks() -> None:
+    """Fetch and merge JWKS from Bot Framework + tenant-specific OpenID endpoints."""
+    global _merged_jwks_keys, _jwks_fetched_at
+    now: float = time.monotonic()
+    if _merged_jwks_keys and (now - _jwks_fetched_at) < JWKS_CACHE_TTL_SECONDS:
+        return
+
+    all_keys: list[dict[str, Any]] = []
+    seen_kids: set[str] = set()
+
+    async with httpx.AsyncClient() as client:
+        # 1. Bot Framework OpenID (multi-tenant / emulator tokens)
+        try:
+            keys = await _fetch_jwks_from_openid(client, BOT_OPENID_URL)
+            for k in keys:
+                kid = k.get("kid", "")
+                if kid and kid not in seen_kids:
+                    all_keys.append(k)
+                    seen_kids.add(kid)
+        except Exception as exc:
+            logger.warning("[teams_events] Failed to fetch Bot Framework JWKS: %s", exc)
+
+        # 2. Tenant-specific OpenID (single-tenant bot tokens)
+        tenant_id: str | None = settings.MICROSOFT_TENANT_ID
+        if tenant_id:
+            tenant_openid_url: str = (
+                f"https://login.microsoftonline.com/{tenant_id}/v2.0/"
+                ".well-known/openid-configuration"
+            )
+            try:
+                keys = await _fetch_jwks_from_openid(client, tenant_openid_url)
+                for k in keys:
+                    kid = k.get("kid", "")
+                    if kid and kid not in seen_kids:
+                        all_keys.append(k)
+                        seen_kids.add(kid)
+            except Exception as exc:
+                logger.warning("[teams_events] Failed to fetch tenant JWKS: %s", exc)
+
+        # 3. Common Azure AD fallback (covers both single/multi tenant edge cases)
+        common_openid_url: str = (
+            "https://login.microsoftonline.com/common/v2.0/"
+            ".well-known/openid-configuration"
+        )
+        try:
+            keys = await _fetch_jwks_from_openid(client, common_openid_url)
+            for k in keys:
+                kid = k.get("kid", "")
+                if kid and kid not in seen_kids:
+                    all_keys.append(k)
+                    seen_kids.add(kid)
+        except Exception as exc:
+            logger.debug("[teams_events] Failed to fetch common JWKS: %s", exc)
+
+    if not all_keys:
+        raise RuntimeError("Could not fetch any JWKS keys")
+
+    _merged_jwks_keys = all_keys
+    _jwks_fetched_at = now
+
+
+def _verify_teams_jwt(token: str) -> dict[str, Any]:
+    """Verify Bot Framework Bearer token and return claims.
+
+    Uses merged JWKS from Bot Framework + Azure AD endpoints.
+    Validates audience and expiry; issuer is not strictly checked
+    because single-tenant and multi-tenant tokens use different issuers.
+    """
+    app_id: str | None = settings.MICROSOFT_APP_ID
+    if not app_id:
+        raise ValueError("MICROSOFT_APP_ID not configured")
+
+    if not _merged_jwks_keys:
+        raise ValueError("JWKS not available; call _refresh_jwks() first")
+
+    unverified = jwt.get_unverified_header(token)
+    kid: str | None = unverified.get("kid")
+    if not kid:
+        raise ValueError("Token missing kid")
+
+    signing_key_pem: str | None = None
+    for key in _merged_jwks_keys:
+        if key.get("kid") == kid:
+            signing_key_pem = jwk.construct(key).to_pem().decode("utf-8")
+            break
+    if not signing_key_pem:
+        raise ValueError("Unknown signing key")
+
+    payload: dict[str, Any] = jwt.decode(
+        token,
+        signing_key_pem,
+        algorithms=["RS256", "RS384", "RS512"],
+        audience=app_id,
+        options={"verify_aud": True, "verify_exp": True, "verify_iss": False},
+    )
+    return payload
+
+
+async def verify_teams_request(request: Request) -> None:
+    """Validate Authorization Bearer token. Raises HTTPException on failure."""
+    auth: str | None = request.headers.get("Authorization")
+    if not auth or not auth.startswith("Bearer "):
+        raise HTTPException(
+            status_code=401,
+            detail="Missing or invalid Authorization header",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    token: str = auth[7:].strip()
+    if not token:
+        raise HTTPException(status_code=401, detail="Empty token")
+    try:
+        await _refresh_jwks()
+    except Exception as e:
+        logger.warning("[teams_events] Failed to fetch JWKS: %s", e)
+        raise HTTPException(status_code=503, detail="Auth metadata unavailable")
+    try:
+        # Run blocking JWT verify in thread pool to avoid blocking
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: _verify_teams_jwt(token),
+        )
+    except ValueError as e:
+        logger.warning("[teams_events] JWT validation failed: %s", e)
+        raise HTTPException(status_code=401, detail="Invalid token")
+    except JWTError as e:
+        logger.warning("[teams_events] JWT error: %s", e)
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+
+async def is_duplicate_activity(activity_id: str) -> bool:
+    try:
+        r = await get_redis()
+        key = f"revtops:teams_events:{activity_id}"
+        was_set = await r.set(key, "1", nx=True, ex=3600)
+        return not was_set
+    except Exception as e:
+        logger.error("[teams_events] Redis dedup error: %s", e)
+        return False
+
+
+def _tenant_id_from_activity(activity: dict[str, Any]) -> str | None:
+    channel_data: dict[str, Any] | None = activity.get("channelData") or {}
+    tenant: dict[str, Any] | None = channel_data.get("tenant") if isinstance(channel_data, dict) else None
+    if isinstance(tenant, dict):
+        tid: str | None = tenant.get("id")
+        if tid:
+            return tid
+    return None
+
+
+def _build_inbound_message(
+    activity: dict[str, Any],
+    message_type: MessageType,
+    *,
+    text_override: str | None = None,
+) -> InboundMessage:
+    """Build InboundMessage from a Bot Framework message activity."""
+    from_obj: dict[str, Any] = activity.get("from") or {}
+    user_id: str = from_obj.get("aadObjectId") or from_obj.get("id") or ""
+    conversation: dict[str, Any] = activity.get("conversation") or {}
+    conv_id: str = conversation.get("id") or ""
+    tenant_id: str | None = _tenant_id_from_activity(activity)
+    workspace_id: str = tenant_id or ""
+    service_url: str = (activity.get("serviceUrl") or "").strip()
+    recipient: dict[str, Any] = activity.get("recipient") or {}
+    bot_id: str | None = recipient.get("id")
+    reply_to_id: str | None = activity.get("replyToId")
+    text: str = text_override if text_override is not None else (activity.get("text") or "")
+    message_id: str = activity.get("id") or ""
+    attachments: list[dict[str, Any]] = activity.get("attachments") or []
+
+    return InboundMessage(
+        external_user_id=user_id,
+        text=text,
+        message_type=message_type,
+        raw_attachments=attachments,
+        messenger_context={
+            "workspace_id": workspace_id,
+            "channel_id": conv_id,
+            "thread_id": reply_to_id,
+            "thread_ts": reply_to_id,
+            "event_ts": message_id,
+            "service_url": service_url,
+            "bot_id": bot_id,
+        },
+        message_id=message_id,
+    )
+
+
+def _strip_mentions(text: str, bot_id: str | None) -> str:
+    """Remove <at>bot_id</at> style mentions from Teams text."""
+    if not text or not bot_id:
+        return text.strip()
+    pattern = re.compile(
+        re.escape("<at>") + ".*?" + re.escape("</at>"),
+        re.IGNORECASE | re.DOTALL,
+    )
+    cleaned = pattern.sub("", text)
+    return cleaned.strip()
+
+
+def _activity_mentions_bot(activity: dict[str, Any], bot_id: str | None) -> bool:
+    if not bot_id:
+        return False
+    entities: list[dict[str, Any]] = activity.get("entities") or []
+    for e in entities:
+        if not isinstance(e, dict) or (e.get("type") or "").lower() != "mention":
+            continue
+        mentioned: dict[str, Any] | None = e.get("mentioned")
+        if isinstance(mentioned, dict) and mentioned.get("id") == bot_id:
+            return True
+        if e.get("id") == bot_id:
+            return True
+    return False
+
+
+async def _process_message_activity(activity: dict[str, Any]) -> None:
+    """Handle message activity: route to DIRECT, MENTION, or THREAD_REPLY."""
+    channel_data: dict[str, Any] = activity.get("channelData") or {}
+    conv_type: str = (channel_data.get("channel") or {}).get("id") if isinstance(channel_data.get("channel"), dict) else ""
+    conversation: dict[str, Any] = activity.get("conversation") or {}
+    is_group: bool = (conversation.get("isGroup") or "").lower() == "true"
+    reply_to_id: str | None = activity.get("replyToId")
+    recipient: dict[str, Any] = activity.get("recipient") or {}
+    bot_id: str | None = recipient.get("id")
+    text: str = (activity.get("text") or "").strip()
+    attachments: list[dict[str, Any]] = activity.get("attachments") or []
+
+    if not text and not attachments:
+        return
+
+    tenant_id: str | None = _tenant_id_from_activity(activity)
+    conv_id: str = (conversation.get("id") or "").strip()
+    if not conv_id or not tenant_id:
+        logger.warning("[teams_events] message missing conversation.id or tenant")
+        return
+
+    if activity.get("from", {}).get("id") == bot_id:
+        return
+
+    # 1:1 chat -> DIRECT
+    if not is_group:
+        msg = _build_inbound_message(activity, MessageType.DIRECT)
+        await TeamsMessenger().process_inbound(msg)
+        return
+
+    # Channel: @mention (no replyToId or replyToId is root) -> MENTION
+    mentions_bot = _activity_mentions_bot(activity, bot_id)
+    if mentions_bot:
+        normalized_text = _strip_mentions(text, bot_id)
+        if not normalized_text and not attachments:
+            return
+        lock_key = _thread_lock_manager.build_lock_key(
+            tenant_id, conv_id, reply_to_id or activity.get("id")
+        )
+        async with _thread_lock_manager.thread_lock(lock_key):
+            msg = _build_inbound_message(
+                activity, MessageType.MENTION, text_override=normalized_text
+            )
+            await TeamsMessenger().process_inbound(msg)
+        return
+
+    # Channel thread reply -> THREAD_REPLY
+    if reply_to_id:
+        lock_key = _thread_lock_manager.build_lock_key(tenant_id, conv_id, reply_to_id)
+        async with _thread_lock_manager.thread_lock(lock_key):
+            msg = _build_inbound_message(activity, MessageType.THREAD_REPLY)
+            await TeamsMessenger().process_inbound(msg)
+
+
+@router.post("/messages", response_model=None)
+async def handle_teams_messages(request: Request) -> dict[str, Any]:
+    """
+    Bot Framework messaging endpoint. Receives POST with Activity JSON.
+    Validates JWT and processes message, conversationUpdate, installationUpdate.
+    """
+    await verify_teams_request(request)
+    body: bytes = await request.body()
+    try:
+        activity: dict[str, Any] = json.loads(body.decode("utf-8"))
+    except Exception as e:
+        logger.error("[teams_events] Invalid JSON: %s", e)
+        raise HTTPException(status_code=400, detail="Invalid JSON")
+
+    activity_type: str = (activity.get("type") or "").strip()
+    activity_id: str = activity.get("id") or ""
+
+    if activity_type == "conversationUpdate":
+        return {}
+    if activity_type == "installationUpdate":
+        return {}
+
+    if activity_type != "message":
+        return {}
+
+    if activity_id and await is_duplicate_activity(activity_id):
+        logger.info("[teams_events] Duplicate activity: %s", activity_id)
+        return {}
+
+    asyncio.create_task(_process_message_activity(activity))
+    return {}
+
+
+@router.get("/messages/health")
+async def teams_events_health() -> dict[str, Any]:
+    return {
+        "status": "ok",
+        "app_id_configured": bool(settings.MICROSOFT_APP_ID),
+    }

--- a/backend/config.py
+++ b/backend/config.py
@@ -126,6 +126,11 @@ class Settings(BaseSettings):
     SLACK_CLIENT_SECRET: Optional[str] = None
     # Public backend URL (for Slack OAuth redirect_uri). Default from FRONTEND_URL for local.
     BACKEND_PUBLIC_URL: Optional[str] = None
+
+    # Microsoft Teams Bot Framework (Azure Bot registration)
+    MICROSOFT_APP_ID: Optional[str] = None
+    MICROSOFT_APP_PASSWORD: Optional[str] = None
+    MICROSOFT_TENANT_ID: Optional[str] = None  # Required for single-tenant bots
     
     # ScrapingBee (for fetch_url tool - web scraping with proxy support)
     SCRAPINGBEE_API_KEY: Optional[str] = None

--- a/backend/connectors/teams.py
+++ b/backend/connectors/teams.py
@@ -1,0 +1,267 @@
+"""
+Microsoft Teams Bot Framework connector.
+
+Provides token acquisition and REST API calls for the Bot Framework
+(conversations, typing) and Microsoft Graph (user profile). Used by
+the Teams messenger for sending replies and resolving user identity.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from config import settings
+
+logger = logging.getLogger(__name__)
+
+BOT_FRAMEWORK_TOKEN_URL: str = (
+    "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token"
+)
+BOT_FRAMEWORK_SCOPE: str = "https://api.botframework.com/.default"
+MICROSOFT_GRAPH_API_BASE: str = "https://graph.microsoft.com/v1.0"
+GRAPH_SCOPE: str = "https://graph.microsoft.com/.default"
+TOKEN_CACHE_BUFFER_SECONDS: int = 300
+_bot_token_cache: tuple[str, float] | None = None
+_graph_token_cache: dict[str, tuple[str, float]] = {}  # tenant_id -> (token, expiry)
+
+
+async def get_bot_framework_token() -> str:
+    """Get a Bot Framework connector token (client credentials). Cached until near expiry."""
+    global _bot_token_cache
+    now: float = time.monotonic()
+    if _bot_token_cache is not None and _bot_token_cache[1] > now:
+        return _bot_token_cache[0]
+
+    app_id: str | None = settings.MICROSOFT_APP_ID
+    app_password: str | None = settings.MICROSOFT_APP_PASSWORD
+    if not app_id or not app_password:
+        raise RuntimeError(
+            "MICROSOFT_APP_ID and MICROSOFT_APP_PASSWORD must be set for Teams"
+        )
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            BOT_FRAMEWORK_TOKEN_URL,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": app_id,
+                "client_secret": app_password,
+                "scope": BOT_FRAMEWORK_SCOPE,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=15.0,
+        )
+        response.raise_for_status()
+        data: dict[str, Any] = response.json()
+
+    token: str = data.get("access_token", "")
+    expires_in: int = int(data.get("expires_in", 3600))
+    if not token:
+        raise RuntimeError("Bot Framework token response missing access_token")
+
+    _bot_token_cache = (token, now + max(0, expires_in - TOKEN_CACHE_BUFFER_SECONDS))
+    return token
+
+
+async def get_graph_token(tenant_id: str) -> str:
+    """Get a Microsoft Graph token (client credentials) for the given tenant. Cached per tenant until near expiry."""
+    global _graph_token_cache
+    now: float = time.monotonic()
+    cached = _graph_token_cache.get(tenant_id)
+    if cached is not None and cached[1] > now:
+        return cached[0]
+
+    app_id: str | None = settings.MICROSOFT_APP_ID
+    app_password: str | None = settings.MICROSOFT_APP_PASSWORD
+    if not app_id or not app_password:
+        raise RuntimeError(
+            "MICROSOFT_APP_ID and MICROSOFT_APP_PASSWORD must be set for Teams"
+        )
+
+    token_url: str = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            token_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": app_id,
+                "client_secret": app_password,
+                "scope": GRAPH_SCOPE,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=15.0,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+    token = data.get("access_token", "")
+    expires_in = int(data.get("expires_in", 3600))
+    if not token:
+        raise RuntimeError("Graph token response missing access_token")
+
+    _graph_token_cache[tenant_id] = (
+        token,
+        now + max(0, expires_in - TOKEN_CACHE_BUFFER_SECONDS),
+    )
+    return token
+
+
+async def post_message(
+    service_url: str,
+    conversation_id: str,
+    text: str,
+    *,
+    reply_to_id: str | None = None,
+    bot_id: str | None = None,
+) -> str | None:
+    """
+    Send a reply activity to the Bot Framework connector.
+
+    Args:
+        service_url: activity.serviceUrl from the incoming request
+        conversation_id: activity.conversation.id
+        text: message text
+        reply_to_id: activity.replyToId for threaded replies
+        bot_id: activity.recipient.id (bot's ID in the conversation)
+
+    Returns:
+        ID of the sent message, or None on failure
+    """
+    token: str = await get_bot_framework_token()
+    app_id: str | None = settings.MICROSOFT_APP_ID
+    if not app_id:
+        return None
+
+    url: str = f"{service_url.rstrip('/')}/v3/conversations/{conversation_id}/activities"
+    payload: dict[str, Any] = {
+        "type": "message",
+        "text": text,
+        "from": {"id": bot_id or app_id, "name": "Bot"},
+    }
+    if reply_to_id:
+        payload["replyToId"] = reply_to_id
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                url,
+                json=payload,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+                timeout=15.0,
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data.get("id")
+    except Exception as exc:
+        logger.error("[teams] post_message failed: %s", exc)
+        return None
+
+
+async def send_typing_indicator(
+    service_url: str,
+    conversation_id: str,
+    *,
+    bot_id: str | None = None,
+) -> None:
+    """Send a typing activity to the conversation."""
+    token = await get_bot_framework_token()
+    app_id = settings.MICROSOFT_APP_ID
+    if not app_id:
+        return
+
+    url = f"{service_url.rstrip('/')}/v3/conversations/{conversation_id}/activities"
+    payload: dict[str, Any] = {
+        "type": "typing",
+        "from": {"id": bot_id or app_id, "name": "Bot"},
+    }
+
+    try:
+        async with httpx.AsyncClient() as client:
+            await client.post(
+                url,
+                json=payload,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+                timeout=10.0,
+            )
+    except Exception as exc:
+        logger.debug("[teams] send_typing_indicator failed: %s", exc)
+
+
+async def get_user_info(tenant_id: str, user_aad_id: str) -> dict[str, Any] | None:
+    """
+    Fetch user profile from Microsoft Graph (requires User.Read.All application permission).
+
+    Args:
+        tenant_id: Azure AD tenant ID
+        user_aad_id: User's Azure AD object ID (activity.from.aadObjectId or activity.from.id)
+
+    Returns:
+        Graph user resource dict (mail, displayName, etc.) or None
+    """
+    try:
+        token = await get_graph_token(tenant_id)
+        url = f"{MICROSOFT_GRAPH_API_BASE}/users/{user_aad_id}"
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                url,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+                params={"$select": "id,mail,userPrincipalName,displayName"},
+                timeout=10.0,
+            )
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            return response.json()
+    except Exception as exc:
+        logger.warning("[teams] get_user_info failed for %s: %s", user_aad_id, exc)
+        return None
+
+
+async def download_teams_file(
+    download_url: str,
+    *,
+    bot_token: str | None = None,
+) -> tuple[bytes, str, str] | None:
+    """
+    Download a file from a Teams attachment (contentUrl with auth).
+
+    If contentUrl requires auth, the Bot Framework token may be used;
+    some URLs are pre-authenticated. Returns (data, filename, content_type) or None.
+    """
+    token: str = bot_token or await get_bot_framework_token()
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                download_url,
+                headers={"Authorization": f"Bearer {token}"},
+                follow_redirects=True,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            data: bytes = response.content
+            content_type: str = (
+                response.headers.get("content-type") or "application/octet-stream"
+            )
+            filename: str = "teams_file"
+            cd: str | None = response.headers.get("content-disposition")
+            if cd and "filename=" in cd:
+                part = cd.split("filename=", 1)[1].strip().strip('"')
+                if part:
+                    filename = part
+            return (data, filename, content_type)
+    except Exception as exc:
+        logger.error("[teams] download_teams_file failed: %s", exc)
+        return None

--- a/backend/messengers/teams.py
+++ b/backend/messengers/teams.py
@@ -1,0 +1,211 @@
+"""
+Microsoft Teams messenger — platform-specific hooks for :class:`WorkspaceMessenger`.
+
+Uses the Bot Framework for delivery and Microsoft Graph for user resolution.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from connectors import teams as teams_connector
+from messengers._workspace import WorkspaceMessenger
+from messengers.base import InboundMessage, MessengerMeta, OutboundResponse, ResponseMode
+
+logger = logging.getLogger(__name__)
+
+# Short-lived cache so post_message can resolve service_url/bot_id when base calls it without context.
+_TEAMS_CONTEXT_CACHE_TTL_SECONDS: float = 120.0
+_teams_context_cache: dict[tuple[str, str], tuple[dict[str, Any], float]] = {}
+
+
+def _set_teams_conversation_context(
+    workspace_id: str,
+    channel_id: str,
+    service_url: str,
+    bot_id: str | None,
+) -> None:
+    """Set service_url and bot_id for a conversation (called from route when building message)."""
+    key: tuple[str, str] = (workspace_id, channel_id)
+    _teams_context_cache[key] = (
+        {"service_url": service_url, "bot_id": bot_id},
+        time.monotonic() + _TEAMS_CONTEXT_CACHE_TTL_SECONDS,
+    )
+
+
+def _get_teams_conversation_context(
+    workspace_id: str | None,
+    channel_id: str,
+) -> tuple[str | None, str | None]:
+    """Get service_url and bot_id for a conversation. Returns (None, None) if missing or expired."""
+    if not workspace_id or not channel_id:
+        return (None, None)
+    key = (workspace_id, channel_id)
+    entry = _teams_context_cache.get(key)
+    if entry is None:
+        return (None, None)
+    ctx, expiry = entry
+    if time.monotonic() > expiry:
+        _teams_context_cache.pop(key, None)
+        return (None, None)
+    return (ctx.get("service_url"), ctx.get("bot_id"))
+
+
+class TeamsMessenger(WorkspaceMessenger):
+    meta = MessengerMeta(
+        name="Microsoft Teams",
+        slug="teams",
+        response_mode=ResponseMode.STREAMING,
+        description="Microsoft Teams chat (DMs, channels, threads, mentions)",
+    )
+
+    # ------------------------------------------------------------------
+    # Platform-specific hooks
+    # ------------------------------------------------------------------
+
+    async def fetch_user_info(
+        self,
+        workspace_id: str,
+        external_user_id: str,
+    ) -> dict[str, Any] | None:
+        """Fetch user profile from Microsoft Graph (activity.from.aadObjectId)."""
+        try:
+            return await teams_connector.get_user_info(workspace_id, external_user_id)
+        except Exception as exc:
+            logger.warning(
+                "[teams] Failed to fetch user info for %s: %s",
+                external_user_id,
+                exc,
+            )
+            return None
+
+    async def post_message(
+        self,
+        channel_id: str,
+        text: str,
+        thread_id: str | None = None,
+        *,
+        workspace_id: str | None = None,
+        organization_id: str | None = None,
+        service_url: str | None = None,
+        bot_id: str | None = None,
+    ) -> str | None:
+        """Post a message via the Bot Framework connector."""
+        if not service_url or not channel_id:
+            service_url, bot_id = _get_teams_conversation_context(
+                workspace_id, channel_id
+            )
+            if not service_url:
+                logger.warning("[teams] post_message: missing service_url for channel")
+                return None
+        return await teams_connector.post_message(
+            service_url=service_url,
+            conversation_id=channel_id,
+            text=text,
+            reply_to_id=thread_id,
+            bot_id=bot_id,
+        )
+
+    async def download_file(
+        self,
+        file_info: dict[str, Any],
+        *,
+        workspace_id: str | None = None,
+        organization_id: str | None = None,
+    ) -> tuple[bytes, str, str] | None:
+        """Download a Teams attachment (contentUrl)."""
+        from services.file_handler import MAX_FILE_SIZE
+
+        content_url: str | None = file_info.get("contentUrl") or file_info.get(
+            "content"
+        )
+        if not content_url:
+            return None
+        name: str = file_info.get("name", "teams_file")
+        content_type: str = file_info.get("contentType") or "application/octet-stream"
+        result = await teams_connector.download_teams_file(content_url)
+        if result is None:
+            return None
+        data, filename, ct = result
+        if len(data) > MAX_FILE_SIZE:
+            logger.warning("[teams] File %s too large (%d bytes)", name, len(data))
+            return None
+        return (data, filename or name, ct or content_type)
+
+    def format_text(self, markdown: str) -> str:
+        """Teams supports a subset of markdown; pass through with minimal normalization."""
+        return markdown
+
+    # ------------------------------------------------------------------
+    # Typing indicators
+    # ------------------------------------------------------------------
+
+    async def add_typing_indicator(self, message: InboundMessage) -> None:
+        ctx: dict[str, Any] = message.messenger_context
+        service_url: str | None = ctx.get("service_url")
+        channel_id: str = ctx.get("channel_id", "")
+        bot_id: str | None = ctx.get("bot_id")
+        if not service_url or not channel_id:
+            return
+        try:
+            await teams_connector.send_typing_indicator(
+                service_url=service_url,
+                conversation_id=channel_id,
+                bot_id=bot_id,
+            )
+        except Exception as exc:
+            logger.debug("[teams] add_typing_indicator failed: %s", exc)
+
+    async def remove_typing_indicator(self, message: InboundMessage) -> None:
+        """Teams does not support removing typing; no-op."""
+
+    # ------------------------------------------------------------------
+    # Profile helpers
+    # ------------------------------------------------------------------
+
+    def _extract_email_from_profile(self, profile: dict[str, Any]) -> str | None:
+        mail: str = (profile.get("mail") or "").strip().lower()
+        if mail:
+            return mail
+        upn: str = (profile.get("userPrincipalName") or "").strip().lower()
+        return upn if upn else None
+
+    def unknown_user_message(self) -> str:
+        return (
+            "I couldn't link your Microsoft Teams identity to a Basebase account. "
+            "Please verify your email in Basebase or ask your admin to link your Teams user."
+        )
+
+    # ------------------------------------------------------------------
+    # Override to set conversation context for post_message and to pass service_url/bot_id
+    # ------------------------------------------------------------------
+
+    async def process_inbound(self, message: InboundMessage) -> dict[str, Any]:
+        ctx: dict[str, Any] = message.messenger_context
+        ws: str | None = ctx.get("workspace_id")
+        ch: str = ctx.get("channel_id", "")
+        svc: str | None = ctx.get("service_url")
+        bot: str | None = ctx.get("bot_id")
+        if ws and ch and svc:
+            _set_teams_conversation_context(ws, ch, svc, bot)
+        return await super().process_inbound(message)
+
+    async def send_response(
+        self,
+        message: InboundMessage,
+        response: OutboundResponse,
+    ) -> None:
+        ctx: dict[str, Any] = message.messenger_context
+        if not response.text:
+            return
+        await self.post_message(
+            channel_id=ctx.get("channel_id", ""),
+            text=response.text,
+            thread_id=ctx.get("thread_id") or ctx.get("thread_ts"),
+            workspace_id=ctx.get("workspace_id"),
+            organization_id=ctx.get("organization_id"),
+            service_url=ctx.get("service_url"),
+            bot_id=ctx.get("bot_id"),
+        )

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -27,7 +27,7 @@ ConversationType = Literal["agent", "workflow"]
 
 # Conversation sources — should match messenger slugs from messengers.registry.
 # New sources are added by creating a new messenger in backend/messengers/.
-ConversationSource = Literal["web", "slack", "sms", "whatsapp"]
+ConversationSource = Literal["web", "slack", "sms", "whatsapp", "teams"]
 
 # Conversation scopes
 ConversationScope = Literal["private", "shared"]


### PR DESCRIPTION
## Summary

- Adds a full Microsoft Teams messenger using the Bot Framework, extending the same `WorkspaceMessenger` base class used by Slack
- Supports 1:1 DMs, channel @mentions, and threaded replies with streaming responses and typing indicators
- JWT validation against Bot Framework + tenant-specific Azure AD endpoints (single-tenant compatible)
- User identity resolution via Microsoft Graph `User.Read.All` with email-based matching to Basebase accounts
- New files: `connectors/teams.py` (Bot Framework REST client), `messengers/teams.py` (TeamsMessenger), `api/routes/teams_events.py` (webhook)
- Config: `MICROSOFT_APP_ID`, `MICROSOFT_APP_PASSWORD`, `MICROSOFT_TENANT_ID`
- Adds `"teams"` to `ConversationSource` literal

## Test plan

- [ ] Deploy to staging with Azure Bot configured (app ID, password, tenant ID in env)
- [ ] Send a DM to the bot in Teams — verify response arrives
- [ ] @mention the bot in a Teams channel — verify mention is stripped and response is threaded
- [ ] Reply in an existing bot thread — verify THREAD_REPLY handling
- [ ] Verify typing indicator appears while bot is processing
- [ ] Confirm user email resolution links Teams identity to Basebase account
- [ ] Verify health endpoint at GET /api/teams/messages/health

Made with [Cursor](https://cursor.com)