### PR TITLE
Allow composing chat input while agent is running

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1619,7 +1619,7 @@ export function Chat({
             className={`relative rounded-2xl border bg-surface-900 transition-all duration-150 ${
               isDragOver
                 ? 'border-primary-500 ring-2 ring-primary-500/40'
-                : (!isConnected || agentRunning || outOfCredits) ? 'border-surface-700 opacity-50' : 'border-surface-700 focus-within:ring-2 focus-within:ring-primary-500 focus-within:border-transparent'
+                : (!isConnected || outOfCredits) ? 'border-surface-700 opacity-50' : 'border-surface-700 focus-within:ring-2 focus-within:ring-primary-500 focus-within:border-transparent'
             }`}
           >
             {/* Drop zone overlay */}
@@ -1660,7 +1660,7 @@ export function Chat({
               className="w-full resize-none bg-transparent text-surface-100 px-4 pt-3 pb-1 text-sm placeholder-surface-500 focus:outline-none leading-5 scrollbar-none disabled:cursor-not-allowed"
               style={{ minHeight: '36px', maxHeight: '240px' }}
               rows={1}
-              disabled={!isConnected || agentRunning || outOfCredits}
+              disabled={!isConnected || outOfCredits}
               autoFocus={chatId === null}
             />
 


### PR DESCRIPTION
### Motivation
- The chat composer was visually disabled and prevented typing whenever an agent task was active, which blocked users from composing messages during long-running agent work.
- Make the input available for composition while preserving disable behavior when disconnected or out of credits.

### Description
- Removed `agentRunning` from the container class condition so the composer no longer shows disabled styling solely because an agent is running (`frontend/src/components/Chat.tsx`).
- Removed `agentRunning` from the textarea `disabled` prop so users can type while an agent task is active (`frontend/src/components/Chat.tsx`).
- Kept other guards such as disconnect and out-of-credits checks intact, and left the attach button behavior unchanged.

### Testing
- Ran `npm run build` in `frontend/` and the build completed successfully.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the app served successfully.
- Captured a Playwright screenshot of the running app showing the chat input enabled while an agent is running (artifact saved).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b61856bd28832185ad43d9d3c65946)