### PR TITLE
Add passive Anthropic out-of-credits incident health check

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -28,6 +28,7 @@ from models.chat_message import ChatMessage
 from models.conversation import Conversation
 from models.database import get_session
 from models.memory import Memory
+from services.anthropic_health import report_anthropic_call_failure, report_anthropic_call_success
 
 logger = logging.getLogger(__name__)
 
@@ -1185,9 +1186,14 @@ class ChatOrchestrator:
                             })
                     
                     # Success - break out of retry loop
+                    await report_anthropic_call_success(source="agents.orchestrator._stream_with_tools")
                     break
                     
                 except APIStatusError as e:
+                    await report_anthropic_call_failure(
+                        exc=e,
+                        source="agents.orchestrator._stream_with_tools",
+                    )
                     last_error = e
                     error_type = getattr(e, "body", {}).get("error", {}).get("type", "") if isinstance(getattr(e, "body", None), dict) else ""
 

--- a/backend/services/anthropic_health.py
+++ b/backend/services/anthropic_health.py
@@ -1,0 +1,75 @@
+"""Passive Anthropic credit health monitoring and incidenting."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from anthropic import APIStatusError
+
+from services.incident_throttling import clear_incident_failure, evaluate_incident_creation
+from services.pagerduty import create_pagerduty_incident
+
+logger = logging.getLogger(__name__)
+
+_ANTHROPIC_CREDITS_CHECK_NAME = "Anthropic Credits"
+
+# Common Anthropic/API billing exhaustion phrases observed in 4xx responses.
+_OUT_OF_CREDITS_PATTERNS = (
+    "out of credits",
+    "credit balance is too low",
+    "insufficient credits",
+    "exceeded your current quota",
+    "billing",
+)
+
+
+def _extract_error_message(exc: Exception) -> str:
+    """Extract a normalized error message from Anthropic exceptions."""
+    if isinstance(exc, APIStatusError):
+        body = getattr(exc, "body", None)
+        if isinstance(body, dict):
+            error_payload = body.get("error")
+            if isinstance(error_payload, dict):
+                msg = error_payload.get("message")
+                if isinstance(msg, str):
+                    return msg.lower()
+        return str(exc).lower()
+
+    return str(exc).lower()
+
+
+def is_anthropic_out_of_credits_error(exc: Exception) -> bool:
+    """Return True when an Anthropic failure indicates account credits are exhausted."""
+    message = _extract_error_message(exc)
+    return any(pattern in message for pattern in _OUT_OF_CREDITS_PATTERNS)
+
+
+async def report_anthropic_call_success(*, source: str) -> None:
+    """Clear throttled failure state after a successful Anthropic call."""
+    logger.info("Anthropic passive credit health passing source=%s", source)
+    await clear_incident_failure(_ANTHROPIC_CREDITS_CHECK_NAME)
+
+
+async def report_anthropic_call_failure(*, exc: Exception, source: str) -> None:
+    """Raise a throttled incident if Anthropic reports exhausted account credits."""
+    if not is_anthropic_out_of_credits_error(exc):
+        logger.debug("Anthropic failure is not credit exhaustion source=%s error=%s", source, exc)
+        return
+
+    logger.warning("Anthropic passive credit health failing source=%s error=%s", source, exc)
+    should_create, reason = await evaluate_incident_creation(_ANTHROPIC_CREDITS_CHECK_NAME)
+    if not should_create:
+        logger.info(
+            "Anthropic credit incident suppressed by throttle source=%s reason=%s",
+            source,
+            reason,
+        )
+        return
+
+    await create_pagerduty_incident(
+        title="Anthropic credits exhausted",
+        details=(
+            "Passive Anthropic credit health check observed an out-of-credits response. "
+            f"Source={source}. Reason={reason}. Error={exc}"
+        ),
+    )

--- a/backend/services/conversation_summary.py
+++ b/backend/services/conversation_summary.py
@@ -21,6 +21,8 @@ from models.chat_message import ChatMessage as ChatMessageModel
 from models.database import get_session
 from sqlalchemy import select, update
 
+from services.anthropic_health import report_anthropic_call_failure, report_anthropic_call_success
+
 logger = logging.getLogger(__name__)
 
 _MIN_MESSAGES_FOR_SUMMARY = 4
@@ -117,12 +119,20 @@ async def generate_conversation_summary(
 
         # Call Claude Haiku
         client = AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
-        response = await client.messages.create(
-            model=_MODEL,
-            max_tokens=300,
-            system=_SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": user_prompt}],
-        )
+        try:
+            response = await client.messages.create(
+                model=_MODEL,
+                max_tokens=300,
+                system=_SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": user_prompt}],
+            )
+            await report_anthropic_call_success(source="services.conversation_summary.generate_conversation_summary")
+        except Exception as exc:
+            await report_anthropic_call_failure(
+                exc=exc,
+                source="services.conversation_summary.generate_conversation_summary",
+            )
+            raise
 
         # Parse response
         raw_text = response.content[0].text if response.content else ""

--- a/backend/tests/test_anthropic_health.py
+++ b/backend/tests/test_anthropic_health.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from anthropic import APIStatusError
+
+from services import anthropic_health
+
+
+def _api_status_error(message: str, status_code: int = 429, error_type: str = "rate_limit_error") -> APIStatusError:
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(status_code=status_code, request=request, headers={"request-id": "req_test"})
+    return APIStatusError(
+        message=message,
+        response=response,
+        body={"error": {"type": error_type, "message": message}},
+    )
+
+
+def test_is_anthropic_out_of_credits_error_detects_known_message() -> None:
+    exc = _api_status_error("Credit balance is too low to access this model")
+    assert anthropic_health.is_anthropic_out_of_credits_error(exc) is True
+
+
+def test_is_anthropic_out_of_credits_error_ignores_non_credit_error() -> None:
+    exc = _api_status_error("Request exceeded max context window", status_code=400, error_type="invalid_request_error")
+    assert anthropic_health.is_anthropic_out_of_credits_error(exc) is False
+
+
+def test_report_anthropic_call_failure_creates_incident_when_allowed(monkeypatch: Any) -> None:
+    eval_calls: list[str] = []
+    incident_titles: list[str] = []
+
+    async def _fake_evaluate(check_name: str) -> tuple[bool, str]:
+        eval_calls.append(check_name)
+        return True, "new_failure"
+
+    async def _fake_incident(*, title: str, details: str) -> bool:
+        incident_titles.append(title)
+        assert "workers.tasks.workflows._action_llm" in details
+        return True
+
+    monkeypatch.setattr(anthropic_health, "evaluate_incident_creation", _fake_evaluate)
+    monkeypatch.setattr(anthropic_health, "create_pagerduty_incident", _fake_incident)
+
+    import asyncio
+
+    asyncio.run(
+        anthropic_health.report_anthropic_call_failure(
+            exc=_api_status_error("out of credits"),
+            source="workers.tasks.workflows._action_llm",
+        )
+    )
+
+    assert eval_calls == ["Anthropic Credits"]
+    assert incident_titles == ["Anthropic credits exhausted"]
+
+
+def test_report_anthropic_call_failure_suppresses_when_throttled(monkeypatch: Any) -> None:
+    incident_titles: list[str] = []
+
+    async def _fake_evaluate(check_name: str) -> tuple[bool, str]:
+        return False, "suppressed_for_100s"
+
+    async def _fake_incident(*, title: str, details: str) -> bool:
+        incident_titles.append(title)
+        return True
+
+    monkeypatch.setattr(anthropic_health, "evaluate_incident_creation", _fake_evaluate)
+    monkeypatch.setattr(anthropic_health, "create_pagerduty_incident", _fake_incident)
+
+    import asyncio
+
+    asyncio.run(
+        anthropic_health.report_anthropic_call_failure(
+            exc=_api_status_error("insufficient credits"),
+            source="agents.orchestrator._stream_with_tools",
+        )
+    )
+
+    assert incident_titles == []
+
+
+def test_report_anthropic_call_success_clears_failure_state(monkeypatch: Any) -> None:
+    cleared: list[str] = []
+
+    async def _fake_clear(check_name: str) -> None:
+        cleared.append(check_name)
+
+    monkeypatch.setattr(anthropic_health, "clear_incident_failure", _fake_clear)
+
+    import asyncio
+
+    asyncio.run(
+        anthropic_health.report_anthropic_call_success(source="services.conversation_summary.generate_conversation_summary")
+    )
+
+    assert cleared == ["Anthropic Credits"]

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -20,6 +20,7 @@ from typing import Any
 from uuid import UUID
 
 from workers.celery_app import celery_app
+from services.anthropic_health import report_anthropic_call_failure, report_anthropic_call_success
 from workers.run_async import run_async
 
 logger = logging.getLogger(__name__)
@@ -1209,12 +1210,20 @@ async def _generate_meeting_summary(
 
     # Call Claude
     client = AsyncAnthropic(api_key=settings.ANTHROPIC_API_KEY)
-    response = await client.messages.create(
-        model=_SUMMARY_MODEL,
-        max_tokens=1024,
-        system=_SUMMARY_SYSTEM_PROMPT,
-        messages=[{"role": "user", "content": user_message}],
-    )
+    try:
+        response = await client.messages.create(
+            model=_SUMMARY_MODEL,
+            max_tokens=1024,
+            system=_SUMMARY_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": user_message}],
+        )
+        await report_anthropic_call_success(source="workers.tasks.sync._generate_meeting_summary")
+    except Exception as exc:
+        await report_anthropic_call_failure(
+            exc=exc,
+            source="workers.tasks.sync._generate_meeting_summary",
+        )
+        raise
     summary_text = response.content[0].text.strip()
 
     # Save

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -25,6 +25,7 @@ from typing import Any
 from uuid import UUID
 
 from workers.celery_app import celery_app
+from services.anthropic_health import report_anthropic_call_failure, report_anthropic_call_success
 
 logger = logging.getLogger(__name__)
 
@@ -1263,12 +1264,20 @@ async def _action_llm(
         }
 
     client = anthropic.Anthropic(api_key=settings.ANTHROPIC_API_KEY)
-    response = client.messages.create(
-        model=model,
-        max_tokens=1024,
-        messages=[{"role": "user", "content": prompt}],
-    )
-    
+    try:
+        response = client.messages.create(
+            model=model,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        await report_anthropic_call_success(source="workers.tasks.workflows._action_llm")
+    except Exception as exc:
+        await report_anthropic_call_failure(
+            exc=exc,
+            source="workers.tasks.workflows._action_llm",
+        )
+        raise
+
     output = response.content[0].text if response.content else ""
     
     return {


### PR DESCRIPTION
### Motivation
- Detect passive Anthropic API failures that indicate an account has run out of credits and surface them as PagerDuty incidents without adding any active polling to Anthropic.
- Debounce repeated incident creation using the existing Redis-backed incident throttle so repeated failures do not spam incidenting and incidents can re-open only after a passing call or after the 3-hour cooldown.

### Description
- Add a new service `services.anthropic_health` that normalizes Anthropic error messages, classifies out-of-credits errors (`is_anthropic_out_of_credits_error`), clears throttle state on success (`report_anthropic_call_success`), and raises throttled incidents on credit exhaustion (`report_anthropic_call_failure`) using `evaluate_incident_creation`, `clear_incident_failure`, and `create_pagerduty_incident`.
- Integrate passive reporting into in-repo Anthropic call sites by calling `report_anthropic_call_success` on success and `report_anthropic_call_failure` on exception in `agents.orchestrator._stream_with_tools`, `services.conversation_summary.generate_conversation_summary`, `workers.tasks.sync._generate_meeting_summary`, and `workers.tasks.workflows._action_llm` so all Anthropic usage participates in the shared health signal.
- Add targeted unit tests `backend/tests/test_anthropic_health.py` that verify out-of-credits detection, incident creation when allowed, suppression when throttled, and clearing behavior on success.
- This change is passive only and does not add any active healthchecks or periodic requests to Anthropic.

### Testing
- Ran the focused pytest suite with `pytest -q tests/test_anthropic_health.py tests/test_monitoring_task.py tests/test_incident_throttling.py`, initially addressing failing assertions, and concluded with all tests passing: `21 passed`.
- Performed syntax validation with `python -m py_compile` on the modified modules which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b738a5593083218ae2dd84392e0cf3)