### PR TITLE
Fix Slack mrkdwn formatting: double-wrapped code blocks and stream splits

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -19,43 +19,55 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 
+_SEPARATOR_ROW_RE: re.Pattern[str] = re.compile(r'^\|[\s\-:]+\|$')
+
+
+def _clean_table_lines(raw: str) -> str:
+    """Strip markdown separator rows from a pipe-delimited table."""
+    lines: list[str] = raw.strip().split('\n')
+    filtered: list[str] = [
+        line for line in lines if not _SEPARATOR_ROW_RE.match(line.strip())
+    ]
+    return '\n'.join(filtered)
+
+
 def markdown_to_mrkdwn(text: str) -> str:
+    """Convert standard Markdown to Slack mrkdwn format.
+
+    Handles bold, italic, links, headers, and tables.  Existing fenced code
+    blocks are extracted first so their contents are never double-processed.
     """
-    Convert standard Markdown to Slack mrkdwn format.
-    
-    Key differences:
-    - Bold: **text** → *text*
-    - Italic: *text* → _text_ (when not already bold)
-    - Links: [text](url) → <url|text>
-    - Headers: # Header → *Header*
-    - Tables: Wrapped in code blocks (Slack doesn't support tables)
-    """
-    # Convert markdown tables to code blocks (Slack doesn't support tables)
-    # Match table pattern: lines starting with | and containing |
-    table_pattern = r'((?:^\|.+\|$\n?)+)'
-    
-    def wrap_table_in_code_block(match: re.Match[str]) -> str:
-        table = match.group(1)
-        # Remove the separator row (|---|---|) as it's just visual noise in monospace
-        lines = table.strip().split('\n')
-        filtered_lines: list[str] = []
-        for line in lines:
-            # Skip separator rows like |---|---| or | --- | --- |
-            if not re.match(r'^\|[\s\-:]+\|$', line.strip()):
-                filtered_lines.append(line)
-        return '```\n' + '\n'.join(filtered_lines) + '\n```'
-    
-    text = re.sub(table_pattern, wrap_table_in_code_block, text, flags=re.MULTILINE)
-    
-    # Convert bold: **text** → *text*
+
+    # -- Step 1: extract fenced code blocks into placeholders ---------------
+    code_blocks: list[str] = []
+    _FENCE_RE: re.Pattern[str] = re.compile(r'```\w*\n(.*?)```', re.DOTALL)
+
+    def _extract_fence(match: re.Match[str]) -> str:
+        content: str = match.group(1)
+        cleaned: str = _clean_table_lines(content) if '|' in content else content.strip()
+        idx: int = len(code_blocks)
+        code_blocks.append('```\n' + cleaned + '\n```')
+        return f'\x00CB{idx}\x00'
+
+    text = _FENCE_RE.sub(_extract_fence, text)
+
+    # -- Step 2: wrap bare markdown tables that weren't already fenced ------
+    _TABLE_RE: re.Pattern[str] = re.compile(r'((?:^\|.+\|$\n?)+)', re.MULTILINE)
+
+    def _wrap_table(match: re.Match[str]) -> str:
+        return '```\n' + _clean_table_lines(match.group(1)) + '\n```'
+
+    text = _TABLE_RE.sub(_wrap_table, text)
+
+    # -- Step 3: inline formatting ------------------------------------------
     text = re.sub(r'\*\*(.+?)\*\*', r'*\1*', text)
-    
-    # Convert markdown links: [text](url) → <url|text>
     text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<\2|\1>', text)
-    
-    # Convert headers: # Header → *Header*
     text = re.sub(r'^#{1,6}\s+(.+)$', r'*\1*', text, flags=re.MULTILINE)
-    
+
+    # -- Step 4: restore code blocks ----------------------------------------
+    for i, block in enumerate(code_blocks):
+        text = text.replace(f'\x00CB{i}\x00', block)
+
     return text
 
 from api.websockets import broadcast_sync_progress

--- a/backend/messengers/_stream_breaks.py
+++ b/backend/messengers/_stream_breaks.py
@@ -6,6 +6,32 @@ from typing import Literal
 StreamBreakStrategy = Literal["best", "quickest_safe"]
 
 _SENTENCE_BREAK_RE: re.Pattern[str] = re.compile(r"[.!?](?:\s|$)")
+_FENCE_RE: re.Pattern[str] = re.compile(r"^```", re.MULTILINE)
+
+
+def _build_fence_ranges(text: str) -> list[tuple[int, int]]:
+    """Return (start, end) ranges for fenced code blocks in *text*.
+
+    Unpaired opening fences extend to the end of the string so that we
+    never break inside an in-progress code block.
+    """
+    fences: list[int] = [m.start() for m in _FENCE_RE.finditer(text)]
+    ranges: list[tuple[int, int]] = []
+    i: int = 0
+    while i < len(fences):
+        open_pos: int = fences[i]
+        close_pos: int = fences[i + 1] if i + 1 < len(fences) else len(text)
+        ranges.append((open_pos, close_pos))
+        i += 2
+    return ranges
+
+
+def _inside_code_fence(position: int, ranges: list[tuple[int, int]]) -> bool:
+    """Return True if *position* falls inside any fenced code block range."""
+    for start, end in ranges:
+        if start <= position <= end:
+            return True
+    return False
 
 
 def _is_valid_sentence_break(text: str, punct_idx: int) -> bool:
@@ -38,6 +64,8 @@ def find_safe_break(
 
     - ``best``: choose the farthest safe sentence break within ``limit``.
     - ``quickest_safe``: choose the first safe sentence break within ``limit``.
+
+    Breaks inside fenced code blocks (````` ``` `````) are always skipped.
     """
     if not text:
         return 0
@@ -46,12 +74,16 @@ def find_safe_break(
     if max_index <= 0:
         return 0
 
+    fence_ranges: list[tuple[int, int]] = _build_fence_ranges(text)
+
     selected_break: int = 0
     for match in _SENTENCE_BREAK_RE.finditer(text):
         candidate: int = match.end()
         if candidate > max_index:
             break
         punct_idx: int = match.start()
+        if _inside_code_fence(punct_idx, fence_ranges):
+            continue
         if not _is_valid_sentence_break(text, punct_idx):
             continue
         if strategy == "quickest_safe":


### PR DESCRIPTION
## Summary
- **`markdown_to_mrkdwn`** now extracts existing fenced code blocks into placeholders before processing, preventing double-wrapping when the LLM already wraps tables in backticks. Bold/link/header conversions also no longer apply inside code blocks.
- **`find_safe_break`** now builds fence ranges and skips any break candidate that falls inside a code block, so streamed Slack messages are never split mid-fence.

## Test plan
- [ ] Send a message to the Slack bot that triggers a table response (e.g. "what should I work on today?") and verify tables render cleanly inside a single code block
- [ ] Verify longer responses with tables aren't split mid-code-block across multiple Slack messages
- [ ] Confirm bold, links, and headers still convert correctly outside code blocks


Made with [Cursor](https://cursor.com)