### PR TITLE
Fix artifact creation failures and add streaming progress indicators

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -189,6 +189,8 @@ SYSTEM_PROMPT_MAIN = """
 
 Do NOT narrate internal lookups like `get_connector_docs` or `list_connected_connectors` — just call them silently and move on to the actual action.
 
+**When the user attaches files** (documents, spreadsheets, images, PDFs, etc.), briefly acknowledge what you received before proceeding — e.g. "I see you've attached a Discovery Report template — let me review it and fill it in." This shows the user you understood the attachment's content and purpose. Keep the acknowledgement to one sentence, then move on to the task.
+
 Also please keep your responses concise and to the point (1-2 sentences), UNLESS the user is specifically asking your for detailed information.
 
 ## Planning for Complex Tasks
@@ -1160,6 +1162,14 @@ class ChatOrchestrator:
                                     yield text
                                 elif event.delta.type == "input_json_delta":
                                     current_tool_input_json += event.delta.partial_json
+                                    token_len: int = len(current_tool_input_json)
+                                    if token_len % 200 < len(event.delta.partial_json):
+                                        yield json.dumps({
+                                            "type": "tool_input_progress",
+                                            "tool_id": current_tool["id"] if current_tool else "",
+                                            "tool_name": current_tool["name"] if current_tool else "",
+                                            "chars": token_len,
+                                        })
                             
                             elif event.type == "content_block_stop":
                                 if is_thinking_block:

--- a/backend/connectors/artifacts.py
+++ b/backend/connectors/artifacts.py
@@ -137,18 +137,30 @@ class ArtifactConnector(BaseConnector):
             return await self._update(data)
         return {"error": f"Unknown operation: {operation}. Use 'create' or 'update'."}
 
+    _MIME_TO_SHORT: dict[str, str] = {
+        "text/plain": "text",
+        "text/markdown": "markdown",
+        "text/x-markdown": "markdown",
+        "application/pdf": "pdf",
+        "application/json": "chart",
+    }
+    _VALID_TYPES: set[str] = {"text", "markdown", "pdf", "chart"}
+
+    @classmethod
+    def _normalise_content_type(cls, raw: str) -> str:
+        return cls._MIME_TO_SHORT.get(raw, raw)
+
     async def _create(self, data: dict[str, Any]) -> dict[str, Any]:
         title: str = str(data.get("title", "Untitled"))
         filename: str = str(data.get("filename", "artifact.txt"))
-        content_type: str = str(data.get("content_type", "text"))
+        content_type: str = self._normalise_content_type(str(data.get("content_type", "text")))
         content: str = str(data.get("content", ""))
         conversation_id: str | None = data.get("conversation_id")
         message_id: str | None = data.get("message_id")
 
-        valid_types: set[str] = {"text", "markdown", "pdf", "chart"}
-        if content_type not in valid_types:
+        if content_type not in self._VALID_TYPES:
             return {
-                "error": f"Invalid content_type '{content_type}'. Must be one of: {', '.join(valid_types)}"
+                "error": f"Invalid content_type '{content_type}'. Must be one of: {', '.join(self._VALID_TYPES)}"
             }
         if not content.strip():
             return {"error": "Content cannot be empty"}
@@ -225,8 +237,8 @@ class ArtifactConnector(BaseConnector):
             return {"error": "At least one of content, title, filename, or content_type must be provided"}
 
         if content_type is not None:
-            valid_types: set[str] = {"text", "markdown", "pdf", "chart"}
-            if content_type not in valid_types:
+            content_type = self._normalise_content_type(content_type)
+            if content_type not in self._VALID_TYPES:
                 return {"error": f"Invalid content_type '{content_type}'"}
         if content is not None and not str(content).strip():
             return {"error": "Content cannot be empty"}

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -724,6 +724,35 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
                   timestamp: new Date(),
                 });
               }
+            } else if (data.type === 'tool_input_progress') {
+              const toolId = data.tool_id as string;
+              const chars = data.chars as number;
+              const toolName = data.tool_name as string;
+              const state = useAppStore.getState();
+              const convState = state.conversations[conversation_id];
+              if (convState) {
+                const updated = convState.messages.map((msg) => {
+                  const hasBlock = msg.contentBlocks.some(
+                    (b) => b.type === 'tool_use' && b.id === toolId,
+                  );
+                  if (!hasBlock) return msg;
+                  return {
+                    ...msg,
+                    contentBlocks: msg.contentBlocks.map((block) => {
+                      if (block.type === 'tool_use' && block.id === toolId) {
+                        return { ...block, input: { ...block.input, _streaming_chars: chars, tool_name: toolName } };
+                      }
+                      return block;
+                    }),
+                  };
+                });
+                useAppStore.setState({
+                  conversations: {
+                    ...state.conversations,
+                    [conversation_id]: { ...convState, messages: updated },
+                  },
+                });
+              }
             } else if (data.type === 'tool_call') {
               // Tool call fully parsed — find and update the streaming placeholder
               const state = useAppStore.getState();
@@ -1156,6 +1185,10 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
                       timestamp: new Date(),
                     });
                   }
+                } else if (data.type === 'tool_input_progress') {
+                  updateConversationToolMessage(conversationId, data.tool_id as string, {
+                    input: { _streaming_chars: data.chars as number, tool_name: data.tool_name as string },
+                  });
                 } else if (data.type === 'tool_call') {
                   updateConversationToolMessage(conversationId, data.tool_id as string, {
                     toolName: data.tool_name as string,

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2213,7 +2213,9 @@ function ThinkingBlockIndicator({
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
         </svg>
         <span>
-          {block.isStreaming ? 'Thinking…' : 'Thought process'}
+          {block.isStreaming
+            ? `Thinking${block.text.length > 0 ? ` (${formatStreamingChars(block.text.length)})` : ''}…`
+            : `Thought process (${formatStreamingChars(block.text.length)})`}
         </span>
         {block.isStreaming && (
           <span className="inline-block w-1 h-1 rounded-full bg-primary-400 animate-pulse" />
@@ -2364,12 +2366,19 @@ function getErrorSummary(errorMessage: string): string {
 /**
  * Generate user-friendly status text for tool calls
  */
+function formatStreamingChars(chars: number): string {
+  if (chars < 1000) return `${chars} chars`;
+  return `${(chars / 1000).toFixed(1)}k chars`;
+}
+
 function getToolStatusText(
   toolName: string, 
   input: Record<string, unknown> | undefined, 
   isComplete: boolean,
   result: Record<string, unknown> | undefined
 ): string {
+  const streamingChars: number | undefined = typeof input?._streaming_chars === 'number' ? input._streaming_chars : undefined;
+
   switch (toolName) {
     case 'think': {
       return isComplete ? 'Thinking' : 'Thinking...';
@@ -2504,6 +2513,9 @@ function getToolStatusText(
       const writeOp: string = typeof input?.operation === 'string' ? input.operation : 'write';
       const data: Record<string, unknown> = typeof input?.data === 'object' && input?.data !== null ? input.data as Record<string, unknown> : {};
       const errorMsg: string = typeof result?.error === 'string' ? result.error : '';
+      if (streamingChars !== undefined) {
+        return `Writing to connector (${formatStreamingChars(streamingChars)} generated)...`;
+      }
       if (writeConnector === 'artifacts') {
         const artifactTitle: string = typeof data?.title === 'string' ? data.title : '';
         const titleSuffix: string = artifactTitle ? `: ${artifactTitle}` : '';
@@ -2554,6 +2566,9 @@ function getToolStatusText(
       return 'Running action (details when available)...';
     }
     default:
+      if (streamingChars !== undefined) {
+        return `Generating ${toolName} input (${formatStreamingChars(streamingChars)})...`;
+      }
       return isComplete ? `Completed ${toolName}` : `Running ${toolName}...`;
   }
 }


### PR DESCRIPTION
## Summary
- **Artifacts connector**: Normalize MIME content_types (e.g. `text/markdown` → `markdown`) so the agent's `write_on_connector` calls no longer fail validation — this was the root cause of the "Failed to create artifact" error
- **Orchestrator**: Emit `tool_input_progress` events every ~200 chars during tool input streaming, so the frontend can show live progress instead of a static spinner that looks hung
- **Chat UI**: Display character counts on thinking blocks ("Thinking (4.2k chars)…") and tool call spinners ("Writing to connector (12.3k chars generated)…") so users see continuous progress during long-running operations

## Test plan
- [x] Frontend build passes (`npm run build`)
- [ ] Trigger an artifact creation with `content_type: 'text/markdown'` — should succeed instead of returning validation error
- [ ] During a long tool call (e.g. writing a large artifact), verify the spinner text updates with character count
- [ ] Thinking blocks should show character count while streaming and after completion
- [ ] Failed tool calls still show red warning icon and "Failed" status

Made with [Cursor](https://cursor.com)