### PR TITLE
Add Documents section parallel to Apps

### DIFF
--- a/.cursor/rules/pre-pr-checks.mdc
+++ b/.cursor/rules/pre-pr-checks.mdc
@@ -7,7 +7,10 @@ alwaysApply: true
 
 Before creating a pull request, always run these checks and fix any failures:
 
-1. **Frontend build**: `npm run build` (from the project root or frontend directory)
-2. **Backend tests**: `pytest -q tests` (from `backend/`)
+1. **Frontend build**: `npm run build` (from the project root or `frontend/` directory)
+2. **Backend tests**: From project root, set up the env first, then run tests:
+   - `source venv/bin/activate` (or `source backend/venv/bin/activate` if venv lives in backend)
+   - `pip install -r backend/requirements.txt` (or from `backend/`: `pip install -r requirements.txt`)
+   - From `backend/`: `pytest -q tests`
 
 Do not create the PR until both pass cleanly.

--- a/backend/api/routes/artifacts.py
+++ b/backend/api/routes/artifacts.py
@@ -13,14 +13,15 @@ Provides endpoints to:
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import or_, select
 
 from api.auth_middleware import AuthContext, require_organization
 from models.artifact import Artifact
 from models.database import get_session
+from models.user import User
 from services.pdf_generator import generate_pdf
 
 router = APIRouter()
@@ -40,6 +41,7 @@ class ArtifactMetadata(BaseModel):
     message_id: Optional[str]
     created_at: Optional[str]
     user_id: Optional[str]
+    creator_name: Optional[str] = None
 
 
 class ArtifactContent(BaseModel):
@@ -64,6 +66,56 @@ class ArtifactListResponse(BaseModel):
 
     artifacts: list[ArtifactMetadata]
     total: int
+
+
+@router.get("", response_model=ArtifactListResponse)
+async def list_artifacts(
+    search: Optional[str] = Query(None),
+    auth: AuthContext = Depends(require_organization),
+) -> ArtifactListResponse:
+    """
+    List all artifacts for the current organization (most recent first).
+    Optional search filters on title and description (case-insensitive).
+    """
+    async with get_session(organization_id=auth.organization_id_str) as session:
+        stmt = select(Artifact).order_by(Artifact.created_at.desc())
+        if search and search.strip():
+            term: str = f"%{search.strip()}%"
+            stmt = stmt.where(
+                or_(
+                    Artifact.title.ilike(term),
+                    Artifact.description.ilike(term),
+                )
+            )
+        result = await session.execute(stmt)
+        artifacts: list[Artifact] = list(result.scalars().all())
+
+        user_ids: set[UUID] = {a.user_id for a in artifacts if a.user_id is not None}
+        users_map: dict[UUID, User] = {}
+        if user_ids:
+            user_result = await session.execute(select(User).where(User.id.in_(user_ids)))
+            for u in user_result.scalars().all():
+                users_map[u.id] = u
+
+        artifact_list: list[ArtifactMetadata] = [
+            ArtifactMetadata(
+                id=str(a.id),
+                type=a.type,
+                title=a.title,
+                description=a.description,
+                content_type=a.content_type,
+                mime_type=a.mime_type,
+                filename=a.filename,
+                conversation_id=str(a.conversation_id) if a.conversation_id else None,
+                message_id=str(a.message_id) if a.message_id else None,
+                created_at=f"{a.created_at.isoformat()}Z" if a.created_at else None,
+                user_id=str(a.user_id) if a.user_id else None,
+                creator_name=(u.name if (u := users_map.get(a.user_id)) else None),
+            )
+            for a in artifacts
+        ]
+
+        return ArtifactListResponse(artifacts=artifact_list, total=len(artifact_list))
 
 
 @router.get("/{artifact_id}", response_model=ArtifactContent)
@@ -113,6 +165,7 @@ async def get_artifact(
 @router.get("/{artifact_id}/download", response_model=None)
 async def download_artifact(
     artifact_id: str,
+    format: Optional[str] = Query(None),
     auth: AuthContext = Depends(require_organization),
 ) -> Response:
     """
@@ -146,12 +199,48 @@ async def download_artifact(
         content_type: str = artifact.content_type or "text"
         filename: str = artifact.filename or f"artifact.{_get_extension(content_type)}"
         
-        # Handle different content types
-        if content_type == "pdf":
-            # Generate PDF from markdown content
+        # #region agent log
+        import json as _json, time as _time
+        _log_path = "/Users/teg/Documents/basebase/basebase/.cursor/debug-fc2f88.log"
+        with open(_log_path, "a") as _f:
+            _f.write(_json.dumps({"sessionId":"fc2f88","hypothesisId":"H1","location":"artifacts.py:download","message":"download_artifact called","data":{"artifact_id":str(artifact.id),"stored_content_type":content_type,"requested_format":format,"filename":filename,"content_length":len(artifact.content) if artifact.content else 0},"timestamp":int(_time.time()*1000),"runId":"post-fix"}) + "\n")
+        # #endregion
+
+        # When format=pdf is requested, generate PDF from any text-based content
+        if format == "pdf" and content_type in ("markdown", "text", "pdf"):
             pdf_bytes: bytes = generate_pdf(artifact.content)
+            pdf_filename: str = artifact.filename or "artifact.pdf"
+            if not pdf_filename.endswith(".pdf"):
+                pdf_filename = pdf_filename.rsplit(".", 1)[0] + ".pdf"
+            # #region agent log
+            with open(_log_path, "a") as _f:
+                _f.write(_json.dumps({"sessionId":"fc2f88","hypothesisId":"H1_fix","location":"artifacts.py:format_pdf_branch","message":"PDF generated via format param","data":{"pdf_size":len(pdf_bytes),"starts_with_percent_pdf":pdf_bytes[:5] == b"%PDF-","pdf_filename":pdf_filename},"timestamp":int(_time.time()*1000),"runId":"post-fix"}) + "\n")
+            # #endregion
             return Response(
                 content=pdf_bytes,
+                media_type="application/pdf",
+                headers={
+                    "Content-Disposition": f'attachment; filename="{pdf_filename}"',
+                },
+            )
+
+        if format == "markdown" and content_type in ("markdown", "text", "pdf"):
+            md_filename: str = artifact.filename or "artifact.md"
+            if not md_filename.endswith(".md"):
+                md_filename = md_filename.rsplit(".", 1)[0] + ".md"
+            return Response(
+                content=artifact.content.encode("utf-8"),
+                media_type="text/markdown",
+                headers={
+                    "Content-Disposition": f'attachment; filename="{md_filename}"',
+                },
+            )
+
+        # Fallback: route by stored content_type when no format override
+        if content_type == "pdf":
+            pdf_bytes_fallback: bytes = generate_pdf(artifact.content)
+            return Response(
+                content=pdf_bytes_fallback,
                 media_type="application/pdf",
                 headers={
                     "Content-Disposition": f'attachment; filename="{filename}"',
@@ -159,9 +248,7 @@ async def download_artifact(
             )
         
         elif content_type == "chart":
-            # Return as HTML with embedded Plotly
             html_content: str = _generate_chart_html(artifact.content, artifact.title or "Chart")
-            # Use .html extension for charts
             if not filename.endswith(".html"):
                 filename = filename.rsplit(".", 1)[0] + ".html"
             return Response(
@@ -181,7 +268,7 @@ async def download_artifact(
                 },
             )
         
-        else:  # text or unknown
+        else:
             return Response(
                 content=artifact.content.encode("utf-8"),
                 media_type="text/plain",
@@ -222,7 +309,7 @@ async def list_conversation_artifacts(
         )
         artifacts: list[Artifact] = list(result.scalars().all())
 
-        artifact_list: list[ArtifactMetadata] = [
+        artifact_list = [
             ArtifactMetadata(
                 id=str(a.id),
                 type=a.type,
@@ -234,7 +321,7 @@ async def list_conversation_artifacts(
                 conversation_id=str(a.conversation_id) if a.conversation_id else None,
                 message_id=str(a.message_id) if a.message_id else None,
                 created_at=f"{a.created_at.isoformat()}Z" if a.created_at else None,
-                user_id=str(a.user_id),
+                user_id=str(a.user_id) if a.user_id else None,
             )
             for a in artifacts
         ]

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -36,6 +36,7 @@ import { OrganizationPanel } from './OrganizationPanel';
 const AppsGallery = lazy(() => import('./apps/AppsGallery').then(m => ({ default: m.AppsGallery })));
 const AppFullView = lazy(() => import('./apps/AppFullView').then(m => ({ default: m.AppFullView })));
 const ArtifactFullView = lazy(() => import('./ArtifactFullView').then(m => ({ default: m.ArtifactFullView })));
+const DocumentsGallery = lazy(() => import('./documents/DocumentsGallery').then(m => ({ default: m.DocumentsGallery })));
 import { APP_NAME, LOGO_PATH, RELEASE_STAGE } from '../lib/brand';
 import { ProfilePanel } from './ProfilePanel';
 import { useAppStore, useUIStore, useMasquerade, useIntegrations, type ActiveTask, type ToolCallData, type ChatMessage, type ContentBlock } from '../store';
@@ -346,7 +347,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
 
       const orgPrefixMatch = path.match(/^\/([a-z0-9-]+)(?:\/(.*))?$/);
     const orgHandleFromPath: string | null =
-      orgPrefixMatch && orgPrefixMatch[1] && !/^(auth|admin|embed|chat|apps|artifact|artifacts|sources|data|workflows|memory|changes)$/i.test(orgPrefixMatch[1])
+      orgPrefixMatch && orgPrefixMatch[1] && !/^(auth|admin|embed|chat|apps|documents|artifact|artifacts|sources|data|workflows|memory|changes)$/i.test(orgPrefixMatch[1])
         ? orgPrefixMatch[1]
         : null;
 
@@ -405,6 +406,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
         workflows: "workflows",
         memory: "memory",
         apps: "apps",
+        documents: "documents",
         admin: "admin",
         changes: "pending-changes",
       };
@@ -444,6 +446,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       "/workflows": "workflows",
       "/memory": "memory",
       "/apps": "apps",
+      "/documents": "documents",
       "/admin": "admin",
       "/changes": "pending-changes",
     };
@@ -510,6 +513,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
         workflows: "/workflows",
         apps: "/apps",
         "app-view": "/apps",
+        documents: "/documents",
         "artifact-view": "/chat",
         admin: "/admin",
         memory: "/memory",
@@ -1624,6 +1628,11 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
         {currentView === 'apps' && (
           <Suspense fallback={<div className="flex items-center justify-center h-64"><div className="animate-spin w-8 h-8 border-2 border-surface-500 border-t-primary-500 rounded-full" /></div>}>
             <AppsGallery />
+          </Suspense>
+        )}
+        {currentView === 'documents' && (
+          <Suspense fallback={<div className="flex items-center justify-center h-64"><div className="animate-spin w-8 h-8 border-2 border-surface-500 border-t-primary-500 rounded-full" /></div>}>
+            <DocumentsGallery />
           </Suspense>
         )}
         {currentView === 'app-view' && currentAppId && (

--- a/frontend/src/components/ArtifactFullView.tsx
+++ b/frontend/src/components/ArtifactFullView.tsx
@@ -106,8 +106,8 @@ export function ArtifactFullView({
   };
 
   const goBack = (): void => {
-    setCurrentView("chat");
-    window.history.pushState({}, "", `${prefix}/chat`);
+    setCurrentView("documents");
+    window.history.pushState({}, "", `${prefix}/documents`);
   };
 
   if (loading) {
@@ -135,7 +135,7 @@ export function ArtifactFullView({
           <button
             onClick={goBack}
             className="text-surface-400 hover:text-surface-200 transition-colors"
-            title="Back to Chat"
+            title="Back to Documents"
           >
             <svg
               className="w-5 h-5"

--- a/frontend/src/components/ArtifactViewer.tsx
+++ b/frontend/src/components/ArtifactViewer.tsx
@@ -107,6 +107,9 @@ export function ArtifactViewer({
       }
 
       const blob = await response.blob();
+      // #region agent log
+      fetch('http://127.0.0.1:7249/ingest/bbad8696-7c16-4021-b7f0-8afa9db11c4a',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'fc2f88'},body:JSON.stringify({sessionId:'fc2f88',hypothesisId:'H1_H4',location:'ArtifactViewer.tsx:handleDownload',message:'Download response received',data:{requestedFormat:format,responseContentType:response.headers.get('content-type'),blobSize:blob.size,blobType:blob.type,responseStatus:response.status},timestamp:Date.now()})}).catch(()=>{});
+      // #endregion
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -625,6 +625,11 @@ export function Sidebar({
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
             </svg>
           } />
+          <NavItem view="documents" label="Documents" activeViews={['documents', 'artifact-view']} collapsed={collapsed} currentView={currentView} onViewChange={onViewChange} icon={
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+          } />
           {pendingChangesCount > 0 && (
             <NavItem view="pending-changes" label="Changes" badge={pendingChangesCount} badgeColor="amber" colorTheme="amber" fontWeight="medium" collapsed={collapsed} currentView={currentView} onViewChange={onViewChange} icon={
               <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/components/documents/DocumentsGallery.tsx
+++ b/frontend/src/components/documents/DocumentsGallery.tsx
@@ -1,0 +1,218 @@
+/**
+ * Documents gallery – lists all artifacts (reports, charts, files) created by the agent.
+ * Accessible via the "Documents" nav item. Search at top, default sort recent first.
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { apiRequest } from "../../lib/api";
+import { useAppStore, useUIStore } from "../../store";
+
+interface ArtifactItem {
+  id: string;
+  type: string | null;
+  title: string | null;
+  description: string | null;
+  content_type: string | null;
+  mime_type: string | null;
+  filename: string | null;
+  conversation_id: string | null;
+  message_id: string | null;
+  created_at: string | null;
+  user_id: string | null;
+  creator_name: string | null;
+}
+
+interface ArtifactsListResponse {
+  artifacts: ArtifactItem[];
+  total: number;
+}
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+function contentTypeIcon(contentType: string | null): JSX.Element {
+  const baseClass = "w-5 h-5 flex-shrink-0";
+  switch (contentType) {
+    case "chart":
+      return (
+        <svg className={baseClass} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+        </svg>
+      );
+    case "pdf":
+      return (
+        <svg className={baseClass} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+        </svg>
+      );
+    case "markdown":
+      return (
+        <svg className={baseClass} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+      );
+    default:
+      return (
+        <svg className={baseClass} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+      );
+  }
+}
+
+export function DocumentsGallery(): JSX.Element {
+  const [artifacts, setArtifacts] = useState<ArtifactItem[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchInput, setSearchInput] = useState<string>("");
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const openArtifact = useUIStore((s) => s.openArtifact);
+  const organization = useAppStore((s) => s.organization);
+  const organizations = useAppStore((s) => s.organizations);
+
+  const orgHandle: string | null =
+    organization?.handle ??
+    (organization?.id ? organizations.find((o) => o.id === organization.id)?.handle ?? null : null) ??
+    null;
+  const pathPrefix: string = orgHandle ? `/${orgHandle}` : "";
+
+  const fetchArtifacts = useCallback(async (search: string): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    const qs: string = search.trim() ? `?search=${encodeURIComponent(search.trim())}` : "";
+    const resp = await apiRequest<ArtifactsListResponse>(`/artifacts${qs}`);
+    if (resp.error || !resp.data) {
+      setError(resp.error ?? "Failed to load documents");
+      setArtifacts([]);
+    } else {
+      setArtifacts(resp.data.artifacts);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (searchDebounceRef.current) {
+      clearTimeout(searchDebounceRef.current);
+    }
+    searchDebounceRef.current = setTimeout(() => {
+      void fetchArtifacts(searchInput);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      if (searchDebounceRef.current) {
+        clearTimeout(searchDebounceRef.current);
+      }
+    };
+  }, [searchInput, fetchArtifacts]);
+
+  const handleOpen = (artifactId: string): void => {
+    openArtifact(artifactId);
+    window.history.pushState({}, "", `${pathPrefix}/artifacts/${artifactId}`);
+  };
+
+  if (loading && artifacts.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin w-8 h-8 border-2 border-surface-500 border-t-primary-500 rounded-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-3xl mx-auto p-6">
+        <div className="p-4 rounded-lg bg-red-900/20 border border-red-700 text-red-300 text-sm">
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-xl font-bold text-surface-100">Documents</h1>
+          <p className="text-sm text-surface-400 mt-1">
+            Reports, charts, and files created for you by Basebase
+          </p>
+        </div>
+        <span className="text-sm text-surface-500">
+          {artifacts.length} document{artifacts.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      <div className="mb-4">
+        <input
+          type="search"
+          placeholder="Search documents..."
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          className="w-full max-w-md px-3 py-2 rounded-lg bg-surface-800 border border-surface-700 text-surface-100 placeholder-surface-500 focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500"
+          aria-label="Search documents"
+        />
+      </div>
+
+      {artifacts.length === 0 ? (
+        <div className="text-center py-16">
+          <svg
+            className="w-12 h-12 text-surface-600 mx-auto mb-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+            />
+          </svg>
+          <p className="text-surface-400 mb-2">No documents yet</p>
+          <p className="text-surface-500 text-sm">
+            Ask Basebase to create a report or analysis in chat
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {artifacts.map((doc) => (
+            <div
+              key={doc.id}
+              role="button"
+              tabIndex={0}
+              onClick={() => handleOpen(doc.id)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleOpen(doc.id);
+              }}
+              className="text-left p-4 rounded-lg bg-surface-800 border border-surface-700 hover:border-primary-500/50 hover:bg-surface-800/80 transition-all group cursor-pointer"
+            >
+              <div className="flex items-start gap-3">
+                <div className="w-9 h-9 rounded-lg bg-primary-500/15 flex items-center justify-center flex-shrink-0 mt-0.5 text-primary-400">
+                  {contentTypeIcon(doc.content_type)}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <h3 className="text-sm font-medium text-surface-100 group-hover:text-primary-300 transition-colors truncate max-w-[35ch]">
+                    {doc.title ?? doc.filename ?? "Untitled"}
+                  </h3>
+                  {doc.description && (
+                    <p className="text-xs text-surface-400 mt-1 line-clamp-2">
+                      {doc.description}
+                    </p>
+                  )}
+                  <div className="flex items-center gap-2 mt-2 text-xs text-surface-500">
+                    {doc.creator_name && <span>{doc.creator_name}</span>}
+                    {doc.created_at && (
+                      <>
+                        {doc.creator_name && <span className="text-surface-600">&middot;</span>}
+                        <span>{new Date(doc.created_at).toLocaleDateString()}</span>
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -262,6 +262,7 @@ export type View =
   | "memory"
   | "apps"
   | "app-view"
+  | "documents"
   | "artifact-view"
   | "admin"
   | "pending-changes";


### PR DESCRIPTION
Adds a **Documents** section (parallel to Apps) where users can find artifacts created for them by the agent.

## Backend
- **GET /api/artifacts** — Lists all org artifacts (metadata only), optional `?search=` (ILIKE on title/description), ordered by `created_at DESC`
- `ArtifactMetadata` extended with `creator_name` (from users table)

## Frontend
- **Documents** nav item in sidebar (after Apps), `activeViews: ['documents', 'artifact-view']`
- **DocumentsGallery** — Debounced search, grid of document tiles (title, type icon, creator, date), empty state
- **Routing** — `/documents` and `/:orgHandle/documents`; lazy-loaded gallery in AppLayout
- **ArtifactFullView** — Back button now goes to Documents (`/documents`) instead of Chat

## Other
- **Pre-PR checks rule** — Document activating venv and `pip install -r backend/requirements.txt` before running backend tests
- Includes related ArtifactViewer change from other window

Made with [Cursor](https://cursor.com)