### PR TITLE
Add per-chat credit usage dashboard and deep links

### DIFF
--- a/backend/api/routes/billing.py
+++ b/backend/api/routes/billing.py
@@ -132,9 +132,17 @@ class UserUsageItem(BaseModel):
     total_credits_used: int
 
 
+class ConversationUsageItem(BaseModel):
+    conversation_id: str
+    title: Optional[str] = None
+    total_credits_used: int
+    last_used_at: Optional[str] = None
+
+
 class CreditDetailsResponse(BaseModel):
     transactions: list[CreditTransactionItem]
     usage_by_user: list[UserUsageItem]
+    usage_by_conversation: list[ConversationUsageItem] = []
     period_start: Optional[str] = None
     period_end: Optional[str] = None
     starting_balance: int = 0
@@ -466,6 +474,8 @@ async def get_credit_details(
         from sqlalchemy import select, func
         from models.credit_transaction import CreditTransaction
         from models.user import User
+        from models.conversation import Conversation
+        from models.database import get_session
         
         # Get org with period info
         result = await session.execute(
@@ -542,19 +552,94 @@ async def get_credit_details(
         
         usage_by_user: list[UserUsageItem] = []
         for user_id, email, name, total_used in usage_rows:
-            usage_by_user.append(UserUsageItem(
-                user_id=str(user_id) if user_id else "unknown",
-                user_email=email or "Unknown user",
-                user_name=name,
-                total_credits_used=int(total_used) if total_used else 0,
-            ))
+            usage_by_user.append(
+                UserUsageItem(
+                    user_id=str(user_id) if user_id else "unknown",
+                    user_email=email or "Unknown user",
+                    user_name=name,
+                    total_credits_used=int(total_used) if total_used else 0,
+                )
+            )
+
+        # Aggregate usage by conversation (per-chat credit consumption)
+        conv_usage_rows: list[tuple[str, int, datetime]] = []
+        if rows:
+            conv_usage_query = (
+                select(
+                    CreditTransaction.reference_id,
+                    func.sum(func.abs(CreditTransaction.amount)).label("total_used"),
+                    func.max(CreditTransaction.created_at).label("last_used_at"),
+                )
+                .where(CreditTransaction.organization_id == org_id)
+                .where(CreditTransaction.reference_type == "conversation")
+                .where(CreditTransaction.amount < 0)
+            )
+            if effective_period_start:
+                conv_usage_query = conv_usage_query.where(
+                    CreditTransaction.created_at >= effective_period_start
+                )
+            conv_usage_result = await session.execute(conv_usage_query.group_by(CreditTransaction.reference_id))
+            conv_usage_rows = conv_usage_result.all()
+
+        # Resolve conversation titles from the org-scoped database
+        usage_by_conversation: list[ConversationUsageItem] = []
+        if conv_usage_rows:
+            # Filter out rows without a reference_id
+            conv_id_strs = [
+                ref_id for (ref_id, _total_used, _last_used_at) in conv_usage_rows if ref_id
+            ]
+
+            id_to_title: dict[str, Optional[str]] = {}
+            if conv_id_strs:
+                # Best-effort: some IDs may be invalid UUIDs; skip those
+                valid_conv_ids: list[UUID] = []
+                for cid in conv_id_strs:
+                    try:
+                        valid_conv_ids.append(UUID(cid))
+                    except Exception:
+                        continue
+
+                if valid_conv_ids:
+                    async with get_session(organization_id=str(org_id)) as org_session:
+                        conv_result = await org_session.execute(
+                            select(Conversation.id, Conversation.title).where(
+                                Conversation.id.in_(valid_conv_ids)
+                            )
+                        )
+                        for conv_id, title in conv_result.all():
+                            id_to_title[str(conv_id)] = title
+
+            for ref_id, total_used, last_used_at in conv_usage_rows:
+                if not ref_id:
+                    continue
+                title = id_to_title.get(ref_id)
+                usage_by_conversation.append(
+                    ConversationUsageItem(
+                        conversation_id=ref_id,
+                        title=title,
+                        total_credits_used=int(total_used) if total_used else 0,
+                        last_used_at=last_used_at.isoformat().replace("+00:00", "Z")
+                        if last_used_at
+                        else None,
+                    )
+                )
+
+            # Sort by total credits used (descending)
+            usage_by_conversation.sort(
+                key=lambda item: item.total_credits_used, reverse=True
+            )
         
         # Return effective period (None if showing all-time)
         return CreditDetailsResponse(
             transactions=transactions,
             usage_by_user=usage_by_user,
-            period_start=effective_period_start.isoformat().replace("+00:00", "Z") if effective_period_start else None,
-            period_end=period_end.isoformat().replace("+00:00", "Z") if period_end and effective_period_start else None,
+            usage_by_conversation=usage_by_conversation,
+            period_start=effective_period_start.isoformat().replace("+00:00", "Z")
+            if effective_period_start
+            else None,
+            period_end=period_end.isoformat().replace("+00:00", "Z")
+            if period_end and effective_period_start
+            else None,
             starting_balance=starting_balance,
         )
 

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -54,9 +54,17 @@ interface UserUsage {
   total_credits_used: number;
 }
 
+interface ConversationUsage {
+  conversation_id: string;
+  title: string | null;
+  total_credits_used: number;
+  last_used_at: string | null;
+}
+
 interface CreditDetails {
   transactions: CreditTransaction[];
   usage_by_user: UserUsage[];
+  usage_by_conversation: ConversationUsage[];
   period_start: string | null;
   period_end: string | null;
   starting_balance: number;
@@ -1346,6 +1354,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
       {/* Credit Details Modal */}
       {showCreditDetails && (
         <CreditDetailsModal
+          organizationHandle={organization.handle ?? null}
           details={creditDetails}
           loading={creditDetailsLoading}
           onClose={() => setShowCreditDetails(false)}
@@ -1357,12 +1366,13 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
 
 
 interface CreditDetailsModalProps {
+  organizationHandle: string | null;
   details: CreditDetails | null;
   loading: boolean;
   onClose: () => void;
 }
 
-function CreditDetailsModal({ details, loading, onClose }: CreditDetailsModalProps): JSX.Element {
+function CreditDetailsModal({ organizationHandle, details, loading, onClose }: CreditDetailsModalProps): JSX.Element {
   const [PlotComponent, setPlotComponent] = useState<typeof import('react-plotly.js').default | null>(null);
   const [chartRange, setChartRange] = useState<[string, string] | null>(null);
 
@@ -1427,6 +1437,16 @@ function CreditDetailsModal({ details, loading, onClose }: CreditDetailsModalPro
     
     return { labels, values, emails };
   }, [details]);
+
+  const conversationUsage = useMemo(() => {
+    if (!details?.usage_by_conversation?.length) return [];
+    return details.usage_by_conversation;
+  }, [details]);
+
+  const navigateToConversation = (conversationId: string): void => {
+    const base = organizationHandle ? `/${organizationHandle}` : '';
+    window.location.href = `${base}/chat/${conversationId}`;
+  };
 
   return (
     <div 
@@ -1583,6 +1603,55 @@ function CreditDetailsModal({ details, loading, onClose }: CreditDetailsModalPro
                 ) : (
                   <div className="bg-surface-800/50 rounded-lg p-8 text-center text-surface-400">
                     No usage data for this period yet
+                  </div>
+                )}
+              </div>
+
+              {/* Usage by Conversation (per chat) */}
+              <div>
+                <h3 className="text-sm font-medium text-surface-200 mb-4">Usage by Chat</h3>
+                {conversationUsage.length > 0 ? (
+                  <div className="space-y-2">
+                    {conversationUsage.map((conv) => (
+                      <button
+                        key={conv.conversation_id}
+                        type="button"
+                        onClick={() => navigateToConversation(conv.conversation_id)}
+                        className="w-full flex items-center justify-between gap-3 px-3 py-2 rounded-lg bg-surface-800/50 hover:bg-surface-700/70 border border-surface-700 hover:border-primary-500/60 transition-colors text-left"
+                      >
+                        <div className="min-w-0">
+                          <p className="text-sm text-surface-100 truncate">
+                            {conv.title || 'Untitled chat'}
+                          </p>
+                          {conv.last_used_at && (
+                            <p className="text-xs text-surface-500 mt-0.5">
+                              Last used{' '}
+                              {new Date(conv.last_used_at).toLocaleString(undefined, {
+                                month: 'short',
+                                day: 'numeric',
+                                hour: '2-digit',
+                                minute: '2-digit',
+                              })}
+                            </p>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-3 flex-shrink-0">
+                          <span className="text-sm font-medium text-surface-50 whitespace-nowrap">
+                            {conv.total_credits_used} credits
+                          </span>
+                          <span className="inline-flex items-center gap-1 text-xs text-primary-300">
+                            View chat
+                            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                            </svg>
+                          </span>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="bg-surface-800/50 rounded-lg p-6 text-center text-surface-400">
+                    No per-chat credit usage recorded for this period yet
                   </div>
                 )}
               </div>


### PR DESCRIPTION
- Backend: Extend /billing/credit-details to aggregate credit transactions by reference_type="conversation", returning usage_by_conversation with total credits and last-used timestamps per chat.
- Frontend: Update OrganizationPanel billing modal to consume the new usage_by_conversation data, render a “Usage by Chat” section showing per-chat credit consumption, and add links that navigate directly into each chat’s conversation view.
- Behavior: Per-chat usage respects the current billing period (with existing all-time fallback), and titles are resolved from the org-scoped conversations table when available.