### PR TITLE
fix: tool call errors (schema hints, error display, embedding message)

### DIFF
--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -97,12 +97,12 @@ register_tool(
 Use this for any data analysis: filtering, joins, aggregations, date comparisons, etc.
 The query is automatically scoped to the user's organization for multi-tenant tables.
 
-Available tables:
-- meetings: Canonical meeting entities - deduplicated across all sources
+Available tables (use these exact column names):
+- meetings: id, title, scheduled_start, scheduled_end, summary, participants (JSONB), status, duration_minutes, organizer_email, account_id. Use scheduled_start/scheduled_end for dates (not start_time/end_time). Canonical meeting entities - deduplicated across all sources.
 - deals: Sales opportunities (name, amount, stage, close_date, owner_id, account_id)
 - accounts: Companies/customers (name, domain, industry, employee_count)
 - contacts: People at accounts (name, email, title, phone, account_id)
-- activities: Raw activity records - query by TYPE not source. Has a vector embedding column for semantic search (see below)
+- activities: id, type, subject, description, activity_date, embedding (vector). Raw activity records - query by TYPE not source. Use semantic_embed() for semantic search (see below). Do not query information_schema - only the tables listed here are allowed.
 - pipelines: Sales pipelines (name, display_order, is_default)
 - pipeline_stages: Stages in pipelines (pipeline_id, name, probability)
 - goals: Revenue goals and quotas synced from CRM (name, target_amount, start_date, end_date, goal_type, owner_id, pipeline_id, source_system, source_id, custom_fields JSONB). Compare target_amount against deal totals to measure progress.

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -495,8 +495,8 @@ async def _resolve_semantic_embeds(query: str) -> tuple[str, str | None]:
         svc = get_embedding_service()
     except ValueError:
         return query, (
-            "semantic_embed() requires OPENAI_API_KEY to be configured. "
-            "Use ILIKE for text search instead."
+            "semantic_embed() requires OPENAI_API_KEY in .env (see env.example). "
+            "Use ILIKE for text search if you don't need embeddings."
         )
 
     texts: list[str] = [m.group(1).replace("\\'", "'") for m in matches]

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2398,20 +2398,23 @@ function getToolStatusText(
       const query = typeof input?.query === 'string' ? input.query.toLowerCase() : '';
       const tableNames: string[] = [];
       const knownTables = [
-        'deals', 'accounts', 'contacts', 'activities', 'integrations', 
-        'users', 'organizations', 'pipelines', 'pipeline_stages'
+        'deals', 'accounts', 'contacts', 'activities', 'integrations',
+        'users', 'organizations', 'pipelines', 'pipeline_stages', 'meetings',
       ];
       for (const table of knownTables) {
         if (query.includes(table)) {
           tableNames.push(table === 'pipeline_stages' ? 'stages' : table);
         }
       }
-      const tableDesc = tableNames.length > 0 
-        ? tableNames.join(' and ') 
-        : 'synced data';
-      
+      const tableDesc: string =
+        tableNames.length > 0 ? tableNames.join(' and ') : 'synced data';
+
       if (isComplete) {
-        const rowCount = typeof result?.row_count === 'number' ? result.row_count : 0;
+        if (result?.error) {
+          return `Query to ${tableDesc} failed`;
+        }
+        const rowCount: number =
+          typeof result?.row_count === 'number' ? result.row_count : 0;
         return `Queried ${tableDesc} (${rowCount} row${rowCount === 1 ? '' : 's'})`;
       }
       return `Querying ${tableDesc}...`;


### PR DESCRIPTION
## Summary
Fixes tool call errors when the chat agent queries meetings/activities.

## Changes
- **backend/agents/registry.py**: Add column hints for `meetings` (`scheduled_start`, `scheduled_end`, etc.) and `activities` so the AI generates valid SQL; note that only listed tables are allowed (no `information_schema`).
- **backend/agents/tools.py**: Clarify `semantic_embed()` error message to point users to `OPENAI_API_KEY` in `.env` (see `env.example`).
- **frontend/src/components/Chat.tsx**: When `run_sql_query` returns an error, show "Query to [table] failed" instead of the misleading "Queried … (0 rows)"; add `meetings` to knownTables for the status label.

## Testing
- Frontend build and backend tests (178) pass.
- Manual: new chat, ask about a meeting (e.g. with Henk); first SQL should use correct columns; any failed query shows the new error label.

Made with [Cursor](https://cursor.com)