### PR TITLE
Add generic MCP connector

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -529,11 +529,10 @@ async def _get_connector_instance(
     Returns (connector_instance, None) on success or (None, error_message) on failure.
     """
     from connectors.base import BaseConnector
-    from connectors.registry import Capability, ConnectorMeta, ConnectorScope, discover_connectors
+    from connectors.registry import Capability, ConnectorMeta, ConnectorScope, resolve_connector
     from models.integration import Integration
 
-    registry = discover_connectors()
-    connector_cls: type[BaseConnector] | None = registry.get(slug)
+    connector_cls: type[BaseConnector] | None = resolve_connector(slug)
     if connector_cls is None:
         return None, f"Unknown connector '{slug}'. Use list_connected_connectors to see available connectors."
 
@@ -631,28 +630,44 @@ async def _get_connector_instance(
 
 async def _list_connected_connectors(organization_id: str) -> dict[str, Any]:
     """Return the connectors manifest for all connected connectors."""
-    from connectors.registry import Capability, ConnectorMeta, discover_connectors
+    from connectors.registry import Capability, ConnectorMeta, discover_connectors, resolve_connector
     from models.integration import Integration
 
     async with get_session(organization_id=organization_id) as session:
         result = await session.execute(
-            select(Integration.connector).where(
+            select(Integration.connector, Integration.extra_data).where(
                 Integration.organization_id == UUID(organization_id),
                 Integration.is_active == True,  # noqa: E712
             )
         )
-        active_providers: set[str] = {row[0] for row in result.all()}
+        rows: list[tuple[str, dict[str, Any] | None]] = [(r[0], r[1]) for r in result.all()]
+
+    active_providers: set[str] = {row[0] for row in rows}
+    extra_data_by_provider: dict[str, dict[str, Any]] = {
+        row[0]: row[1] for row in rows if row[1]
+    }
 
     registry = discover_connectors()
 
+    # Collect all slugs to iterate: static registry entries + dynamic mcp_* slugs
+    all_slugs: set[str] = set(registry.keys()) | active_providers
+
     connectors: list[dict[str, Any]] = []
-    for slug, connector_cls in sorted(registry.items()):
+    for slug in sorted(all_slugs):
         if slug not in active_providers:
             continue
+        connector_cls = resolve_connector(slug)
+        if connector_cls is None:
+            continue
         meta: ConnectorMeta = connector_cls.meta  # type: ignore[attr-defined]
+
+        is_dynamic_mcp: bool = slug.startswith("mcp_")
+        mcp_extra: dict[str, Any] = extra_data_by_provider.get(slug, {}) if is_dynamic_mcp else {}
+        display_name: str = mcp_extra.get("display_name", slug) if is_dynamic_mcp else meta.name
+
         entry: dict[str, Any] = {
-            "slug": meta.slug,
-            "name": meta.name,
+            "slug": slug,
+            "name": display_name,
             "capabilities": [c.value for c in meta.capabilities],
         }
         if meta.query_description:
@@ -667,7 +682,19 @@ async def _list_connected_connectors(organization_id: str) -> dict[str, Any]:
                 {"name": act.name, "description": act.description, "parameters": act.parameters}
                 for act in meta.actions
             ]
+        if is_dynamic_mcp:
+            mcp_tools: list[dict[str, Any]] = mcp_extra.get("tools", [])
+            entry["mcp_tools_count"] = len(mcp_tools)
+            if mcp_tools:
+                entry["mcp_tools"] = [
+                    {"name": t.get("name", ""), "description": t.get("description", "")}
+                    for t in mcp_tools
+                    if isinstance(t, dict)
+                ]
         connectors.append(entry)
+
+    # Exclude the base "mcp" slug — it's a template, not a real connection
+    connectors = [c for c in connectors if c["slug"] != "mcp"]
 
     return {"connectors": connectors, "count": len(connectors)}
 
@@ -679,30 +706,35 @@ async def _get_connector_docs(
 
     Returns the connector's usage_guide if present, plus auto-generated
     parameter reference from actions, write_operations, and query_description.
+    For the MCP connector, appends dynamically-discovered tool schemas.
     """
-    from connectors.registry import Capability, ConnectorMeta, discover_connectors
+    from connectors.registry import Capability, ConnectorMeta, resolve_connector
     from models.integration import Integration
 
     slug: str = (params.get("connector") or "").strip().lower()
     if not slug:
         return {"error": "connector is required (e.g. 'google_drive', 'hubspot')"}
 
+    integration_extra_data: dict[str, Any] | None = None
     async with get_session(organization_id=organization_id) as session:
         result = await session.execute(
-            select(Integration.connector).where(
+            select(Integration.connector, Integration.extra_data).where(
                 Integration.organization_id == UUID(organization_id),
                 Integration.is_active == True,  # noqa: E712
             )
         )
-        active_providers: set[str] = {row[0] for row in result.all()}
+        active_providers: set[str] = set()
+        for row in result.all():
+            active_providers.add(row[0])
+            if row[0] == slug:
+                integration_extra_data = row[1]
 
     if slug not in active_providers:
         return {
             "error": f"'{slug}' is not connected. Use list_connected_connectors to see available connectors.",
         }
 
-    registry = discover_connectors()
-    connector_cls = registry.get(slug)
+    connector_cls = resolve_connector(slug)
     if not connector_cls:
         return {"error": f"Unknown connector: {slug}"}
 
@@ -728,6 +760,34 @@ async def _get_connector_docs(
         for act in meta.actions:
             param_parts = [f"- **{p['name']}** ({p.get('type', 'string')})" for p in act.parameters]
             param_lines.append(f"### {act.name}\n{act.description}\n" + "\n".join(param_parts))
+
+    if slug.startswith("mcp_") and integration_extra_data:
+        mcp_tools: list[dict[str, Any]] = integration_extra_data.get("tools", [])
+        if mcp_tools:
+            tool_lines: list[str] = ["## Available MCP tools\n"]
+            for tool in mcp_tools:
+                if not isinstance(tool, dict):
+                    continue
+                tool_name: str = tool.get("name", "unknown")
+                tool_desc: str = tool.get("description", "")
+                tool_lines.append(f"### {tool_name}")
+                if tool_desc:
+                    tool_lines.append(tool_desc)
+                input_schema: dict[str, Any] | None = tool.get("inputSchema")
+                if isinstance(input_schema, dict):
+                    props: dict[str, Any] = input_schema.get("properties", {})
+                    required_params: list[str] = input_schema.get("required", [])
+                    if props:
+                        for pname, pschema in props.items():
+                            ptype: str = pschema.get("type", "any") if isinstance(pschema, dict) else "any"
+                            pdesc: str = pschema.get("description", "") if isinstance(pschema, dict) else ""
+                            req_marker: str = " (required)" if pname in required_params else ""
+                            line: str = f"- **{pname}** ({ptype}{req_marker})"
+                            if pdesc:
+                                line += f": {pdesc}"
+                            tool_lines.append(line)
+                tool_lines.append("")
+            param_lines.append("\n".join(tool_lines))
 
     if param_lines:
         sections.append("\n\n---\n\n# Parameter reference\n\n" + "\n\n".join(param_lines))

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -384,6 +384,8 @@ class IntegrationResponse(BaseModel):
     team_total: int = 0
     # Sync statistics
     sync_stats: Optional[dict[str, int]] = None
+    # Optional display name override (e.g. user-provided name for MCP connectors)
+    display_name: Optional[str] = None
 
 
 class IntegrationsListResponse(BaseModel):
@@ -3233,15 +3235,21 @@ async def patch_integration_sharing(
     }
 
 
-_BUILTIN_CONNECTORS: frozenset[str] = frozenset({"web_search", "code_sandbox", "twilio", "artifacts", "apps"})
+_BUILTIN_CONNECTORS: frozenset[str] = frozenset({"web_search", "code_sandbox", "twilio", "artifacts", "apps", "mcp"})
+
+
+def _is_builtin_connector(provider: str) -> bool:
+    """Check if a provider is a builtin connector, including dynamic mcp_* slugs."""
+    return provider in _BUILTIN_CONNECTORS or provider.startswith("mcp_")
 
 
 class ConnectBuiltinRequest(BaseModel):
     """Request to connect a built-in connector (no OAuth)."""
 
     organization_id: str
-    provider: str  # web_search | code_sandbox | twilio
+    provider: str  # web_search | code_sandbox | twilio | mcp
     user_id: str  # Required - all integrations are user-scoped
+    extra_data: dict[str, Any] | None = None  # Provider-specific config (e.g. MCP endpoint URL)
 
 
 @router.post("/integrations/connect-builtin")
@@ -3252,7 +3260,7 @@ async def connect_builtin(request: ConnectBuiltinRequest) -> dict[str, Any]:
     These connectors use platform credentials and do not go through Nango.
     The user must explicitly "connect" them in the Connectors tab before the agent can use them.
     """
-    if request.provider not in _BUILTIN_CONNECTORS:
+    if not _is_builtin_connector(request.provider):
         raise HTTPException(
             status_code=400,
             detail=f"Provider '{request.provider}' is not a built-in connector. Use the regular connect flow for OAuth integrations.",
@@ -3266,6 +3274,45 @@ async def connect_builtin(request: ConnectBuiltinRequest) -> dict[str, Any]:
         user_uuid = UUID(request.user_id)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid user ID")
+
+    # MCP connector: validate endpoint, discover tools, generate dynamic slug
+    connection_extra_data: dict[str, Any] | None = None
+    mcp_tool_count: int = 0
+    is_mcp: bool = request.provider == "mcp" or request.provider.startswith("mcp_")
+    if is_mcp:
+        if not request.extra_data or not request.extra_data.get("endpoint_url"):
+            raise HTTPException(status_code=400, detail="MCP connector requires 'endpoint_url' in extra_data")
+        endpoint_url: str = request.extra_data["endpoint_url"].strip()
+        auth_header: str | None = (request.extra_data.get("auth_header") or request.extra_data.get("bearer_token") or "").strip() or None
+
+        from connectors.mcp import GenericMcpClient
+        mcp_client: GenericMcpClient = GenericMcpClient(endpoint_url=endpoint_url, auth_header=auth_header)
+        try:
+            await mcp_client.initialize()
+            discovered_tools: list[dict[str, Any]] = await mcp_client.list_tools()
+        except Exception as exc:
+            logger.warning("MCP connect validation failed for %s: %s", endpoint_url, exc)
+            raise HTTPException(
+                status_code=400,
+                detail=f"Could not connect to MCP server at {endpoint_url}: {exc}",
+            ) from exc
+
+        mcp_tool_count = len(discovered_tools)
+        display_name: str = (request.extra_data.get("display_name") or "").strip() or "MCP Server"
+
+        # Generate a stable slug from the display name: "SimilarWeb" → "mcp_similarweb"
+        import re as _re
+        slug_suffix: str = _re.sub(r"[^a-z0-9]+", "_", display_name.lower()).strip("_")
+        if not slug_suffix:
+            slug_suffix = "server"
+        request.provider = f"mcp_{slug_suffix}"
+
+        connection_extra_data = {
+            "display_name": display_name,
+            "endpoint_url": endpoint_url,
+            "auth_header": auth_header,
+            "tools": discovered_tools,
+        }
 
     sharing_defaults = get_provider_sharing_defaults(request.provider)
 
@@ -3287,6 +3334,8 @@ async def connect_builtin(request: ConnectBuiltinRequest) -> dict[str, Any]:
                 existing.is_active = True
                 existing.nango_connection_id = "builtin"
                 existing.updated_at = datetime.utcnow()
+                if connection_extra_data:
+                    existing.extra_data = connection_extra_data
             else:
                 new_integration = Integration(
                     organization_id=org_uuid,
@@ -3296,6 +3345,7 @@ async def connect_builtin(request: ConnectBuiltinRequest) -> dict[str, Any]:
                     nango_connection_id="builtin",
                     connected_by_user_id=user_uuid,
                     is_active=True,
+                    extra_data=connection_extra_data,
                     share_synced_data=sharing_defaults.share_synced_data,
                     share_query_access=sharing_defaults.share_query_access,
                     share_write_access=sharing_defaults.share_write_access,
@@ -3303,6 +3353,8 @@ async def connect_builtin(request: ConnectBuiltinRequest) -> dict[str, Any]:
                 )
                 session.add(new_integration)
             await session.commit()
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception(
             "connect_builtin failed: provider=%s org=%s user=%s",
@@ -3312,7 +3364,10 @@ async def connect_builtin(request: ConnectBuiltinRequest) -> dict[str, Any]:
         )
         raise HTTPException(status_code=500, detail="Failed to connect built-in integration.") from e
 
-    return {"status": "connected", "provider": request.provider}
+    response: dict[str, Any] = {"status": "connected", "provider": request.provider}
+    if is_mcp:
+        response["tools_discovered"] = mcp_tool_count
+    return response
 
 
 @router.get("/connect/{provider}/redirect")
@@ -3578,6 +3633,10 @@ async def list_integrations(
                 owner = team_members[ref_integration.user_id]
                 connected_by_name = owner.name or owner.email
 
+            mcp_display_name: str | None = None
+            if provider.startswith("mcp_") and ref_integration and ref_integration.extra_data:
+                mcp_display_name = ref_integration.extra_data.get("display_name")
+
             response_integrations.append(IntegrationResponse(
                 id=str(ref_integration.id) if ref_integration else f"pending-{provider}",
                 provider=provider,
@@ -3607,6 +3666,7 @@ async def list_integrations(
                 team_connections=team_connections,
                 team_total=team_total,
                 sync_stats=ref_integration.sync_stats if ref_integration else None,
+                display_name=mcp_display_name,
             ))
 
         return IntegrationsListResponse(integrations=response_integrations)

--- a/backend/connectors/mcp.py
+++ b/backend/connectors/mcp.py
@@ -1,0 +1,361 @@
+"""
+Generic MCP connector.
+
+Lets users connect any MCP-compatible server by URL. On connect, performs
+an MCP handshake and discovers available tools. The agent can then invoke
+those tools via the standard run_on_connector / query_on_connector dispatch.
+
+Uses raw Streamable HTTP transport (JSON-RPC 2.0 over HTTP POST) — same
+pattern as the Granola connector, no MCP SDK dependency required.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import httpx
+from sqlalchemy import select
+
+from connectors.base import BaseConnector
+from connectors.registry import (
+    AuthField,
+    AuthType,
+    Capability,
+    ConnectorAction,
+    ConnectorMeta,
+    ConnectorScope,
+)
+from models.database import get_session
+from models.integration import Integration
+
+logger = logging.getLogger(__name__)
+
+MCP_JSONRPC_VERSION: str = "2.0"
+MCP_PROTOCOL_VERSION: str = "2025-03-26"
+MCP_CLIENT_INFO: dict[str, str] = {"name": "basebase", "version": "1.0.0"}
+DEFAULT_TIMEOUT: float = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Generic MCP client (Streamable HTTP transport, JSON-RPC 2.0)
+# ---------------------------------------------------------------------------
+
+
+class GenericMcpClient:
+    """Reusable JSON-RPC 2.0 client for any MCP server over Streamable HTTP."""
+
+    def __init__(self, endpoint_url: str, auth_header: str | None = None) -> None:
+        self._endpoint_url: str = endpoint_url
+        self._auth_header: tuple[str, str] | None = self._parse_auth(auth_header)
+        self._request_id: int = 0
+        self._session_id: str | None = None
+
+    @staticmethod
+    def _parse_auth(raw: str | None) -> tuple[str, str] | None:
+        """Parse an auth string into a (header_name, header_value) tuple.
+
+        Supports two formats:
+          - "header-name: value"  →  custom header  (e.g. "api-key: abc123")
+          - "raw-token"           →  Authorization: Bearer raw-token
+        """
+        if not raw:
+            return None
+        raw = raw.strip()
+        if ": " in raw:
+            name, _, value = raw.partition(": ")
+            return (name.strip(), value.strip())
+        return ("Authorization", f"Bearer {raw}")
+
+    def _next_id(self) -> int:
+        self._request_id += 1
+        return self._request_id
+
+    def _headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        if self._auth_header:
+            headers[self._auth_header[0]] = self._auth_header[1]
+        if self._session_id:
+            headers["Mcp-Session-Id"] = self._session_id
+        return headers
+
+    async def _rpc(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        """Send a JSON-RPC 2.0 request and return the result."""
+        payload: dict[str, Any] = {
+            "jsonrpc": MCP_JSONRPC_VERSION,
+            "id": self._next_id(),
+            "method": method,
+        }
+        if params is not None:
+            payload["params"] = params
+
+        async with httpx.AsyncClient(timeout=DEFAULT_TIMEOUT) as client:
+            response: httpx.Response = await client.post(
+                self._endpoint_url,
+                headers=self._headers(),
+                json=payload,
+            )
+            response.raise_for_status()
+
+            session_id: str | None = response.headers.get("Mcp-Session-Id")
+            if session_id:
+                self._session_id = session_id
+
+            content_type: str = response.headers.get("content-type", "")
+
+            if "text/event-stream" in content_type:
+                return self._parse_sse(response.text)
+
+            data: dict[str, Any] = response.json()
+            if "error" in data:
+                error_info: dict[str, Any] = data["error"]
+                raise RuntimeError(
+                    f"MCP error {error_info.get('code')}: {error_info.get('message')}"
+                )
+            return data.get("result")
+
+    @staticmethod
+    def _parse_sse(raw_text: str) -> Any:
+        """Extract the last JSON-RPC result from an SSE stream."""
+        last_result: Any = None
+        for line in raw_text.splitlines():
+            if line.startswith("data: "):
+                try:
+                    event_data: dict[str, Any] = json.loads(line[6:])
+                    if "result" in event_data:
+                        last_result = event_data["result"]
+                    elif "error" in event_data:
+                        error_info: dict[str, Any] = event_data["error"]
+                        raise RuntimeError(
+                            f"MCP error {error_info.get('code')}: {error_info.get('message')}"
+                        )
+                except json.JSONDecodeError:
+                    continue
+        return last_result
+
+    async def initialize(self) -> dict[str, Any]:
+        """Perform MCP initialize handshake."""
+        result: Any = await self._rpc("initialize", {
+            "protocolVersion": MCP_PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": MCP_CLIENT_INFO,
+        })
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            await client.post(
+                self._endpoint_url,
+                headers=self._headers(),
+                json={
+                    "jsonrpc": MCP_JSONRPC_VERSION,
+                    "method": "notifications/initialized",
+                },
+            )
+        return result if isinstance(result, dict) else {}
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """Call tools/list and return the tool descriptors."""
+        result: Any = await self._rpc("tools/list")
+        if isinstance(result, dict):
+            tools: Any = result.get("tools", [])
+            return tools if isinstance(tools, list) else []
+        return []
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> Any:
+        """Call an MCP tool and return the result content."""
+        params: dict[str, Any] = {
+            "name": tool_name,
+            "arguments": arguments if arguments is not None else {},
+        }
+        return await self._rpc("tools/call", params)
+
+
+def _extract_text_from_content(result: Any) -> str:
+    """Pull text out of MCP content blocks (same format as tools/call responses)."""
+    if isinstance(result, dict):
+        content: Any = result.get("content")
+        if isinstance(content, list):
+            parts: list[str] = []
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text: Any = block.get("text", "")
+                    if isinstance(text, str):
+                        parts.append(text)
+            if parts:
+                return "\n".join(parts)
+        if isinstance(result.get("result"), str):
+            return result["result"]
+    if isinstance(result, str):
+        return result
+    return json.dumps(result, default=str)
+
+
+# ---------------------------------------------------------------------------
+# Connector
+# ---------------------------------------------------------------------------
+
+
+class McpConnector(BaseConnector):
+    """Generic connector for any MCP-compatible server."""
+
+    source_system: str = "mcp"
+
+    meta = ConnectorMeta(
+        name="MCP Server",
+        slug="mcp",
+        description="Connect any MCP-compatible server by URL",
+        auth_type=AuthType.CUSTOM,
+        scope=ConnectorScope.USER,
+        entity_types=[],
+        capabilities=[Capability.QUERY, Capability.ACTION],
+        actions=[
+            ConnectorAction(
+                name="call_tool",
+                description="Call a tool on the connected MCP server",
+                parameters=[
+                    {"name": "tool", "type": "string", "required": True,
+                     "description": "Name of the MCP tool to call"},
+                    {"name": "arguments", "type": "object", "required": False,
+                     "description": "Arguments to pass to the tool"},
+                ],
+            ),
+        ],
+        query_description="Query 'list_tools' to see available tools on the MCP server, or pass a tool name to get its schema.",
+        auth_fields=[
+            AuthField(
+                name="endpoint_url",
+                label="MCP Endpoint URL",
+                type="url",
+                required=True,
+                help_text="Full URL of the MCP server (e.g. https://mcp.example.com/mcp)",
+            ),
+            AuthField(
+                name="auth_header",
+                label="Auth Header / Token",
+                type="password",
+                required=False,
+                help_text="e.g. 'api-key: abc123' or a raw Bearer token",
+            ),
+        ],
+        usage_guide=(
+            "This connector lets you interact with a remote MCP server.\n\n"
+            "1. Use query_on_connector(connector='mcp', query='list_tools') to see available tools.\n"
+            "2. Use run_on_connector(connector='mcp', action='call_tool', "
+            "params={'tool': '<tool_name>', 'arguments': {…}}) to invoke a tool.\n\n"
+            "The available tools depend on which MCP server the user has connected."
+        ),
+    )
+
+    async def _get_mcp_config(self) -> tuple[str, str | None, list[dict[str, Any]]]:
+        """Load endpoint URL, auth header, and cached tools from integration extra_data."""
+        if not self._integration:
+            await self._load_integration()
+        if not self._integration:
+            raise ValueError("No active MCP integration found")
+
+        extra: dict[str, Any] = self._integration.extra_data or {}
+        endpoint_url: str | None = extra.get("endpoint_url")
+        if not endpoint_url:
+            raise ValueError("MCP integration missing endpoint_url in extra_data")
+
+        auth_header: str | None = extra.get("auth_header") or extra.get("bearer_token")
+        cached_tools: list[dict[str, Any]] = extra.get("tools", [])
+        return endpoint_url, auth_header, cached_tools
+
+    def _make_client(self, endpoint_url: str, auth_header: str | None) -> GenericMcpClient:
+        return GenericMcpClient(endpoint_url=endpoint_url, auth_header=auth_header)
+
+    # ------------------------------------------------------------------
+    # QUERY capability
+    # ------------------------------------------------------------------
+
+    async def query(self, request: str) -> dict[str, Any]:
+        """List available tools or describe a specific tool."""
+        endpoint_url, auth_header, cached_tools = await self._get_mcp_config()
+
+        query_lower: str = request.strip().lower()
+
+        if query_lower in ("list_tools", "list", "tools", ""):
+            if cached_tools:
+                tool_summaries: list[dict[str, Any]] = [
+                    {
+                        "name": t.get("name", ""),
+                        "description": t.get("description", ""),
+                        "inputSchema": t.get("inputSchema"),
+                    }
+                    for t in cached_tools
+                ]
+                return {"tools": tool_summaries, "count": len(tool_summaries)}
+
+            client: GenericMcpClient = self._make_client(endpoint_url, auth_header)
+            await client.initialize()
+            tools: list[dict[str, Any]] = await client.list_tools()
+            return {"tools": tools, "count": len(tools)}
+
+        for tool in cached_tools:
+            if isinstance(tool, dict) and tool.get("name", "").lower() == query_lower:
+                return {
+                    "name": tool.get("name", ""),
+                    "description": tool.get("description", ""),
+                    "inputSchema": tool.get("inputSchema"),
+                }
+
+        return {"error": f"Unknown query '{request}'. Use 'list_tools' to see available tools."}
+
+    # ------------------------------------------------------------------
+    # ACTION capability
+    # ------------------------------------------------------------------
+
+    async def execute_action(self, action: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Call a tool on the MCP server."""
+        if action != "call_tool":
+            raise ValueError(f"Unknown action: {action}. Use 'call_tool'.")
+
+        tool_name: str | None = params.get("tool")
+        if not tool_name:
+            return {"error": "Missing required parameter 'tool' (name of the MCP tool to call)"}
+
+        arguments: dict[str, Any] = params.get("arguments") or {}
+
+        endpoint_url, auth_header, _cached_tools = await self._get_mcp_config()
+        client: GenericMcpClient = self._make_client(endpoint_url, auth_header)
+        await client.initialize()
+
+        try:
+            result: Any = await client.call_tool(tool_name, arguments)
+        except RuntimeError as exc:
+            return {"error": f"MCP tool '{tool_name}' failed: {exc}"}
+        except httpx.HTTPStatusError as exc:
+            return {"error": f"HTTP error calling MCP tool '{tool_name}': {exc.response.status_code}"}
+
+        text_output: str = _extract_text_from_content(result)
+        return {"tool": tool_name, "output": text_output}
+
+    # ------------------------------------------------------------------
+    # Stubs for abstract methods (MCP connector does not sync CRM data)
+    # ------------------------------------------------------------------
+
+    async def sync_deals(self) -> list[Any]:
+        return []
+
+    async def sync_accounts(self) -> list[Any]:
+        return []
+
+    async def sync_contacts(self) -> list[Any]:
+        return []
+
+    async def sync_activities(self) -> list[Any]:
+        return []
+
+    async def fetch_deal(self, deal_id: str) -> dict[str, Any]:
+        raise NotImplementedError("MCP connector does not support fetch_deal")

--- a/backend/connectors/registry.py
+++ b/backend/connectors/registry.py
@@ -180,3 +180,17 @@ def discover_connectors() -> dict[str, type[BaseConnector]]:
         pass
 
     return registry
+
+
+def resolve_connector(slug: str) -> type[BaseConnector] | None:
+    """Look up a connector class by slug, with mcp_* wildcard fallback.
+
+    Dynamic MCP slugs like ``mcp_similarweb`` are stored in the integrations
+    table but don't have dedicated connector modules.  They all resolve to
+    the generic ``McpConnector`` class registered under the ``mcp`` slug.
+    """
+    registry: dict[str, type[BaseConnector]] = discover_connectors()
+    cls: type[BaseConnector] | None = registry.get(slug)
+    if cls is None and slug.startswith("mcp_"):
+        cls = registry.get("mcp")
+    return cls

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -26,7 +26,7 @@ import {
   SiJira,
   SiAsana,
 } from 'react-icons/si';
-import { HiOutlineCalendar, HiOutlineMail, HiGlobeAlt, HiUserGroup, HiDeviceMobile, HiMicrophone, HiLightningBolt, HiX, HiCog, HiShare, HiLockClosed, HiDocumentText, HiCube } from 'react-icons/hi';
+import { HiOutlineCalendar, HiOutlineMail, HiGlobeAlt, HiUserGroup, HiDeviceMobile, HiMicrophone, HiLightningBolt, HiX, HiCog, HiShare, HiLockClosed, HiDocumentText, HiCube, HiLink } from 'react-icons/hi';
 // Custom Apollo.io icon - 8-ray starburst matching their brand
 const ApolloIcon: IconType = ({ className, ...props }) => (
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" className={className} {...props}>
@@ -66,6 +66,7 @@ const ICON_MAP: Record<string, IconType> = {
   sms: HiDeviceMobile,
   artifacts: HiDocumentText,
   apps: HiCube,
+  plug: HiLink,
 };
 
 // Sharing defaults for providers (used when showing the sharing modal)
@@ -125,15 +126,21 @@ const INTEGRATION_CONFIG: Record<string, IntegrationConfigEntry> = {
   twilio: { name: 'Twilio', description: 'Send SMS messages to phone numbers', icon: 'sms', color: 'from-red-500 to-pink-600', scope: 'organization' },
   artifacts: { name: 'Artifact Builder', description: 'Create and update downloadable files (reports, markdown, PDFs, charts)', icon: 'artifacts', color: 'from-slate-500 to-slate-600', scope: 'organization' },
   apps: { name: 'App Builder', description: 'Create and update interactive mini-apps with React + SQL', icon: 'apps', color: 'from-violet-500 to-purple-600', scope: 'organization' },
+  mcp: { name: 'MCP Server', description: 'Connect any MCP-compatible server by URL', icon: 'plug', color: 'from-cyan-500 to-blue-600', scope: 'user' },
 };
 
 const SUPPORTED_PROVIDERS = new Set(Object.keys(INTEGRATION_CONFIG));
 
+/** Check if a provider is "supported" for display (static config or dynamic MCP). */
+function isSupportedProvider(provider: string): boolean {
+  return SUPPORTED_PROVIDERS.has(provider) || provider.startsWith('mcp_');
+}
+
 /** Built-in connectors that connect with one click (no OAuth popup). */
-const BUILTIN_CONNECTORS = new Set(['web_search', 'code_sandbox', 'twilio', 'artifacts', 'apps']);
+const BUILTIN_CONNECTORS = new Set(['web_search', 'code_sandbox', 'twilio', 'artifacts', 'apps', 'mcp']);
 
 /** Connectors that have no sync — on-demand only (no Sync button, no "Starting sync"). */
-const NO_SYNC_PROVIDERS = new Set(['apollo', 'web_search', 'code_sandbox', 'twilio', 'artifacts', 'apps']);
+const NO_SYNC_PROVIDERS = new Set(['apollo', 'web_search', 'code_sandbox', 'twilio', 'artifacts', 'apps', 'mcp']);
 
 // Common integrations to show as tiles when org has zero connected (display order)
 const COMMON_INTEGRATION_KEYS: ReadonlyArray<string> = [
@@ -320,6 +327,14 @@ export function DataSources(): JSX.Element {
   const [showSlackVerificationModal, setShowSlackVerificationModal] = useState(false);
   const [showConnectModal, setShowConnectModal] = useState(false);
   const [connectSearch, setConnectSearch] = useState('');
+
+  // MCP connect form state
+  const [showMcpForm, setShowMcpForm] = useState(false);
+  const [mcpName, setMcpName] = useState('');
+  const [mcpEndpointUrl, setMcpEndpointUrl] = useState('');
+  const [mcpBearerToken, setMcpBearerToken] = useState('');
+  const [mcpConnecting, setMcpConnecting] = useState(false);
+  const [mcpError, setMcpError] = useState<string | null>(null);
 
 
   // GitHub: available repos (from token), tracked repo ids, selection, loading
@@ -543,17 +558,20 @@ export function DataSources(): JSX.Element {
       if (integration.provider === 'microsoft') {
         return false;
       }
-      if (!SUPPORTED_PROVIDERS.has(integration.provider)) {
+      if (!isSupportedProvider(integration.provider)) {
         console.warn('[DataSources] Hiding unsupported integration provider from UI:', integration.provider);
         return false;
       }
       return true;
     })
     .map((integration) => {
-      const config = INTEGRATION_CONFIG[integration.provider]!;
+      const config: IntegrationConfigEntry = INTEGRATION_CONFIG[integration.provider]
+        ?? (integration.provider.startsWith('mcp_') ? INTEGRATION_CONFIG['mcp']! : undefined)!;
+      const name: string = integration.displayName ?? config.name;
       return {
         ...integration,
         ...config,
+        name,
         connected: integration.isActive,
       };
     });
@@ -580,6 +598,7 @@ export function DataSources(): JSX.Element {
         teamConnections: [],
         teamTotal: 0,
         syncStats: null,
+        displayName: null,
         shareSyncedData: defaults.shareSyncedData,
         shareQueryAccess: defaults.shareQueryAccess,
         shareWriteAccess: defaults.shareWriteAccess,
@@ -617,6 +636,7 @@ export function DataSources(): JSX.Element {
         teamConnections: [],
         teamTotal: 0,
         syncStats: null,
+        displayName: null,
         shareSyncedData: defaults.shareSyncedData,
         shareQueryAccess: defaults.shareQueryAccess,
         shareWriteAccess: defaults.shareWriteAccess,
@@ -637,6 +657,17 @@ export function DataSources(): JSX.Element {
     setConnectingProvider(provider);
 
     try {
+      // MCP connector — needs a form for URL + optional token
+      if (provider === 'mcp') {
+        setConnectingProvider(null);
+        setMcpName('');
+        setMcpEndpointUrl('');
+        setMcpBearerToken('');
+        setMcpError(null);
+        setShowMcpForm(true);
+        return;
+      }
+
       // Built-in connectors (Open Web, Code Sandbox, Twilio) — one-click, no OAuth
       if (BUILTIN_CONNECTORS.has(provider)) {
         const res = await fetch(`${API_BASE}/auth/integrations/connect-builtin`, {
@@ -731,6 +762,49 @@ export function DataSources(): JSX.Element {
     } catch (error) {
       console.error('Failed to connect:', error);
       setConnectingProvider(null);
+    }
+  };
+
+  const handleMcpConnect = async (): Promise<void> => {
+    if (!organizationId || !userId || mcpConnecting) return;
+    const trimmedUrl: string = mcpEndpointUrl.trim();
+    const trimmedName: string = mcpName.trim();
+    if (!trimmedName) {
+      setMcpError('Name is required');
+      return;
+    }
+    if (!trimmedUrl) {
+      setMcpError('Endpoint URL is required');
+      return;
+    }
+
+    setMcpConnecting(true);
+    setMcpError(null);
+    try {
+      const res: Response = await fetch(`${API_BASE}/auth/integrations/connect-builtin`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          organization_id: organizationId,
+          provider: 'mcp',
+          user_id: userId,
+          extra_data: {
+            display_name: trimmedName,
+            endpoint_url: trimmedUrl,
+            auth_header: mcpBearerToken.trim() || null,
+          },
+        }),
+      });
+      if (!res.ok) {
+        const err: { detail?: string } = await res.json().catch(() => ({ detail: res.statusText }));
+        throw new Error(err.detail ?? 'Failed to connect');
+      }
+      setShowMcpForm(false);
+      void fetchIntegrations();
+    } catch (error) {
+      setMcpError(error instanceof Error ? error.message : 'Failed to connect');
+    } finally {
+      setMcpConnecting(false);
     }
   };
 
@@ -852,12 +926,11 @@ export function DataSources(): JSX.Element {
 
   // Open sharing modal for editing an existing integration
   const handleOpenSharingSettings = (integration: DisplayIntegration): void => {
-    const config = INTEGRATION_CONFIG[integration.provider];
     setSharingModal({
       isOpen: true,
       integrationId: integration.id,
       provider: integration.provider,
-      providerName: config?.name ?? integration.provider,
+      providerName: integration.name,
       shareSyncedData: integration.shareSyncedData,
       shareQueryAccess: integration.shareQueryAccess,
       shareWriteAccess: integration.shareWriteAccess,
@@ -1089,7 +1162,7 @@ export function DataSources(): JSX.Element {
     const isConnecting = connectingProvider === integration.provider;
     const isStartingSync =
       (state === 'connected' || state === 'org-connected') &&
-      !NO_SYNC_PROVIDERS.has(integration.provider) &&
+      !NO_SYNC_PROVIDERS.has(integration.provider) && !integration.provider.startsWith('mcp_') &&
       !integration.lastSyncAt &&
       !syncingProviders.has(integration.provider);
     const isSyncing = syncingProviders.has(integration.provider) || isStartingSync;
@@ -1115,7 +1188,7 @@ export function DataSources(): JSX.Element {
     const getButtonConfig = (): { text: string; className: string; action: () => void; disabled: boolean; hidden?: boolean } => {
       if (state === 'connected' || state === 'org-connected') {
         // Apollo, artifacts, apps, web_search, code_sandbox, twilio — no sync, on-demand only
-        if (NO_SYNC_PROVIDERS.has(integration.provider)) {
+        if (NO_SYNC_PROVIDERS.has(integration.provider) || integration.provider.startsWith('mcp_')) {
           return {
             text: '',
             className: '',
@@ -1596,6 +1669,119 @@ export function DataSources(): JSX.Element {
                 })
               )}
             </ul>
+          </div>
+        </div>
+      )}
+
+      {/* MCP Connect Form Modal */}
+      {showMcpForm && (
+        <div className="fixed inset-0 z-50 flex items-start justify-center pt-[10vh]">
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={() => { if (!mcpConnecting) setShowMcpForm(false); }}
+          />
+          <div className="relative bg-surface-900 border border-surface-700 rounded-2xl shadow-2xl w-full max-w-md mx-4 overflow-hidden">
+            <div className="p-5 border-b border-surface-700/50">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <div className="bg-gradient-to-br from-cyan-500 to-blue-600 p-2 rounded-lg text-white">
+                    <HiLink className="w-5 h-5" />
+                  </div>
+                  <h2 className="text-lg font-semibold text-surface-100">Connect MCP Server</h2>
+                </div>
+                <button
+                  onClick={() => { if (!mcpConnecting) setShowMcpForm(false); }}
+                  className="text-surface-400 hover:text-surface-200 transition-colors"
+                >
+                  <HiX className="w-5 h-5" />
+                </button>
+              </div>
+            </div>
+            <form
+              onSubmit={(e) => { e.preventDefault(); void handleMcpConnect(); }}
+              className="p-5 space-y-4"
+            >
+              <div>
+                <label htmlFor="mcp-name" className="block text-sm font-medium text-surface-300 mb-1.5">
+                  Name <span className="text-red-400">*</span>
+                </label>
+                <input
+                  id="mcp-name"
+                  type="text"
+                  value={mcpName}
+                  onChange={(e) => setMcpName(e.target.value)}
+                  placeholder="e.g. SimilarWeb, Stripe, Notion"
+                  required
+                  disabled={mcpConnecting}
+                  autoFocus
+                  className="w-full rounded-lg bg-surface-800 border border-surface-600 px-4 py-2.5 text-sm text-surface-100 placeholder:text-surface-500 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500/30 disabled:opacity-50"
+                />
+              </div>
+              <div>
+                <label htmlFor="mcp-url" className="block text-sm font-medium text-surface-300 mb-1.5">
+                  Endpoint URL <span className="text-red-400">*</span>
+                </label>
+                <input
+                  id="mcp-url"
+                  type="url"
+                  value={mcpEndpointUrl}
+                  onChange={(e) => setMcpEndpointUrl(e.target.value)}
+                  placeholder="https://mcp.example.com/mcp"
+                  required
+                  disabled={mcpConnecting}
+                  className="w-full rounded-lg bg-surface-800 border border-surface-600 px-4 py-2.5 text-sm text-surface-100 placeholder:text-surface-500 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500/30 disabled:opacity-50"
+                />
+              </div>
+              <div>
+                <label htmlFor="mcp-token" className="block text-sm font-medium text-surface-300 mb-1.5">
+                  Auth Header <span className="text-surface-500 font-normal">(optional)</span>
+                </label>
+                <input
+                  id="mcp-token"
+                  type="password"
+                  value={mcpBearerToken}
+                  onChange={(e) => setMcpBearerToken(e.target.value)}
+                  placeholder="e.g. api-key: abc123  or  Bearer token"
+                  disabled={mcpConnecting}
+                  className="w-full rounded-lg bg-surface-800 border border-surface-600 px-4 py-2.5 text-sm text-surface-100 placeholder:text-surface-500 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500/30 disabled:opacity-50"
+                />
+              </div>
+              {mcpError && (
+                <div className="text-sm text-red-400 bg-red-400/10 border border-red-400/20 rounded-lg px-3 py-2">
+                  {mcpError}
+                </div>
+              )}
+              <div className="flex gap-3 pt-1">
+                <button
+                  type="button"
+                  onClick={() => setShowMcpForm(false)}
+                  disabled={mcpConnecting}
+                  className="flex-1 px-4 py-2.5 text-sm font-medium text-surface-300 bg-surface-800 hover:bg-surface-700 border border-surface-600 rounded-lg transition-colors disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={mcpConnecting || !mcpName.trim() || !mcpEndpointUrl.trim()}
+                  className="flex-1 px-4 py-2.5 text-sm font-semibold text-white bg-primary-600 hover:bg-primary-500 rounded-lg transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+                >
+                  {mcpConnecting ? (
+                    <>
+                      <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                      </svg>
+                      Connecting...
+                    </>
+                  ) : (
+                    'Connect'
+                  )}
+                </button>
+              </div>
+              <p className="text-xs text-surface-500">
+                We&apos;ll validate the connection and discover available tools from the MCP server.
+              </p>
+            </form>
           </div>
         </div>
       )}

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -1094,6 +1094,7 @@ export const useChatStore = create<ChatState>()(
           }>;
           team_total: number;
           sync_stats: SyncStats | null;
+          display_name: string | null;
         }
 
         const data = (await response.json()) as {
@@ -1122,6 +1123,7 @@ export const useChatStore = create<ChatState>()(
           })),
           teamTotal: i.team_total,
           syncStats: i.sync_stats,
+          displayName: i.display_name ?? null,
         }));
 
         console.log("[Store] Fetched", integrations.length, "integrations");

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -97,6 +97,7 @@ export interface Integration {
   teamConnections: TeamConnection[];
   teamTotal: number;
   syncStats: SyncStats | null;
+  displayName: string | null;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- New `backend/connectors/mcp.py` with a generic JSON-RPC 2.0 MCP client and `McpConnector` that supports `query` (list/describe tools) and `execute_action` (call any MCP tool)
- Updated `connect-builtin` flow in `auth.py` to accept an MCP endpoint URL + optional bearer token, validate via MCP handshake, discover tools, and persist them in `extra_data`
- Enhanced `_get_connector_docs` and `_list_connected_connectors` in `tools.py` to surface dynamically-discovered MCP tool schemas to the agent
- Added MCP Server entry + connect form modal (URL + bearer token) to `DataSources.tsx`

## Test plan
- [ ] Connect an MCP server (e.g. `https://mcp.similarweb.com` with a SimilarWeb API key as bearer token) and verify tools are discovered
- [ ] Verify bad URL / invalid token shows an error in the connect form
- [ ] Ask the agent "what tools are available on my MCP server" and confirm it lists discovered tools
- [ ] Ask the agent to invoke an MCP tool and verify it returns results
- [ ] Disconnect and reconnect with different credentials; confirm `extra_data` updates
- [ ] Verify `get_connector_docs(connector='mcp')` returns full tool schemas with parameter descriptions

Made with [Cursor](https://cursor.com)