### PR TITLE
Add generic MCP connector for any MCP-compatible server

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -526,7 +526,7 @@ class ChatOrchestrator:
 
         Full parameter docs are fetched on demand via get_connector_docs(connector).
         """
-        from connectors.registry import ConnectorMeta, discover_connectors
+        from connectors.registry import ConnectorMeta, discover_connectors, resolve_connector
         from models.integration import Integration
 
         try:
@@ -536,6 +536,7 @@ class ChatOrchestrator:
                         Integration.connector,
                         Integration.last_sync_at,
                         Integration.last_error,
+                        Integration.extra_data,
                     )
                     .where(
                         Integration.organization_id == UUID(self.organization_id),
@@ -550,16 +551,25 @@ class ChatOrchestrator:
                 active_providers[row[0]] = {
                     "last_sync": row[1],
                     "last_error": row[2],
+                    "extra_data": row[3],
                 }
 
             registry = discover_connectors()
+            all_slugs: set[str] = set(registry.keys()) | set(active_providers.keys())
 
             lines: list[str] = [
                 "Call `get_connector_docs(connector)` to get detailed usage instructions and parameter reference before using a connector for the first time.",
                 "",
             ]
-            for slug, connector_cls in sorted(registry.items()):
+            for slug in sorted(all_slugs):
                 if slug not in active_providers:
+                    continue
+                # Skip the base "mcp" template — only show dynamic mcp_* instances
+                if slug == "mcp":
+                    continue
+
+                connector_cls = resolve_connector(slug)
+                if connector_cls is None:
                     continue
 
                 meta: ConnectorMeta = connector_cls.meta  # type: ignore[attr-defined]
@@ -573,6 +583,10 @@ class ChatOrchestrator:
                     elif provider_info["last_sync"]:
                         sync_status = f" (synced {provider_info['last_sync'].strftime('%Y-%m-%d %H:%M')} UTC)"
 
+                is_dynamic_mcp: bool = slug.startswith("mcp_")
+                extra: dict[str, Any] = (provider_info or {}).get("extra_data") or {}
+                display_name: str = extra.get("display_name", slug) if is_dynamic_mcp else meta.name
+
                 summary: str = meta.description or ""
                 action_names: list[str] = []
                 if meta.write_operations:
@@ -580,7 +594,15 @@ class ChatOrchestrator:
                 if meta.actions:
                     action_names.extend(act.name for act in meta.actions)
                 action_str: str = f" Actions: {', '.join(action_names)}" if action_names else ""
-                label: str = f"- **{meta.slug}** ({meta.name}) [{caps}]{sync_status} – {summary}{action_str}"
+
+                label: str = f"- **{slug}** ({display_name}) [{caps}]{sync_status} – {summary}{action_str}"
+                if is_dynamic_mcp:
+                    mcp_tools: list[dict[str, Any]] = extra.get("tools", [])
+                    if mcp_tools:
+                        tool_names: list[str] = [
+                            t.get("name", "") for t in mcp_tools if isinstance(t, dict)
+                        ]
+                        label += f" MCP tools: {', '.join(tool_names)}"
                 lines.append(label)
 
             connected_block: str = (
@@ -589,7 +611,8 @@ class ChatOrchestrator:
 
             # List connectors that exist but are not enabled for this org (no active Integration).
             not_enabled_slugs: list[str] = sorted(
-                set(registry.keys()) - set(active_providers.keys())
+                slug for slug in (set(registry.keys()) - set(active_providers.keys()))
+                if slug != "mcp"
             )
             not_enabled_block: str = ""
             if not_enabled_slugs:

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -625,6 +625,11 @@ async def _get_connector_instance(
     # Instantiate connector with the integration owner's user_id
     instance: BaseConnector = connector_cls(organization_id, user_id=integration_user_id)
 
+    # Dynamic MCP slugs (mcp_deepwiki, etc.) share the McpConnector class whose
+    # source_system is "mcp", but the Integration row uses the dynamic slug.
+    if slug.startswith("mcp_") and hasattr(instance, "source_system"):
+        instance.source_system = slug
+
     return instance, None
 
 
@@ -739,10 +744,14 @@ async def _get_connector_docs(
         return {"error": f"Unknown connector: {slug}"}
 
     meta: ConnectorMeta = connector_cls.meta  # type: ignore[attr-defined]
+    is_dynamic_mcp: bool = slug.startswith("mcp_")
     sections: list[str] = []
 
     if meta.usage_guide:
-        sections.append(meta.usage_guide)
+        guide: str = meta.usage_guide
+        if is_dynamic_mcp:
+            guide = guide.replace("<SLUG>", slug)
+        sections.append(guide)
 
     param_lines: list[str] = []
 
@@ -792,8 +801,12 @@ async def _get_connector_docs(
     if param_lines:
         sections.append("\n\n---\n\n# Parameter reference\n\n" + "\n\n".join(param_lines))
 
-    docs: str = "\n\n".join(sections) if sections else f"No documentation available for {meta.name}."
-    return {"connector": slug, "name": meta.name, "docs": docs}
+    display_name: str = meta.name
+    if is_dynamic_mcp and integration_extra_data:
+        display_name = integration_extra_data.get("display_name", slug)
+
+    docs: str = "\n\n".join(sections) if sections else f"No documentation available for {display_name}."
+    return {"connector": slug, "name": display_name, "docs": docs}
 
 
 async def _query_on_connector(

--- a/backend/connectors/mcp.py
+++ b/backend/connectors/mcp.py
@@ -249,9 +249,10 @@ class McpConnector(BaseConnector):
         ],
         usage_guide=(
             "This connector lets you interact with a remote MCP server.\n\n"
-            "1. Use query_on_connector(connector='mcp', query='list_tools') to see available tools.\n"
-            "2. Use run_on_connector(connector='mcp', action='call_tool', "
+            "1. Use query_on_connector(connector='<SLUG>', query='list_tools') to see available tools.\n"
+            "2. Use run_on_connector(connector='<SLUG>', action='call_tool', "
             "params={'tool': '<tool_name>', 'arguments': {…}}) to invoke a tool.\n\n"
+            "Replace <SLUG> with the actual connector slug (e.g. mcp_deepwiki).\n"
             "The available tools depend on which MCP server the user has connected."
         ),
     )


### PR DESCRIPTION
## Summary
- Adds a generic MCP Connector that lets users connect any MCP-compatible server by URL, with optional auth header support (Bearer tokens or custom headers like `api-key: value`)
- Supports multiple MCP connections with user-provided display names and dynamic `mcp_<name>` slugs
- Agent system prompt, connector docs, and DB lookups all correctly resolve dynamic MCP slugs so the AI agent can discover and invoke MCP tools

## Test plan
- [ ] Connect an MCP server (e.g. DeepWiki at `https://mcp.deepwiki.com/mcp` with no auth) via Settings → Connectors
- [ ] Verify it appears in the connector list with the user-provided name
- [ ] Start a new conversation and confirm the agent can discover and call MCP tools
- [ ] Connect a second MCP server and verify both work independently


Made with [Cursor](https://cursor.com)