### PR TITLE
Skip archived and empty channels during Slack sync

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -566,10 +566,15 @@ Send a message to a Slack channel, DM, or user.
             status="syncing",
         )
         
-        # Get channels
-        channels = await self.get_channels()
+        # Get channels, then filter out archived and empty ones
+        all_channels = await self.get_channels()
+        channels = [
+            ch for ch in all_channels
+            if not ch.get("is_archived") and (ch.get("num_members") or 0) > 0
+        ]
         logger.info(
-            "[Slack Sync] Retrieved %d channels for org=%s",
+            "[Slack Sync] Retrieved %d channels (%d active with members) for org=%s",
+            len(all_channels),
             len(channels),
             self.organization_id,
         )


### PR DESCRIPTION
## Summary
- Cro Metrics has 1883 Slack channels but **1463 are archived** and **1481 have 0 members**. The sync was iterating all of them — joining each one, fetching history — burning through Slack API rate limits and exceeding the 30-minute Celery task timeout before completing.
- Adds a filter after `get_channels()` to skip archived channels and channels with 0 members.
- For Cro Metrics this drops from 1883 to ~340 channels — an 82% reduction.

## What changed
One filter added in `sync_activities()` after the channel list is fetched. No other files changed.

## Test plan
- [ ] Verify Cro Metrics Slack sync completes within the 30-minute task limit
- [ ] Verify `last_sync_at` gets set after sync
- [ ] Verify active channel messages are still synced with channel names
- [ ] Verify archived channels are excluded from sync (no activities created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)