### PR TITLE
Resolve HubSpot deal stages to names and populate probability

### DIFF
--- a/backend/connectors/hubspot.py
+++ b/backend/connectors/hubspot.py
@@ -494,6 +494,9 @@ Use `m.external_userid` when setting `hubspot_owner_id`. If no mapping exists, t
                     )
                     await session.merge(stage)
 
+                    # Pre-populate stage cache so sync_deals skips the DB query
+                    self._stage_cache[hs_stage_id] = (stage.name, probability)
+
                 count += 1
             await session.commit()
 


### PR DESCRIPTION
## Summary

HubSpot's CRM API returns `dealstage` as an internal ID (e.g. `99977530`), not a human-readable name like "Proposal" or "Negotiation". The `Deal.probability` field was never populated during HubSpot sync. This made all pipeline analytics, SQL queries, and automated workflows (like the Daily Deal Signal Report) see raw stage IDs and 0% probabilities.

For context: Salesforce returns `StageName` and `Probability` as direct properties. HubSpot stores stage metadata separately in pipeline definitions, requiring a lookup.

## What changed

**One file: `connectors/hubspot.py`**

1. **`_ensure_pipeline_cache()`** now also loads a `_stage_cache` dict mapping `stage_source_id → (name, probability)` from the `pipeline_stages` table (already synced by `sync_pipelines()`).

2. **`_normalize_deal()`** resolves the raw `dealstage` ID to a human-readable name and populates `Deal.probability` from the stage's default probability. The raw stage ID is preserved in `custom_fields["stage_id"]` for traceability.

3. **`sync_deals()` upsert** now includes `probability` in both the row dict and update columns.

## Performance impact

**None.** One additional DB query at sync start to load all pipeline stages (~10-20 rows), cached in a dict for the entire run. Per-deal resolution is a dict lookup (nanoseconds). No additional HubSpot API calls.

## Design decision: Option A (resolve at sync time)

We considered two approaches:
- **Option A (this PR):** Store resolved stage name directly in `Deal.stage`. Simple, no migration, fixes all downstream consumers immediately.
- **Option B (future):** Add a `stage_id` column to preserve the raw HubSpot ID separately from the display name. Requires a migration but is cleaner long-term.

We chose Option A for immediate impact. Option B is tracked as a follow-up in Linear.

## Test plan

- [ ] Trigger a HubSpot sync for an org with HubSpot connected
- [ ] Verify `deals.stage` now shows human-readable names (e.g. "Proposal") instead of IDs
- [ ] Verify `deals.probability` is populated (e.g. 20, 50, 80) instead of NULL
- [ ] Verify `custom_fields.stage_id` contains the original HubSpot stage ID
- [ ] Verify the Daily Deal Signal Report workflow shows meaningful stage/probability data
- [ ] Verify no increase in sync duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)