### PR TITLE
feat(slack): Block Kit tables for structured tabular data in Slack

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -34,25 +34,25 @@ def _clean_table_lines(raw: str) -> str:
     return '\n'.join(filtered)
 
 
-def markdown_to_mrkdwn(text: str) -> str:
+def markdown_to_mrkdwn(text: str) -> tuple[str, Optional[list[dict[str, Any]]]]:
     """Convert standard Markdown to Slack mrkdwn format.
 
     Handles bold, italic, links, headers, and tables.  Existing fenced code
-    blocks are extracted first so their contents are never double-processed.
+    blocks are extracted first. Tables may be returned as Block Kit blocks.
+    Returns (mrkdwn_text, blocks_or_none).
     """
-
     from connectors.slack_tables import format_markdown_table_inline
 
-    # -- Step 1: extract fenced code blocks into placeholders ---------------
-    code_blocks: list[str] = []
+    # Placeholder content: plain string, or (blocks|None, fallback_text) for tables
+    code_blocks: list[str | tuple[Optional[list[dict[str, Any]]], str]] = []
     _FENCE_RE: re.Pattern[str] = re.compile(r'```\w*\n(.*?)```', re.DOTALL)
 
     def _extract_fence(match: re.Match[str]) -> str:
         content: str = match.group(1)
         idx: int = len(code_blocks)
         if '|' in content:
-            formatted: str = format_markdown_table_inline(content)
-            code_blocks.append(formatted)
+            table_blocks, fallback = format_markdown_table_inline(content)
+            code_blocks.append((table_blocks, fallback))
         else:
             code_blocks.append('```\n' + content.strip() + '\n```')
         return f'\x00CB{idx}\x00'
@@ -67,7 +67,10 @@ def markdown_to_mrkdwn(text: str) -> str:
 
     def _wrap_table(match: re.Match[str]) -> str:
         cleaned: str = _clean_table_lines(match.group(1))
-        return format_markdown_table_inline(cleaned)
+        table_blocks, fallback = format_markdown_table_inline(cleaned)
+        idx = len(code_blocks)
+        code_blocks.append((table_blocks, fallback))
+        return f'\x00CB{idx}\x00'
 
     text = _TABLE_RE.sub(_wrap_table, text)
 
@@ -76,11 +79,19 @@ def markdown_to_mrkdwn(text: str) -> str:
     text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<\2|\1>', text)
     text = re.sub(r'^#{1,6}\s+(.+)$', r'*\1*', text, flags=re.MULTILINE)
 
-    # -- Step 4: restore code blocks ----------------------------------------
+    # -- Step 4: restore placeholders and collect first table blocks ---------
+    out_blocks: Optional[list[dict[str, Any]]] = None
     for i, block in enumerate(code_blocks):
-        text = text.replace(f'\x00CB{i}\x00', block)
+        if isinstance(block, tuple):
+            table_blocks, fallback = block
+            text = text.replace(f'\x00CB{i}\x00', fallback)
+            if out_blocks is None and table_blocks is not None:
+                out_blocks = table_blocks
+        else:
+            assert isinstance(block, str)
+            text = text.replace(f'\x00CB{i}\x00', block)
 
-    return text
+    return (text, out_blocks)
 
 from api.websockets import broadcast_sync_progress
 from connectors.base import BaseConnector
@@ -1046,9 +1057,12 @@ Send a message to a Slack channel, DM, or user.
         """
         channel = await self._resolve_channel_for_post(channel)
 
-        # Auto-convert any Markdown to Slack mrkdwn format
-        formatted_text = markdown_to_mrkdwn(text)
-        
+        # When blocks are provided, text is already mrkdwn from the caller. Otherwise convert.
+        if blocks is not None:
+            formatted_text: str = text
+        else:
+            formatted_text, _ = markdown_to_mrkdwn(text)
+
         payload: dict[str, Any] = {
             "channel": channel,
             "text": formatted_text,

--- a/backend/connectors/slack_tables.py
+++ b/backend/connectors/slack_tables.py
@@ -1,9 +1,6 @@
 """
-Slack table formatting utilities for markdown_to_mrkdwn.
-
-Parses markdown pipe tables and reformats them for Slack's narrow
-monospace display.  The main entry point is ``format_markdown_table_inline``
-which is called from ``markdown_to_mrkdwn`` in ``connectors/slack.py``.
+Slack table formatting: parse markdown pipe tables and convert to Block Kit
+or fallback text for chat.postMessage.
 """
 
 import re
@@ -11,7 +8,16 @@ from typing import Any
 
 _SEPARATOR_RE: re.Pattern[str] = re.compile(r"^\|?[\s\-:|]+\|?$")
 
-_SLACK_CODE_LINE_MAX: int = 44
+# Slack: max 10 fields per section, 50 blocks per message. Use Block Kit for small tables.
+_BLOCK_KIT_MAX_ROWS: int = 15
+_FIELDS_PER_SECTION_MAX: int = 10
+
+
+def _cell_str(value: Any) -> str:
+    if value is None:
+        return ""
+    s: str = str(value).strip()
+    return s if s else "—"
 
 
 def _split_pipe_cells(line: str) -> list[str]:
@@ -53,61 +59,74 @@ def parse_markdown_table(md_table: str) -> tuple[list[str], list[dict[str, Any]]
     return (columns, rows)
 
 
-def _fits_in_codeblock(columns: list[str], rows: list[dict[str, Any]]) -> bool:
-    """Check whether an aligned pipe table would fit within Slack's line width."""
-    all_rows: list[list[str]] = [[str(c) for c in columns]]
-    for row in rows:
-        all_rows.append([str(row.get(col, "")) for col in columns])
-    col_widths: list[int] = [
-        max(len(all_rows[r][c]) for r in range(len(all_rows)))
-        for c in range(len(columns))
+def format_table_as_blocks(
+    columns: list[str],
+    rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build Block Kit blocks for a table: header section, divider, one section per row.
+
+    Slack section.fields are capped at 10; total blocks capped at 50.
+    Caller should limit rows before calling (e.g. _BLOCK_KIT_MAX_ROWS).
+    """
+    num_cols: int = len(columns)
+    if num_cols > _FIELDS_PER_SECTION_MAX:
+        num_cols = _FIELDS_PER_SECTION_MAX
+    cols_used: list[str] = columns[:num_cols]
+
+    blocks: list[dict[str, Any]] = []
+
+    # Header row
+    header_fields: list[dict[str, str]] = [
+        {"type": "mrkdwn", "text": f"*{col}*"} for col in cols_used
     ]
-    line_len: int = sum(col_widths) + 3 * (len(columns) - 1)
-    return line_len <= _SLACK_CODE_LINE_MAX
+    blocks.append({"type": "section", "fields": header_fields})
+    blocks.append({"type": "divider"})
+
+    for row in rows:
+        row_fields: list[dict[str, str]] = [
+            {"type": "mrkdwn", "text": _cell_str(row.get(col))} for col in cols_used
+        ]
+        blocks.append({"type": "section", "fields": row_fields})
+
+    return blocks
 
 
-def _format_aligned_table(columns: list[str], rows: list[dict[str, Any]]) -> str:
-    """Aligned pipe table in a code block (only when it fits)."""
+def _format_as_codeblock_fallback(columns: list[str], rows: list[dict[str, Any]]) -> str:
+    """Fallback: aligned pipe table in a code block when Block Kit is not used."""
     all_cells: list[list[str]] = [[str(c) for c in columns]]
     for row in rows:
-        all_cells.append([str(row.get(col, "")) for col in columns])
+        all_cells.append([_cell_str(row.get(col)) for col in columns])
     col_widths: list[int] = [
         max(len(all_cells[r][c]) for r in range(len(all_cells)))
         for c in range(len(columns))
     ]
-    lines: list[str] = []
-    for row_cells in all_cells:
-        line: str = " | ".join(cell.ljust(col_widths[j]) for j, cell in enumerate(row_cells))
-        lines.append(line)
+    lines: list[str] = [
+        " | ".join(cell.ljust(col_widths[j]) for j, cell in enumerate(row_cells))
+        for row_cells in all_cells
+    ]
     return "```\n" + "\n".join(lines) + "\n```"
 
 
-def _format_as_list(columns: list[str], rows: list[dict[str, Any]]) -> str:
-    """Format each row as a bold-label list, which never wraps in Slack."""
-    parts: list[str] = []
-    for i, row in enumerate(rows):
-        lines: list[str] = []
-        for col in columns:
-            val: str = str(row.get(col, "") or "—")
-            lines.append(f"*{col}:* {val}")
-        parts.append("\n".join(lines))
-    return "\n\n".join(parts)
+def format_markdown_table_inline(md_table: str) -> tuple[list[dict[str, Any]] | None, str]:
+    """Format a markdown pipe table for Slack.
 
-
-def format_markdown_table_inline(md_table: str) -> str:
-    """Format a markdown pipe table for Slack inline display.
-
-    - If the table fits in ~68 chars wide, use an aligned code block.
-    - Otherwise, format each row as a labeled list (no wrapping).
-    - Falls back to raw code block if parsing fails.
+    Returns (blocks, fallback_text). When the table fits Block Kit limits,
+    blocks is a list of Block Kit dicts and fallback_text is a short summary.
+    When it does not fit or parse fails, blocks is None and fallback_text
+    is the code-block or raw table string.
     """
     parsed: tuple[list[str], list[dict[str, Any]]] | None = parse_markdown_table(md_table)
     if parsed is None:
-        return "```\n" + md_table.strip() + "\n```"
+        return (None, "```\n" + md_table.strip() + "\n```")
     columns: list[str] = parsed[0]
     rows: list[dict[str, Any]] = parsed[1]
     if not rows:
-        return "```\n" + md_table.strip() + "\n```"
-    if _fits_in_codeblock(columns, rows):
-        return _format_aligned_table(columns, rows)
-    return _format_as_list(columns, rows)
+        return (None, "```\n" + md_table.strip() + "\n```")
+
+    if len(rows) <= _BLOCK_KIT_MAX_ROWS and len(columns) <= _FIELDS_PER_SECTION_MAX:
+        blocks = format_table_as_blocks(columns, rows)
+        if len(blocks) <= 50:
+            fallback: str = f"Table: {len(rows)} rows × {len(columns)} columns"
+            return (blocks, fallback)
+
+    return (None, _format_as_codeblock_fallback(columns, rows))

--- a/backend/messengers/_stream_breaks.py
+++ b/backend/messengers/_stream_breaks.py
@@ -7,7 +7,6 @@ StreamBreakStrategy = Literal["best", "quickest_safe"]
 
 _SENTENCE_BREAK_RE: re.Pattern[str] = re.compile(r"[.!?](?:\s|$)")
 _FENCE_RE: re.Pattern[str] = re.compile(r"^```", re.MULTILINE)
-_PIPE_TABLE_LINE_RE: re.Pattern[str] = re.compile(r"\|.+\||[^|\n]+(?:\|[^|\n]+){2,}")
 _TITLE_ABBREVIATIONS: set[str] = {
     "mr",
     "mrs",
@@ -69,21 +68,6 @@ def _is_valid_sentence_break(text: str, punct_idx: int) -> bool:
     return True
 
 
-def _ends_inside_pipe_table(text: str) -> bool:
-    """Return True if *text* ends in the middle of a markdown pipe table.
-
-    A pipe table is a contiguous block of lines matching ``| ... |``.
-    If the last non-blank line is a pipe-table row and there is no blank line
-    or non-table text after it, assume more table rows are coming.
-    """
-    stripped: str = text.rstrip()
-    if not stripped:
-        return False
-    last_newline: int = stripped.rfind("\n")
-    last_line: str = stripped[last_newline + 1:].strip() if last_newline >= 0 else stripped.strip()
-    return bool(_PIPE_TABLE_LINE_RE.fullmatch(last_line))
-
-
 def find_safe_break(
     text: str,
     *,
@@ -102,11 +86,6 @@ def find_safe_break(
 
     max_index: int = len(text) if limit is None else min(limit, len(text))
     if max_index <= 0:
-        return 0
-
-    # If the text ends mid-pipe-table, defer the break entirely so the table
-    # isn't split across messages.
-    if _ends_inside_pipe_table(text):
         return 0
 
     fence_ranges: list[tuple[int, int]] = _build_fence_ranges(text)

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -52,7 +52,6 @@ logger = logging.getLogger(__name__)
 
 STREAM_FLUSH_CHAR_THRESHOLD: int = 240
 STREAM_FLUSH_INTERVAL_SECONDS: float = 0.7
-STREAM_MAX_BUFFER_CHARS: int = 3000
 SLOW_REPLY_TIMEOUT_SECONDS: int = 30
 SLOW_REPLY_MESSAGE: str = "Still working on this, one moment…"
 
@@ -149,6 +148,25 @@ class WorkspaceMessenger(BaseMessenger):
     ) -> tuple[bytes, str, str] | None:
         """Download a file. Returns ``(data, filename, content_type)`` or None."""
         return None
+
+    async def format_and_post(
+        self,
+        channel_id: str,
+        thread_id: str | None,
+        text_to_send: str,
+        *,
+        workspace_id: str | None = None,
+        organization_id: str | None = None,
+    ) -> None:
+        """Format text and post to the channel. Override to use blocks (e.g. Slack)."""
+        formatted: str = self.format_text(text_to_send)
+        await self.post_message(
+            channel_id=channel_id,
+            text=formatted,
+            thread_id=thread_id,
+            workspace_id=workspace_id,
+            organization_id=organization_id,
+        )
 
     async def fetch_channel_name(
         self,
@@ -570,11 +588,10 @@ class WorkspaceMessenger(BaseMessenger):
             if not text_to_send:
                 return
 
-            formatted: str = self.format_text(text_to_send)
-            await self.post_message(
-                channel_id=channel_id,
-                text=formatted,
-                thread_id=thread_id,
+            await self.format_and_post(
+                channel_id,
+                thread_id,
+                text_to_send,
                 workspace_id=workspace_id,
                 organization_id=organization_id,
             )
@@ -593,9 +610,7 @@ class WorkspaceMessenger(BaseMessenger):
                     buf_len: int = len(current_text)
                     size_flush: bool = buf_len >= STREAM_FLUSH_CHAR_THRESHOLD
                     time_flush: bool = (time.monotonic() - last_flush_at) >= STREAM_FLUSH_INTERVAL_SECONDS
-                    if buf_len >= STREAM_MAX_BUFFER_CHARS:
-                        await _flush(reason="max_buffer", force=True)
-                    elif size_flush or time_flush:
+                    if size_flush or time_flush:
                         await _flush(reason="buffer_size" if size_flush else "interval")
         except Exception as exc:
             logger.error("[%s] Error during streaming: %s", self.meta.slug, exc, exc_info=True)

--- a/backend/messengers/slack.py
+++ b/backend/messengers/slack.py
@@ -73,6 +73,7 @@ class SlackMessenger(WorkspaceMessenger):
         *,
         workspace_id: str | None = None,
         organization_id: str | None = None,
+        blocks: list[dict[str, Any]] | None = None,
     ) -> str | None:
         """Post a message to Slack via ``chat.postMessage``."""
         connector: SlackConnector = await self._get_connector(
@@ -82,6 +83,7 @@ class SlackMessenger(WorkspaceMessenger):
             channel=channel_id,
             text=text,
             thread_ts=thread_id,
+            blocks=blocks,
         )
         return result.get("ts")
 
@@ -128,7 +130,30 @@ class SlackMessenger(WorkspaceMessenger):
 
     def format_text(self, markdown: str) -> str:
         """Convert Markdown to Slack mrkdwn format."""
-        return markdown_to_mrkdwn(markdown)
+        text, _ = markdown_to_mrkdwn(markdown)
+        return text
+
+    async def format_and_post(
+        self,
+        channel_id: str,
+        thread_id: str | None,
+        text_to_send: str,
+        *,
+        workspace_id: str | None = None,
+        organization_id: str | None = None,
+    ) -> None:
+        """Format with markdown_to_mrkdwn and post; use blocks when table is present."""
+        text: str
+        blocks: list[dict[str, Any]] | None
+        text, blocks = markdown_to_mrkdwn(text_to_send)
+        await self.post_message(
+            channel_id=channel_id,
+            text=text,
+            thread_id=thread_id,
+            workspace_id=workspace_id,
+            organization_id=organization_id,
+            blocks=blocks,
+        )
 
     # ------------------------------------------------------------------
     # Typing indicators (reactions)

--- a/backend/tests/test_slack_tables.py
+++ b/backend/tests/test_slack_tables.py
@@ -2,6 +2,7 @@
 
 from connectors.slack_tables import (
     format_markdown_table_inline,
+    format_table_as_blocks,
     parse_markdown_table,
 )
 
@@ -40,28 +41,48 @@ def test_parse_markdown_table_empty_returns_none() -> None:
     assert parse_markdown_table("\n\n") is None
 
 
-def test_format_inline_narrow_table_uses_codeblock() -> None:
+def test_format_table_as_blocks_structure() -> None:
+    columns: list[str] = ["Name", "Email"]
+    rows: list[dict[str, str]] = [
+        {"Name": "Alice", "Email": "alice@example.com"},
+        {"Name": "Bob", "Email": "bob@example.com"},
+    ]
+    blocks = format_table_as_blocks(columns, rows)
+    assert len(blocks) == 4  # header section, divider, 2 row sections
+    assert blocks[0]["type"] == "section"
+    assert blocks[0]["fields"][0]["text"] == "*Name*"
+    assert blocks[0]["fields"][1]["text"] == "*Email*"
+    assert blocks[1]["type"] == "divider"
+    assert blocks[2]["fields"][0]["text"] == "Alice"
+    assert blocks[2]["fields"][1]["text"] == "alice@example.com"
+    assert blocks[3]["fields"][0]["text"] == "Bob"
+    assert blocks[3]["fields"][1]["text"] == "bob@example.com"
+
+
+def test_format_inline_small_table_returns_blocks() -> None:
     md = "| X | Y |\n| a | b |"
-    result: str = format_markdown_table_inline(md)
-    assert result.startswith("```")
-    assert result.endswith("```")
-    assert "X" in result and "Y" in result
+    blocks, fallback = format_markdown_table_inline(md)
+    assert blocks is not None
+    assert len(blocks) == 3  # header, divider, one row
+    assert "Table" in fallback and "1" in fallback and "2" in fallback
 
 
-def test_format_inline_wide_table_uses_list() -> None:
+def test_format_inline_medium_table_returns_blocks() -> None:
     md = (
         "| Name | Title | Email | Phone |\n"
         "| --- | --- | --- | --- |\n"
         "| Jon Alferness | CEO | jon@basebase.com | +1 (415) 596-7768 |\n"
         "| Teg Grenager | Head of Engineering | teg@basebase.com | +1 (415) 902-8648 |"
     )
-    result: str = format_markdown_table_inline(md)
-    assert "```" not in result
-    assert "*Name:*" in result
-    assert "*Email:*" in result
-    assert "jon@basebase.com" in result
+    blocks, fallback = format_markdown_table_inline(md)
+    assert blocks is not None
+    assert blocks[0]["type"] == "section"
+    assert "*Name*" in blocks[0]["fields"][0]["text"]
+    assert "Table" in fallback and "2" in fallback and "4" in fallback
 
 
 def test_format_inline_fallback_on_bad_input() -> None:
-    result: str = format_markdown_table_inline("not a table at all")
-    assert result.startswith("```")
+    blocks, fallback = format_markdown_table_inline("not a table at all")
+    assert blocks is None
+    assert fallback.startswith("```")
+    assert "not a table" in fallback


### PR DESCRIPTION
- slack_tables: format_table_as_blocks() returns Block Kit JSON; format_markdown_table_inline() returns (blocks | None, fallback_text)
- markdown_to_mrkdwn returns (text, blocks | None); tables become blocks when within Slack limits (≤15 rows, ≤10 cols, ≤50 blocks)
- SlackMessenger: post_message accepts optional blocks; format_and_post override uses markdown_to_mrkdwn and posts with blocks when present
- _workspace: add format_and_post(); _flush uses it (Slack uses blocks)
- Revert streaming band-aids: remove _ends_inside_pipe_table, STREAM_MAX_BUFFER_CHARS, .com/pipe sentence-break logic in _stream_breaks
- Tests: update test_slack_tables for Block Kit API and add format_table_as_blocks tests

Made-with: Cursor