### PR TITLE
fix(streaming): restore sentence-break guards for emails and pipe-table rows

### DIFF
--- a/backend/messengers/_stream_breaks.py
+++ b/backend/messengers/_stream_breaks.py
@@ -7,6 +7,7 @@ StreamBreakStrategy = Literal["best", "quickest_safe"]
 
 _SENTENCE_BREAK_RE: re.Pattern[str] = re.compile(r"[.!?](?:\s|$)")
 _FENCE_RE: re.Pattern[str] = re.compile(r"^```", re.MULTILINE)
+_PIPE_TABLE_LINE_RE: re.Pattern[str] = re.compile(r"\|.+\||[^|\n]+(?:\|[^|\n]+){2,}")
 _TITLE_ABBREVIATIONS: set[str] = {
     "mr",
     "mrs",
@@ -58,6 +59,8 @@ def _is_valid_sentence_break(text: str, punct_idx: int) -> bool:
             return False
 
     line_start: int = text.rfind("\n", 0, punct_idx) + 1
+    line_end: int = text.find("\n", punct_idx)
+    full_line: str = text[line_start:line_end] if line_end >= 0 else text[line_start:]
     line_prefix: str = text[line_start:punct_idx].strip()
 
     if line_prefix.startswith(("-", "*", "+")):
@@ -65,7 +68,32 @@ def _is_valid_sentence_break(text: str, punct_idx: int) -> bool:
     if re.fullmatch(r"\d+", line_prefix):
         return False
 
+    if "|" in full_line:
+        return False
+
+    if text[punct_idx] == ".":
+        after: str = text[punct_idx + 1: punct_idx + 5]
+        if re.match(r"[a-z]{2,4}\b", after, re.IGNORECASE):
+            before_char: str = text[punct_idx - 1] if punct_idx >= 1 else ""
+            if before_char.isalpha():
+                return False
+
     return True
+
+
+def _ends_inside_pipe_table(text: str) -> bool:
+    """Return True if *text* ends in the middle of a markdown pipe table.
+
+    A pipe table is a contiguous block of lines matching ``| ... |``.
+    If the last non-blank line is a pipe-table row and there is no blank line
+    or non-table text after it, assume more table rows are coming.
+    """
+    stripped: str = text.rstrip()
+    if not stripped:
+        return False
+    last_newline: int = stripped.rfind("\n")
+    last_line: str = stripped[last_newline + 1:].strip() if last_newline >= 0 else stripped.strip()
+    return bool(_PIPE_TABLE_LINE_RE.fullmatch(last_line))
 
 
 def find_safe_break(
@@ -86,6 +114,9 @@ def find_safe_break(
 
     max_index: int = len(text) if limit is None else min(limit, len(text))
     if max_index <= 0:
+        return 0
+
+    if _ends_inside_pipe_table(text):
         return 0
 
     fence_ranges: list[tuple[int, int]] = _build_fence_ranges(text)


### PR DESCRIPTION
## Summary
- Restores three stream-break guards that were incorrectly removed in #647: email/URL period check (`.com` is not a sentence ending), pipe-table row check (`|` in line), and `_ends_inside_pipe_table` buffering
- Without these, `find_safe_break` splits on the `.` in `jon@basebase.com`, flushing a partial table row before Block Kit can see the complete table

## Test plan
- [x] `pytest -q tests` passes (201 tests)
- [ ] Deploy and ask Basebase in Slack for a team contact table — should render as Block Kit sections, not a broken code block + plain text

Made with [Cursor](https://cursor.com)