### PR TITLE
feat: centralize tool status text in registry

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -22,6 +22,7 @@ from anthropic import APIStatusError, AsyncAnthropic
 from sqlalchemy import select, update
 
 from agents.model_routing import is_short_phrase_for_cheap_model
+from agents.registry import format_tool_status
 from agents.tools import execute_tool, get_tools
 from config import settings
 from models.chat_message import ChatMessage
@@ -1206,12 +1207,14 @@ class ChatOrchestrator:
                                         current_tool["input"] = {}
                                     
                                     tool_uses.append(current_tool)
+                                    _running_input: dict[str, Any] = current_tool["input"]
                                     yield json.dumps({
                                         "type": "tool_call",
                                         "tool_name": current_tool["name"],
-                                        "tool_input": current_tool["input"],
+                                        "tool_input": _running_input,
                                         "tool_id": current_tool["id"],
                                         "status": "running",
+                                        "status_text": format_tool_status(current_tool["name"], _running_input, "running"),
                                     })
                                     current_tool = None
                                     current_tool_input_json = ""
@@ -1331,6 +1334,7 @@ class ChatOrchestrator:
                     "tool_input": tool_input,
                     "tool_id": tool_id,
                     "status": "running",
+                    "status_text": format_tool_status(tool_name, tool_input, "running"),
                 })
             
             # Early save: fire-and-forget so it doesn't block tool execution.
@@ -1440,6 +1444,7 @@ class ChatOrchestrator:
                     "tool_input": tool_input,
                     "result": tool_result,
                     "status": "complete",
+                    "status_text": format_tool_status(tool_name, tool_input, "complete"),
                 })
 
                 if tool_result.get("status") == "success":

--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -13,6 +13,7 @@ Mental Model ("Cursor for your business"):
 - EXTERNAL_WRITE: CRM, email, Slack - permanent, external (like git push)
 """
 
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Awaitable
@@ -55,7 +56,14 @@ class ToolDefinition:
 
     workflow_only: bool = False
     """Whether this tool should only be exposed during workflow executions."""
-    
+
+    status_running: str = ""
+    """Human-friendly text when the tool starts (e.g. 'Querying your database'). Use {connector}, {provider}, etc. for placeholders."""
+    status_complete: str = ""
+    """Human-friendly text when the tool finishes (e.g. 'Queried your database')."""
+    hidden_status: bool = False
+    """If True, do not show status in Slack/Teams/UI (think, keep_notes, manage_memory)."""
+
     # Note: execute_fn is set separately to avoid circular imports
     # The actual execution functions are in tools.py
 
@@ -74,6 +82,10 @@ def register_tool(
     category: ToolCategory,
     default_requires_approval: bool = False,
     workflow_only: bool = False,
+    *,
+    status_running: str = "",
+    status_complete: str = "",
+    hidden_status: bool = False,
 ) -> None:
     """Register a tool in the registry."""
     TOOL_DEFINITIONS[name] = ToolDefinition(
@@ -83,6 +95,9 @@ def register_tool(
         category=category,
         default_requires_approval=default_requires_approval,
         workflow_only=workflow_only,
+        status_running=status_running,
+        status_complete=status_complete,
+        hidden_status=hidden_status,
     )
 
 
@@ -140,6 +155,8 @@ IMPORTANT: Only SELECT queries are allowed. No INSERT, UPDATE, DELETE, DROP, etc
     },
     category=ToolCategory.LOCAL_READ,
     default_requires_approval=False,
+    status_running="Querying your database",
+    status_complete="Queried your database",
 )
 
 
@@ -158,6 +175,8 @@ need to verify a connector is connected before using it.""",
     },
     category=ToolCategory.LOCAL_READ,
     default_requires_approval=False,
+    status_running="Checking connected tools",
+    status_complete="Checked connected tools",
 )
 
 
@@ -181,6 +200,8 @@ examples) written by the connector author. Use the connector slug (e.g. 'google_
     },
     category=ToolCategory.LOCAL_READ,
     default_requires_approval=False,
+    status_running="Reading {connector} docs",
+    status_complete="Read {connector} docs",
 )
 
 
@@ -209,6 +230,8 @@ detailed query formats, parameters, and examples before using a connector.""",
     },
     category=ToolCategory.EXTERNAL_READ,
     default_requires_approval=False,
+    status_running="Looking up data in {connector}",
+    status_complete="Queried {connector}",
 )
 
 
@@ -240,6 +263,8 @@ Check the Connected Connectors manifest for available operations and their requi
     },
     category=ToolCategory.EXTERNAL_WRITE,
     default_requires_approval=False,
+    status_running="Writing to {connector}",
+    status_complete="Wrote to {connector}",
 )
 
 
@@ -272,6 +297,8 @@ Check the Connected Connectors manifest for available actions and their required
     },
     category=ToolCategory.EXTERNAL_WRITE,
     default_requires_approval=False,
+    status_running="Running action on {connector}",
+    status_complete="Ran action on {connector}",
 )
 
 
@@ -339,6 +366,8 @@ Rules:
     },
     category=ToolCategory.LOCAL_WRITE,
     default_requires_approval=False,
+    status_running="Updating your database",
+    status_complete="Updated your database",
 )
 
 
@@ -364,6 +393,8 @@ The sync runs in the background and may take a few minutes to complete.""",
     },
     category=ToolCategory.EXTERNAL_WRITE,
     default_requires_approval=False,  # Syncing is safe, just refreshes data
+    status_running="Syncing {provider}",
+    status_complete="Synced {provider}",
 )
 
 
@@ -398,6 +429,8 @@ Available connectors include:
     },
     category=ToolCategory.LOCAL_WRITE,
     default_requires_approval=False,
+    status_running="Setting up connection",
+    status_complete="Set up connection",
 )
 
 
@@ -440,6 +473,8 @@ IMPORTANT: Avoid circular calls (A calls B calls A) - this will be detected and 
     },
     category=ToolCategory.LOCAL_WRITE,
     default_requires_approval=False,
+    status_running="Running workflow",
+    status_complete="Completed workflow",
 )
 
 
@@ -510,6 +545,8 @@ Set max_concurrent=1 for sequential execution, higher for parallel. Blocks until
     },
     category=ToolCategory.LOCAL_WRITE,
     default_requires_approval=False,
+    status_running="Processing items",
+    status_complete="Processed items",
 )
 
 # -----------------------------------------------------------------------------
@@ -542,6 +579,7 @@ This is workflow-scoped memory, not user-wide memory.""",
     category=ToolCategory.LOCAL_WRITE,
     default_requires_approval=False,
     workflow_only=True,
+    hidden_status=True,
 )
 
 register_tool(
@@ -567,6 +605,7 @@ bulk operations, or ambiguous requests that need decomposition.""",
     },
     category=ToolCategory.LOCAL_READ,
     default_requires_approval=False,
+    hidden_status=True,
 )
 
 
@@ -617,6 +656,7 @@ Each memory should be a single, self-contained statement. Do NOT save conversati
     },
     category=ToolCategory.LOCAL_WRITE,
     default_requires_approval=False,
+    hidden_status=True,
 )
 
 
@@ -624,6 +664,44 @@ Each memory should be a single, self-contained statement. Do NOT save conversati
 # =============================================================================
 # Helper Functions
 # =============================================================================
+
+def _title_slug(slug: str) -> str:
+    """Turn a connector/provider slug into a display label (e.g. google_drive -> Google Drive)."""
+    if not slug or not isinstance(slug, str):
+        return ""
+    return slug.replace("_", " ").strip().title()
+
+
+def format_tool_status(
+    tool_name: str,
+    tool_input: dict[str, Any],
+    phase: str,
+) -> str | None:
+    """Return human-friendly status text for a tool call, or None if hidden or unknown.
+
+    phase must be 'running' or 'complete'. Template placeholders like {connector}
+    are filled from tool_input with title-cased display labels.
+    """
+    tool: ToolDefinition | None = TOOL_DEFINITIONS.get(tool_name)
+    if tool is None or tool.hidden_status:
+        return None
+    template: str = tool.status_running if phase == "running" else tool.status_complete
+    if not template:
+        return None
+    raw: dict[str, Any] = tool_input or {}
+    placeholders: list[str] = re.findall(r"\{(\w+)\}", template)
+    format_map: dict[str, str] = {}
+    for key in placeholders:
+        val = raw.get(key)
+        if isinstance(val, str) and val.strip():
+            format_map[key] = _title_slug(val)
+        else:
+            format_map[key] = key.replace("_", " ").title()
+    try:
+        return template.format(**format_map)
+    except KeyError:
+        return template
+
 
 def get_tool(name: str) -> ToolDefinition | None:
     """Get a tool definition by name."""

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -619,6 +619,10 @@ class WorkspaceMessenger(BaseMessenger):
         await _flush(reason="stream_end", force=True)
         return total_length
 
+    def format_tool_status_for_display(self, status_text: str) -> str:
+        """Format status text for this platform (e.g. Slack may wrap in italics). Default: return as-is."""
+        return status_text
+
     async def _handle_json_chunk(
         self,
         chunk: str,
@@ -627,7 +631,31 @@ class WorkspaceMessenger(BaseMessenger):
         workspace_id: str | None,
         organization_id: str | None,
     ) -> None:
-        """Process a JSON orchestrator chunk (artifacts, apps, etc.). Override to post links."""
+        """Process a JSON orchestrator chunk (artifacts, apps, etc.). Post tool status when present."""
+        try:
+            data: dict[str, Any] = json.loads(chunk)
+        except (json.JSONDecodeError, TypeError):
+            return
+        if data.get("type") != "tool_call":
+            return
+        status_text: str | None = data.get("status_text") if isinstance(data.get("status_text"), str) else None
+        if not status_text or not status_text.strip():
+            return
+        message: str = self.format_tool_status_for_display(status_text.strip())
+
+        async def _post() -> None:
+            try:
+                await self.post_message(
+                    channel_id=channel_id,
+                    text=message,
+                    thread_id=thread_id,
+                    workspace_id=workspace_id,
+                    organization_id=organization_id,
+                )
+            except Exception as exc:
+                logger.debug("[%s] Tool status message failed: %s", self.meta.slug, exc)
+
+        asyncio.create_task(_post())
 
     # ------------------------------------------------------------------
     # Overridden process_inbound with streaming + typing indicator support

--- a/backend/messengers/slack.py
+++ b/backend/messengers/slack.py
@@ -8,8 +8,6 @@ and formatting.
 """
 from __future__ import annotations
 
-import asyncio
-import json
 import logging
 from typing import Any
 
@@ -18,39 +16,6 @@ from messengers._workspace import WorkspaceMessenger
 from messengers.base import InboundMessage, MessengerMeta, ResponseMode
 
 logger = logging.getLogger(__name__)
-
-# Tool names we do not show status for (internal/bookkeeping).
-_SKIP_TOOL_STATUS: frozenset[str] = frozenset({"think", "keep_notes", "manage_memory"})
-
-# Human-friendly status text for tool_call events. Use {connector} for connector slug.
-TOOL_STATUS_LABELS: dict[str, str] = {
-    "run_sql_query": "Querying your database",
-    "run_sql_write": "Updating your database",
-    "query_on_connector": "Looking up data in {connector}",
-    "write_on_connector": "Updating records in {connector}",
-    "run_on_connector": "Running action on {connector}",
-    "send_slack_table": "Preparing a table",
-    "trigger_sync": "Syncing data",
-    "run_workflow": "Running workflow",
-    "foreach": "Processing items",
-    "list_connected_connectors": "Checking connected tools",
-    "get_connector_docs": "Reading connector docs",
-    "initiate_connector": "Setting up a connection",
-}
-
-
-def _tool_status_text(tool_name: str, tool_input: dict[str, Any]) -> str | None:
-    """Return human-friendly status text for a tool call, or None to skip posting."""
-    if tool_name in _SKIP_TOOL_STATUS:
-        return None
-    label: str | None = TOOL_STATUS_LABELS.get(tool_name)
-    if label is None:
-        return None
-    connector_slug: str = (tool_input.get("connector") or "").strip() if isinstance(tool_input.get("connector"), str) else ""
-    if "{connector}" in label:
-        connector_display: str = connector_slug.replace("_", " ").title() if connector_slug else "connector"
-        return label.format(connector=connector_display)
-    return label
 
 
 class SlackMessenger(WorkspaceMessenger):
@@ -283,46 +248,9 @@ class SlackMessenger(WorkspaceMessenger):
         )
 
     # ------------------------------------------------------------------
-    # Tool call status (override _handle_json_chunk)
+    # Tool call status (format only; base class posts using status_text from stream)
     # ------------------------------------------------------------------
 
-    async def _handle_json_chunk(
-        self,
-        chunk: str,
-        channel_id: str,
-        thread_id: str | None,
-        workspace_id: str | None,
-        organization_id: str | None,
-    ) -> None:
-        """Post a short status message to Slack when a tool call starts."""
-        await super()._handle_json_chunk(
-            chunk, channel_id, thread_id, workspace_id, organization_id,
-        )
-        try:
-            data: dict[str, Any] = json.loads(chunk)
-        except (json.JSONDecodeError, TypeError):
-            return
-        if data.get("type") != "tool_call":
-            return
-        tool_name: str = (data.get("tool_name") or "").strip()
-        tool_input: dict[str, Any] = data.get("tool_input") or {}
-        if not isinstance(tool_input, dict):
-            tool_input = {}
-        status_text: str | None = _tool_status_text(tool_name, tool_input)
-        if status_text is None:
-            return
-        message: str = f"_{status_text}…_"
-
-        async def _post_status() -> None:
-            try:
-                await self.post_message(
-                    channel_id=channel_id,
-                    text=message,
-                    thread_id=thread_id,
-                    workspace_id=workspace_id,
-                    organization_id=organization_id,
-                )
-            except Exception as exc:
-                logger.debug("[slack] Tool status message failed: %s", exc)
-
-        asyncio.create_task(_post_status())
+    def format_tool_status_for_display(self, status_text: str) -> str:
+        """Slack mrkdwn italic for tool status messages."""
+        return f"_{status_text}…_"

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -781,6 +781,9 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
                           ...block,
                           input: data.tool_input as Record<string, unknown>,
                           status: 'running' as const,
+                          ...(typeof data.status_text === 'string' && data.status_text
+                            ? { statusText: data.status_text }
+                            : {}),
                         };
                       }
                       return block;
@@ -811,6 +814,9 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
                             name: data.tool_name as string,
                             input: data.tool_input as Record<string, unknown>,
                             status: 'running' as const,
+                            ...(typeof data.status_text === 'string' && data.status_text
+                              ? { statusText: data.status_text }
+                              : {}),
                           },
                         ],
                       };
@@ -831,6 +837,9 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
                         name: data.tool_name as string,
                         input: data.tool_input as Record<string, unknown>,
                         status: 'running',
+                        ...(typeof data.status_text === 'string' && data.status_text
+                          ? { statusText: data.status_text }
+                          : {}),
                       }],
                       timestamp: new Date(),
                     });
@@ -845,6 +854,9 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
               };
               if (data.tool_input != null && typeof data.tool_input === 'object') {
                 updates.input = data.tool_input as Record<string, unknown>;
+              }
+              if (typeof data.status_text === 'string' && data.status_text) {
+                updates.statusText = data.status_text;
               }
               updateConversationToolMessage(conversation_id, data.tool_id as string, updates);
               
@@ -1204,6 +1216,9 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
                     toolName: data.tool_name as string,
                     input: data.tool_input as Record<string, unknown>,
                     status: 'running',
+                    ...(typeof data.status_text === 'string' && data.status_text
+                      ? { statusText: data.status_text }
+                      : {}),
                   });
                 } else if (data.type === 'tool_result') {
                   const updates: Partial<ToolCallData> = {
@@ -1212,6 +1227,9 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
                   };
                   if (data.tool_input != null && typeof data.tool_input === 'object') {
                     updates.input = data.tool_input as Record<string, unknown>;
+                  }
+                  if (typeof data.status_text === 'string' && data.status_text) {
+                    updates.statusText = data.status_text;
                   }
                   updateConversationToolMessage(conversationId, data.tool_id as string, updates);
                 } else if (data.type === 'artifact') {

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2267,7 +2267,13 @@ function ToolBlockIndicator({
 }): JSX.Element {
   const isComplete: boolean = block.status === 'complete';
   const hasError: boolean = isComplete && !!(block.result as Record<string, unknown> | undefined)?.error;
-  const statusText: string = getToolStatusText(block.name, block.input, isComplete, block.result);
+  const statusText: string = getToolStatusText(
+    block.name,
+    block.input,
+    isComplete,
+    block.result,
+    block.statusText,
+  );
 
   return (
     <button
@@ -2372,11 +2378,15 @@ function formatStreamingChars(chars: number): string {
 }
 
 function getToolStatusText(
-  toolName: string, 
-  input: Record<string, unknown> | undefined, 
+  toolName: string,
+  input: Record<string, unknown> | undefined,
   isComplete: boolean,
-  result: Record<string, unknown> | undefined
+  result: Record<string, unknown> | undefined,
+  statusTextFromBlock?: string,
 ): string {
+  if (statusTextFromBlock != null && statusTextFromBlock.trim() !== "") {
+    return statusTextFromBlock;
+  }
   const streamingChars: number | undefined = typeof input?._streaming_chars === 'number' ? input._streaming_chars : undefined;
 
   switch (toolName) {

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -905,6 +905,9 @@ export const useChatStore = create<ChatState>()(
             | "running"
             | "complete"
             | undefined) ?? "running",
+        ...(updates.statusText !== undefined
+          ? { statusText: updates.statusText }
+          : {}),
       };
 
       if (!current) {
@@ -959,6 +962,9 @@ export const useChatStore = create<ChatState>()(
                   | "running"
                   | "complete"
                   | undefined) ?? block.status,
+              ...(updates.statusText !== undefined
+                ? { statusText: updates.statusText }
+                : {}),
             };
           }
           return block;

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -136,6 +136,8 @@ export interface ToolUseBlock {
   input: Record<string, unknown>;
   result?: Record<string, unknown>;
   status?: "pending" | "running" | "complete" | "streaming";
+  /** Human-friendly status from registry; set from stream events. */
+  statusText?: string;
 }
 
 export interface ErrorBlock {
@@ -194,6 +196,8 @@ export interface ToolCallData {
   input: Record<string, unknown>;
   result?: Record<string, unknown>;
   status: "running" | "complete" | "error";
+  /** Human-friendly status from registry (e.g. "Querying your database"); set from stream events. */
+  statusText?: string;
 }
 
 export interface ChatMessage {


### PR DESCRIPTION
Tool status snippets (e.g. "Querying your database", "Looking up data in Salesforce") are now defined once in the backend registry and used everywhere.

**Backend**
- `ToolDefinition` in `registry.py` has `status_running`, `status_complete`, `hidden_status`; `format_tool_status()` resolves `{connector}` etc.
- Orchestrator adds `status_text` to `tool_call` and `tool_result` stream events
- `WorkspaceMessenger._handle_json_chunk` posts status when `tool_call` has `status_text` (Slack + Teams); Slack overrides `format_tool_status_for_display` for italics

**Frontend**
- `status_text` from stream is stored on `ToolUseBlock.statusText`
- `getToolStatusText()` uses `block.statusText` when present, else existing rich switch

**Result:** Web, Slack, and Teams show the same human-friendly tool messages from a single source.

Made with [Cursor](https://cursor.com)