### PR TITLE
Handle revoked Slack connector errors

### DIFF
--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -24,9 +24,54 @@ logger = logging.getLogger(__name__)
 
 PENDING_SHARING_CONFIG_TIMEOUT = timedelta(minutes=30)
 
+_CONNECTION_REMOVED_ERROR_SNIPPETS: tuple[str, ...] = (
+    "connection not found",
+    "404 not found",
+    "404 client error",
+    "invalid_auth",
+    "account_inactive",
+    "token_revoked",
+    "not_authed",
+    "auth revoked",
+)
+
+_PROVIDER_DISPLAY_NAMES: dict[str, str] = {
+    "google_calendar": "Google Calendar",
+    "google-calendar": "Google Calendar",
+    "google_mail": "Google Mail",
+    "google-mail": "Google Mail",
+}
+
+
+def get_provider_display_name(provider: str) -> str:
+    """Return a human-readable provider label for user-facing errors."""
+    normalized = provider.strip()
+    if normalized in _PROVIDER_DISPLAY_NAMES:
+        return _PROVIDER_DISPLAY_NAMES[normalized]
+    return normalized.replace("_", " ").replace("-", " ").title()
+
+
+def build_connection_removed_message(provider: str) -> str:
+    """Return a coherent reconnect message when upstream access was removed."""
+    provider_name = get_provider_display_name(provider)
+    return (
+        f"The {provider_name} connection was removed or revoked in {provider_name}. "
+        f"Please disconnect it in Basebase and reconnect it if you still want to sync."
+    )
+
+
+def is_connection_removed_error(error: Exception | str) -> bool:
+    """Return True when an error looks like a revoked or deleted upstream connection."""
+    message = str(error).lower()
+    return any(snippet in message for snippet in _CONNECTION_REMOVED_ERROR_SNIPPETS)
+
 
 class SyncCancelledError(RuntimeError):
     """Raised when a sync should stop because the integration was disconnected."""
+
+
+class ExternalConnectionRevokedError(RuntimeError):
+    """Raised when the upstream integration was removed or revoked outside Basebase."""
 
 
 class BaseConnector(ABC):
@@ -442,6 +487,20 @@ class BaseConnector(ABC):
             return self._token, ""
         except Exception as e:
             print(f"[Connector] Failed to get token: {e}")
+            if is_connection_removed_error(e):
+                logger.warning(
+                    "Upstream connection appears removed while getting token",
+                    extra={
+                        "organization_id": self.organization_id,
+                        "provider": self.source_system,
+                        "user_id": self.user_id,
+                        "connection_id": connection_id,
+                    },
+                    exc_info=True,
+                )
+                raise ExternalConnectionRevokedError(
+                    build_connection_removed_message(self.source_system)
+                ) from e
             raise ValueError(
                 f"Failed to get token from Nango for {self.source_system}: {str(e)}"
             )
@@ -473,9 +532,26 @@ class BaseConnector(ABC):
                 f"No Nango connection ID stored for {self.source_system} integration"
             )
 
-        self._credentials = await nango.get_credentials(
-            nango_integration_id, connection_id
-        )
+        try:
+            self._credentials = await nango.get_credentials(
+                nango_integration_id, connection_id
+            )
+        except Exception as exc:
+            if is_connection_removed_error(exc):
+                logger.warning(
+                    "Upstream connection appears removed while getting credentials",
+                    extra={
+                        "organization_id": self.organization_id,
+                        "provider": self.source_system,
+                        "user_id": self.user_id,
+                        "connection_id": connection_id,
+                    },
+                    exc_info=True,
+                )
+                raise ExternalConnectionRevokedError(
+                    build_connection_removed_message(self.source_system)
+                ) from exc
+            raise
         return self._credentials
 
     async def update_last_sync(self, counts: Optional[dict[str, int]] = None) -> None:

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -94,7 +94,7 @@ def markdown_to_mrkdwn(text: str) -> tuple[str, Optional[list[dict[str, Any]]]]:
     return (text, out_blocks)
 
 from api.websockets import broadcast_sync_progress
-from connectors.base import BaseConnector
+from connectors.base import BaseConnector, ExternalConnectionRevokedError, build_connection_removed_message
 from connectors.registry import (
     AuthType, Capability, ConnectorAction, ConnectorMeta, ConnectorScope,
 )
@@ -363,7 +363,19 @@ Send a message to a Slack channel, DM, or user.
                 data: dict[str, Any] = response.json()
 
                 if not data.get("ok"):
-                    raise ValueError(f"Slack API error: {data.get('error', 'Unknown')}")
+                    error_code = str(data.get("error", "Unknown"))
+                    if error_code in {"invalid_auth", "account_inactive", "token_revoked", "not_authed"}:
+                        logger.warning(
+                            "[Slack API] Slack connection was revoked org=%s user=%s endpoint=%s error=%s",
+                            self.organization_id,
+                            self.user_id,
+                            endpoint,
+                            error_code,
+                        )
+                        raise ExternalConnectionRevokedError(
+                            build_connection_removed_message(self.source_system)
+                        )
+                    raise ValueError(f"Slack API error: {error_code}")
 
                 return data
 

--- a/backend/tests/test_connector_error_messages.py
+++ b/backend/tests/test_connector_error_messages.py
@@ -1,0 +1,23 @@
+from connectors.base import (
+    build_connection_removed_message,
+    get_provider_display_name,
+    is_connection_removed_error,
+)
+
+
+def test_build_connection_removed_message_for_slack() -> None:
+    message = build_connection_removed_message("slack")
+
+    assert "Slack connection was removed or revoked in Slack" in message
+    assert "disconnect it in Basebase and reconnect it" in message
+
+
+def test_provider_display_name_humanizes_known_and_unknown_values() -> None:
+    assert get_provider_display_name("google_calendar") == "Google Calendar"
+    assert get_provider_display_name("salesforce") == "Salesforce"
+
+
+def test_is_connection_removed_error_detects_revoked_auth_patterns() -> None:
+    assert is_connection_removed_error("Slack API error: invalid_auth") is True
+    assert is_connection_removed_error("Client error '404 Not Found' for url") is True
+    assert is_connection_removed_error("temporary upstream timeout") is False

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -299,6 +299,24 @@ function getActivityLabel(provider: string, count: number, step?: string): strin
   }
 }
 
+async function getResponseErrorMessage(response: Response, fallback: string): Promise<string> {
+  const responseText = await response.text();
+  if (!responseText) return fallback;
+
+  try {
+    const payload = JSON.parse(responseText) as { detail?: string; message?: string } | string;
+    if (typeof payload === 'string' && payload.trim()) return payload;
+    if (payload && typeof payload === 'object') {
+      if (typeof payload.detail === 'string' && payload.detail.trim()) return payload.detail;
+      if (typeof payload.message === 'string' && payload.message.trim()) return payload.message;
+    }
+  } catch {
+    // Fall through to raw response text.
+  }
+
+  return responseText.trim() || fallback;
+}
+
 export function DataSources(): JSX.Element {
   // Get user/org from Zustand (auth state)
   const { user, organization } = useAppStore();
@@ -467,6 +485,7 @@ export function DataSources(): JSX.Element {
     step: 'confirm' | 'ask-delete';
   }
   const [disconnectModal, setDisconnectModal] = useState<DisconnectModalState | null>(null);
+  const [syncError, setSyncError] = useState<string | null>(null);
   const [disconnectError, setDisconnectError] = useState<string | null>(null);
   const [disconnectSuccess, setDisconnectSuccess] = useState<string | null>(null);
   const [sharingError, setSharingError] = useState<string | null>(null);
@@ -936,6 +955,7 @@ export function DataSources(): JSX.Element {
 
   const handleDisconnect = (provider: string): void => {
     if (!organizationId || !userId || disconnectingProviders.has(provider)) return;
+    setSyncError(null);
     setDisconnectError(null);
     setDisconnectModal({ provider, step: 'confirm' });
   };
@@ -957,7 +977,20 @@ export function DataSources(): JSX.Element {
       const responseText = await response.text();
 
       if (!response.ok) {
-        throw new Error(responseText);
+        let message = `Failed to disconnect ${getConnectorDisplay(provider).name}`;
+        if (responseText) {
+          try {
+            const payload = JSON.parse(responseText) as { detail?: string; message?: string } | string;
+            if (typeof payload === 'string' && payload.trim()) {
+              message = payload;
+            } else if (payload && typeof payload === 'object') {
+              message = payload.detail ?? payload.message ?? message;
+            }
+          } catch {
+            message = responseText;
+          }
+        }
+        throw new Error(message);
       }
 
       // Parse response to show deletion summary
@@ -1067,6 +1100,7 @@ export function DataSources(): JSX.Element {
   const handleSync = async (provider: string): Promise<void> => {
     if (syncingProviders.has(provider) || !organizationId) return;
 
+    setSyncError(null);
     setSyncingProviders((prev) => new Set(prev).add(provider));
 
     try {
@@ -1091,7 +1125,7 @@ export function DataSources(): JSX.Element {
         method: 'POST',
       });
 
-      if (!response.ok) throw new Error('Sync failed');
+      if (!response.ok) throw new Error(await getResponseErrorMessage(response, `Failed to sync ${getConnectorDisplay(provider).name}`));
 
       // Poll for completion (GitHub sync can take 1–2 min; allow 2.5 min)
       let attempts = 0;
@@ -1106,6 +1140,13 @@ export function DataSources(): JSX.Element {
             next.delete(provider);
             return next;
           });
+
+          if (status.status === 'failed') {
+            const providerName = getConnectorDisplay(provider).name;
+            const detail = typeof status.error === 'string' && status.error.trim() ? status.error : `Failed to sync ${providerName}`;
+            setSyncError(detail);
+            setTimeout(() => setSyncError(null), 8000);
+          }
 
           // Always refetch: on completion, failure, or timeout (slow syncs like GitHub can exceed 30s)
           void fetchIntegrations();
@@ -1122,6 +1163,8 @@ export function DataSources(): JSX.Element {
       void checkStatus();
     } catch (error) {
       console.error('Sync error:', error);
+      setSyncError(error instanceof Error ? error.message : `Failed to sync ${getConnectorDisplay(provider).name}`);
+      setTimeout(() => setSyncError(null), 8000);
       setSyncingProviders((prev) => {
         const next = new Set(prev);
         next.delete(provider);
@@ -2182,6 +2225,11 @@ export function DataSources(): JSX.Element {
       </div>
 
       {/* Disconnect / error / success banners */}
+      {syncError && (
+        <div className="fixed bottom-4 right-4 z-50 bg-red-500/10 border border-red-500/30 text-red-400 px-4 py-3 rounded-lg text-sm max-w-sm shadow-lg">
+          {syncError}
+        </div>
+      )}
       {disconnectError && (
         <div className="fixed bottom-4 right-4 z-50 bg-red-500/10 border border-red-500/30 text-red-400 px-4 py-3 rounded-lg text-sm max-w-sm shadow-lg">
           {disconnectError}


### PR DESCRIPTION
### Motivation
- When a Slack app/connector is removed in Slack (or its token revoked) sync or disconnect operations surfaced low-level errors and raw payloads instead of a coherent message instructing users what to do.
- Provide a clear, user-facing error and avoid leaking Nango/raw API failure details during sync/disconnect flows.

### Description
- Add reusable helpers in `backend/connectors/base.py`: `is_connection_removed_error`, `build_connection_removed_message`, and `get_provider_display_name`, plus a new `ExternalConnectionRevokedError` to normalize upstream-revoked-credential cases.
- Convert token/credentials failures in the base connector (`get_oauth_token` / `get_credentials`) into `ExternalConnectionRevokedError` when the error looks like a removed/revoked connection.
- Update `backend/connectors/slack.py` to treat Slack API auth error codes (`invalid_auth`, `account_inactive`, `token_revoked`, `not_authed`) as revoked-connection cases and raise the new error with a friendly reconnect message.
- Improve frontend error handling in `frontend/src/components/DataSources.tsx` by parsing API error payloads for sync/disconnect calls, adding a `syncError` banner, and surfacing coherent messages to users instead of raw response text.
- Add focused unit tests in `backend/tests/test_connector_error_messages.py` for the new helper functions.

### Testing
- Ran unit tests: `pytest -q backend/tests/test_connector_error_messages.py backend/tests/test_sync_cancellation.py` — all tests passed (`5 passed`, 2 warnings).
- Type-check/build check: `npx tsc -p frontend/tsconfig.json --noEmit` — succeeded.
- Lint: attempted `npx eslint frontend/src/components/DataSources.tsx backend/connectors/base.py backend/connectors/slack.py backend/tests/test_connector_error_messages.py` — ESLint failed in this environment due to the installed ESLint v9 expecting `eslint.config.js` while repository uses legacy config (warning only; not blocking the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb43065c288321a9ca5651f923d3c5)