### PR TITLE
Fix Slack workflow reminders: propagate Slack context, inject output_config and auto-approve send_slack

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -1379,6 +1379,25 @@ def _workflow_insert_would_auto_run(query: str) -> bool:
     return bool(trigger_type and trigger_type != "manual" and is_enabled is True)
 
 
+def _build_slack_workflow_output_config(context: dict[str, Any] | None) -> dict[str, str] | None:
+    """Build Slack delivery metadata for workflows created from a Slack conversation."""
+    if not context or context.get("source") != "slack":
+        return None
+
+    channel_id = (context.get("slack_channel_id") or "").strip()
+    if not channel_id:
+        return None
+
+    output_config: dict[str, str] = {
+        "platform": "slack",
+        "channel_id": channel_id,
+    }
+    thread_ts = (context.get("slack_thread_ts") or "").strip()
+    if thread_ts:
+        output_config["thread_ts"] = thread_ts
+    return output_config
+
+
 def _parse_update_values(query: str) -> tuple[dict[str, Any], str] | None:
     """
     Parse an UPDATE query to extract SET values and WHERE clause.
@@ -1558,10 +1577,14 @@ async def _run_sql_write(
                 parsed = _parse_insert_for_injection(query_to_use)
                 if parsed is None:
                     return {"error": "INSERT query format not recognized. Use: INSERT INTO table (columns) VALUES (values)"}
-                
+
                 table_part, columns, values = parsed
                 columns_lower = columns.lower()
-                
+                column_name_set = {
+                    col.strip().lower()
+                    for col in _split_sql_csv(columns)
+                }
+
                 # Build lists of extra columns and values to inject
                 extra_cols: list[str] = []
                 extra_vals: list[str] = []
@@ -1576,22 +1599,30 @@ async def _run_sql_write(
                 
                 # Workflow-specific defaults
                 if table == "workflows":
-                    if "id" not in columns_lower:
+                    if "id" not in column_name_set:
                         extra_cols.append("id")
                         extra_vals.append("gen_random_uuid()")
-                    if "steps" not in columns_lower:
+                    if "steps" not in column_name_set:
                         extra_cols.append("steps")
                         extra_vals.append("'[]'::jsonb")
-                    if "auto_approve_tools" not in columns_lower:
+                    slack_output_config = _build_slack_workflow_output_config(context)
+                    if "output_config" not in column_name_set and slack_output_config:
+                        extra_cols.append("output_config")
+                        extra_vals.append(f"'{json.dumps(slack_output_config)}'::jsonb")
+                    if "auto_approve_tools" not in column_name_set:
                         extra_cols.append("auto_approve_tools")
-                        extra_vals.append("'[]'::jsonb")
-                    if "is_enabled" not in columns_lower:
+                        extra_vals.append(
+                            '\'["send_slack"]\'::jsonb'
+                            if slack_output_config
+                            else "'[]'::jsonb"
+                        )
+                    if "is_enabled" not in column_name_set:
                         extra_cols.append("is_enabled")
                         extra_vals.append("true")
-                
+
                 # Artifacts-specific defaults
                 if table == "artifacts":
-                    if "id" not in columns_lower:
+                    if "id" not in column_name_set:
                         extra_cols.append("id")
                         extra_vals.append("gen_random_uuid()")
                 

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -682,6 +682,15 @@ class WorkspaceMessenger(BaseMessenger):
         ctx: dict[str, Any] = message.messenger_context
         slack_user_email: str | None = ctx.get("user_email")
 
+        workflow_context: dict[str, Any] = dict(ctx.get("workflow_context") or {})
+        if self.meta.slug == "slack":
+            channel_id = ctx.get("channel_id")
+            thread_ts = ctx.get("thread_id") or ctx.get("thread_ts")
+            if channel_id:
+                workflow_context.setdefault("slack_channel_id", channel_id)
+            if thread_ts:
+                workflow_context.setdefault("slack_thread_ts", thread_ts)
+
         orchestrator = ChatOrchestrator(
             user_id=str(user.id),
             organization_id=organization_id,
@@ -689,7 +698,7 @@ class WorkspaceMessenger(BaseMessenger):
             user_email=user.email,
             source_user_id=message.external_user_id,
             source_user_email=slack_user_email or user.email,
-            workflow_context=ctx.get("workflow_context"),
+            workflow_context=workflow_context or None,
             source=self.meta.slug,
             timezone=ctx.get("timezone"),
             local_time=ctx.get("local_time"),

--- a/backend/tests/test_slack_workflow_reminders.py
+++ b/backend/tests/test_slack_workflow_reminders.py
@@ -1,0 +1,126 @@
+import importlib
+import sys
+import types
+from uuid import uuid4
+
+import pytest
+
+
+@pytest.fixture
+def tools_module():
+    fake_websockets = types.ModuleType("api.websockets")
+    fake_websockets.broadcast_sync_progress = lambda *args, **kwargs: None
+    sys.modules.setdefault("api.websockets", fake_websockets)
+    return importlib.import_module("agents.tools")
+
+
+@pytest.fixture
+def workflows_module():
+    return importlib.import_module("workers.tasks.workflows")
+
+
+class _AllowedResult:
+    allowed = True
+    deny_reason = None
+    transformed_query = None
+
+
+class _FakeExecuteResult:
+    rowcount = 1
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, stmt):
+        self.queries.append(str(stmt))
+        return _FakeExecuteResult()
+
+    async def commit(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_run_sql_write_injects_slack_delivery_defaults_for_workflows(monkeypatch, tools_module):
+    fake_session = _FakeSession()
+
+    async def _fake_check_sql(*args, **kwargs):
+        return _AllowedResult()
+
+    def _fake_get_session(*args, **kwargs):
+        return fake_session
+
+    monkeypatch.setattr(tools_module, "check_sql", _fake_check_sql)
+    monkeypatch.setattr(tools_module, "get_session", _fake_get_session)
+
+    organization_id = str(uuid4())
+    user_id = str(uuid4())
+    query = (
+        "INSERT INTO workflows (name, prompt, trigger_type, trigger_config) "
+        "VALUES ('Reminder', 'Remind me later', 'schedule', '{\"cron\":\"15 9 * * *\"}'::jsonb)"
+    )
+
+    result = await tools_module._run_sql_write(
+        {"query": query},
+        organization_id=organization_id,
+        user_id=user_id,
+        context={
+            "source": "slack",
+            "slack_channel_id": "C123456",
+            "slack_thread_ts": "1740000000.123456",
+        },
+    )
+
+    assert result["success"] is True
+    assert fake_session.queries, "expected the workflow INSERT to be executed"
+    final_query = fake_session.queries[-1]
+    assert 'output_config' in final_query
+    assert '"platform": "slack"' in final_query
+    assert '"channel_id": "C123456"' in final_query
+    assert '"thread_ts": "1740000000.123456"' in final_query
+    assert "auto_approve_tools" in final_query
+    assert '["send_slack"]' in final_query
+
+
+def test_build_slack_workflow_output_config_requires_slack_channel(tools_module):
+    assert tools_module._build_slack_workflow_output_config(None) is None
+    assert tools_module._build_slack_workflow_output_config({"source": "web"}) is None
+    assert tools_module._build_slack_workflow_output_config({"source": "slack"}) is None
+
+    assert tools_module._build_slack_workflow_output_config(
+        {
+            "source": "slack",
+            "slack_channel_id": "C999",
+            "slack_thread_ts": "123.456",
+        }
+    ) == {
+        "platform": "slack",
+        "channel_id": "C999",
+        "thread_ts": "123.456",
+    }
+
+
+def test_get_slack_delivery_context_normalizes_supported_shapes(workflows_module):
+    assert workflows_module._get_slack_delivery_context(None) is None
+    assert workflows_module._get_slack_delivery_context({"platform": "email", "channel_id": "C1"}) is None
+
+    assert workflows_module._get_slack_delivery_context(
+        {"platform": "slack", "channel_id": "C1", "thread_ts": "100.2"}
+    ) == {
+        "channel_id": "C1",
+        "thread_ts": "100.2",
+    }
+
+    assert workflows_module._get_slack_delivery_context(
+        {"provider": "slack", "channel": "C2", "thread_id": "200.3"}
+    ) == {
+        "channel_id": "C2",
+        "thread_ts": "200.3",
+    }

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -485,6 +485,39 @@ def format_workflow_runtime_context_for_prompt(
 from workers.run_async import run_async
 
 
+def _get_slack_delivery_context(output_config: dict[str, Any] | None) -> dict[str, str] | None:
+    """Normalize Slack delivery metadata stored on a workflow."""
+    if not output_config:
+        return None
+
+    platform = str(
+        output_config.get("platform")
+        or output_config.get("provider")
+        or output_config.get("type")
+        or ""
+    ).strip().lower()
+    if platform != "slack":
+        return None
+
+    channel_id = str(
+        output_config.get("channel_id")
+        or output_config.get("channel")
+        or ""
+    ).strip()
+    if not channel_id:
+        return None
+
+    delivery_context: dict[str, str] = {"channel_id": channel_id}
+    thread_ts = str(
+        output_config.get("thread_ts")
+        or output_config.get("thread_id")
+        or ""
+    ).strip()
+    if thread_ts:
+        delivery_context["thread_ts"] = thread_ts
+    return delivery_context
+
+
 async def _check_scheduled_workflows() -> dict[str, Any]:
     """
     Check for workflows scheduled to run now.
@@ -843,6 +876,20 @@ async def _execute_workflow_via_agent(
     # guardrails are enforced without being shown in workflow run UI.
     prompt = workflow.prompt
     persisted_prompt = workflow.prompt
+    slack_delivery_context = _get_slack_delivery_context(getattr(workflow, "output_config", None))
+
+    if slack_delivery_context:
+        delivery_instruction = (
+            "When this workflow completes, deliver the reminder back to Slack by calling "
+            f"send_slack with channel='{slack_delivery_context['channel_id']}'"
+        )
+        if slack_delivery_context.get("thread_ts"):
+            delivery_instruction += (
+                f" and thread_ts='{slack_delivery_context['thread_ts']}'"
+            )
+        delivery_instruction += ". Do not leave the result only in the workflow conversation."
+        prompt += f"\n\n{delivery_instruction}"
+        persisted_prompt += f"\n\n{delivery_instruction}"
 
     runtime_context = build_workflow_runtime_context(
         workflow=workflow,
@@ -894,6 +941,12 @@ async def _execute_workflow_via_agent(
         workflow_auto_approve_tools=workflow.auto_approve_tools,
         parent_auto_approve_tools=parent_auto_approve_tools,
     )
+    if slack_delivery_context and "send_slack" not in effective_auto_approve_tools:
+        effective_auto_approve_tools = [*effective_auto_approve_tools, "send_slack"]
+        logger.info(
+            "[Workflow] Added send_slack auto-approval for workflow %s due to Slack output_config",
+            workflow.id,
+        )
     effective_auto_approve_tools = await apply_user_auto_approve_permissions(
         session=session,
         user_id=workflow.created_by_user_id,
@@ -918,13 +971,19 @@ async def _execute_workflow_via_agent(
         "call_stack": call_stack,  # For nested workflow recursion detection
         "execution_guardrails": [WORKFLOW_NESTING_GUARDRAIL],
     }
-    
+    orchestrator_source = "workflow"
+    if slack_delivery_context:
+        workflow_context["slack_channel_id"] = slack_delivery_context["channel_id"]
+        if slack_delivery_context.get("thread_ts"):
+            workflow_context["slack_thread_ts"] = slack_delivery_context["thread_ts"]
+        orchestrator_source = "slack"
+
     orchestrator = ChatOrchestrator(
         user_id=str(workflow.created_by_user_id),
         organization_id=str(workflow.organization_id),
         conversation_id=str(conversation.id),
         workflow_context=workflow_context,
-        source="workflow",
+        source=orchestrator_source,
     )
     
     # Process the prompt (this streams through the agent)


### PR DESCRIPTION
### Motivation
- Reminder workflows created from Slack messages were missing the originating channel/thread context and could end up producing results visible only in the workflow conversation instead of being delivered back to Slack.
- Workflows targeting Slack also needed `send_slack` auto-approval when created from Slack so delayed reminders wouldn't be blocked by approval UI.

### Description
- Propagate Slack conversation context into the orchestrator by adding Slack `channel_id` and `thread_ts` into the `workflow_context` for Slack incoming messages in `backend/messengers/_workspace.py` so workflows know the original Slack destination.
- Add `_build_slack_workflow_output_config` in `backend/agents/tools.py` to construct a Slack `output_config` from Slack conversation context when a workflow is created from Slack.
- Modify `_run_sql_write` in `backend/agents/tools.py` to inject `output_config` and default `auto_approve_tools` (including `send_slack`) into an `INSERT INTO workflows` when the creator context is Slack and the INSERT did not already specify those columns.
- In workflow execution (`backend/workers/tasks/workflows.py`) normalize Slack `output_config`, append a delivery instruction to the agent prompt to return the result to Slack, propagate the Slack delivery metadata into the workflow execution context, and ensure `send_slack` is auto-approved for runs with Slack delivery metadata; also set the orchestrator `source` to `slack` when appropriate so messenger-specific routing applies.
- Add regression tests (`backend/tests/test_slack_workflow_reminders.py`) that stub the websockets import to avoid circular imports and verify: `_build_slack_workflow_output_config` behavior, `_get_slack_delivery_context` normalization, and that `_run_sql_write` injects `output_config` and `auto_approve_tools` for Slack-originated workflow INSERTs.

### Testing
- Ran `pytest -q tests/test_slack_workflow_reminders.py` in `backend` and all tests passed (3 passed). 
- Ran `pytest -q tests/test_workflow_send_slack_action.py` in `backend` and the existing Slack action test passed (1 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb433282048321afa22e7b9289af51)