### PR TITLE
Retry Slack DMs across linked identities

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -1257,12 +1257,12 @@ Send a message to a Slack channel, DM, or user.
             raise ValueError(f"Empty response downloading Slack file: {url_private}")
         return data
 
-    async def send_direct_message(
+    async def _send_direct_message_once(
         self,
         slack_user_id: str,
         text: str,
     ) -> dict[str, Any]:
-        """Open a DM channel and send a direct message."""
+        """Open a DM channel for one Slack user ID and send a message."""
         logger.info("[SlackConnector] Opening DM for slack_user_id=%s", slack_user_id)
         try:
             open_data = await self._make_request(
@@ -1290,3 +1290,59 @@ Send a message to a Slack channel, DM, or user.
             channel_id,
         )
         return await self.post_message(channel=channel_id, text=text)
+
+    async def send_direct_message(
+        self,
+        slack_user_id: str,
+        text: str,
+    ) -> dict[str, Any]:
+        """Open a DM channel and send a direct message.
+
+        If Slack rejects the provided user ID with ``user_not_found``, try any
+        sibling Slack identities we know for the same person before letting the
+        caller fall back to a broader channel announcement.
+        """
+        normalized_slack_user_id = str(slack_user_id).strip().upper()
+        try:
+            return await self._send_direct_message_once(normalized_slack_user_id, text)
+        except ValueError as exc:
+            if "user_not_found" not in str(exc):
+                raise
+            logger.warning(
+                "[SlackConnector] DM target user_not_found for slack_user_id=%s org=%s; checking alternate identities",
+                normalized_slack_user_id,
+                self.organization_id,
+            )
+
+        from services.slack_identity import get_alternate_slack_user_ids_for_identity
+
+        alternate_user_ids = await get_alternate_slack_user_ids_for_identity(
+            organization_id=self.organization_id,
+            slack_user_id=normalized_slack_user_id,
+        )
+        last_error: Exception = ValueError(f"Slack API error: user_not_found ({normalized_slack_user_id})")
+        for idx, alternate_user_id in enumerate(alternate_user_ids, start=1):
+            try:
+                logger.info(
+                    "[SlackConnector] Retrying DM via alternate Slack identity org=%s original=%s alternate=%s attempt=%d/%d",
+                    self.organization_id,
+                    normalized_slack_user_id,
+                    alternate_user_id,
+                    idx,
+                    len(alternate_user_ids),
+                )
+                return await self._send_direct_message_once(alternate_user_id, text)
+            except Exception as exc:  # noqa: BLE001 - keep trying alternates
+                last_error = exc
+                logger.warning(
+                    "[SlackConnector] Alternate Slack DM failed org=%s original=%s alternate=%s attempt=%d/%d error=%s",
+                    self.organization_id,
+                    normalized_slack_user_id,
+                    alternate_user_id,
+                    idx,
+                    len(alternate_user_ids),
+                    exc,
+                    exc_info=True,
+                )
+
+        raise last_error

--- a/backend/services/slack_identity.py
+++ b/backend/services/slack_identity.py
@@ -22,7 +22,7 @@ from typing import Any
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
-from sqlalchemy import or_, select, update
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -52,6 +52,10 @@ def _normalize_slack_user_id(slack_user_id: str | None) -> str:
 
 def _normalize_slack_team_id(team_id: str | None) -> str:
     return (team_id or "").strip().upper()
+
+
+def _normalize_slack_email(email: str | None) -> str:
+    return (email or "").strip().lower()
 
 
 def _normalize_name(value: str | None) -> str:
@@ -552,6 +556,96 @@ async def upsert_slack_user_mapping_for_user(
         slack_email=slack_email,
         match_source=match_source,
     )
+
+
+async def get_alternate_slack_user_ids_for_identity(
+    organization_id: str,
+    slack_user_id: str,
+    session: AsyncSession | None = None,
+) -> list[str]:
+    """Return alternate Slack user IDs linked to the same person in this org.
+
+    This is used when Slack rejects a DM target with ``user_not_found``. We
+    first find the seed identity row(s) for the failed Slack user ID, then look
+    for sibling mappings tied to the same internal user and/or normalized email.
+    """
+    normalized_slack_user_id: str = _normalize_slack_user_id(slack_user_id)
+    if not normalized_slack_user_id:
+        return []
+
+    async def _query(sess: AsyncSession) -> list[ExternalIdentityMapping]:
+        seed_result = await sess.execute(
+            select(ExternalIdentityMapping)
+            .where(ExternalIdentityMapping.organization_id == UUID(organization_id))
+            .where(_slack_mapping_source_clause())
+            .where(ExternalIdentityMapping.external_userid == normalized_slack_user_id)
+            .order_by(ExternalIdentityMapping.updated_at.desc())
+        )
+        seed_mappings: list[ExternalIdentityMapping] = list(seed_result.scalars().all())
+        if not seed_mappings:
+            logger.info(
+                "[slack_identity] No seed Slack identity rows for org=%s slack_user_id=%s",
+                organization_id,
+                normalized_slack_user_id,
+            )
+            return []
+
+        related_user_ids: set[UUID] = {
+            mapping.user_id
+            for mapping in seed_mappings
+            if mapping.user_id is not None
+        }
+        related_emails: set[str] = {
+            normalized_email
+            for mapping in seed_mappings
+            if (normalized_email := _normalize_slack_email(mapping.external_email))
+        }
+
+        related_filters: list[Any] = []
+        if related_user_ids:
+            related_filters.append(ExternalIdentityMapping.user_id.in_(related_user_ids))
+        if related_emails:
+            related_filters.append(func.lower(ExternalIdentityMapping.external_email).in_(related_emails))
+
+        if not related_filters:
+            logger.info(
+                "[slack_identity] Seed Slack identity org=%s slack_user_id=%s had no linked user/email metadata",
+                organization_id,
+                normalized_slack_user_id,
+            )
+            return seed_mappings
+
+        related_result = await sess.execute(
+            select(ExternalIdentityMapping)
+            .where(ExternalIdentityMapping.organization_id == UUID(organization_id))
+            .where(_slack_mapping_source_clause())
+            .where(or_(*related_filters))
+            .order_by(ExternalIdentityMapping.updated_at.desc())
+        )
+        return list(related_result.scalars().all())
+
+    if session is not None:
+        related_mappings = await _query(session)
+    else:
+        async with get_admin_session() as admin_sess:
+            related_mappings = await _query(admin_sess)
+
+    alternate_ids: list[str] = []
+    seen_ids: set[str] = {normalized_slack_user_id}
+    for mapping in related_mappings:
+        candidate_id: str = _normalize_slack_user_id(mapping.external_userid)
+        if not candidate_id or candidate_id in seen_ids:
+            continue
+        seen_ids.add(candidate_id)
+        alternate_ids.append(candidate_id)
+
+    logger.info(
+        "[slack_identity] Resolved %d alternate Slack IDs for org=%s slack_user_id=%s",
+        len(alternate_ids),
+        organization_id,
+        normalized_slack_user_id,
+    )
+    return alternate_ids
 
 
 async def get_slack_user_ids_for_revtops_user(

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -151,3 +151,60 @@ def test_post_message_retries_with_org_credentials_on_channel_not_found(monkeypa
     assert result["ok"] is True
     assert calls == ["11111111-1111-1111-1111-111111111111", None]
     assert connector.user_id == "11111111-1111-1111-1111-111111111111"
+
+
+def test_send_direct_message_retries_other_slack_identities_on_user_not_found(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    attempts: list[str] = []
+
+    async def _fake_send_direct_message_once(slack_user_id: str, text: str):
+        attempts.append(f"{slack_user_id}:{text}")
+        if slack_user_id == "U123":
+            raise ValueError("Slack API error: user_not_found")
+        return {"ok": True, "channel": "D456", "sent_to": slack_user_id}
+
+    async def _fake_get_alternates(*, organization_id: str, slack_user_id: str):
+        assert organization_id == "00000000-0000-0000-0000-000000000001"
+        assert slack_user_id == "U123"
+        return ["U456", "U789"]
+
+    monkeypatch.setattr(connector, "_send_direct_message_once", _fake_send_direct_message_once)
+    monkeypatch.setattr(
+        "services.slack_identity.get_alternate_slack_user_ids_for_identity",
+        _fake_get_alternates,
+    )
+
+    result = asyncio.run(connector.send_direct_message("u123", "Hello there"))
+
+    assert result == {"ok": True, "channel": "D456", "sent_to": "U456"}
+    assert attempts == ["U123:Hello there", "U456:Hello there"]
+
+
+def test_send_direct_message_raises_when_all_alternate_slack_identities_fail(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    attempts: list[str] = []
+
+    async def _fake_send_direct_message_once(slack_user_id: str, text: str):
+        attempts.append(f"{slack_user_id}:{text}")
+        raise ValueError(f"Slack API error: user_not_found:{slack_user_id}")
+
+    async def _fake_get_alternates(*, organization_id: str, slack_user_id: str):
+        assert organization_id == "00000000-0000-0000-0000-000000000001"
+        assert slack_user_id == "U123"
+        return ["U456"]
+
+    monkeypatch.setattr(connector, "_send_direct_message_once", _fake_send_direct_message_once)
+    monkeypatch.setattr(
+        "services.slack_identity.get_alternate_slack_user_ids_for_identity",
+        _fake_get_alternates,
+    )
+
+    try:
+        asyncio.run(connector.send_direct_message("U123", "Hello there"))
+        raise AssertionError("Expected ValueError")
+    except ValueError as exc:
+        assert "user_not_found:U456" in str(exc)
+
+    assert attempts == ["U123:Hello there", "U456:Hello there"]


### PR DESCRIPTION
### Motivation
- Improve reliability of direct Slack messages by handling the `user_not_found` case more gracefully. 
- If a Slack user ID is rejected, attempt delivery to other Slack identities linked to the same person before falling back to a broader channel or error path.

### Description
- Add `get_alternate_slack_user_ids_for_identity` in `backend/services/slack_identity.py` to find sibling Slack IDs via linked `ExternalIdentityMapping` rows and normalized email/user linkage, and add a helper `'_normalize_slack_email'` to support matching.
- Split DM logic in `backend/connectors/slack.py` into `_send_direct_message_once` (single-attempt DM) and public `send_direct_message` which retries alternate IDs when the first attempt raises a `user_not_found` error and logs attempts.
- Add two connector-level tests in `backend/tests/test_slack_connector_actions.py` covering successful retry via alternate identity and failure when all alternates fail.
- Import `func` from SQLAlchemy where needed and add logging around alternate-resolution flows.

### Testing
- Ran `pytest -q backend/tests/test_slack_connector_actions.py backend/tests/test_slack_user_mapping_request_code.py` and all tests passed (`10 passed`).
- Unit tests exercise both the new alternate-identity retry success and the all-alternates-fail behavior and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc052fe5bc83219e0083b9356cfeef)