### PR TITLE
Persist Slack identity preference order; promote on success and demote on user_not_found

### DIFF
--- a/backend/api/routes/slack_user_mappings.py
+++ b/backend/api/routes/slack_user_mappings.py
@@ -142,7 +142,7 @@ async def list_user_mappings_for_identity(
             .where(ExternalIdentityMapping.organization_id == org_uuid)
             .where(ExternalIdentityMapping.source == "slack")
             .where(ExternalIdentityMapping.user_id == user_uuid)
-            .order_by(ExternalIdentityMapping.created_at.desc())
+            .order_by(ExternalIdentityMapping.updated_at.desc(), ExternalIdentityMapping.created_at.desc())
         )
         mappings = result.scalars().all()
 

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -1315,8 +1315,19 @@ Send a message to a Slack channel, DM, or user.
         caller fall back to a broader channel announcement.
         """
         normalized_slack_user_id = str(slack_user_id).strip().upper()
+        from services.slack_identity import (
+            demote_slack_user_id_preference,
+            get_alternate_slack_user_ids_for_identity,
+            mark_slack_user_id_preferred,
+        )
+
         try:
-            return await self._send_direct_message_once(normalized_slack_user_id, text)
+            response = await self._send_direct_message_once(normalized_slack_user_id, text)
+            await mark_slack_user_id_preferred(
+                organization_id=self.organization_id,
+                slack_user_id=normalized_slack_user_id,
+            )
+            return response
         except ValueError as exc:
             if "user_not_found" not in str(exc):
                 raise
@@ -1325,8 +1336,10 @@ Send a message to a Slack channel, DM, or user.
                 normalized_slack_user_id,
                 self.organization_id,
             )
-
-        from services.slack_identity import get_alternate_slack_user_ids_for_identity
+            await demote_slack_user_id_preference(
+                organization_id=self.organization_id,
+                slack_user_id=normalized_slack_user_id,
+            )
 
         alternate_user_ids = await get_alternate_slack_user_ids_for_identity(
             organization_id=self.organization_id,
@@ -1343,9 +1356,19 @@ Send a message to a Slack channel, DM, or user.
                     idx,
                     len(alternate_user_ids),
                 )
-                return await self._send_direct_message_once(alternate_user_id, text)
+                response = await self._send_direct_message_once(alternate_user_id, text)
+                await mark_slack_user_id_preferred(
+                    organization_id=self.organization_id,
+                    slack_user_id=alternate_user_id,
+                )
+                return response
             except Exception as exc:  # noqa: BLE001 - keep trying alternates
                 last_error = exc
+                if "user_not_found" in str(exc):
+                    await demote_slack_user_id_preference(
+                        organization_id=self.organization_id,
+                        slack_user_id=alternate_user_id,
+                    )
                 logger.warning(
                     "[SlackConnector] Alternate Slack DM failed org=%s original=%s alternate=%s attempt=%d/%d error=%s",
                     self.organization_id,

--- a/backend/services/slack_identity.py
+++ b/backend/services/slack_identity.py
@@ -17,7 +17,7 @@ import logging
 import re
 import time
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
 from zoneinfo import ZoneInfo
@@ -646,6 +646,154 @@ async def get_alternate_slack_user_ids_for_identity(
         normalized_slack_user_id,
     )
     return alternate_ids
+
+
+async def mark_slack_user_id_preferred(
+    organization_id: str,
+    slack_user_id: str,
+) -> None:
+    """Promote a Slack identity to the top of the preference list for its person."""
+    normalized_slack_user_id: str = _normalize_slack_user_id(slack_user_id)
+    if not normalized_slack_user_id:
+        logger.info(
+            "[slack_identity] Skipping preference promotion for empty Slack user id org=%s",
+            organization_id,
+        )
+        return
+
+    now: datetime = datetime.now(UTC).replace(tzinfo=None)
+    try:
+        async with get_admin_session() as session:
+            result = await session.execute(
+                select(ExternalIdentityMapping)
+                .where(ExternalIdentityMapping.organization_id == UUID(organization_id))
+                .where(_slack_mapping_source_clause())
+                .where(ExternalIdentityMapping.external_userid == normalized_slack_user_id)
+            )
+            target_mappings: list[ExternalIdentityMapping] = list(result.scalars().all())
+            if not target_mappings:
+                logger.info(
+                    "[slack_identity] No mapping rows found to promote org=%s slack_user_id=%s",
+                    organization_id,
+                    normalized_slack_user_id,
+                )
+                return
+
+            for mapping in target_mappings:
+                mapping.updated_at = now
+            await session.commit()
+            logger.info(
+                "[slack_identity] Promoted Slack identity org=%s slack_user_id=%s rows=%d",
+                organization_id,
+                normalized_slack_user_id,
+                len(target_mappings),
+            )
+    except Exception as exc:
+        logger.warning(
+            "[slack_identity] Failed to promote Slack identity org=%s slack_user_id=%s: %s",
+            organization_id,
+            normalized_slack_user_id,
+            exc,
+            exc_info=True,
+        )
+
+
+async def demote_slack_user_id_preference(
+    organization_id: str,
+    slack_user_id: str,
+) -> None:
+    """Move an unresolved Slack identity to the bottom of its preference group."""
+    normalized_slack_user_id: str = _normalize_slack_user_id(slack_user_id)
+    if not normalized_slack_user_id:
+        logger.info(
+            "[slack_identity] Skipping preference demotion for empty Slack user id org=%s",
+            organization_id,
+        )
+        return
+
+    try:
+        async with get_admin_session() as session:
+            seed_result = await session.execute(
+                select(ExternalIdentityMapping)
+                .where(ExternalIdentityMapping.organization_id == UUID(organization_id))
+                .where(_slack_mapping_source_clause())
+                .where(ExternalIdentityMapping.external_userid == normalized_slack_user_id)
+                .order_by(ExternalIdentityMapping.updated_at.desc())
+            )
+            seed_mappings: list[ExternalIdentityMapping] = list(seed_result.scalars().all())
+            if not seed_mappings:
+                logger.info(
+                    "[slack_identity] No mapping rows found to demote org=%s slack_user_id=%s",
+                    organization_id,
+                    normalized_slack_user_id,
+                )
+                return
+
+            related_user_ids: set[UUID] = {
+                mapping.user_id
+                for mapping in seed_mappings
+                if mapping.user_id is not None
+            }
+            related_emails: set[str] = {
+                normalized_email
+                for mapping in seed_mappings
+                if (normalized_email := _normalize_slack_email(mapping.external_email))
+            }
+
+            related_filters: list[Any] = []
+            if related_user_ids:
+                related_filters.append(ExternalIdentityMapping.user_id.in_(related_user_ids))
+            if related_emails:
+                related_filters.append(func.lower(ExternalIdentityMapping.external_email).in_(related_emails))
+
+            if related_filters:
+                related_result = await session.execute(
+                    select(ExternalIdentityMapping)
+                    .where(ExternalIdentityMapping.organization_id == UUID(organization_id))
+                    .where(_slack_mapping_source_clause())
+                    .where(or_(*related_filters))
+                    .order_by(ExternalIdentityMapping.updated_at.desc())
+                )
+                related_mappings: list[ExternalIdentityMapping] = list(related_result.scalars().all())
+            else:
+                related_mappings = seed_mappings
+
+            non_target_timestamps: list[datetime] = [
+                (mapping.updated_at or mapping.created_at)
+                for mapping in related_mappings
+                if _normalize_slack_user_id(mapping.external_userid) != normalized_slack_user_id
+            ]
+            if not non_target_timestamps:
+                logger.info(
+                    "[slack_identity] No sibling mappings to demote behind org=%s slack_user_id=%s",
+                    organization_id,
+                    normalized_slack_user_id,
+                )
+                return
+
+            demoted_updated_at: datetime = min(non_target_timestamps) - timedelta(microseconds=1)
+            updated_rows: int = 0
+            for mapping in seed_mappings:
+                mapping.updated_at = demoted_updated_at
+                updated_rows += 1
+
+            await session.commit()
+            logger.info(
+                "[slack_identity] Demoted Slack identity org=%s slack_user_id=%s rows=%d sibling_count=%d demoted_updated_at=%s",
+                organization_id,
+                normalized_slack_user_id,
+                updated_rows,
+                len(non_target_timestamps),
+                demoted_updated_at.isoformat(),
+            )
+    except Exception as exc:
+        logger.warning(
+            "[slack_identity] Failed to demote Slack identity org=%s slack_user_id=%s: %s",
+            organization_id,
+            normalized_slack_user_id,
+            exc,
+            exc_info=True,
+        )
 
 
 async def get_slack_user_ids_for_revtops_user(

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -157,6 +157,8 @@ def test_send_direct_message_retries_other_slack_identities_on_user_not_found(mo
     connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
 
     attempts: list[str] = []
+    demotions: list[str] = []
+    promotions: list[str] = []
 
     async def _fake_send_direct_message_once(slack_user_id: str, text: str):
         attempts.append(f"{slack_user_id}:{text}")
@@ -169,22 +171,35 @@ def test_send_direct_message_retries_other_slack_identities_on_user_not_found(mo
         assert slack_user_id == "U123"
         return ["U456", "U789"]
 
+    async def _fake_demote(*, organization_id: str, slack_user_id: str):
+        assert organization_id == "00000000-0000-0000-0000-000000000001"
+        demotions.append(slack_user_id)
+
+    async def _fake_promote(*, organization_id: str, slack_user_id: str):
+        assert organization_id == "00000000-0000-0000-0000-000000000001"
+        promotions.append(slack_user_id)
+
     monkeypatch.setattr(connector, "_send_direct_message_once", _fake_send_direct_message_once)
     monkeypatch.setattr(
         "services.slack_identity.get_alternate_slack_user_ids_for_identity",
         _fake_get_alternates,
     )
+    monkeypatch.setattr("services.slack_identity.demote_slack_user_id_preference", _fake_demote)
+    monkeypatch.setattr("services.slack_identity.mark_slack_user_id_preferred", _fake_promote)
 
     result = asyncio.run(connector.send_direct_message("u123", "Hello there"))
 
     assert result == {"ok": True, "channel": "D456", "sent_to": "U456"}
     assert attempts == ["U123:Hello there", "U456:Hello there"]
+    assert demotions == ["U123"]
+    assert promotions == ["U456"]
 
 
 def test_send_direct_message_raises_when_all_alternate_slack_identities_fail(monkeypatch) -> None:
     connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
 
     attempts: list[str] = []
+    demotions: list[str] = []
 
     async def _fake_send_direct_message_once(slack_user_id: str, text: str):
         attempts.append(f"{slack_user_id}:{text}")
@@ -195,11 +210,20 @@ def test_send_direct_message_raises_when_all_alternate_slack_identities_fail(mon
         assert slack_user_id == "U123"
         return ["U456"]
 
+    async def _fake_demote(*, organization_id: str, slack_user_id: str):
+        assert organization_id == "00000000-0000-0000-0000-000000000001"
+        demotions.append(slack_user_id)
+
+    async def _fake_promote(*, organization_id: str, slack_user_id: str):
+        raise AssertionError("Should not promote any Slack identity when all attempts fail")
+
     monkeypatch.setattr(connector, "_send_direct_message_once", _fake_send_direct_message_once)
     monkeypatch.setattr(
         "services.slack_identity.get_alternate_slack_user_ids_for_identity",
         _fake_get_alternates,
     )
+    monkeypatch.setattr("services.slack_identity.demote_slack_user_id_preference", _fake_demote)
+    monkeypatch.setattr("services.slack_identity.mark_slack_user_id_preferred", _fake_promote)
 
     try:
         asyncio.run(connector.send_direct_message("U123", "Hello there"))
@@ -208,3 +232,4 @@ def test_send_direct_message_raises_when_all_alternate_slack_identities_fail(mon
         assert "user_not_found:U456" in str(exc)
 
     assert attempts == ["U123:Hello there", "U456:Hello there"]
+    assert demotions == ["U123", "U456"]

--- a/backend/tests/test_slack_user_resolution.py
+++ b/backend/tests/test_slack_user_resolution.py
@@ -1,6 +1,7 @@
 """Tests for Slack identity resolution functions in services.slack_identity."""
 import asyncio
 
+from datetime import datetime
 from types import SimpleNamespace
 from uuid import UUID
 
@@ -31,9 +32,13 @@ class _FakeExecuteResult:
 class _FakeSession:
     def __init__(self, query_results):
         self._query_results = list(query_results)
+        self.commit_calls = 0
 
     async def execute(self, _query):
         return _FakeExecuteResult(self._query_results.pop(0))
+
+    async def commit(self):
+        self.commit_calls += 1
 
 
 class _FakeAdminSessionContext:
@@ -270,3 +275,86 @@ def test_resolve_revtops_user_falls_back_to_guest_for_empty_slack_id(monkeypatch
 
     assert resolved is not None
     assert resolved.id == guest_id
+
+
+def test_get_alternate_slack_user_ids_for_identity_returns_updated_preference_order(monkeypatch):
+    org_id = "11111111-1111-1111-1111-111111111111"
+    user_id = UUID("22222222-2222-2222-2222-222222222222")
+    newer = datetime(2026, 3, 19, 12, 0, 0)
+    older = datetime(2026, 3, 19, 11, 0, 0)
+
+    seed_rows = [
+        SimpleNamespace(
+            user_id=user_id,
+            external_userid="U123",
+            external_email="person@example.com",
+            updated_at=newer,
+        ),
+    ]
+    related_rows = [
+        SimpleNamespace(
+            user_id=user_id,
+            external_userid="U123",
+            external_email="person@example.com",
+            updated_at=newer,
+        ),
+        SimpleNamespace(
+            user_id=user_id,
+            external_userid="U456",
+            external_email="person@example.com",
+            updated_at=older,
+        ),
+        SimpleNamespace(
+            user_id=user_id,
+            external_userid="U789",
+            external_email="person@example.com",
+            updated_at=datetime(2026, 3, 19, 10, 0, 0),
+        ),
+    ]
+
+    monkeypatch.setattr(
+        slack_identity,
+        "get_admin_session",
+        lambda: _FakeAdminSessionContext([seed_rows, related_rows]),
+    )
+
+    alternate_ids = asyncio.run(
+        slack_identity.get_alternate_slack_user_ids_for_identity(
+            organization_id=org_id,
+            slack_user_id="u123",
+        )
+    )
+
+    assert alternate_ids == ["U456", "U789"]
+
+
+def test_demote_slack_user_id_preference_moves_user_not_found_to_bottom(monkeypatch):
+    org_id = "11111111-1111-1111-1111-111111111111"
+    user_id = UUID("22222222-2222-2222-2222-222222222222")
+    target = SimpleNamespace(
+        user_id=user_id,
+        external_userid="U123",
+        external_email="person@example.com",
+        created_at=datetime(2026, 3, 19, 9, 0, 0),
+        updated_at=datetime(2026, 3, 19, 12, 0, 0),
+    )
+    sibling = SimpleNamespace(
+        user_id=user_id,
+        external_userid="U456",
+        external_email="person@example.com",
+        created_at=datetime(2026, 3, 19, 8, 0, 0),
+        updated_at=datetime(2026, 3, 19, 11, 0, 0),
+    )
+    fake_ctx = _FakeAdminSessionContext([[target], [target, sibling]])
+
+    monkeypatch.setattr(slack_identity, "get_admin_session", lambda: fake_ctx)
+
+    asyncio.run(
+        slack_identity.demote_slack_user_id_preference(
+            organization_id=org_id,
+            slack_user_id="U123",
+        )
+    )
+
+    assert fake_ctx._session.commit_calls == 1
+    assert target.updated_at < sibling.updated_at


### PR DESCRIPTION
### Motivation
- Ensure users with multiple Slack identities have a durable preference ordering so the UI and runtime resolution agree. 
- When a Slack identity cannot be resolved (e.g. Slack `user_not_found`), move that identity to the bottom of the preference list to avoid repeated failures.

### Description
- Added `mark_slack_user_id_preferred` and `demote_slack_user_id_preference` to `services/slack_identity.py` to promote successful identities and demote identities that fail resolution by adjusting `updated_at` timestamps.
- Updated `connectors/slack.py` to call the new promotion on successful DM sends and demotion when a `user_not_found` error occurs, and to promote whichever alternate identity actually succeeds.
- Changed the team-panel listing endpoint in `backend/api/routes/slack_user_mappings.py` to order mappings by `updated_at DESC, created_at DESC` so the API reflects the persisted preference order.
- Updated and extended unit tests in `backend/tests/` to cover promotion/demotion and ordering behavior.

### Testing
- Ran `pytest -q backend/tests/test_slack_connector_actions.py backend/tests/test_slack_user_resolution.py backend/tests/test_slack_user_mapping_manual_unlink.py`, and the targeted tests passed (all assertions in these suites succeeded).
- Ran `python -m compileall backend/services/slack_identity.py backend/connectors/slack.py backend/api/routes/slack_user_mappings.py` to verify syntax, and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc11ac08ac832180beb8bd2b93cdf9)