### PR TITLE
Show guest user in org members list when disabled

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1407,7 +1407,7 @@ async def get_organization_members(
         if not requester_check.scalar_one_or_none():
             raise HTTPException(status_code=403, detail="Not authorized to view this organization's members")
 
-        # Load org to check guest_user_enabled (hide guest from list when disabled)
+        # Load org so the response can still report guest-user toggle state.
         org = await session.get(Organization, org_uuid)
         guest_user_enabled: bool = bool(org and org.guest_user_enabled)
 
@@ -1444,10 +1444,6 @@ async def get_organization_members(
             # Skip crm_only stub users entirely — they shouldn't appear in the team list
             if u.status == "crm_only":
                 continue
-            # Hide guest user until enabled (avoids confusing "Guest user" for new orgs without Slack)
-            if u.is_guest and not guest_user_enabled:
-                continue
-
             user_mappings: list[ExternalIdentityMapping] = mappings_by_user.get(u.id, [])
             identities: list[IdentityMappingResponse] = [
                 IdentityMappingResponse(

--- a/backend/tests/test_org_members_guest_visibility.py
+++ b/backend/tests/test_org_members_guest_visibility.py
@@ -1,0 +1,131 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID
+
+from api.routes import auth
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _RowsResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _ScalarsResult:
+    def __init__(self, values):
+        self._values = values
+
+    def all(self):
+        return self._values
+
+
+class _MappingsResult:
+    def __init__(self, values):
+        self._values = values
+
+    def scalars(self):
+        return _ScalarsResult(self._values)
+
+
+class _FakeSession:
+    def __init__(self, *, org, execute_results):
+        self._org = org
+        self._execute_results = list(execute_results)
+        self._execute_calls = 0
+
+    async def get(self, _model, _model_id):
+        return self._org
+
+    async def execute(self, _query):
+        if self._execute_calls >= len(self._execute_results):
+            raise AssertionError(f"unexpected execute call {self._execute_calls + 1}")
+        result = self._execute_results[self._execute_calls]
+        self._execute_calls += 1
+        return result
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_get_organization_members_keeps_guest_user_visible_when_disabled(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    requester_id = UUID("22222222-2222-2222-2222-222222222222")
+    guest_user_id = UUID("33333333-3333-3333-3333-333333333333")
+    member_user_id = UUID("44444444-4444-4444-4444-444444444444")
+
+    org = SimpleNamespace(id=org_id, guest_user_enabled=False)
+    requester_membership = SimpleNamespace(user_id=requester_id, organization_id=org_id, status="active")
+    guest_user = SimpleNamespace(
+        id=guest_user_id,
+        name="Guest User",
+        email="guest@example.com",
+        avatar_url=None,
+        status="active",
+        is_guest=True,
+        role="member",
+        roles=[],
+    )
+    member_user = SimpleNamespace(
+        id=member_user_id,
+        name="Member User",
+        email="member@example.com",
+        avatar_url=None,
+        status="active",
+        is_guest=False,
+        role="member",
+        roles=[],
+    )
+    guest_membership = SimpleNamespace(
+        user_id=guest_user_id,
+        organization_id=org_id,
+        status="active",
+        role="member",
+        title=None,
+    )
+    member_membership = SimpleNamespace(
+        user_id=member_user_id,
+        organization_id=org_id,
+        status="active",
+        role="member",
+        title=None,
+    )
+
+    fake_session = _FakeSession(
+        org=org,
+        execute_results=[
+            _ScalarResult(requester_membership),
+            _RowsResult([(guest_user, guest_membership), (member_user, member_membership)]),
+            _MappingsResult([]),
+        ],
+    )
+    monkeypatch.setattr(auth, "get_admin_session", lambda: _FakeSessionContext(fake_session))
+
+    response = asyncio.run(
+        auth.get_organization_members(
+            org_id=str(org_id),
+            auth=SimpleNamespace(user_id=requester_id),
+        )
+    )
+
+    assert response.guest_user_enabled is False
+    assert [member.id for member in response.members] == [str(guest_user_id), str(member_user_id)]
+    assert response.members[0].is_guest is True
+    assert response.members[0].email == "guest@example.com"


### PR DESCRIPTION
### Motivation
- The organization members API previously filtered out the guest user when the `guest_user_enabled` toggle was false, which hid the guest identity from team lists and caused confusion in the UI. 
- The change aims to keep the guest user visible in member lists while still exposing the toggle state so the frontend can render the control independently.

### Description
- Removed the server-side suppression that skipped users with `is_guest` when `guest_user_enabled` was false in `get_organization_members` (backend file `backend/api/routes/auth.py`).
- Kept returning the `guest_user_enabled` flag in the `TeamMembersListResponse` so clients can still show the toggle state separately.
- Added a regression test `backend/tests/test_org_members_guest_visibility.py` that exercises `get_organization_members` with the guest-user toggle disabled and asserts the guest user remains visible and is pinned first in the returned ordering.

### Testing
- Ran the focused regression test with `pytest -q backend/tests/test_org_members_guest_visibility.py`, which passed.
- Ran related identity/guest guard tests with `pytest -q backend/tests/test_auth_guest_identity_guards.py backend/tests/test_remove_member_unlinks_identities.py`, which all passed.
- No other tests were modified; the new test validates the behavior change and prevents regression of the previous suppression logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc9a175f5c83218ae9e57f1f797deb)