### PR TITLE
Deduplicate consecutive tool progress updates

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -136,6 +136,13 @@ async def update_tool_result(
             
             for block in new_blocks:
                 if block.get("type") == "tool_use" and block.get("id") == tool_id:
+                    if block.get("status") == status and block.get("result") == result:
+                        logger.info(
+                            "[update_tool_result] Skipping duplicate tool update for tool=%s status=%s",
+                            tool_id[:8] if tool_id else None,
+                            status,
+                        )
+                        return False
                     block["result"] = result
                     block["status"] = status
                     updated = True

--- a/backend/tests/test_tool_progress_dedup.py
+++ b/backend/tests/test_tool_progress_dedup.py
@@ -1,0 +1,154 @@
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+from uuid import uuid4
+
+_fake_websockets = types.ModuleType("api.websockets")
+
+async def _noop_broadcast_sync_progress(**_kwargs: object) -> None:
+    return None
+
+async def _noop_broadcast_tool_progress(**_kwargs: object) -> None:
+    return None
+
+_fake_websockets.broadcast_sync_progress = _noop_broadcast_sync_progress
+_fake_websockets.broadcast_tool_progress = _noop_broadcast_tool_progress
+sys.modules.setdefault("api.websockets", _fake_websockets)
+
+from agents import orchestrator
+
+
+class _FakeExecuteResult:
+    def __init__(self, row: object) -> None:
+        self._row = row
+
+    def scalar_one_or_none(self) -> object:
+        return self._row
+
+
+class _FakeSession:
+    def __init__(self, message: object) -> None:
+        self._message = message
+        self.commit_calls = 0
+
+    async def execute(self, _query: object) -> _FakeExecuteResult:
+        return _FakeExecuteResult(self._message)
+
+    async def commit(self) -> None:
+        self.commit_calls += 1
+
+
+class _FakeSessionContext:
+    def __init__(self, session: _FakeSession) -> None:
+        self._session = session
+
+    async def __aenter__(self) -> _FakeSession:
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+def test_update_tool_result_skips_duplicate_progress_updates(monkeypatch) -> None:
+    conversation_id = str(uuid4())
+    tool_id = "tool-123"
+    message = SimpleNamespace(
+        content_blocks=[
+            {
+                "type": "tool_use",
+                "id": tool_id,
+                "name": "write_on_connector",
+                "status": "running",
+                "result": {"message": "Writing to Linear"},
+            }
+        ]
+    )
+    fake_session = _FakeSession(message)
+    broadcasts: list[dict[str, object]] = []
+
+    async def _fake_broadcast_tool_progress(**kwargs: object) -> None:
+        broadcasts.append(kwargs)
+
+    monkeypatch.setattr(
+        orchestrator,
+        "get_session",
+        lambda **_kwargs: _FakeSessionContext(fake_session),
+    )
+    monkeypatch.setattr(
+        sys.modules["api.websockets"],
+        "broadcast_tool_progress",
+        _fake_broadcast_tool_progress,
+    )
+
+    updated = asyncio.run(
+        orchestrator.update_tool_result(
+            conversation_id=conversation_id,
+            tool_id=tool_id,
+            result={"message": "Writing to Linear"},
+            status="running",
+            organization_id=str(uuid4()),
+        )
+    )
+
+    assert updated is False
+    assert fake_session.commit_calls == 0
+    assert broadcasts == []
+    assert message.content_blocks[0]["result"] == {"message": "Writing to Linear"}
+
+
+def test_update_tool_result_allows_status_change_with_same_result(monkeypatch) -> None:
+    conversation_id = str(uuid4())
+    tool_id = "tool-456"
+    organization_id = str(uuid4())
+    message = SimpleNamespace(
+        content_blocks=[
+            {
+                "type": "tool_use",
+                "id": tool_id,
+                "name": "write_on_connector",
+                "status": "running",
+                "result": {"message": "Writing to Linear"},
+            }
+        ]
+    )
+    fake_session = _FakeSession(message)
+    broadcasts: list[dict[str, object]] = []
+
+    async def _fake_broadcast_tool_progress(**kwargs: object) -> None:
+        broadcasts.append(kwargs)
+
+    monkeypatch.setattr(
+        orchestrator,
+        "get_session",
+        lambda **_kwargs: _FakeSessionContext(fake_session),
+    )
+    monkeypatch.setattr(
+        sys.modules["api.websockets"],
+        "broadcast_tool_progress",
+        _fake_broadcast_tool_progress,
+    )
+
+    updated = asyncio.run(
+        orchestrator.update_tool_result(
+            conversation_id=conversation_id,
+            tool_id=tool_id,
+            result={"message": "Writing to Linear"},
+            status="complete",
+            organization_id=organization_id,
+        )
+    )
+
+    assert updated is True
+    assert fake_session.commit_calls == 1
+    assert message.content_blocks[0]["status"] == "complete"
+    assert broadcasts == [
+        {
+            "organization_id": organization_id,
+            "conversation_id": conversation_id,
+            "tool_id": tool_id,
+            "tool_name": "write_on_connector",
+            "result": {"message": "Writing to Linear"},
+            "status": "complete",
+        }
+    ]


### PR DESCRIPTION
### Motivation
- Prevent noisy duplicate in-progress messages (e.g., repeated "Writing to Linear...") from being committed and rebroadcast to clients.
- Keep the shared tool-progress update path efficient and avoid unnecessary DB writes and websocket fanout when nothing meaningful changed.

### Description
- Add a short-circuit in `update_tool_result` that returns early when a `tool_use` block already has the same `status` and `result`, avoiding an unnecessary commit and broadcast (file: `backend/agents/orchestrator.py`).
- Ensure legitimate transitions (for example the same `result` but a different `status` like `running` -> `complete`) still proceed and are persisted/broadcast.
- Add focused regression tests in `backend/tests/test_tool_progress_dedup.py` that cover both skipping identical progress updates and allowing status changes that should be broadcast.

### Testing
- Ran `pytest backend/tests/test_tool_progress_dedup.py backend/tests/test_slack_sync_activities.py` and all tests passed.
- The new tests verify that duplicate in-progress updates are skipped (no DB commit and no broadcast) and that status transitions with the same payload are applied and broadcast.
- Existing Slack sync activity tests were executed alongside the new tests and succeeded, confirming no regression in that area.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bca4cd981c83218114c4a76b776f23)