### PR TITLE
Deduplicate messenger tool status posts

### DIFF
--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -571,6 +571,7 @@ class WorkspaceMessenger(BaseMessenger):
         current_text: str = ""
         total_length: int = 0
         last_flush_at: float = time.monotonic()
+        posted_tool_statuses: dict[str, tuple[str, str]] = {}
 
         async def _flush(*, reason: str, force: bool = False) -> None:
             nonlocal current_text, total_length, last_flush_at
@@ -604,7 +605,14 @@ class WorkspaceMessenger(BaseMessenger):
             ):
                 if chunk.startswith("{"):
                     await _flush(reason="tool_boundary", force=True)
-                    await self._handle_json_chunk(chunk, channel_id, thread_id, workspace_id, organization_id)
+                    await self._handle_json_chunk(
+                        chunk,
+                        channel_id,
+                        thread_id,
+                        workspace_id,
+                        organization_id,
+                        posted_tool_statuses=posted_tool_statuses,
+                    )
                 else:
                     current_text += chunk
                     buf_len: int = len(current_text)
@@ -630,6 +638,8 @@ class WorkspaceMessenger(BaseMessenger):
         thread_id: str | None,
         workspace_id: str | None,
         organization_id: str | None,
+        *,
+        posted_tool_statuses: dict[str, tuple[str, str]] | None = None,
     ) -> None:
         """Process a JSON orchestrator chunk (artifacts, apps, etc.). Post tool status when present."""
         try:
@@ -641,7 +651,30 @@ class WorkspaceMessenger(BaseMessenger):
         status_text: str | None = data.get("status_text") if isinstance(data.get("status_text"), str) else None
         if not status_text or not status_text.strip():
             return
-        message: str = self.format_tool_status_for_display(status_text.strip())
+        normalized_status_text: str = status_text.strip()
+        tool_status: str = data.get("status") if isinstance(data.get("status"), str) else "running"
+        dedup_key: str = (
+            data.get("tool_id")
+            if isinstance(data.get("tool_id"), str) and data.get("tool_id")
+            else data.get("tool_name")
+            if isinstance(data.get("tool_name"), str) and data.get("tool_name")
+            else normalized_status_text
+        )
+        last_posted_status: tuple[str, str] | None = None
+        if posted_tool_statuses is not None:
+            last_posted_status = posted_tool_statuses.get(dedup_key)
+        if last_posted_status == (tool_status, normalized_status_text):
+            logger.info(
+                "[%s] Skipping duplicate tool status message key=%s status=%s text=%s",
+                self.meta.slug,
+                dedup_key,
+                tool_status,
+                normalized_status_text,
+            )
+            return
+        message: str = self.format_tool_status_for_display(normalized_status_text)
+        if posted_tool_statuses is not None:
+            posted_tool_statuses[dedup_key] = (tool_status, normalized_status_text)
 
         async def _post() -> None:
             try:

--- a/backend/tests/test_workspace_tool_status_dedup.py
+++ b/backend/tests/test_workspace_tool_status_dedup.py
@@ -1,0 +1,144 @@
+import asyncio
+import json
+
+from messengers._workspace import WorkspaceMessenger
+from messengers.base import MessengerMeta, ResponseMode
+
+
+class _TestWorkspaceMessenger(WorkspaceMessenger):
+    meta = MessengerMeta(
+        name="Test",
+        slug="test",
+        response_mode=ResponseMode.STREAMING,
+    )
+
+    def __init__(self) -> None:
+        self.posted_messages: list[dict[str, str | None]] = []
+
+    async def resolve_organization(self, user, message):  # type: ignore[override]
+        raise NotImplementedError
+
+    async def find_or_create_conversation(self, organization_id, user, message):  # type: ignore[override]
+        raise NotImplementedError
+
+    async def download_attachments(self, message):  # type: ignore[override]
+        raise NotImplementedError
+
+    def format_text(self, markdown: str) -> str:
+        return markdown
+
+    async def post_message(
+        self,
+        channel_id: str,
+        text: str,
+        thread_id: str | None = None,
+        *,
+        workspace_id: str | None = None,
+        organization_id: str | None = None,
+    ) -> str | None:
+        self.posted_messages.append(
+            {
+                "channel_id": channel_id,
+                "text": text,
+                "thread_id": thread_id,
+                "workspace_id": workspace_id,
+                "organization_id": organization_id,
+            }
+        )
+        return "posted"
+
+
+def test_handle_json_chunk_skips_duplicate_running_tool_status_messages() -> None:
+    messenger = _TestWorkspaceMessenger()
+    posted_tool_statuses: dict[str, tuple[str, str]] = {}
+    chunk = json.dumps(
+        {
+            "type": "tool_call",
+            "tool_id": "tool-123",
+            "tool_name": "get_connector_docs",
+            "status": "running",
+            "status_text": "Reading Linear docs",
+        }
+    )
+
+    async def _run() -> None:
+        await messenger._handle_json_chunk(
+            chunk,
+            channel_id="C123",
+            thread_id="thread-1",
+            workspace_id="T123",
+            organization_id="org-1",
+            posted_tool_statuses=posted_tool_statuses,
+        )
+        await asyncio.sleep(0)
+        await messenger._handle_json_chunk(
+            chunk,
+            channel_id="C123",
+            thread_id="thread-1",
+            workspace_id="T123",
+            organization_id="org-1",
+            posted_tool_statuses=posted_tool_statuses,
+        )
+        await asyncio.sleep(0)
+
+    asyncio.run(_run())
+
+    assert messenger.posted_messages == [
+        {
+            "channel_id": "C123",
+            "text": "Reading Linear docs",
+            "thread_id": "thread-1",
+            "workspace_id": "T123",
+            "organization_id": "org-1",
+        }
+    ]
+
+
+def test_handle_json_chunk_allows_same_status_text_after_status_change() -> None:
+    messenger = _TestWorkspaceMessenger()
+    posted_tool_statuses: dict[str, tuple[str, str]] = {}
+    running_chunk = json.dumps(
+        {
+            "type": "tool_call",
+            "tool_id": "tool-456",
+            "tool_name": "get_connector_docs",
+            "status": "running",
+            "status_text": "Reading Linear docs",
+        }
+    )
+    complete_chunk = json.dumps(
+        {
+            "type": "tool_call",
+            "tool_id": "tool-456",
+            "tool_name": "get_connector_docs",
+            "status": "complete",
+            "status_text": "Reading Linear docs",
+        }
+    )
+
+    async def _run() -> None:
+        await messenger._handle_json_chunk(
+            running_chunk,
+            channel_id="C123",
+            thread_id="thread-1",
+            workspace_id="T123",
+            organization_id="org-1",
+            posted_tool_statuses=posted_tool_statuses,
+        )
+        await asyncio.sleep(0)
+        await messenger._handle_json_chunk(
+            complete_chunk,
+            channel_id="C123",
+            thread_id="thread-1",
+            workspace_id="T123",
+            organization_id="org-1",
+            posted_tool_statuses=posted_tool_statuses,
+        )
+        await asyncio.sleep(0)
+
+    asyncio.run(_run())
+
+    assert [message["text"] for message in messenger.posted_messages] == [
+        "Reading Linear docs",
+        "Reading Linear docs",
+    ]


### PR DESCRIPTION
### Motivation

- Prevent duplicate in-progress tool status messages (e.g. "Reading Linear docs… Reading Linear docs…") from being posted during streaming delivery. 
- Duplicate `tool_call` events were produced by the orchestrator and the messenger posted each one, causing noisy repeated Slack messages. 
- Keep UI behavior intact by only suppressing exact duplicate postings while allowing legitimate status transitions to still be posted.

### Description

- Track per-stream posted tool statuses with a `posted_tool_statuses` dict in `WorkspaceMessenger.stream_and_post_responses` and pass it into `_handle_json_chunk`. 
- Compute a `dedup_key` (prefer `tool_id`, then `tool_name`, then the normalized status text) and skip posting when the last posted tuple equals `(status, status_text)`. 
- Update the recorded last-posted tuple after posting so future identical updates are suppressed but different status transitions (e.g. `running` → `complete`) are allowed. 
- Add regression tests in `backend/tests/test_workspace_tool_status_dedup.py` that verify duplicate running-status suppression and that the same status text is reposted after a status change.

### Testing

- Ran `pytest -q tests/test_workspace_tool_status_dedup.py tests/test_tool_progress_dedup.py` and all tests passed (`4 passed`). 
- New tests exercise `WorkspaceMessenger._handle_json_chunk` behavior for duplicate suppression and status transitions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bca71b02b88321892df21e7d79c739)