### PR TITLE
Disallow organization-scoped memories with clear error message

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -271,7 +271,8 @@ You have access to the user's CRM data, emails, calendar, meeting transcripts, a
 
 ## Context Gathering
 
-You have a rich profile system with three levels: personal (user), organization, and job role.
+You have a rich profile system with two memory levels: personal (user) and job role.
+Organization-level memories are not allowed and must never be stored.
 Each level's memories are injected into this prompt under "Context Profile" when available.
 
 ### Structured fields vs. memories

--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -622,6 +622,8 @@ Memories are scoped via entity_type:
 - "user": Personal facts/preferences (default).
 - "organization_member": Facts about the user's specific role.
 
+Organization-scoped memories are not allowed.
+
 Use when the user asks you to "remember" or "forget" something, or when a saved memory needs revision.
 Each memory should be a single, self-contained statement. Do NOT save conversation-specific context.""",
     input_schema={
@@ -644,7 +646,7 @@ Each memory should be a single, self-contained statement. Do NOT save conversati
             "entity_type": {
                 "type": "string",
                 "enum": ["user", "organization_member"],
-                "description": "Scope level. Defaults to 'user'.",
+                "description": "Scope level. Defaults to 'user'. Organization-scoped memories are not allowed.",
                 "default": "user",
             },
             "category": {

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -5669,6 +5669,12 @@ async def execute_keep_notes(
 
 GLOBAL_COMMAND_CATEGORY = "global_commands"
 GLOBAL_COMMAND_MAX_LENGTH = 400
+SUPPORTED_MEMORY_ENTITY_TYPES = {"user", "organization_member"}
+ORG_LEVEL_MEMORY_ERROR = (
+    "Org-level memories are not allowed. "
+    "Use entity_type='user' for personal memories or "
+    "entity_type='organization_member' for role-specific memories."
+)
 
 
 def _normalize_memory_category(category: str | None) -> str | None:
@@ -5683,6 +5689,21 @@ def _normalize_memory_category(category: str | None) -> str | None:
 def _validate_memory_content_for_category(content: str, category: str | None) -> str | None:
     if category == GLOBAL_COMMAND_CATEGORY and len(content) > GLOBAL_COMMAND_MAX_LENGTH:
         return f"Global command memories must be {GLOBAL_COMMAND_MAX_LENGTH} characters or fewer."
+    return None
+
+
+def _validate_memory_entity_type(entity_type: str) -> str | None:
+    normalized_entity_type = entity_type.strip()
+    if not normalized_entity_type:
+        return "entity_type is required."
+    if normalized_entity_type == "organization":
+        logger.info("[Tools.manage_memory] Rejected org-level memory save attempt")
+        return ORG_LEVEL_MEMORY_ERROR
+    if normalized_entity_type not in SUPPORTED_MEMORY_ENTITY_TYPES:
+        return (
+            f"Invalid entity_type '{normalized_entity_type}'. "
+            "Must be 'user' or 'organization_member'."
+        )
     return None
 
 async def _manage_memory(
@@ -5711,8 +5732,9 @@ async def _save_memory(
         return {"error": "Cannot save memory without a user context."}
 
     entity_type: str = params.get("entity_type", "user").strip()
-    if entity_type not in ("user", "organization_member"):
-        return {"error": f"Invalid entity_type '{entity_type}'. Must be 'user' or 'organization_member'."}
+    entity_type_error = _validate_memory_entity_type(entity_type)
+    if entity_type_error:
+        return {"error": entity_type_error}
 
     if skip_approval:
         logger.info("[Tools._save_memory] Auto-approved, saving memory immediately")
@@ -5752,6 +5774,9 @@ async def execute_save_memory(
 
     entity_type: str = params.get("entity_type", "user").strip()
     category: str | None = _normalize_memory_category(params.get("category"))
+    entity_type_error = _validate_memory_entity_type(entity_type)
+    if entity_type_error:
+        return {"status": "failed", "error": entity_type_error}
     content_error = _validate_memory_content_for_category(content, category)
     if content_error:
         return {"status": "failed", "error": content_error}
@@ -5777,7 +5802,13 @@ async def execute_save_memory(
                 return {"status": "failed", "error": "No organization membership found for this user."}
             entity_id = membership_id
     else:
-        return {"status": "failed", "error": f"Invalid entity_type '{entity_type}'."}
+        return {
+            "status": "failed",
+            "error": (
+                f"Invalid entity_type '{entity_type}'. "
+                "Must be 'user' or 'organization_member'."
+            ),
+        }
 
     memory = Memory(
         entity_type=entity_type,

--- a/backend/tests/test_memory_policy.py
+++ b/backend/tests/test_memory_policy.py
@@ -1,0 +1,58 @@
+import asyncio
+import sys
+import types
+
+fake_websockets = types.ModuleType("api.websockets")
+
+
+async def _broadcast_sync_progress(*_args: object, **_kwargs: object) -> None:
+    return None
+
+
+fake_websockets.broadcast_sync_progress = _broadcast_sync_progress
+sys.modules.setdefault("api.websockets", fake_websockets)
+
+from agents.tools import (
+    ORG_LEVEL_MEMORY_ERROR,
+    _save_memory,
+    _validate_memory_entity_type,
+    execute_save_memory,
+)
+
+
+def test_validate_memory_entity_type_rejects_org_scope() -> None:
+    assert _validate_memory_entity_type("organization") == ORG_LEVEL_MEMORY_ERROR
+
+
+def test_save_memory_rejects_org_scope_with_coherent_error() -> None:
+    result = asyncio.run(
+        _save_memory(
+            params={
+                "content": "Remember this for everyone in the org",
+                "entity_type": "organization",
+            },
+            organization_id="00000000-0000-0000-0000-000000000010",
+            user_id="00000000-0000-0000-0000-000000000001",
+            skip_approval=False,
+        )
+    )
+
+    assert result == {"error": ORG_LEVEL_MEMORY_ERROR}
+
+
+def test_execute_save_memory_rejects_org_scope_before_db_work() -> None:
+    result = asyncio.run(
+        execute_save_memory(
+            params={
+                "content": "Remember this for everyone in the org",
+                "entity_type": "organization",
+            },
+            organization_id="00000000-0000-0000-0000-000000000010",
+            user_id="00000000-0000-0000-0000-000000000001",
+        )
+    )
+
+    assert result == {
+        "status": "failed",
+        "error": ORG_LEVEL_MEMORY_ERROR,
+    }


### PR DESCRIPTION
### Motivation
- Prevent storing org-level memories for security and data isolation by ensuring only per-user or org-member (role) memories are permitted.
- Provide a coherent, user-facing error when an agent or API call attempts to save an organization-scoped memory.

### Description
- Add a shared validator ` _validate_memory_entity_type` and constants `SUPPORTED_MEMORY_ENTITY_TYPES` and `ORG_LEVEL_MEMORY_ERROR` to centralize entity-type checks in `backend/agents/tools.py`.
- Enforce the validator in both the pre-approval path (`_save_memory`) and the post-approval persistence path (`execute_save_memory`) so org-scoped writes are rejected consistently.
- Update the `manage_memory` tool metadata in `backend/agents/registry.py` and the orchestrator guidance in `backend/agents/orchestrator.py` to document that only `user` and `organization_member` scopes are allowed and that organization-scoped memories are forbidden.
- Add targeted tests in `backend/tests/test_memory_policy.py` that assert the validator and both save paths return the coherent `ORG_LEVEL_MEMORY_ERROR` when `entity_type == "organization"` is attempted.

### Testing
- Ran `pytest -q backend/tests/test_memory_policy.py backend/tests/test_workflow_permissions.py` and all tests passed (`9 passed`).
- Ran `python -m compileall backend/agents/tools.py backend/agents/registry.py backend/agents/orchestrator.py backend/tests/test_memory_policy.py` to verify bytecode compilation with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdc19cd58c8321b0ed7ee8acc42bc6)