### PR TITLE
Allow credit use during pending billing

### DIFF
--- a/backend/services/credits.py
+++ b/backend/services/credits.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 ACTIVE_SUBSCRIPTION_STATUSES: frozenset[str] = frozenset({"active", "trialing"})
+PENDING_BILLING_STATUSES: frozenset[str] = frozenset({"incomplete", "past_due", "unpaid"})
 
 
 async def get_balance(organization_id: str) -> int:
@@ -54,10 +55,41 @@ MIN_CREDITS_TO_START: int = 5
 
 
 async def can_use_credits(organization_id: str) -> bool:
-    """Return True if the org has an active subscription and enough credits to start a task."""
-    if not await has_active_subscription(organization_id):
-        return False
-    return await get_balance(organization_id) >= MIN_CREDITS_TO_START
+    """Return True when the org can spend existing credits to start a task."""
+    async with get_admin_session() as session:
+        result = await session.execute(
+            select(
+                Organization.subscription_status,
+                Organization.credits_balance,
+            ).where(Organization.id == UUID(organization_id))
+        )
+        row = result.one_or_none()
+        if row is None:
+            logger.warning(
+                "[Credits] can_use_credits: organization %s not found",
+                organization_id,
+            )
+            return False
+
+        status: str = (row.subscription_status or "").strip().lower()
+        balance: int = int(row.credits_balance or 0)
+        has_minimum_balance = balance >= MIN_CREDITS_TO_START
+        status_allows_queries = (
+            status in ACTIVE_SUBSCRIPTION_STATUSES
+            or (status in PENDING_BILLING_STATUSES and has_minimum_balance)
+        )
+        logger.info(
+            (
+                "[Credits] can_use_credits: org=%s status=%s balance=%d "
+                "has_minimum_balance=%s status_allows_queries=%s"
+            ),
+            organization_id,
+            status or "<none>",
+            balance,
+            has_minimum_balance,
+            status_allows_queries,
+        )
+        return status_allows_queries and has_minimum_balance
 
 
 async def check_sufficient(organization_id: str, amount: int) -> bool:
@@ -159,7 +191,10 @@ async def deduct_with_grace(
         )
         org: Organization | None = result.scalar_one_or_none()
         if org is None:
-            logger.warning("[Credits] deduct_with_grace: organization %s not found", organization_id)
+            logger.warning(
+                "[Credits] deduct_with_grace: organization %s not found",
+                organization_id,
+            )
             return False, False
 
         current: int = int(org.credits_balance)

--- a/backend/tests/test_credits_access.py
+++ b/backend/tests/test_credits_access.py
@@ -1,0 +1,79 @@
+import asyncio
+from types import SimpleNamespace
+
+from services import credits
+
+
+class _ExecResult:
+    def __init__(self, row):
+        self._row = row
+
+    def one_or_none(self):
+        return self._row
+
+
+class _FakeSession:
+    def __init__(self, row):
+        self._row = row
+
+    async def execute(self, _query):
+        return _ExecResult(self._row)
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_can_use_credits_allows_pending_billing_with_balance(monkeypatch) -> None:
+    row = SimpleNamespace(
+        subscription_status="past_due",
+        credits_balance=credits.MIN_CREDITS_TO_START,
+    )
+    monkeypatch.setattr(
+        credits,
+        "get_admin_session",
+        lambda: _FakeSessionContext(_FakeSession(row)),
+    )
+
+    allowed = asyncio.run(credits.can_use_credits("00000000-0000-0000-0000-000000000001"))
+
+    assert allowed is True
+
+
+def test_can_use_credits_blocks_pending_billing_without_enough_balance(monkeypatch) -> None:
+    row = SimpleNamespace(
+        subscription_status="past_due",
+        credits_balance=credits.MIN_CREDITS_TO_START - 1,
+    )
+    monkeypatch.setattr(
+        credits,
+        "get_admin_session",
+        lambda: _FakeSessionContext(_FakeSession(row)),
+    )
+
+    allowed = asyncio.run(credits.can_use_credits("00000000-0000-0000-0000-000000000001"))
+
+    assert allowed is False
+
+
+def test_can_use_credits_blocks_canceled_subscription_even_with_balance(monkeypatch) -> None:
+    row = SimpleNamespace(
+        subscription_status="canceled",
+        credits_balance=credits.MIN_CREDITS_TO_START + 20,
+    )
+    monkeypatch.setattr(
+        credits,
+        "get_admin_session",
+        lambda: _FakeSessionContext(_FakeSession(row)),
+    )
+
+    allowed = asyncio.run(credits.can_use_credits("00000000-0000-0000-0000-000000000001"))
+
+    assert allowed is False


### PR DESCRIPTION
### Motivation
- Organizations in certain Stripe states (e.g. `past_due`, `incomplete`, `unpaid`) should still be able to start queries if they have sufficient on-account credits.

### Description
- Add `PENDING_BILLING_STATUSES` and update `can_use_credits` in `backend/services/credits.py` to do a single DB lookup for `subscription_status` and `credits_balance` and make the gating decision based on status plus `MIN_CREDITS_TO_START`.
- Allow queries when `subscription_status` is in `ACTIVE_SUBSCRIPTION_STATUSES` or in `PENDING_BILLING_STATUSES` provided the org has the minimum required credits, otherwise block (canceled/non-allowed statuses remain blocked).
- Add structured logging for the decision inputs (`org id`, `status`, `balance`, `has_minimum_balance`, `status_allows_queries`) to aid debugging.
- Add focused unit tests `backend/tests/test_credits_access.py` to cover pending billing with enough balance (allowed), pending billing without enough balance (blocked), and canceled subscription (blocked).

### Testing
- Ran `pytest -q tests/test_credits_access.py` which completed successfully (`3 passed`).
- Ran `python -m py_compile backend/services/credits.py backend/tests/test_credits_access.py` which succeeded (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdc087224c8321a5d25198a7be6b70)