### PR TITLE
Block org-level memory saves

### DIFF
--- a/backend/agents/memory_guardrails.py
+++ b/backend/agents/memory_guardrails.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+ORG_LEVEL_MEMORY_ENTITY_TYPES = {
+    "org",
+    "org_level",
+    "organization",
+    "organization-level",
+    "organization_level",
+    "team",
+    "workspace",
+    "company",
+}
+ORG_LEVEL_MEMORY_ERROR = (
+    "Organization-level memories are not allowed. "
+    "I can only save memories for an individual user or their organization-member role."
+)
+
+
+def normalize_memory_entity_type(entity_type: Any) -> str:
+    if entity_type is None:
+        return "user"
+    return str(entity_type).strip().lower()
+
+
+def validate_memory_entity_type(entity_type: str) -> str | None:
+    if entity_type in ORG_LEVEL_MEMORY_ENTITY_TYPES:
+        logger.info("[MemoryGuardrails] Blocked org-level memory attempt for entity_type=%s", entity_type)
+        return ORG_LEVEL_MEMORY_ERROR
+    if entity_type not in ("user", "organization_member"):
+        return (
+            f"Invalid entity_type '{entity_type}'. "
+            "Must be 'user' or 'organization_member'."
+        )
+    return None

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -298,7 +298,8 @@ goes into the `memories` table as free-text.
 - Job title → structured column (`org_members.title`)
 - Reporting relationship → structured column (`org_members.reports_to_membership_id`)
 - Phone number → collect it in E.164 format and store it as a user memory via `manage_memory` (do not write to `users` directly)
-- Everything else (preferences, responsibilities, projects, company facts) → `manage_memory`
+- Personal preferences/details and role-specific responsibilities/projects → `manage_memory`
+- Company/org/workspace facts → do NOT save as memory; explain that organization-level memories are not allowed
 
 ### When and what to ask
 
@@ -324,6 +325,8 @@ Do not use `run_sql_write` against the `users` table for phone updates. Persist 
 - Never ask more than 2 context-gathering questions per conversation.
 - Be natural — weave questions into the conversation flow rather than interrogating.
 - If the user volunteers information unprompted, save it as a memory at the appropriate level.
+- If the user asks you to remember something about the whole company/org/workspace, do not call `manage_memory`;
+  reply with a clear explanation that organization-level memories are not allowed.
 - When the user shares a job title (theirs or a colleague's), ALWAYS set the structured column
   via `run_sql_write` in addition to saving a memory if there are other details worth remembering.
 - Use `manage_memory` with `action="update"` when existing information becomes stale (e.g. user got promoted, project completed).

--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -622,6 +622,9 @@ Memories are scoped via entity_type:
 - "user": Personal facts/preferences (default).
 - "organization_member": Facts about the user's specific role.
 
+Organization-level memories are not supported. If a user asks to remember something about the whole org/company/workspace,
+explain that only user-level or organization-member-level memories can be saved.
+
 Use when the user asks you to "remember" or "forget" something, or when a saved memory needs revision.
 Each memory should be a single, self-contained statement. Do NOT save conversation-specific context.""",
     input_schema={

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -42,6 +42,10 @@ from models.tracker_team import TrackerTeam
 
 # Import the unified tool registry
 from agents.registry import get_tools_for_claude, get_tool, requires_approval
+from agents.memory_guardrails import (
+    normalize_memory_entity_type,
+    validate_memory_entity_type,
+)
 from access_control import (
     ConnectorContext,
     RightsContext,
@@ -5710,9 +5714,10 @@ async def _save_memory(
     if not user_id:
         return {"error": "Cannot save memory without a user context."}
 
-    entity_type: str = params.get("entity_type", "user").strip()
-    if entity_type not in ("user", "organization_member"):
-        return {"error": f"Invalid entity_type '{entity_type}'. Must be 'user' or 'organization_member'."}
+    entity_type = normalize_memory_entity_type(params.get("entity_type", "user"))
+    entity_type_error = validate_memory_entity_type(entity_type)
+    if entity_type_error:
+        return {"error": entity_type_error}
 
     if skip_approval:
         logger.info("[Tools._save_memory] Auto-approved, saving memory immediately")
@@ -5750,7 +5755,10 @@ async def execute_save_memory(
     if not content:
         return {"status": "failed", "error": "content is required."}
 
-    entity_type: str = params.get("entity_type", "user").strip()
+    entity_type = normalize_memory_entity_type(params.get("entity_type", "user"))
+    entity_type_error = validate_memory_entity_type(entity_type)
+    if entity_type_error:
+        return {"status": "failed", "error": entity_type_error}
     category: str | None = _normalize_memory_category(params.get("category"))
     content_error = _validate_memory_content_for_category(content, category)
     if content_error:

--- a/backend/tests/test_memory_guardrails.py
+++ b/backend/tests/test_memory_guardrails.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from agents.memory_guardrails import (
+    ORG_LEVEL_MEMORY_ERROR,
+    normalize_memory_entity_type,
+    validate_memory_entity_type,
+)
+
+
+def test_validate_memory_entity_type_rejects_org_level_scope() -> None:
+    assert validate_memory_entity_type("organization") == ORG_LEVEL_MEMORY_ERROR
+    assert validate_memory_entity_type("workspace") == ORG_LEVEL_MEMORY_ERROR
+
+
+def test_normalize_memory_entity_type_defaults_to_user() -> None:
+    assert normalize_memory_entity_type(None) == "user"
+    assert normalize_memory_entity_type(" Organization_Member ") == "organization_member"
+
+
+def test_tools_module_uses_memory_entity_type_guardrail() -> None:
+    tools_source = Path("backend/agents/tools.py").read_text()
+
+    assert "validate_memory_entity_type(entity_type)" in tools_source
+    assert "normalize_memory_entity_type(params.get(\"entity_type\", \"user\"))" in tools_source


### PR DESCRIPTION
### Motivation
- Prevent saving organization-wide memories and surface a clear, user-facing error when such an attempt is made.
- Centralize the guardrail so the restriction is reusable and consistently enforced both before approval and at persistence time.

### Description
- Add `backend/agents/memory_guardrails.py` introducing `ORG_LEVEL_MEMORY_ENTITY_TYPES`, `ORG_LEVEL_MEMORY_ERROR`, `normalize_memory_entity_type`, and `validate_memory_entity_type` to centralize the org-level memory policy.
- Enforce the guardrail in the `manage_memory` flow by wiring the new helpers into `backend/agents/tools.py` for both the pre-approval `_save_memory` path and the post-approval `execute_save_memory` path.
- Update documentation/prompts so the agent explains organization-level memories are not supported by changing `backend/agents/registry.py` and `backend/agents/orchestrator.py` guidance.
- Add `backend/tests/test_memory_guardrails.py` to validate the guardrail helpers and to assert the tools module uses the guardrail.

### Testing
- Ran `pytest backend/tests/test_memory_guardrails.py backend/tests/test_workflow_permissions.py` which executed the targeted test suite.
- All tests passed: `9 passed` (ran in ~1.58s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdc19cd58c8321b0ed7ee8acc42bc6)