### PR TITLE
Allow canceled orgs to spend credits

### DIFF
--- a/backend/services/credits.py
+++ b/backend/services/credits.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 ACTIVE_SUBSCRIPTION_STATUSES: frozenset[str] = frozenset({"active", "trialing"})
 PENDING_BILLING_STATUSES: frozenset[str] = frozenset({"incomplete", "past_due", "unpaid"})
+BALANCE_ONLY_SUBSCRIPTION_STATUSES: frozenset[str] = frozenset({"canceled"})
 
 
 async def get_balance(organization_id: str) -> int:
@@ -77,6 +78,7 @@ async def can_use_credits(organization_id: str) -> bool:
         status_allows_queries = (
             status in ACTIVE_SUBSCRIPTION_STATUSES
             or (status in PENDING_BILLING_STATUSES and has_minimum_balance)
+            or (status in BALANCE_ONLY_SUBSCRIPTION_STATUSES and has_minimum_balance)
         )
         logger.info(
             (

--- a/backend/tests/test_credits_access.py
+++ b/backend/tests/test_credits_access.py
@@ -63,10 +63,26 @@ def test_can_use_credits_blocks_pending_billing_without_enough_balance(monkeypat
     assert allowed is False
 
 
-def test_can_use_credits_blocks_canceled_subscription_even_with_balance(monkeypatch) -> None:
+def test_can_use_credits_allows_canceled_subscription_with_balance(monkeypatch) -> None:
     row = SimpleNamespace(
         subscription_status="canceled",
         credits_balance=credits.MIN_CREDITS_TO_START + 20,
+    )
+    monkeypatch.setattr(
+        credits,
+        "get_admin_session",
+        lambda: _FakeSessionContext(_FakeSession(row)),
+    )
+
+    allowed = asyncio.run(credits.can_use_credits("00000000-0000-0000-0000-000000000001"))
+
+    assert allowed is True
+
+
+def test_can_use_credits_blocks_canceled_subscription_without_enough_balance(monkeypatch) -> None:
+    row = SimpleNamespace(
+        subscription_status="canceled",
+        credits_balance=credits.MIN_CREDITS_TO_START - 1,
     )
     monkeypatch.setattr(
         credits,


### PR DESCRIPTION
### Motivation
- Organizations with a `canceled` subscription should still be able to start queries/tasks if they maintain the minimum credit balance rather than being blocked unconditionally.
- Preserve the existing minimum-balance gate so only orgs with sufficient credits can start work.
- Add regression coverage for both allowed and blocked cases for `canceled` subscriptions.

### Description
- Introduce `BALANCE_ONLY_SUBSCRIPTION_STATUSES` and include `"canceled"` in that set in `backend/services/credits.py`.
- Update `can_use_credits` to permit query access for `canceled` orgs when `balance >= MIN_CREDITS_TO_START` by extending the `status_allows_queries` condition.
- Update `backend/tests/test_credits_access.py` to assert that a `canceled` org is allowed when above the minimum balance and blocked when below it.

### Testing
- Ran `pytest -q tests/test_credits_access.py`, which passed (`4 passed`).
- Compiled the modified module with `python -m compileall services/credits.py` to validate syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdc600d9bc8321930dcd14ea5ac36f)