### PR TITLE
Block package installation commands in code sandbox

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -31,6 +31,7 @@ from openai import AsyncOpenAI
 from sqlalchemy import select, text
 
 from config import settings
+from connectors.code_sandbox import get_blocked_package_install_reason
 from models.account import Account
 from models.conversation import Conversation
 from models.contact import Contact
@@ -6579,12 +6580,16 @@ async def _execute_command(
 ) -> dict[str, Any]:
     """Execute a shell command in a persistent E2B sandbox."""
 
-    if not settings.E2B_API_KEY:
-        return {"error": "E2B_API_KEY is not configured. Cannot run sandboxed commands."}
-
     command: str = params.get("command", "").strip()
     if not command:
         return {"error": "No command provided."}
+
+    blocked_reason: str | None = get_blocked_package_install_reason(command)
+    if blocked_reason:
+        return {"error": blocked_reason}
+
+    if not settings.E2B_API_KEY:
+        return {"error": "E2B_API_KEY is not configured. Cannot run sandboxed commands."}
 
     conversation_id: str | None = (context or {}).get("conversation_id")
     if not conversation_id:

--- a/backend/connectors/code_sandbox.py
+++ b/backend/connectors/code_sandbox.py
@@ -7,6 +7,7 @@ The sandbox persists across calls within a conversation.
 
 import asyncio
 import logging
+import re
 from typing import Any
 
 from config import settings
@@ -24,6 +25,43 @@ logger = logging.getLogger(__name__)
 _SANDBOX_TIMEOUT_SECONDS: int = 1800
 _COMMAND_TIMEOUT_SECONDS: float = 120
 _MAX_OUTPUT_LENGTH: int = 50_000
+
+_PACKAGE_INSTALL_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(^|[;&|()\s])npm\s+(?:install|i)\b", re.IGNORECASE), "npm install"),
+    (re.compile(r"(^|[;&|()\s])yarn\s+(?:global\s+add|add|install)\b", re.IGNORECASE), "yarn add/install"),
+    (re.compile(r"(^|[;&|()\s])pnpm\s+(?:add|install)\b", re.IGNORECASE), "pnpm add/install"),
+    (re.compile(r"(^|[;&|()\s])bun\s+(?:add|install)\b", re.IGNORECASE), "bun add/install"),
+    (re.compile(r"(^|[;&|()\s])pip(?:3)?\s+install\b", re.IGNORECASE), "pip install"),
+    (re.compile(r"(^|[;&|()\s])python(?:3)?\s+-m\s+pip\s+install\b", re.IGNORECASE), "python -m pip install"),
+    (re.compile(r"(^|[;&|()\s])uv\s+(?:pip\s+install|add)\b", re.IGNORECASE), "uv pip install/add"),
+    (re.compile(r"(^|[;&|()\s])poetry\s+(?:add|install)\b", re.IGNORECASE), "poetry add/install"),
+    (re.compile(r"(^|[;&|()\s])pipx\s+install\b", re.IGNORECASE), "pipx install"),
+    (re.compile(r"(^|[;&|()\s])apt(?:-get)?\s+install\b", re.IGNORECASE), "apt install"),
+    (re.compile(r"(^|[;&|()\s])apk\s+add\b", re.IGNORECASE), "apk add"),
+    (re.compile(r"(^|[;&|()\s])yum\s+install\b", re.IGNORECASE), "yum install"),
+    (re.compile(r"(^|[;&|()\s])dnf\s+install\b", re.IGNORECASE), "dnf install"),
+    (re.compile(r"(^|[;&|()\s])brew\s+install\b", re.IGNORECASE), "brew install"),
+    (re.compile(r"(^|[;&|()\s])pacman\s+-S\b", re.IGNORECASE), "pacman -S"),
+)
+
+_PACKAGE_INSTALL_BLOCK_MESSAGE: str = (
+    "Installing packages inside the code sandbox is disabled. "
+    "Use the preinstalled runtimes and libraries only."
+)
+
+
+def get_blocked_package_install_reason(command: str) -> str | None:
+    """Return a user-facing reason when a sandbox command installs packages."""
+    normalized_command: str = command.strip()
+    if not normalized_command:
+        return None
+
+    for pattern, label in _PACKAGE_INSTALL_PATTERNS:
+        if pattern.search(normalized_command):
+            logger.info("[Sandbox] Blocked package installation attempt via %s", label)
+            return f"{_PACKAGE_INSTALL_BLOCK_MESSAGE} Blocked command pattern: {label}."
+
+    return None
 
 _SANDBOX_DB_HELPER_TEMPLATE: str = """
 import os
@@ -56,7 +94,7 @@ class CodeSandboxConnector(BaseConnector):
             ConnectorAction(
                 name="execute_command",
                 description=(
-                    "Run a shell command in a persistent Linux sandbox (Debian, Python3, Node, pip). "
+                    "Run a shell command in a persistent Linux sandbox (Debian, Python3, Node, preinstalled libraries). "
                     "Files in /home/user/output/ are returned as artifacts. "
                     "A read-only DB connection is at $DATABASE_URL. Use `from db import get_connection`."
                 ),
@@ -94,12 +132,16 @@ class CodeSandboxConnector(BaseConnector):
         return await self._execute_command(params)
 
     async def _execute_command(self, params: dict[str, Any]) -> dict[str, Any]:
-        if not settings.E2B_API_KEY:
-            return {"error": "E2B_API_KEY is not configured. Cannot run sandboxed commands."}
-
         command: str = (params.get("command") or "").strip()
         if not command:
             return {"error": "No command provided."}
+
+        blocked_reason: str | None = get_blocked_package_install_reason(command)
+        if blocked_reason:
+            return {"error": blocked_reason}
+
+        if not settings.E2B_API_KEY:
+            return {"error": "E2B_API_KEY is not configured. Cannot run sandboxed commands."}
 
         conversation_id: str | None = params.get("conversation_id")
         if not conversation_id:

--- a/backend/scripts/test_sandbox.py
+++ b/backend/scripts/test_sandbox.py
@@ -60,7 +60,7 @@ async def main() -> None:
         print(f"\nFailed: {r1['error']}")
         return
 
-    print("\n=== Test 2: Install pandas + query DB ===")
+    print("\n=== Test 2: Package installs are blocked ===")
     r2 = await execute_tool(
         "execute_command",
         {"command": "pip install -q pandas psycopg2-binary"},
@@ -68,7 +68,7 @@ async def main() -> None:
         user_id=None,
         context=context,
     )
-    print(f"exit_code={r2.get('exit_code')}")
+    print(json.dumps(r2, indent=2, default=str))
 
     print("\n=== Test 3: Run Python with DB access ===")
     r3 = await execute_tool(

--- a/backend/tests/test_code_sandbox_command_policy.py
+++ b/backend/tests/test_code_sandbox_command_policy.py
@@ -1,0 +1,47 @@
+import pytest
+
+from connectors.code_sandbox import CodeSandboxConnector, get_blocked_package_install_reason
+
+
+def test_get_blocked_package_install_reason_allows_non_install_commands() -> None:
+    assert get_blocked_package_install_reason("python3 -c 'print(1)'") is None
+    assert get_blocked_package_install_reason("npm run build") is None
+
+
+def test_get_blocked_package_install_reason_blocks_common_package_managers() -> None:
+    commands = [
+        "npm install lodash",
+        "yarn add react",
+        "pnpm install zod",
+        "bun add hono",
+        "pip install pandas",
+        "python3 -m pip install numpy",
+        "uv pip install polars",
+        "poetry add requests",
+        "apt-get install jq",
+        "apk add curl",
+        "brew install wget",
+    ]
+
+    for command in commands:
+        reason = get_blocked_package_install_reason(command)
+        assert reason is not None
+        assert "disabled" in reason
+
+
+@pytest.mark.asyncio
+async def test_execute_action_rejects_package_install_before_sandbox_use() -> None:
+    connector = CodeSandboxConnector(organization_id="org_123")
+
+    result = await connector.execute_action(
+        "execute_command",
+        {"command": "npm install react", "conversation_id": "conv_123"},
+    )
+
+    assert result == {
+        "error": (
+            "Installing packages inside the code sandbox is disabled. "
+            "Use the preinstalled runtimes and libraries only. "
+            "Blocked command pattern: npm install."
+        )
+    }


### PR DESCRIPTION
### Motivation
- Prevent users or agents from installing arbitrary packages inside the code sandbox, which can introduce security and supply-chain risks. 
- Ensure the restriction cannot be bypassed via the legacy direct `execute_command` tool path. 

### Description
- Add a shared command-policy helper `get_blocked_package_install_reason` in `backend/connectors/code_sandbox.py` that detects common package-manager install/add patterns (npm, yarn, pnpm, bun, pip, uv, poetry, apt, brew, pacman, etc.) using regexes and returns a user-facing block reason. 
- Enforce the policy in the Code Sandbox connector by checking the command via `get_blocked_package_install_reason` before any sandbox creation or E2B checks. 
- Reuse the same helper in the legacy agent tool handler by importing and invoking `get_blocked_package_install_reason` in `backend/agents/tools.py` so the connector cannot be bypassed. 
- Add targeted tests in `backend/tests/test_code_sandbox_command_policy.py` that cover allowed commands, blocked package-manager commands, and connector-level rejection behavior, and update the manual sandbox test script `backend/scripts/test_sandbox.py` to reflect blocked installs. 

### Testing
- Ran `pytest backend/tests/test_code_sandbox_command_policy.py` and the targeted suite passed (`3 passed`).
- Verified syntax/compilation with `python -m py_compile backend/connectors/code_sandbox.py backend/agents/tools.py backend/scripts/test_sandbox.py backend/tests/test_code_sandbox_command_policy.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdc8895f108321b97d6606daafb6f5)