### PR TITLE
Hide org switcher chevron on mobile

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -178,6 +178,7 @@ function OrgSwitcherSection({
   onOpenOrgPanel,
   onOpenBilling,
   onCreateNewOrg,
+  isMobile,
 }: {
   organization: OrganizationInfo;
   members: AvatarUser[];
@@ -185,6 +186,7 @@ function OrgSwitcherSection({
   onOpenOrgPanel: () => void;
   onOpenBilling: () => void;
   onCreateNewOrg: () => void;
+  isMobile: boolean;
 }): JSX.Element {
   const organizations: UserOrganization[] = useAppStore((state) => state.organizations);
   const switchActiveOrganization = useAppStore((state) => state.switchActiveOrganization);
@@ -264,9 +266,11 @@ function OrgSwitcherSection({
               </div>
             )}
           </div>
-          <svg className="w-4 h-4 text-surface-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-          </svg>
+          {!isMobile && (
+            <svg className="w-4 h-4 text-surface-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
+          )}
         </button>
 
         {/* Org switcher dropdown — rendered in portal to escape overflow clipping */}
@@ -577,6 +581,7 @@ export function Sidebar({
           onOpenOrgPanel={onOpenOrgPanel}
           onOpenBilling={onOpenBilling}
           onCreateNewOrg={onCreateNewOrg}
+          isMobile={isMobile}
         />
       </div>
 
@@ -1007,4 +1012,3 @@ function ChatAccordion({
     </div>
   );
 }
-


### PR DESCRIPTION
### Motivation
- On mobile, the org switcher header should show minimal chrome so hide the down-arrow glyph next to the current organization to reduce visual clutter while preserving the dropdown behavior on desktop.

### Description
- Pass the existing `isMobile` state into `OrgSwitcherSection` and conditionally render the chevron only when `isMobile` is false in `frontend/src/components/Sidebar.tsx`.

### Testing
- Ran `npm run lint` which completed successfully. 
- Ran `timeout 120 npm run build` which completed successfully (Vite emitted existing chunk-size/dynamic-import warnings but the production build succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdc3cd898c8321a87fd0cd824f5b3f)