### PR TITLE
Require admin access to connect Code Sandbox connector

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -3252,7 +3252,10 @@ class ConnectBuiltinRequest(BaseModel):
 
 
 @router.post("/integrations/connect-builtin")
-async def connect_builtin(request: ConnectBuiltinRequest) -> dict[str, Any]:
+async def connect_builtin(
+    request: ConnectBuiltinRequest,
+    auth: AuthContext = Depends(get_current_auth),
+) -> dict[str, Any]:
     """
     Create an Integration row for a built-in connector (Web Search, Code Sandbox, Twilio).
 
@@ -3273,6 +3276,46 @@ async def connect_builtin(request: ConnectBuiltinRequest) -> dict[str, Any]:
         user_uuid = UUID(request.user_id)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid user ID")
+
+    if auth.user_id != user_uuid:
+        logger.warning(
+            "connect_builtin rejected due to mismatched user auth_user=%s request_user=%s provider=%s",
+            auth.user_id,
+            user_uuid,
+            request.provider,
+        )
+        raise HTTPException(status_code=403, detail="Authenticated user does not match requested user")
+
+    if auth.organization_id != org_uuid:
+        logger.warning(
+            "connect_builtin rejected due to mismatched org auth_org=%s request_org=%s provider=%s user=%s",
+            auth.organization_id,
+            org_uuid,
+            request.provider,
+            auth.user_id,
+        )
+        raise HTTPException(status_code=403, detail="Authenticated organization does not match requested organization")
+
+    async with get_admin_session() as guard_session:
+        requesting_user = await guard_session.get(User, user_uuid)
+        if not requesting_user or requesting_user.organization_id != org_uuid:
+            raise HTTPException(status_code=403, detail="Not authorized for this organization")
+        if requesting_user.is_guest:
+            raise HTTPException(status_code=403, detail="Guest users cannot connect integrations")
+        if request.provider == "code_sandbox" and not await _can_administer_org(
+            guard_session,
+            requesting_user,
+            org_uuid,
+        ):
+            logger.warning(
+                "connect_builtin rejected: code_sandbox requires org admin/global admin org=%s user=%s",
+                org_uuid,
+                user_uuid,
+            )
+            raise HTTPException(
+                status_code=403,
+                detail="Code Sandbox can only be connected by organization admins or global admins",
+            )
 
     # iSpot.tv: store client_id and client_secret in extra_data (client_credentials flow)
     connection_extra_data: dict[str, Any] | None = None

--- a/backend/tests/test_connect_builtin_authz.py
+++ b/backend/tests/test_connect_builtin_authz.py
@@ -1,0 +1,147 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+from fastapi import HTTPException
+
+from api.auth_middleware import AuthContext
+from api.routes import auth
+
+
+class _FakeSession:
+    def __init__(self, *, users):
+        self._users = users
+
+    async def get(self, _model, model_id):
+        return self._users.get(model_id)
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _make_auth_context(*, user_id: UUID, organization_id: UUID) -> AuthContext:
+    return AuthContext(
+        user_id=user_id,
+        organization_id=organization_id,
+        email="user@example.com",
+        role="member",
+        is_global_admin=False,
+    )
+
+
+def test_connect_builtin_rejects_code_sandbox_for_non_admin(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    user_id = UUID("22222222-2222-2222-2222-222222222222")
+    requester = SimpleNamespace(
+        id=user_id,
+        organization_id=org_id,
+        is_guest=False,
+        role="member",
+        roles=[],
+    )
+
+    monkeypatch.setattr(
+        auth,
+        "get_admin_session",
+        lambda: _FakeSessionContext(_FakeSession(users={user_id: requester})),
+    )
+
+    async def _deny_admin(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr(auth, "_can_administer_org", _deny_admin)
+
+    request = auth.ConnectBuiltinRequest(
+        organization_id=str(org_id),
+        provider="code_sandbox",
+        user_id=str(user_id),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            auth.connect_builtin(
+                request,
+                auth=_make_auth_context(user_id=user_id, organization_id=org_id),
+            )
+        )
+
+    assert exc.value.status_code == 403
+    assert "Code Sandbox" in exc.value.detail
+
+
+def test_connect_builtin_allows_web_search_for_non_admin(monkeypatch):
+    org_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    user_id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    requester = SimpleNamespace(
+        id=user_id,
+        organization_id=org_id,
+        is_guest=False,
+        role="member",
+        roles=[],
+    )
+
+    monkeypatch.setattr(
+        auth,
+        "get_admin_session",
+        lambda: _FakeSessionContext(_FakeSession(users={user_id: requester})),
+    )
+
+    async def _unexpected_admin_check(*_args, **_kwargs):
+        raise AssertionError("admin check should not run for web_search")
+
+    monkeypatch.setattr(auth, "_can_administer_org", _unexpected_admin_check)
+
+    class _ConnectSession:
+        def __init__(self):
+            self.executed = []
+            self.added = []
+            self.committed = False
+
+        async def execute(self, query, params=None):
+            self.executed.append((query, params))
+
+            class _EmptyResult:
+                def scalar_one_or_none(self_inner):
+                    return None
+
+            return _EmptyResult()
+
+        def add(self, integration):
+            self.added.append(integration)
+
+        async def commit(self):
+            self.committed = True
+
+    connect_session = _ConnectSession()
+    monkeypatch.setattr(
+        auth,
+        "get_session",
+        lambda organization_id=None: _FakeSessionContext(connect_session),
+    )
+
+    request = auth.ConnectBuiltinRequest(
+        organization_id=str(org_id),
+        provider="web_search",
+        user_id=str(user_id),
+    )
+
+    result = asyncio.run(
+        auth.connect_builtin(
+            request,
+            auth=_make_auth_context(user_id=user_id, organization_id=org_id),
+        )
+    )
+
+    assert result == {"status": "connected", "provider": "web_search"}
+    assert connect_session.committed is True
+    assert len(connect_session.added) == 1
+

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1022,15 +1022,20 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
                 });
               } else if (connectData.action === 'connect_builtin') {
                 // Connect built-in connector directly
-                fetch(`${API_BASE}/auth/integrations/connect-builtin`, {
+                void apiRequest<{ status: string; provider: string }>('/auth/integrations/connect-builtin', {
                   method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
                   body: JSON.stringify({
                     provider: connectData.provider,
                     organization_id: orgId,
+                    user_id: currentUserId,
                   }),
                 })
-                  .then(() => queryClient.invalidateQueries({ queryKey: ['integrations'] }))
+                  .then(({ error }) => {
+                    if (error) {
+                      throw new Error(error);
+                    }
+                    return queryClient.invalidateQueries({ queryKey: ['integrations'] });
+                  })
                   .catch((err) => console.error('Failed to connect builtin:', err));
               }
             } else if (data.type === 'context_usage') {

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -319,7 +319,7 @@ async function getResponseErrorMessage(response: Response, fallback: string): Pr
 
 export function DataSources(): JSX.Element {
   // Get user/org from Zustand (auth state)
-  const { user, organization } = useAppStore();
+  const { user, organization, organizations } = useAppStore();
   
   // Check if on mobile device
   const isMobile = useIsMobile();
@@ -492,6 +492,32 @@ export function DataSources(): JSX.Element {
 
   const organizationId = organization?.id ?? '';
   const userId = user?.id ?? '';
+  const activeMembership = organizations.find((org) => org.id === organizationId);
+  const canConnectCodeSandbox = (user?.roles.includes('global_admin') ?? false) || activeMembership?.role === 'admin';
+
+  const connectBuiltinConnector = useCallback(
+    async (
+      provider: string,
+      extraData?: Record<string, unknown> | null,
+    ): Promise<void> => {
+      const { data, error } = await apiRequest<{ status: string; provider: string }>(
+        '/auth/integrations/connect-builtin',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            organization_id: organizationId,
+            provider,
+            user_id: userId,
+            ...(extraData ? { extra_data: extraData } : {}),
+          }),
+        },
+      );
+      if (error || !data) {
+        throw new Error(error ?? 'Failed to connect');
+      }
+    },
+    [organizationId, userId],
+  );
 
   const slackIntegration = rawIntegrations.find((integration) => integration.provider === 'slack');
   const slackConnected = Boolean(slackIntegration?.isActive);
@@ -752,7 +778,7 @@ export function DataSources(): JSX.Element {
     };
   });
 
-  const handleConnect = async (provider: string): Promise<void> => {
+  const handleConnect = useCallback(async (provider: string): Promise<void> => {
     if (connectingProvider || !organizationId || !userId) return;
 
     setConnectingProvider(provider);
@@ -777,19 +803,10 @@ export function DataSources(): JSX.Element {
       }
 
       if (connectionFlow === 'builtin') {
-        const res = await fetch(`${API_BASE}/auth/integrations/connect-builtin`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            organization_id: organizationId,
-            provider,
-            user_id: userId,
-          }),
-        });
-        if (!res.ok) {
-          const err = await res.json().catch(() => ({ detail: res.statusText }));
-          throw new Error((err as { detail?: string }).detail ?? 'Failed to connect');
+        if (provider === 'code_sandbox' && !canConnectCodeSandbox) {
+          throw new Error('Code Sandbox can only be connected by organization admins or global admins');
         }
+        await connectBuiltinConnector(provider);
         void fetchIntegrations();
         setConnectingProvider(null);
         return;
@@ -870,9 +887,9 @@ export function DataSources(): JSX.Element {
       console.error('Failed to connect:', error);
       setConnectingProvider(null);
     }
-  };
+  }, [canConnectCodeSandbox, connectBuiltinConnector, connectingProvider, fetchIntegrations, getConnectorDisplay, organizationId, userId]);
 
-  const handleMcpConnect = async (): Promise<void> => {
+  const handleMcpConnect = useCallback(async (): Promise<void> => {
     if (!organizationId || !userId || mcpConnecting) return;
     const trimmedUrl: string = mcpEndpointUrl.trim();
     const trimmedName: string = mcpName.trim();
@@ -888,24 +905,11 @@ export function DataSources(): JSX.Element {
     setMcpConnecting(true);
     setMcpError(null);
     try {
-      const res: Response = await fetch(`${API_BASE}/auth/integrations/connect-builtin`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          organization_id: organizationId,
-          provider: 'mcp',
-          user_id: userId,
-          extra_data: {
-            display_name: trimmedName,
-            endpoint_url: trimmedUrl,
-            auth_header: mcpBearerToken.trim() || null,
-          },
-        }),
+      await connectBuiltinConnector('mcp', {
+        display_name: trimmedName,
+        endpoint_url: trimmedUrl,
+        auth_header: mcpBearerToken.trim() || null,
       });
-      if (!res.ok) {
-        const err: { detail?: string } = await res.json().catch(() => ({ detail: res.statusText }));
-        throw new Error(err.detail ?? 'Failed to connect');
-      }
       setShowMcpForm(false);
       void fetchIntegrations();
     } catch (error) {
@@ -913,9 +917,9 @@ export function DataSources(): JSX.Element {
     } finally {
       setMcpConnecting(false);
     }
-  };
+  }, [connectBuiltinConnector, fetchIntegrations, mcpBearerToken, mcpConnecting, mcpEndpointUrl, mcpName, organizationId, userId]);
 
-  const handleIspotConnect = async (): Promise<void> => {
+  const handleIspotConnect = useCallback(async (): Promise<void> => {
     if (!organizationId || !userId || ispotConnecting) return;
     const clientId: string = ispotClientId.trim();
     const clientSecret: string = ispotClientSecret.trim();
@@ -930,20 +934,7 @@ export function DataSources(): JSX.Element {
     setIspotConnecting(true);
     setIspotError(null);
     try {
-      const res: Response = await fetch(`${API_BASE}/auth/integrations/connect-builtin`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          organization_id: organizationId,
-          provider: 'ispot_tv',
-          user_id: userId,
-          extra_data: { client_id: clientId, client_secret: clientSecret },
-        }),
-      });
-      if (!res.ok) {
-        const err: { detail?: string } = await res.json().catch(() => ({ detail: res.statusText }));
-        throw new Error(err.detail ?? 'Failed to connect');
-      }
+      await connectBuiltinConnector('ispot_tv', { client_id: clientId, client_secret: clientSecret });
       setShowIspotForm(false);
       void fetchIntegrations();
     } catch (error) {
@@ -951,7 +942,7 @@ export function DataSources(): JSX.Element {
     } finally {
       setIspotConnecting(false);
     }
-  };
+  }, [connectBuiltinConnector, fetchIntegrations, ispotClientId, ispotClientSecret, ispotConnecting, organizationId, userId]);
 
   const handleDisconnect = (provider: string): void => {
     if (!organizationId || !userId || disconnectingProviders.has(provider)) return;
@@ -1331,6 +1322,7 @@ export function DataSources(): JSX.Element {
     state: TileState
   ): JSX.Element => {
     const isConnecting = connectingProvider === integration.provider;
+    const codeSandboxConnectBlocked = integration.provider === 'code_sandbox' && !canConnectCodeSandbox;
     const isStartingSync =
       (state === 'connected' || state === 'org-connected') &&
       getConnectorDisplay(integration.provider).hasSync !== false &&
@@ -1378,12 +1370,18 @@ export function DataSources(): JSX.Element {
       }
       // team-only and available: show Connect
       return {
-        text: isMobile ? 'Use desktop to connect' : (isConnecting ? 'Connecting...' : 'Connect'),
+        text: isMobile
+          ? 'Use desktop to connect'
+          : codeSandboxConnectBlocked
+            ? 'Admins only'
+            : (isConnecting ? 'Connecting...' : 'Connect'),
         className: isMobile
           ? 'px-4 py-2 text-sm font-medium text-surface-500 border border-surface-700 rounded-lg cursor-not-allowed'
+          : codeSandboxConnectBlocked
+            ? 'px-4 py-2 text-sm font-medium text-surface-500 border border-surface-700 rounded-lg cursor-not-allowed'
           : 'px-4 py-2 text-sm font-medium text-primary-400 border border-primary-500/30 hover:bg-primary-500/10 disabled:opacity-50 rounded-lg transition-colors',
         action: () => { if (!isMobile) void handleConnect(integration.provider); },
-        disabled: isMobile || isConnecting,
+        disabled: isMobile || isConnecting || codeSandboxConnectBlocked,
       };
     };
     const buttonConfig = getButtonConfig();
@@ -1664,6 +1662,11 @@ export function DataSources(): JSX.Element {
                   )}
                 </div>
               )}
+              {state === 'available' && codeSandboxConnectBlocked && (
+                <p className="mt-2 text-xs text-amber-400">
+                  Requires organization admin or global admin access to connect.
+                </p>
+              )}
             </div>
           </div>
 
@@ -1811,6 +1814,7 @@ export function DataSources(): JSX.Element {
               ) : (
                 filteredConnectModalIntegrations.map((integration) => {
                   const isConnecting: boolean = connectingProvider === integration.provider;
+                  const codeSandboxBlocked: boolean = integration.provider === 'code_sandbox' && !canConnectCodeSandbox;
                   return (
                     <li key={integration.provider}>
                       <button
@@ -1818,7 +1822,7 @@ export function DataSources(): JSX.Element {
                           setShowConnectModal(false);
                           void handleConnect(integration.provider);
                         }}
-                        disabled={isConnecting}
+                        disabled={isConnecting || codeSandboxBlocked}
                         className="w-full flex items-center gap-4 px-4 py-3 rounded-xl hover:bg-surface-800 transition-colors text-left group disabled:opacity-50"
                       >
                         <div className={`${isImageIcon(integration.icon) ? '' : getColorClass(integration.color) + ' p-2 text-white'} rounded-lg flex-shrink-0 w-10 h-10 flex items-center justify-center overflow-hidden`}>
@@ -1829,7 +1833,9 @@ export function DataSources(): JSX.Element {
                             {integration.name}
                           </div>
                           <div className="text-xs text-surface-500 truncate mt-0.5">
-                            {integration.description}
+                            {codeSandboxBlocked
+                              ? `${integration.description} • Admin access required to connect`
+                              : integration.description}
                           </div>
                         </div>
                         {isConnecting ? (


### PR DESCRIPTION
### Motivation
- Prevent non-admin users from connecting the Code Sandbox builtin connector and ensure builtin connector requests are performed by the authenticated user in the correct org context.
- Improve security by rejecting guest users and user/org mismatches for builtin connector creation.

### Description
- Backend: `POST /auth/integrations/connect-builtin` now depends on `get_current_auth`, verifies the request `user_id` and `organization_id` match the authenticated `AuthContext`, rejects guest users, and requires `_can_administer_org` (org admin or global admin) for the `code_sandbox` provider; appropriate logging and 403s are added. (`backend/api/routes/auth.py`)
- Tests: Added `backend/tests/test_connect_builtin_authz.py` covering denial of `code_sandbox` for non-admins and allowing `web_search` for regular members. (`backend/tests/test_connect_builtin_authz.py`)
- Frontend: `DataSources.tsx` now derives the active membership, exposes `connectBuiltinConnector` using `apiRequest` (so requests include the JWT), blocks UI connect actions for `code_sandbox` when the user is not org admin/global admin, and surfaces explanatory copy; `AppLayout.tsx` chat-driven builtin flow was switched to use `apiRequest` and include `user_id` so it satisfies backend auth checks. (`frontend/src/components/DataSources.tsx`, `frontend/src/components/AppLayout.tsx`)

### Testing
- Ran `pytest -q backend/tests/test_connect_builtin_authz.py` and the new tests passed (`2 passed`).
- Ran TypeScript check (`cd frontend && npx tsc --noEmit`) and it completed without type errors.
- Ran `git diff --check` to confirm no whitespace/format issues (no issues found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdc87bcd088321a1888876f0248814)