### PR TITLE
Skip duplicate Slack thread messages by normalizing whitespace

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -451,6 +451,8 @@ Send a message to a Slack channel, DM, or user.
         channel_id: str,
         oldest: Optional[float] = None,
         limit: int = 100,
+        latest: Optional[str] = None,
+        inclusive: bool = False,
     ) -> list[dict[str, Any]]:
         """Get messages from a specific channel."""
         messages: list[dict[str, Any]] = []
@@ -463,11 +465,45 @@ Send a message to a Slack channel, DM, or user.
             }
             if oldest:
                 params["oldest"] = oldest
+            if latest:
+                params["latest"] = latest
+                params["inclusive"] = inclusive
             if cursor:
                 params["cursor"] = cursor
 
             data = await self._make_request(
                 "GET", "conversations.history", params=params
+            )
+            messages.extend(data.get("messages", []))
+
+            cursor = data.get("response_metadata", {}).get("next_cursor")
+            if not cursor:
+                break
+
+        return messages
+
+    async def get_thread_messages(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        limit: int = 1000,
+    ) -> list[dict[str, Any]]:
+        """Get messages from a specific Slack thread."""
+        messages: list[dict[str, Any]] = []
+        cursor: Optional[str] = None
+
+        while len(messages) < limit:
+            params: dict[str, Any] = {
+                "channel": channel_id,
+                "ts": thread_ts,
+                "limit": min(100, limit - len(messages)),
+                "inclusive": True,
+            }
+            if cursor:
+                params["cursor"] = cursor
+
+            data = await self._make_request(
+                "GET", "conversations.replies", params=params
             )
             messages.extend(data.get("messages", []))
 

--- a/backend/messengers/slack.py
+++ b/backend/messengers/slack.py
@@ -9,6 +9,7 @@ and formatting.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from connectors.slack import SlackConnector, markdown_to_mrkdwn
@@ -16,6 +17,11 @@ from messengers._workspace import WorkspaceMessenger
 from messengers.base import InboundMessage, MessengerMeta, ResponseMode
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_slack_dedupe_text(text: str) -> str:
+    """Normalize Slack message text for duplicate detection."""
+    return re.sub(r"\s+", "", text or "")
 
 
 class SlackMessenger(WorkspaceMessenger):
@@ -79,6 +85,20 @@ class SlackMessenger(WorkspaceMessenger):
         connector: SlackConnector = await self._get_connector(
             workspace_id, organization_id=organization_id,
         )
+        if await self._should_skip_duplicate_thread_message(
+            connector=connector,
+            channel_id=channel_id,
+            thread_id=thread_id,
+            text=text,
+        ):
+            logger.info(
+                "[slack] Skipping duplicate outbound message channel=%s thread_id=%s text=%s",
+                channel_id,
+                thread_id,
+                text[:120],
+            )
+            return None
+
         result: dict[str, Any] = await connector.post_message(
             channel=channel_id,
             text=text,
@@ -86,6 +106,66 @@ class SlackMessenger(WorkspaceMessenger):
             blocks=blocks,
         )
         return result.get("ts")
+
+    async def _should_skip_duplicate_thread_message(
+        self,
+        *,
+        connector: SlackConnector,
+        channel_id: str,
+        thread_id: str | None,
+        text: str,
+    ) -> bool:
+        """Return True when the next Slack message matches the latest thread message."""
+        normalized_candidate: str = _normalize_slack_dedupe_text(text)
+        if not normalized_candidate:
+            return False
+
+        try:
+            if thread_id:
+                messages = await connector.get_thread_messages(
+                    channel_id=channel_id,
+                    thread_ts=thread_id,
+                    limit=1000,
+                )
+                latest_message = next(
+                    (
+                        msg for msg in reversed(messages)
+                        if (msg.get("text") or "").strip()
+                    ),
+                    None,
+                )
+            else:
+                messages = await connector.get_channel_messages(
+                    channel_id,
+                    limit=1,
+                )
+                latest_message = next(
+                    (msg for msg in messages if (msg.get("text") or "").strip()),
+                    None,
+                )
+        except Exception as exc:
+            logger.debug(
+                "[slack] Duplicate message check failed channel=%s thread_id=%s: %s",
+                channel_id,
+                thread_id,
+                exc,
+            )
+            return False
+
+        if latest_message is None:
+            return False
+
+        latest_text: str = latest_message.get("text") or ""
+        normalized_latest: str = _normalize_slack_dedupe_text(latest_text)
+        is_duplicate: bool = normalized_latest == normalized_candidate
+        logger.debug(
+            "[slack] Duplicate message check channel=%s thread_id=%s duplicate=%s latest_ts=%s",
+            channel_id,
+            thread_id,
+            is_duplicate,
+            latest_message.get("ts"),
+        )
+        return is_duplicate
 
     async def download_file(
         self,

--- a/backend/tests/test_slack_channel_name_resolution.py
+++ b/backend/tests/test_slack_channel_name_resolution.py
@@ -1,9 +1,8 @@
-
 import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
-from uuid import uuid4, UUID
-from datetime import datetime
 
 from messengers.slack import SlackMessenger
 from messengers.base import InboundMessage, MessageType
@@ -142,3 +141,56 @@ async def test_resolve_channel_name_failure_caching():
         name2 = await messenger.resolve_channel_name(workspace_id, channel_id)
         assert name2 is None
         assert mock_connector.get_channel_info.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_post_message_skips_duplicate_thread_message_when_whitespace_only_differs():
+    messenger = SlackMessenger()
+    mock_connector = AsyncMock()
+    mock_connector.get_thread_messages.return_value = [
+        {"ts": "1710711600.001", "text": "_Writing to Linear…_"}
+    ]
+
+    with patch.object(messenger, "_get_connector", return_value=mock_connector):
+        result = await messenger.post_message(
+            channel_id="C456",
+            text="_Writing to  Linear…_",
+            thread_id="1710711600.000",
+            workspace_id="T123",
+            organization_id=str(uuid4()),
+        )
+
+    assert result is None
+    mock_connector.get_thread_messages.assert_awaited_once_with(
+        channel_id="C456",
+        thread_ts="1710711600.000",
+        limit=1000,
+    )
+    mock_connector.post_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_message_sends_when_last_thread_message_differs():
+    messenger = SlackMessenger()
+    mock_connector = AsyncMock()
+    mock_connector.get_thread_messages.return_value = [
+        {"ts": "1710711600.001", "text": "_Looking up data in Github…_"}
+    ]
+    mock_connector.post_message.return_value = {"ts": "1710711600.002"}
+
+    with patch.object(messenger, "_get_connector", return_value=mock_connector):
+        result = await messenger.post_message(
+            channel_id="C456",
+            text="_Writing to Linear…_",
+            thread_id="1710711600.000",
+            workspace_id="T123",
+            organization_id=str(uuid4()),
+        )
+
+    assert result == "1710711600.002"
+    mock_connector.post_message.assert_awaited_once_with(
+        channel="C456",
+        text="_Writing to Linear…_",
+        thread_ts="1710711600.000",
+        blocks=None,
+    )


### PR DESCRIPTION
### Motivation
- Reduce noisy duplicate progress messages (e.g. “Writing to Linear…”, “Looking up data in Github…”) being posted repeatedly to the same Slack thread.
- Ensure deduplication works across separate send attempts and not only within a single streaming run.

### Description
- Add `SlackMessenger.post_message` guard that normalizes whitespace and compares the outbound text to the latest message in the thread/channel and returns early when identical after normalization using `_normalize_slack_dedupe_text`.
- Implement `SlackMessenger._should_skip_duplicate_thread_message` which fetches the latest thread or channel message and performs the whitespace-normalized comparison.
- Add `SlackConnector.get_thread_messages` (uses `conversations.replies`) and extend `SlackConnector.get_channel_messages` with optional `latest`/`inclusive` parameters to support the lookup logic.
- Add tests in `backend/tests/test_slack_channel_name_resolution.py` that validate whitespace-only duplicates are suppressed and that non-matching messages still post.

### Testing
- Ran `pytest backend/tests/test_workspace_tool_status_dedup.py backend/tests/test_slack_channel_name_resolution.py backend/tests/test_tool_progress_dedup.py` and all tests passed (11 passed, 2 pre-existing deprecation warnings reported). 
- Ran `python -m compileall backend/messengers/slack.py backend/connectors/slack.py` to verify files compile successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdcbe007a88321966b5a10b9288efb)