### PR TITLE
fix: preserve auth header on Slack file download redirects

### DIFF
--- a/backend/messengers/slack.py
+++ b/backend/messengers/slack.py
@@ -195,14 +195,39 @@ class SlackMessenger(WorkspaceMessenger):
         try:
             import httpx
             token: str = await connector.get_oauth_token()
-            async with httpx.AsyncClient() as client:
+            auth_headers: dict[str, str] = {"Authorization": f"Bearer {token}"}
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                # Don't auto-follow redirects — httpx strips the Authorization
+                # header on cross-origin redirects (e.g. files.slack.com →
+                # basebase-ai.slack.com), which returns an HTML login page
+                # instead of the actual file.
                 resp = await client.get(
                     url_private,
-                    headers={"Authorization": f"Bearer {token}"},
-                    follow_redirects=True,
-                    timeout=30.0,
+                    headers=auth_headers,
+                    follow_redirects=False,
                 )
+                redirects_followed: int = 0
+                while resp.is_redirect and redirects_followed < 5:
+                    redirect_url: str | None = resp.headers.get("location")
+                    if not redirect_url:
+                        break
+                    resp = await client.get(
+                        redirect_url,
+                        headers=auth_headers,
+                        follow_redirects=False,
+                    )
+                    redirects_followed += 1
                 resp.raise_for_status()
+
+                # Guard against HTML login pages returned on auth failure
+                resp_ct: str = resp.headers.get("content-type", "")
+                if "text/html" in resp_ct and not content_type.startswith("text/"):
+                    logger.error(
+                        "[slack] File download returned HTML instead of %s for %s",
+                        content_type, filename,
+                    )
+                    return None
+
                 return resp.content, filename, content_type
         except Exception as exc:
             logger.error("[slack] Failed to download file %s: %s", filename, exc)

--- a/backend/services/file_handler.py
+++ b/backend/services/file_handler.py
@@ -257,7 +257,34 @@ def build_claude_content_blocks(
     return blocks
 
 
+_IMAGE_MAGIC: dict[str, list[bytes]] = {
+    "image/jpeg": [b"\xff\xd8\xff"],
+    "image/png": [b"\x89PNG\r\n\x1a\n"],
+    "image/gif": [b"GIF87a", b"GIF89a"],
+    "image/webp": [b"RIFF"],
+}
+
+
+def _validate_image_bytes(data: bytes, mime: str) -> bool:
+    """Return True if *data* starts with a magic header matching *mime*."""
+    signatures: list[bytes] | None = _IMAGE_MAGIC.get(mime)
+    if signatures is None:
+        return True  # unknown mime — assume OK
+    return any(data[:len(sig)] == sig for sig in signatures)
+
+
 def _image_block(sf: StoredFile) -> dict[str, Any]:
+    if not _validate_image_bytes(sf.data, sf.mime_type):
+        logger.warning(
+            "Image %s (%s) failed magic-byte validation — sending as text note",
+            sf.filename, sf.mime_type,
+        )
+        return {
+            "type": "text",
+            "text": f"[Attached image '{sf.filename}' could not be processed — "
+                    f"the file data does not appear to be a valid {sf.mime_type}]",
+        }
+
     b64: str = base64.standard_b64encode(sf.data).decode("ascii")
     return {
         "type": "image",


### PR DESCRIPTION
## Summary
- **Root cause**: httpx strips the `Authorization` header on cross-origin redirects (`files.slack.com` → `workspace.slack.com`), so the redirected request returns an HTML login page instead of the actual file. This 53KB HTML blob gets base64-encoded as "image/jpeg" and sent to Anthropic, which returns a 400 "Could not process image" error.
- **Fix 1** (`slack.py`): Manual redirect following that preserves the auth header on every hop, plus a content-type guard that rejects HTML responses when a non-text file was expected.
- **Fix 2** (`file_handler.py`): Magic-byte validation (JPEG `FF D8 FF`, PNG `89 50 4E 47`, etc.) before sending images to Anthropic — falls back to a text note instead of crashing.

## Test plan
- [x] Backend tests pass (237 passed)
- [x] Frontend build passes
- [ ] Send a photo to the Basebase agent in Slack and verify it processes correctly
- [ ] Send a non-image file to verify existing file handling still works

Made with [Cursor](https://cursor.com)