### PR TITLE
fix: clear stale sync errors and retry transient Slack failures

### DIFF
--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -817,6 +817,12 @@ async def trigger_sync(
                 detail=f"No active {provider} integration found",
             )
 
+        # Clear stale errors so the UI doesn't show a previous failure while syncing
+        for integration in integrations:
+            if integration.last_error is not None:
+                integration.last_error = None
+        await session.commit()
+
     sync_since_override: datetime | None = parse_sync_since_param(since)
 
     # Initialize sync status

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -376,6 +376,19 @@ Send a message to a Slack channel, DM, or user.
                     await asyncio.sleep(retry_after)
                     continue
 
+                if response.status_code >= 500 and attempt < self._MAX_RETRIES:
+                    backoff: float = float(2 ** attempt)
+                    logger.warning(
+                        "[Slack API] %d server error on %s (attempt %d/%d), retrying in %.1fs",
+                        response.status_code,
+                        endpoint,
+                        attempt + 1,
+                        self._MAX_RETRIES,
+                        backoff,
+                    )
+                    await asyncio.sleep(backoff)
+                    continue
+
                 response.raise_for_status()
                 data: dict[str, Any] = response.json()
 
@@ -397,7 +410,7 @@ Send a message to a Slack channel, DM, or user.
                 return data
 
         raise httpx.HTTPStatusError(
-            "Rate limited after max retries",
+            f"Slack API request failed after {self._MAX_RETRIES} retries (last status {response.status_code})",
             request=response.request,
             response=response,
         )

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -357,6 +357,44 @@ export function DataSources(): JSX.Element {
   const [syncingProviders, setSyncingProviders] = useState<Set<string>>(new Set());
   /** True while org-wide "Sync all" is running (until all provider polls finish). */
   const [syncingAll, setSyncingAll] = useState<boolean>(false);
+
+  // On mount/org change, check if any syncs are already in-flight (survives page reload)
+  useEffect(() => {
+    if (!organization?.id) return;
+    const orgId: string = organization.id;
+    const syncableProviders: string[] = rawIntegrations
+      .filter((i) => i.isActive)
+      .map((i) => i.provider);
+    if (syncableProviders.length === 0) return;
+
+    let cancelled = false;
+    const checkInFlight = async (): Promise<void> => {
+      const inFlight = new Set<string>();
+      await Promise.all(
+        syncableProviders.map(async (provider: string) => {
+          try {
+            const res: Response = await fetch(`${API_BASE}/sync/${orgId}/${provider}/status`);
+            if (!res.ok) return;
+            const data = (await res.json()) as { status: string };
+            if (data.status === 'syncing') {
+              inFlight.add(provider);
+            }
+          } catch {
+            // ignore — status check is best-effort
+          }
+        }),
+      );
+      if (!cancelled && inFlight.size > 0) {
+        setSyncingProviders((prev) => {
+          const next = new Set(prev);
+          for (const p of inFlight) next.add(p);
+          return next;
+        });
+      }
+    };
+    void checkInFlight();
+    return () => { cancelled = true; };
+  }, [organization?.id, rawIntegrations]);
   const [disconnectingProviders, setDisconnectingProviders] = useState<Set<string>>(new Set());
   const [connectingProvider, setConnectingProvider] = useState<string | null>(null);
   const [slackMappings, setSlackMappings] = useState<SlackUserMapping[]>([]);
@@ -1754,7 +1792,7 @@ export function DataSources(): JSX.Element {
                   Connected by {integration.connectedBy}
                 </p>
               )}
-              {(state === 'connected' || state === 'org-connected') && integration.lastSyncAt && (
+              {(state === 'connected' || state === 'org-connected') && integration.lastSyncAt && !isSyncing && (
                 <p className="text-xs text-surface-500 mt-1 hidden sm:block">
                   Last synced: {new Date(integration.lastSyncAt).toLocaleString()}
                 </p>
@@ -1772,7 +1810,7 @@ export function DataSources(): JSX.Element {
                   ) : null}
                 </p>
               )}
-              {(state === 'connected' || state === 'org-connected') && integration.lastError && (
+              {(state === 'connected' || state === 'org-connected') && integration.lastError && !isSyncing && (
                 <p className="text-xs text-red-400 mt-1">Error: {integration.lastError}</p>
               )}
               {state === 'org-connected' && (


### PR DESCRIPTION
## Summary
- Clears `last_error` on integration rows when a new sync is triggered, so the UI doesn't show a scary error from a previous run while a new sync is actively working
- Hides stale "Last synced" date and error text in the DataSources card while a sync is in-flight
- On page reload, checks backend sync status to restore in-flight indicator (survives browser refresh)
- Adds 5xx retry with exponential backoff in the Slack API client, matching the existing 429 rate-limit retry logic

## Test plan
- [ ] Trigger a Slack sync, verify old error and stale date are hidden while syncing
- [ ] Reload the page mid-sync, verify the syncing state is restored
- [ ] Simulate a Slack 500 response, verify it retries instead of immediately failing
- [ ] Verify sync completion still shows updated "Last synced" date and clears error

Made with [Cursor](https://cursor.com)