### PR TITLE
ui: show full-screen loading when switching organizations

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -39,7 +39,7 @@ const ArtifactFullView = lazy(() => import('./ArtifactFullView').then(m => ({ de
 const DocumentsGallery = lazy(() => import('./documents/DocumentsGallery').then(m => ({ default: m.DocumentsGallery })));
 import { APP_NAME, LOGO_PATH, RELEASE_STAGE } from '../lib/brand';
 import { ProfilePanel } from './ProfilePanel';
-import { useAppStore, useChatStore, useUIStore, useMasquerade, useIntegrations, type ActiveTask, type ToolCallData, type ChatMessage, type ContentBlock } from '../store';
+import { useAppStore, useChatStore, useUIStore, useMasquerade, useIntegrations, useIsSwitchingOrg, type ActiveTask, type ToolCallData, type ChatMessage, type ContentBlock } from '../store';
 import { useTeamMembers, useWebSocket } from '../hooks';
 import { apiRequest } from '../lib/api';
 
@@ -200,6 +200,8 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       recentChats: state.recentChats,
     }))
   );
+
+  const isSwitchingOrg: boolean = useIsSwitchingOrg();
 
   // Zustand: Get integrations for connected count badge
   const integrations = useIntegrations();
@@ -1615,7 +1617,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
   }, [currentView, isGlobalAdmin, setCurrentView]);
 
   // Guard against missing user/org (shouldn't happen, but be safe)
-  if (!user || !organization) {
+  if (!user || !organization || isSwitchingOrg) {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center bg-surface-950">
         <div className="flex flex-col items-center gap-6">
@@ -1626,8 +1628,8 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
             </div>
           </div>
           <div className="flex flex-col items-center gap-1">
-            <p className="text-surface-200 font-medium">Loading</p>
-            <p className="text-surface-500 text-sm">Preparing your workspace…</p>
+            <p className="text-surface-200 font-medium">{isSwitchingOrg ? 'Switching team' : 'Loading'}</p>
+            <p className="text-surface-500 text-sm">{isSwitchingOrg ? 'Loading your workspace…' : 'Preparing your workspace…'}</p>
           </div>
         </div>
       </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -14,7 +14,7 @@
 import { useMemo, useState, useRef, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import type { View, ChatSummary, OrganizationInfo } from './AppLayout';
-import { useAppStore, useChatStore, useIsGlobalAdmin, useActiveTasksByConversation, type UserOrganization } from '../store';
+import { useAppStore, useAuthStore, useChatStore, useIsGlobalAdmin, useActiveTasksByConversation, type UserOrganization } from '../store';
 import { updateConversation } from '../api/client';
 import { apiRequest } from '../lib/api';
 import { FaLifeRing } from 'react-icons/fa';
@@ -231,8 +231,13 @@ function OrgSwitcherSection({
 
   const handleSwitchOrg = async (orgId: string): Promise<void> => {
     setShowDropdown(false);
-    await switchActiveOrganization(orgId);
-    await Promise.all([fetchConversations(), fetchIntegrations()]);
+    useAuthStore.setState({ isSwitchingOrg: true });
+    try {
+      await switchActiveOrganization(orgId);
+      await Promise.all([fetchConversations(), fetchIntegrations()]);
+    } finally {
+      useAuthStore.setState({ isSwitchingOrg: false });
+    }
   };
 
   return (

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -28,6 +28,7 @@ export interface AuthState {
   organizations: UserOrganization[];
   isAuthenticated: boolean;
   masquerade: MasqueradeState | null;
+  isSwitchingOrg: boolean;
 
   // Actions
   setUser: (user: UserProfile | null) => void;
@@ -57,6 +58,7 @@ export const useAuthStore = create<AuthState>()(
       organizations: [],
       isAuthenticated: false,
       masquerade: null,
+      isSwitchingOrg: false,
 
       // Actions
       setUser: (user) =>

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -166,6 +166,8 @@ export const useIsGlobalAdmin = () =>
 export const useMasquerade = () => useAuthStore((state) => state.masquerade);
 export const useIsMasquerading = () =>
   useAuthStore((state) => state.masquerade !== null);
+export const useIsSwitchingOrg = () =>
+  useAuthStore((state) => state.isSwitchingOrg);
 
 // Get the real admin user ID when masquerading (for API headers)
 export const getAdminUserId = (): string | null => {


### PR DESCRIPTION
## Summary
- Adds `isSwitchingOrg` flag to the auth store, set `true` during the entire org switch + data refetch flow in the sidebar
- `AppLayout` renders a full-screen "Switching team" spinner when the flag is active, replacing the stale old-org UI
- Flag is excluded from persistence (always starts `false`) and cleared in a `finally` block for safety

## Test plan
- [ ] Switch orgs via sidebar dropdown — should see a branded spinner instead of old org data
- [ ] Verify the spinner disappears once the new org's data loads
- [ ] Confirm normal page load still shows "Loading / Preparing your workspace…" text


Made with [Cursor](https://cursor.com)