### PR TITLE
feat: sync-in-progress signal via sync_stats DB column

### DIFF
--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -8,7 +8,7 @@ Endpoints:
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import ast
 import logging
 from typing import Any, Optional
@@ -859,53 +859,77 @@ async def get_sync_status(organization_id: str, provider: str) -> SyncStatusResp
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid customer ID")
 
-    status_key = _get_status_key(organization_id, provider)
-    status = _sync_status.get(status_key)
-
-    if not status:
-        # Check database for last sync time
-        async with get_session(organization_id=organization_id) as session:
-            result = await session.execute(
-                select(Integration).where(
-                    Integration.organization_id == UUID(organization_id),
-                    Integration.connector == provider,
-                )
+    # DB is the primary source of truth — check sync_started_at first
+    async with get_session(organization_id=organization_id) as session:
+        result = await session.execute(
+            select(Integration).where(
+                Integration.organization_id == UUID(organization_id),
+                Integration.connector == provider,
             )
-            integration = result.scalar_one_or_none()
+        )
+        integration: Integration | None = result.scalar_one_or_none()
 
-            if integration and integration.last_sync_at:
-                return SyncStatusResponse(
-                    organization_id=organization_id,
-                    provider=provider,
-                    status="completed",
-                    started_at=None,
-                    completed_at=f"{integration.last_sync_at.isoformat()}Z",
-                    error=integration.last_error,
-                    counts=None,
-                )
+    if integration:
+        stats: dict[str, Any] | None = integration.sync_stats
+        sync_started_raw: str | None = (
+            stats.get("sync_started_at") if isinstance(stats, dict) else None
+        )
 
+        if sync_started_raw:
+            try:
+                sync_started: datetime = datetime.fromisoformat(sync_started_raw)
+                stale_cutoff: timedelta = timedelta(hours=2)
+                if datetime.utcnow() - sync_started < stale_cutoff:
+                    return SyncStatusResponse(
+                        organization_id=organization_id,
+                        provider=provider,
+                        status="syncing",
+                        started_at=f"{sync_started.isoformat()}Z",
+                        completed_at=None,
+                        error=None,
+                        counts=None,
+                    )
+            except (ValueError, TypeError):
+                pass
+
+    # Fall back to in-memory status (set by API-initiated syncs in this process)
+    status_key: str = _get_status_key(organization_id, provider)
+    status: dict[str, Any] | None = _sync_status.get(status_key)
+
+    if status:
+        started_at = status.get("started_at")
+        completed_at = status.get("completed_at")
+        counts = status.get("counts")
         return SyncStatusResponse(
             organization_id=organization_id,
             provider=provider,
-            status="never_synced",
-            started_at=None,
-            completed_at=None,
-            error=None,
-            counts=None,
+            status=str(status.get("status", "unknown")),
+            started_at=f"{started_at.isoformat()}Z" if isinstance(started_at, datetime) else None,
+            completed_at=f"{completed_at.isoformat()}Z" if isinstance(completed_at, datetime) else None,
+            error=str(status["error"]) if status.get("error") else None,
+            counts=counts if isinstance(counts, dict) else None,
         )
 
-    started_at = status.get("started_at")
-    completed_at = status.get("completed_at")
-    counts = status.get("counts")
+    # No in-memory status — use DB last_sync_at / never_synced
+    if integration and integration.last_sync_at:
+        return SyncStatusResponse(
+            organization_id=organization_id,
+            provider=provider,
+            status="completed",
+            started_at=None,
+            completed_at=f"{integration.last_sync_at.isoformat()}Z",
+            error=integration.last_error,
+            counts=None,
+        )
 
     return SyncStatusResponse(
         organization_id=organization_id,
         provider=provider,
-        status=str(status.get("status", "unknown")),
-        started_at=f"{started_at.isoformat()}Z" if isinstance(started_at, datetime) else None,
-        completed_at=f"{completed_at.isoformat()}Z" if isinstance(completed_at, datetime) else None,
-        error=str(status["error"]) if status.get("error") else None,
-        counts=counts if isinstance(counts, dict) else None,
+        status="never_synced",
+        started_at=None,
+        completed_at=None,
+        error=None,
+        counts=None,
     )
 
 
@@ -942,6 +966,7 @@ async def sync_integration_data(
             user_id=user_id,
             sync_since_override=sync_since_override,
         )
+        await connector.mark_sync_started()
         counts = await connector.sync_all()
         print(f"[Sync] sync_all returned counts: {counts}")
         await connector.update_last_sync(counts)
@@ -986,6 +1011,11 @@ async def sync_integration_data(
         _sync_status[status_key]["error"] = cancel_msg
         _sync_status[status_key]["completed_at"] = datetime.utcnow()
 
+        try:
+            await connector.clear_sync_started()
+        except Exception:
+            pass
+
         # Emit sync cancelled event (best effort)
         try:
             from workers.events import emit_event
@@ -1012,13 +1042,14 @@ async def sync_integration_data(
         _sync_status[status_key]["error"] = error_msg
         _sync_status[status_key]["completed_at"] = datetime.utcnow()
 
-        # Record error in database
+        # Record error in database and clear in-progress flag
         try:
             connector = connector_class(
                 organization_id,
                 user_id=user_id,
                 sync_since_override=sync_since_override,
             )
+            await connector.clear_sync_started()
             await connector.record_error(error_msg)
         except Exception as record_err:
             print(f"[Sync] Failed to record error to DB: {record_err}")

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -597,6 +597,43 @@ class BaseConnector(ABC):
                 await session.commit()
                 print(f"[Sync] Committed update_last_sync for {self.source_system}")
 
+    async def mark_sync_started(self) -> None:
+        """Persist a ``sync_started_at`` timestamp in ``sync_stats`` so any
+        process (API server, Celery worker) can detect an in-flight sync."""
+        from datetime import datetime
+        from sqlalchemy.orm.attributes import flag_modified
+
+        if not self._integration:
+            await self._load_integration()
+        if not self._integration:
+            return
+
+        async with get_session(organization_id=self.organization_id) as session:
+            integration: Integration | None = await session.get(Integration, self._integration.id)
+            if integration:
+                stats: dict[str, Any] = dict(integration.sync_stats or {})
+                stats["sync_started_at"] = datetime.utcnow().isoformat()
+                integration.sync_stats = stats
+                flag_modified(integration, "sync_stats")
+                integration.last_error = None
+                await session.commit()
+
+    async def clear_sync_started(self) -> None:
+        """Remove the ``sync_started_at`` flag (e.g. after a failure)."""
+        from sqlalchemy.orm.attributes import flag_modified
+
+        if not self._integration:
+            return
+
+        async with get_session(organization_id=self.organization_id) as session:
+            integration: Integration | None = await session.get(Integration, self._integration.id)
+            if integration and isinstance(integration.sync_stats, dict) and "sync_started_at" in integration.sync_stats:
+                stats: dict[str, Any] = dict(integration.sync_stats)
+                del stats["sync_started_at"]
+                integration.sync_stats = stats
+                flag_modified(integration, "sync_stats")
+                await session.commit()
+
     async def record_error(self, error: str) -> None:
         """Record an error for this integration."""
         if not self._integration:

--- a/backend/tests/test_sync_cancellation.py
+++ b/backend/tests/test_sync_cancellation.py
@@ -21,6 +21,12 @@ class CancelledConnector:
     async def sync_all(self) -> dict[str, int]:
         raise SyncCancelledError("hubspot integration disconnected during sync (sync_all:after_accounts)")
 
+    async def mark_sync_started(self) -> None:
+        return None
+
+    async def clear_sync_started(self) -> None:
+        return None
+
     async def update_last_sync(self, counts: dict[str, int]) -> None:
         return None
 

--- a/backend/workers/celery_app.py
+++ b/backend/workers/celery_app.py
@@ -116,50 +116,47 @@ celery_app.conf.update(
     task_default_routing_key="default",
 )
 
-# Beat schedule for periodic tasks
-celery_app.conf.beat_schedule = {
-    # Hourly sync for all organizations - runs at the top of every hour
-    "hourly-sync-all-organizations": {
-        "task": "workers.tasks.sync.sync_all_organizations",
-        "schedule": crontab(minute=0),  # Every hour at :00
-    },
-    
-    # Check for scheduled workflows every minute
-    "check-scheduled-workflows": {
-        "task": "workers.tasks.workflows.check_scheduled_workflows",
-        "schedule": timedelta(minutes=1),
-    },
-    
-    # Process event-triggered workflows (check queue every 10 seconds)
-    "process-workflow-events": {
-        "task": "workers.tasks.workflows.process_pending_events",
-        "schedule": timedelta(seconds=10),
-    },
+# Beat schedule for periodic tasks.
+# Only enabled when ENABLE_CELERY_BEAT=true (set in production only) so that
+# local dev servers never accidentally run hourly syncs against shared APIs.
+_ENABLE_BEAT: bool = os.environ.get("ENABLE_CELERY_BEAT", "").lower() in ("true", "1", "yes")
 
-    # Check critical infrastructure and create PagerDuty incidents when down
-    "monitor-critical-dependencies": {
-        "task": "workers.tasks.monitoring.monitor_dependencies",
-        "schedule": timedelta(minutes=15),
-    },
-
-    # Sweep active huddles every 5 minutes — ends stale conferences, triggers recording check
-    "sweep-active-huddles": {
-        "task": "workers.tasks.sync.sweep_active_huddles",
-        "schedule": timedelta(minutes=5),
-    },
-
-    # Sweep completed calendared Meet meetings every 5 minutes for missing Gemini summaries
-    "sweep-completed-meetings": {
-        "task": "workers.tasks.sync.sweep_completed_meetings",
-        "schedule": timedelta(minutes=5),
-    },
-
-    # Ensure monitor task itself keeps running; incident if no heartbeat for 30m
-    "monitoring-heartbeat-watchdog": {
-        "task": "workers.tasks.monitoring.monitoring_heartbeat_watchdog",
-        "schedule": timedelta(minutes=5),
-    },
-}
+if _ENABLE_BEAT:
+    celery_app.conf.beat_schedule = {
+        "hourly-sync-all-organizations": {
+            "task": "workers.tasks.sync.sync_all_organizations",
+            "schedule": crontab(minute=0),
+        },
+        "check-scheduled-workflows": {
+            "task": "workers.tasks.workflows.check_scheduled_workflows",
+            "schedule": timedelta(minutes=1),
+        },
+        "process-workflow-events": {
+            "task": "workers.tasks.workflows.process_pending_events",
+            "schedule": timedelta(seconds=10),
+        },
+        "monitor-critical-dependencies": {
+            "task": "workers.tasks.monitoring.monitor_dependencies",
+            "schedule": timedelta(minutes=15),
+        },
+        "sweep-active-huddles": {
+            "task": "workers.tasks.sync.sweep_active_huddles",
+            "schedule": timedelta(minutes=5),
+        },
+        "sweep-completed-meetings": {
+            "task": "workers.tasks.sync.sweep_completed_meetings",
+            "schedule": timedelta(minutes=5),
+        },
+        "monitoring-heartbeat-watchdog": {
+            "task": "workers.tasks.monitoring.monitoring_heartbeat_watchdog",
+            "schedule": timedelta(minutes=5),
+        },
+    }
+else:
+    celery_app.conf.beat_schedule = {}
+    logging.getLogger(__name__).info(
+        "Celery beat schedule DISABLED (set ENABLE_CELERY_BEAT=true to enable)"
+    )
 
 
 @worker_process_init.connect

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -96,6 +96,7 @@ async def _sync_integration(
                 "error": dp_result.deny_reason or "Connector sync not allowed",
             }
 
+        await connector.mark_sync_started()
         counts = await connector.sync_all()
         await connector.update_last_sync(counts)
 
@@ -130,6 +131,10 @@ async def _sync_integration(
     except SyncCancelledError as e:
         cancel_msg = str(e)
         logger.info(f"Sync cancelled for {provider} in org {organization_id}: {cancel_msg}")
+        try:
+            await connector.clear_sync_started()
+        except Exception:
+            pass
         return {
             "status": "cancelled",
             "organization_id": organization_id,
@@ -141,9 +146,10 @@ async def _sync_integration(
         error_msg = str(e)
         logger.error(f"Sync failed for {provider} in org {organization_id}: {error_msg}")
 
-        # Record error in database
+        # Record error in database and clear in-progress flag
         try:
             connector = connector_class(organization_id, user_id=user_id)
+            await connector.clear_sync_started()
             await connector.record_error(error_msg)
         except Exception:
             pass


### PR DESCRIPTION
## Summary
- Writes `sync_started_at` into the existing `sync_stats` JSONB column when any sync begins (API or Celery worker), so the frontend shows "Syncing…" for automated hourly syncs — not just manually-triggered ones.
- Status endpoint checks `sync_started_at` as the **primary** signal (with 2h staleness guard), falling back to in-memory status and then `last_sync_at`.
- Celery Beat schedule gated behind `ENABLE_CELERY_BEAT` env var so local dev instances don't accidentally trigger hourly syncs.

## Changes
- **`backend/connectors/base.py`**: `mark_sync_started()` / `clear_sync_started()` helpers on `BaseConnector`
- **`backend/api/routes/sync.py`**: Call helpers at sync start/failure; status endpoint checks DB first
- **`backend/workers/tasks/sync.py`**: Same helpers called in Celery sync path
- **`backend/workers/celery_app.py`**: Conditional Beat schedule via `ENABLE_CELERY_BEAT`
- **`backend/tests/test_sync_cancellation.py`**: Updated mock to include new methods

## Test plan
- [x] `pytest -q tests` — 237 passed
- [x] `npm run build` — clean
- [ ] Trigger manual sync → verify "Syncing…" appears, then "Last synced" after completion
- [ ] Verify Celery-initiated sync also shows "Syncing…" on the frontend


Made with [Cursor](https://cursor.com)