### PR TITLE
fix: widen sync_stats type and handle duplicate integration rows

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -420,7 +420,7 @@ class IntegrationResponse(BaseModel):
     team_connections: list[TeamConnection] = []
     team_total: int = 0
     # Sync statistics
-    sync_stats: Optional[dict[str, int]] = None
+    sync_stats: Optional[dict[str, int | str]] = None
     # Optional display name override (e.g. user-provided name for MCP connectors)
     display_name: Optional[str] = None
 
@@ -3608,19 +3608,11 @@ async def list_integrations(
 
     scope_by_provider: dict[str, str] = _get_scope_by_provider()
 
-    # #region agent log
-    import json as _json_dbg; open("/Users/teg/Documents/basebase/basebase/.cursor/debug-145f20.log","a").write(_json_dbg.dumps({"sessionId":"145f20","hypothesisId":"H1-H2","location":"auth.py:list_integrations","message":"list_integrations called","data":{"org_uuid":str(org_uuid),"current_user_uuid":str(current_user_uuid),"auth_org_id":str(auth.organization_id),"query_param_org_id":organization_id},"timestamp":__import__("time").time()})+"\n")
-    # #endregion
-
     async with get_session(organization_id=str(org_uuid)) as db_session:
         result = await db_session.execute(
             select(Integration).where(Integration.organization_id == org_uuid)
         )
         all_integrations = list(result.scalars().all())
-
-        # #region agent log
-        open("/Users/teg/Documents/basebase/basebase/.cursor/debug-145f20.log","a").write(_json_dbg.dumps({"sessionId":"145f20","hypothesisId":"H2-H4-H5","location":"auth.py:list_integrations:after_query","message":"integrations query result","data":{"count":len(all_integrations),"integrations":[{"id":str(i.id),"connector":i.connector,"is_active":i.is_active,"user_id":str(i.user_id) if i.user_id else None} for i in all_integrations]},"timestamp":__import__("time").time()})+"\n")
-        # #endregion
 
         # Group integrations by provider
         integrations_by_provider: dict[str, list[Integration]] = {}

--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -131,7 +131,7 @@ class AdminIntegration(BaseModel):
     is_active: bool
     last_sync_at: str | None
     last_error: str | None
-    sync_stats: dict[str, int] | None
+    sync_stats: dict[str, int | str] | None
     created_at: str | None
 
 
@@ -867,7 +867,7 @@ async def get_sync_status(organization_id: str, provider: str) -> SyncStatusResp
                 Integration.connector == provider,
             )
         )
-        integration: Integration | None = result.scalar_one_or_none()
+        integration: Integration | None = result.scalars().first()
 
     if integration:
         stats: dict[str, Any] | None = integration.sync_stats
@@ -1112,7 +1112,7 @@ async def match_hubspot_owners(organization_id: str) -> OwnerMatchResponse:
                 Integration.is_active == True,
             )
         )
-        integration: Integration | None = result.scalar_one_or_none()
+        integration: Integration | None = result.scalars().first()
         if not integration:
             raise HTTPException(
                 status_code=404, detail="No active HubSpot integration found"

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -1326,9 +1326,6 @@ export const useChatStore = create<ChatState>()(
           "[Store] Fetching integrations for org:",
           organization.id,
         );
-        // #region agent log
-        fetch('http://127.0.0.1:7249/ingest/bbad8696-7c16-4021-b7f0-8afa9db11c4a',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'145f20'},body:JSON.stringify({sessionId:'145f20',location:'chatStore.ts:fetchIntegrations',message:'frontend fetchIntegrations called',data:{orgId:organization.id,orgName:organization.name,userId:user.id},timestamp:Date.now()})}).catch(()=>{});
-        // #endregion
         const authHeaders: Record<string, string> =
           await getAuthenticatedRequestHeaders();
         const response = await fetch(

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -74,6 +74,8 @@ export interface SyncStats {
   teams?: number;
   projects?: number;
   issues?: number;
+  // Set by mark_sync_started() while a sync is in progress
+  sync_started_at?: string;
 }
 
 export interface Integration {


### PR DESCRIPTION
## Summary
- Widens `sync_stats` Pydantic type from `dict[str, int]` to `dict[str, int | str]` in both `IntegrationResponse` and `AdminIntegration` models, fixing 500 errors caused by the `sync_started_at` ISO timestamp string added in #696
- Replaces `scalar_one_or_none()` with `scalars().first()` in the sync-status and HubSpot-owner-match endpoints, fixing 500s from `MultipleResultsFound` when duplicate integration rows exist for the same (org, connector)
- Adds `sync_started_at?: string` to the frontend `SyncStats` TypeScript interface
- Removes leftover debug instrumentation from the previous debugging session

## Test plan
- [x] Backend tests pass (239 passed)
- [x] Frontend build succeeds
- [ ] Switch between orgs in the UI — no 500 errors on integrations or sync-status endpoints
- [ ] Verify connectors list loads for all orgs including those with `sync_started_at` in sync_stats

Made with [Cursor](https://cursor.com)