### PR TITLE
Standardize terminology: replace "automations" with "workflows" across backend docs and models

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -247,9 +247,9 @@ When the user provides a CSV or file for import, include ALL available fields fr
 | Set up a recurring task | **run_sql_write** (INSERT INTO workflows) |
 | Research a company externally | **query_on_connector** (connector=web_search) — only if web_search is enabled |
 
-### Workflow Automations
+### Workflows
 
-For recurring automated tasks (e.g. "Every morning, send me a summary of stale deals to Slack"), use **run_sql_write** to INSERT INTO workflows. See the run_sql_write tool description for the prompt-based workflow format (name, prompt, trigger_type, trigger_config, auto_approve_tools). After creating a workflow, use **run_workflow** with wait_for_completion=false to test it. Users view workflows in the Automations tab.
+For recurring automated tasks (e.g. "Every morning, send me a summary of stale deals to Slack"), use **run_sql_write** to INSERT INTO workflows. See the run_sql_write tool description for the prompt-based workflow format (name, prompt, trigger_type, trigger_config, auto_approve_tools). After creating a workflow, use **run_workflow** with wait_for_completion=false to test it. Users view workflows in the Workflows tab.
 
 ## Database Schema
 

--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -125,7 +125,7 @@ Available tables (use these exact column names):
 - users: Team members (email, name, role, phone_number in E.164 format e.g. +14155551234)
 - user_mappings_for_identity: Slack identity links (external_userid, external_email, match_source)
 - organizations: User's company info (name, logo_url)
-- workflows: Workflow definitions (name, trigger_type, prompt, is_enabled, auto_approve_tools). Useful for listing and inspecting automations.
+- workflows: Workflow definitions (name, trigger_type, prompt, is_enabled, auto_approve_tools). Useful for listing and inspecting workflows.
 - workflow_runs: Workflow execution history (workflow_id, status, started_at, completed_at, output, workflow_notes). Useful for querying past run outcomes and notes.
 - github_repositories: Tracked GitHub repos (full_name, owner, name, is_tracked, last_sync_at). Join to commits/PRs via repository_id.
 - github_commits: Commits on tracked repos (repository_id, sha, message, author_name, author_email, author_login, author_date, additions, deletions, user_id).

--- a/backend/api/routes/waitlist.py
+++ b/backend/api/routes/waitlist.py
@@ -42,7 +42,7 @@ class WaitlistSubmitRequest(BaseModel):
     company_name: str
     num_employees: str  # e.g., "1-10", "11-50", "51-200", "201-500", "500+"
     apps_of_interest: list[str]  # e.g., ["salesforce", "hubspot", "slack"]
-    core_needs: list[str]  # e.g., ["query_crm", "insights", "automations"]
+    core_needs: list[str]  # e.g., ["query_crm", "insights", "workflows"]
 
 
 class WaitlistSubmitResponse(BaseModel):

--- a/backend/api/routes/workflows.py
+++ b/backend/api/routes/workflows.py
@@ -1,7 +1,7 @@
 """
 Workflow management API endpoints.
 
-Provides CRUD operations for user-defined workflow automations.
+Provides CRUD operations for user-defined workflows.
 """
 from __future__ import annotations
 

--- a/backend/models/workflow.py
+++ b/backend/models/workflow.py
@@ -1,5 +1,5 @@
 """
-Workflow models for user-defined automations.
+Workflow models for user-defined workflows.
 
 Workflows allow users to create automated actions that:
 - Run on a schedule (cron-based)

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -1070,7 +1070,7 @@ async def _execute_step(
     import warnings
     warnings.warn(
         "Legacy workflow step execution is deprecated. "
-        "Use prompt-based workflows for new automations.",
+        "Use prompt-based workflows for new workflows.",
         DeprecationWarning,
     )
     action = step.get("action")


### PR DESCRIPTION
### Motivation
- Clarify and standardize language by using the single term "workflows" instead of "automations" across code, docs, and comments to reduce confusion.

### Description
- Replace occurrences of "Workflow Automations"/"Automations" with "Workflows" and update references (e.g. UI tab text) in `backend/agents/orchestrator.py`.
- Update schema/help text and examples in `backend/agents/registry.py`, `backend/api/routes/workflows.py`, `backend/models/workflow.py`, `backend/api/routes/waitlist.py`, and `backend/workers/tasks/workflows.py` to use "workflows" in docstrings, comments, and examples.

### Testing
- Ran backend unit tests with `pytest -q`, which completed successfully.
- Ran static checks `ruff` and `mypy`, which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3fbfc680483218fddbaa36832e28e)