### PR TITLE
Rename /sources URL slug to /connectors + fix org-switch race

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -92,8 +92,11 @@ function App(): JSX.Element {
             console.log('[Auth] Masquerade active, preserving masquerade state');
             // Don't call handleAuthenticatedUser - keep the masqueraded user/org
           } else {
-            // Always sync with backend to get fresh data (including avatar_url)
-            await handleAuthenticatedUser(session.user);
+            // Always sync with backend to get fresh data (including avatar_url).
+            // When the app is already visible (persisted-user fast path), skip org
+            // updates — the URL sync in AppLayout is the source of truth for which
+            // org should be active.
+            await handleAuthenticatedUser(session.user, !!hasPersistedUser);
             // Refresh user's org list in background
             void useAppStore.getState().fetchUserOrganizations();
           }
@@ -173,7 +176,7 @@ function App(): JSX.Element {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleAuthenticatedUser = async (supabaseUser: User): Promise<void> => {
+  const handleAuthenticatedUser = async (supabaseUser: User, skipOrgUpdate = false): Promise<void> => {
     const email = supabaseUser.email ?? '';
     const domain = getEmailDomain(email);
     setEmailDomain(domain);
@@ -263,12 +266,14 @@ function App(): JSX.Element {
         // If sync returned an organization, set it and route based on onboarding status
         if (userData.organization) {
           const org = userData.organization as { id: string; name: string; logo_url: string | null; handle?: string | null };
-          setOrganization({
-            id: org.id,
-            name: org.name,
-            logoUrl: org.logo_url ?? null,
-            handle: org.handle ?? null,
-          });
+          if (!skipOrgUpdate) {
+            setOrganization({
+              id: org.id,
+              name: org.name,
+              logoUrl: org.logo_url ?? null,
+              handle: org.handle ?? null,
+            });
+          }
           await fetchUserOrganizations();
           if (userData.needs_onboarding) {
             setOnboardingMode(userData.onboarding_mode);
@@ -287,14 +292,16 @@ function App(): JSX.Element {
     await fetchUserOrganizations();
     const organizations = useAppStore.getState().organizations;
     if (organizations.length > 0) {
-      const activeOrg = organizations.find((o) => o.isActive) ?? organizations[0];
-      if (activeOrg) {
-        setOrganization({
-          id: activeOrg.id,
-          name: activeOrg.name,
-          logoUrl: activeOrg.logoUrl ?? null,
-          handle: activeOrg.handle ?? null,
-        });
+      if (!skipOrgUpdate) {
+        const activeOrg = organizations.find((o) => o.isActive) ?? organizations[0];
+        if (activeOrg) {
+          setOrganization({
+            id: activeOrg.id,
+            name: activeOrg.name,
+            logoUrl: activeOrg.logoUrl ?? null,
+            handle: activeOrg.handle ?? null,
+          });
+        }
       }
       setScreen('app');
       return;

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -372,7 +372,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
 
       const orgPrefixMatch = path.match(/^\/([a-z0-9-]+)(?:\/(.*))?$/);
     const orgHandleFromPath: string | null =
-      orgPrefixMatch && orgPrefixMatch[1] && !/^(auth|admin|embed|chat|apps|documents|artifact|artifacts|sources|data|workflows|memory|changes)$/i.test(orgPrefixMatch[1])
+      orgPrefixMatch && orgPrefixMatch[1] && !/^(auth|admin|embed|chat|apps|documents|artifact|artifacts|connectors|data|workflows|memory|changes)$/i.test(orgPrefixMatch[1])
         ? orgPrefixMatch[1]
         : null;
 
@@ -426,7 +426,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       }
       const viewMap: Record<string, typeof currentView> = {
         chats: "chats",
-        sources: "data-sources",
+        connectors: "data-sources",
         data: "data",
         workflows: "workflows",
         memory: "memory",
@@ -466,7 +466,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       "/": "home",
       "/chat": "chat",
       "/chats": "chats",
-      "/sources": "data-sources",
+      "/connectors": "data-sources",
       "/data": "data",
       "/workflows": "workflows",
       "/memory": "memory",
@@ -533,7 +533,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
         home: "/",
         chat: "/chat",
         chats: "/chats",
-        "data-sources": "/sources",
+        "data-sources": "/connectors",
         data: "/data",
         workflows: "/workflows",
         apps: "/apps",


### PR DESCRIPTION
## Summary
- Renames the `/sources` URL slug to `/connectors` to match the sidebar label
- Fixes a race condition where the background auth sync (`handleAuthenticatedUser`) would overwrite the active org set from the URL, causing page reloads on org-prefixed URLs (e.g. `/crometrics/connectors`) to redirect to the wrong org

## Test plan
- [ ] Navigate to `/<org-handle>/connectors` and reload — should stay on the correct org
- [ ] Switch orgs via the dropdown — should switch correctly without snapping back
- [ ] Fresh login navigates to the correct default org

Made with [Cursor](https://cursor.com)