### PR TITLE
fix: use admin session for HubSpot owner→user creation

### DIFF
--- a/backend/connectors/hubspot.py
+++ b/backend/connectors/hubspot.py
@@ -28,7 +28,7 @@ from connectors.registry import (
 from models.account import Account
 from models.activity import Activity
 from models.contact import Contact
-from models.database import get_session
+from models.database import get_admin_session, get_session
 from models.deal import Deal
 from models.goal import Goal
 from models.org_member import OrgMember
@@ -1688,7 +1688,7 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
             OrgMember.organization_id == org_uuid_hs,
             OrgMember.status.in_(_HUBSPOT_ORG_MEMBER_ACTIVE),
         )
-        async with get_session(organization_id=self.organization_id) as session:
+        async with get_admin_session() as session:
             result = await session.execute(
                 select(User).where(
                     User.email == owner_email,
@@ -1704,7 +1704,6 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
             user: User | None = result.scalar_one_or_none()
 
             if user:
-                # Matched — persist identity mapping with user_id
                 await self._ensure_identity_mapping(
                     session,
                     hs_owner_id=hs_owner_id,


### PR DESCRIPTION
## Summary
- HubSpot sync was failing with `permission denied for table users` when trying to create a `crm_only` user for a HubSpot owner during owner→user mapping.
- Root cause: `_map_hs_owner_to_user` used `get_session(organization_id=...)` which sets `ROLE revtops_app` — a role that lacks INSERT on the global `users` table.
- Fix: switch to `get_admin_session()` since user creation is a system-level operation on a non-org-scoped table.

## Test plan
- [ ] Trigger a HubSpot sync for an org where an owner email doesn't match any existing user
- [ ] Verify the sync completes without "permission denied for table users" error
- [ ] Confirm the new `crm_only` user and `OrgMember` rows are created correctly

Made with [Cursor](https://cursor.com)