### PR TITLE
fix: Masquerade admin menu + global admin while impersonating

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -2144,12 +2144,14 @@ async def list_user_organizations(
         if not user:
             raise HTTPException(status_code=404, detail="User not found")
 
+        from models.org_member import ORG_MEMBER_SCOPING_STATUSES
+
         result = await session.execute(
             select(OrgMember, Organization)
             .join(Organization, OrgMember.organization_id == Organization.id)
             .where(
                 OrgMember.user_id == user_uuid,
-                OrgMember.status.in_(MEMBER_ACTIVE_STATUSES),
+                OrgMember.status.in_(ORG_MEMBER_SCOPING_STATUSES),
             )
         )
         rows = result.all()
@@ -2639,7 +2641,7 @@ async def get_masquerade_user(
                     handle=org.handle,
                     subscription_required=not _sub_ok,
                 )
-        
+
         return MasqueradeUserResponse(
             id=str(target_user.id),
             email=target_user.email,

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -10,7 +10,7 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { API_BASE, apiRequest } from '../lib/api';
 import { useDeleteOrganization } from '../hooks';
-import { useAppStore, type UserProfile, type OrganizationInfo } from '../store';
+import { useAppStore, useAuthStore, type UserProfile, type OrganizationInfo } from '../store';
 
 type AdminTab = 'waitlist' | 'users' | 'organizations' | 'sources' | 'jobs';
 
@@ -149,6 +149,10 @@ function OrgRowActions({
     createPortal(
       <div
         ref={menuRef as React.RefObject<HTMLDivElement>}
+        onMouseDown={(e: React.MouseEvent) => {
+          // Keep document-level mousedown listeners from treating in-menu clicks as "outside".
+          e.stopPropagation();
+        }}
         className="fixed z-[9999] py-1 min-w-[120px] bg-surface-800 border border-surface-700 rounded-lg shadow-xl"
         style={{
           bottom: window.innerHeight - menuRect.top + 4,
@@ -234,6 +238,9 @@ function UserRowActions({
     createPortal(
       <div
         ref={menuRef as React.RefObject<HTMLDivElement>}
+        onMouseDown={(e: React.MouseEvent) => {
+          e.stopPropagation();
+        }}
         className="fixed z-[9999] py-1 min-w-[140px] bg-surface-800 border border-surface-700 rounded-lg shadow-xl"
         style={{
           bottom: window.innerHeight - menuRect.top + 4,
@@ -631,7 +638,11 @@ export function AdminPanel(): JSX.Element {
   };
 
   const handleMasquerade = async (targetUserId: string): Promise<void> => {
-    if (!user) return;
+    const actor = useAuthStore.getState().user;
+    if (!actor) {
+      alert('You must be signed in to masquerade. Try refreshing the page.');
+      return;
+    }
 
     setMasquerading(targetUserId);
 
@@ -651,7 +662,7 @@ export function AdminPanel(): JSX.Element {
       };
 
       const { data, error } = await apiRequest<MasqueradeApiResponse>(
-        `/auth/masquerade/${encodeURIComponent(targetUserId)}?admin_user_id=${encodeURIComponent(user.id)}`,
+        `/auth/masquerade/${encodeURIComponent(targetUserId)}?admin_user_id=${encodeURIComponent(actor.id)}`,
         { method: 'GET' },
       );
 
@@ -686,6 +697,7 @@ export function AdminPanel(): JSX.Element {
       };
 
       startMasquerade(targetUser, targetOrg);
+      await fetchUserOrganizations();
       setCurrentView('home');
     } catch (err) {
       console.error('Failed to masquerade:', err);

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -39,7 +39,7 @@ const ArtifactFullView = lazy(() => import('./ArtifactFullView').then(m => ({ de
 const DocumentsGallery = lazy(() => import('./documents/DocumentsGallery').then(m => ({ default: m.DocumentsGallery })));
 import { APP_NAME, LOGO_PATH, RELEASE_STAGE } from '../lib/brand';
 import { ProfilePanel } from './ProfilePanel';
-import { useAppStore, useChatStore, useUIStore, useMasquerade, useIntegrations, useIsSwitchingOrg, type ActiveTask, type ToolCallData, type ChatMessage, type ContentBlock } from '../store';
+import { useAppStore, useChatStore, useUIStore, useMasquerade, useIntegrations, useIsSwitchingOrg, useIsGlobalAdmin, type ActiveTask, type ToolCallData, type ChatMessage, type ContentBlock } from '../store';
 import { useTeamMembers, useWebSocket } from '../hooks';
 import { apiRequest } from '../lib/api';
 
@@ -1604,7 +1604,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
     setCurrentChatId(null);
   }, [setCurrentChatId]);
 
-  const isGlobalAdmin: boolean = user?.roles.includes('global_admin') ?? false;
+  const isGlobalAdmin: boolean = useIsGlobalAdmin();
 
   useEffect(() => {
     if (currentView === 'admin' && !isGlobalAdmin) {

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -140,15 +140,29 @@ export const useAuthStore = create<AuthState>()(
           isActive: o.id === orgId,
         }));
 
-        set({
-          organization: {
-            id: orgInList.id,
-            name: orgInList.name,
-            logoUrl: orgInList.logoUrl,
-            handle: orgInList.handle,
-          },
-          organizations: updatedOrgs,
-        });
+        const nextOrganization: OrganizationInfo = {
+          id: orgInList.id,
+          name: orgInList.name,
+          logoUrl: orgInList.logoUrl,
+          handle: orgInList.handle,
+        };
+
+        const masq = get().masquerade;
+        if (masq) {
+          set({
+            organization: nextOrganization,
+            organizations: updatedOrgs,
+            masquerade: {
+              ...masq,
+              masqueradeOrganization: nextOrganization,
+            },
+          });
+        } else {
+          set({
+            organization: nextOrganization,
+            organizations: updatedOrgs,
+          });
+        }
 
         useChatStore.setState({
           currentChatId: null,

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -159,10 +159,14 @@ export const useIsAuthenticated = () =>
 export const useSidebarCollapsed = () =>
   useUIStore((state) => state.sidebarCollapsed);
 export const useCurrentView = () => useUIStore((state) => state.currentView);
-export const useIsGlobalAdmin = () =>
-  useAuthStore(
-    (state) => state.user?.roles?.includes("global_admin") ?? false,
-  );
+/** True if the signed-in user or the pre-masquerade admin is global_admin (UI access while impersonating). */
+export const useIsGlobalAdmin = (): boolean =>
+  useAuthStore((state) => {
+    if (state.user?.roles?.includes("global_admin")) return true;
+    if (state.masquerade?.originalUser.roles?.includes("global_admin"))
+      return true;
+    return false;
+  });
 export const useMasquerade = () => useAuthStore((state) => state.masquerade);
 export const useIsMasquerading = () =>
   useAuthStore((state) => state.masquerade !== null);


### PR DESCRIPTION
## Summary
Global admin **Masquerade** from the Users tab could close the dropdown on `mousedown` without firing the menu action, so no `/auth/masquerade` request ran. This stops propagation on the portal menu roots (org + user), uses the auth store user for `admin_user_id`, and refreshes organizations after a successful masquerade.

## Also
- **`useIsGlobalAdmin`** includes the pre-masquerade `originalUser` so the admin view guard does not bounce impersonating admins to home.
- **`switchActiveOrganization`** updates `masqueradeOrganization` when masquerading.
- **`list_user_organizations`** uses `ORG_MEMBER_SCOPING_STATUSES` for consistency with masquerade/org membership rules.

## Checks
- `npm run build` (frontend)
- `pytest -q tests` (240 passed)

Made with [Cursor](https://cursor.com)