### PR TITLE
Restrict workflow Slack posts to allowed channels or DMs

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -4755,7 +4755,11 @@ async def execute_send_email_from(
 
 
 async def _send_slack(
-    params: dict[str, Any], organization_id: str, user_id: str | None, skip_approval: bool = False
+    params: dict[str, Any],
+    organization_id: str,
+    user_id: str | None,
+    skip_approval: bool = False,
+    context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """
     Post a message to a Slack channel.
@@ -4780,6 +4784,24 @@ async def _send_slack(
     
     if not message:
         return {"error": "Message text is required."}
+
+    if context and context.get("is_workflow"):
+        allowed_channels = context.get("allowed_slack_channels") or []
+        allowed_lookup = {str(item).strip().lower() for item in allowed_channels if str(item).strip()}
+        is_dm = channel.upper().startswith("D")
+        if not is_dm and channel.lower() not in allowed_lookup:
+            logger.warning(
+                "[Tools._send_slack] Blocked workflow Slack target workflow_id=%s channel=%s allowed_channels=%s",
+                context.get("workflow_id"),
+                channel,
+                list(allowed_lookup),
+            )
+            return {
+                "error": (
+                    "Workflow can only send Slack messages to explicitly allowed channels "
+                    "or direct messages."
+                )
+            }
     
     # Note: SlackConnector.post_message auto-converts markdown to mrkdwn
     

--- a/backend/tests/test_workflow_send_slack_action.py
+++ b/backend/tests/test_workflow_send_slack_action.py
@@ -58,3 +58,37 @@ def test_action_send_slack_posts_with_team_id(monkeypatch) -> None:
         "organization_id": "00000000-0000-0000-0000-000000000001",
         "team_id": "T123",
     }
+
+
+def test_action_send_slack_blocks_unlisted_channel(monkeypatch) -> None:
+    integration = SimpleNamespace(
+        nango_connection_id="conn_123",
+        extra_data={"team_id": "T123"},
+    )
+    workflow = SimpleNamespace(
+        id="wf_1",
+        output_config={"allowed_slack_channels": ["#ops-alerts"]},
+    )
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args: object, **_kwargs: object):
+        yield _FakeSession(integration)
+
+    monkeypatch.setattr("models.database.get_session", _fake_get_session)
+    monkeypatch.setattr("connectors.slack.SlackConnector", _FakeSlackConnector)
+
+    async def _run() -> dict[str, object]:
+        return await workflows._action_send_slack(
+            params={"channel": "#random", "message": "hello"},
+            context={"organization_id": "00000000-0000-0000-0000-000000000001"},
+            workflow=workflow,
+        )
+
+    result = asyncio.run(_run())
+
+    assert result["status"] == "failed"
+    assert "explicitly allowed channels" in str(result["error"])
+
+
+def test_workflow_slack_target_allows_dm_channel() -> None:
+    assert workflows._is_allowed_workflow_slack_target("D12345", ["#ops"]) is True

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -38,6 +38,59 @@ WORKFLOW_NESTING_GUARDRAIL = (
 )
 
 
+def _extract_allowed_slack_channels(workflow: Any) -> list[str]:
+    """Extract workflow-approved Slack channels from output_config."""
+    if not workflow:
+        return []
+
+    output_config = getattr(workflow, "output_config", None)
+    if not isinstance(output_config, dict):
+        return []
+
+    allowed: list[str] = []
+
+    def _collect(value: Any) -> None:
+        if isinstance(value, str) and value.strip():
+            allowed.append(value.strip())
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, str) and item.strip():
+                    allowed.append(item.strip())
+
+    _collect(output_config.get("allowed_slack_channels"))
+    _collect(output_config.get("allowed_channels"))
+    _collect(output_config.get("channels"))
+    _collect(output_config.get("channel"))
+
+    slack_config = output_config.get("slack")
+    if isinstance(slack_config, dict):
+        _collect(slack_config.get("allowed_channels"))
+        _collect(slack_config.get("channels"))
+        _collect(slack_config.get("channel"))
+
+    unique: list[str] = []
+    seen: set[str] = set()
+    for channel in allowed:
+        key = channel.lower()
+        if key not in seen:
+            seen.add(key)
+            unique.append(channel)
+    return unique
+
+
+def _is_allowed_workflow_slack_target(channel: str, allowed_channels: list[str]) -> bool:
+    """Allow only workflow-listed channels and DMs."""
+    normalized = (channel or "").strip()
+    if not normalized:
+        return False
+
+    if normalized.upper().startswith("D"):
+        return True
+
+    allowed_lookup = {item.lower() for item in allowed_channels}
+    return normalized.lower() in allowed_lookup
+
+
 # =============================================================================
 # Schema Validation and Parameter Formatting
 # =============================================================================
@@ -915,6 +968,7 @@ async def _execute_workflow_via_agent(
         "workflow_run_id": str(run.id),
         "runtime_context": runtime_context,
         "auto_approve_tools": effective_auto_approve_tools,
+        "allowed_slack_channels": _extract_allowed_slack_channels(workflow),
         "call_stack": call_stack,  # For nested workflow recursion detection
         "execution_guardrails": [WORKFLOW_NESTING_GUARDRAIL],
     }
@@ -1353,6 +1407,23 @@ async def _action_send_slack(
         return {
             "status": "failed",
             "error": "No message specified",
+        }
+
+    allowed_channels = _extract_allowed_slack_channels(workflow)
+    if workflow is not None and not _is_allowed_workflow_slack_target(channel, allowed_channels):
+        logger.warning(
+            "[workflow.send_slack] Blocked channel outside workflow allowlist org_id=%s workflow_id=%s channel=%s allowed_channels=%s",
+            org_id,
+            getattr(workflow, "id", None),
+            channel,
+            allowed_channels,
+        )
+        return {
+            "status": "failed",
+            "error": (
+                "Workflow can only send Slack messages to explicitly allowed channels "
+                "or direct messages."
+            ),
         }
     
     # Substitute context variables in message


### PR DESCRIPTION
### Motivation
- Prevent workflows from posting Slack messages to arbitrary channels by default and limit destinations to explicit workflow allowlists or direct messages for safety.
- Ensure the workflow execution context carries explicit destination policy so tools invoked during runs can enforce the same guardrails.

### Description
- Added `_extract_allowed_slack_channels(workflow)` to normalize allowed channels from `workflow.output_config` (supports `allowed_slack_channels`, `allowed_channels`, `channels`, `channel`, and nested `slack` shapes). (backend/workers/tasks/workflows.py)
- Added `_is_allowed_workflow_slack_target(channel, allowed_channels)` to validate targets and treat Slack DM channel IDs (starting with `D`) as allowed. (backend/workers/tasks/workflows.py)
- Injected `allowed_slack_channels` into the runtime `workflow_context` for prompt-based workflow runs so tools have access to the allowlist. (backend/workers/tasks/workflows.py)
- Enforced the allowlist in the legacy workflow action path `_action_send_slack`, returning a clear failure and logging when the channel is not permitted. (backend/workers/tasks/workflows.py)
- Propagated the same policy to the tool layer by extending `_send_slack` to accept `context` and block non-allowlisted/non-DM targets when `context["is_workflow"]` is present. (backend/agents/tools.py)
- Added tests to cover blocking behavior for unlisted channels and to allow DM channel IDs, and retained the existing success test. (backend/tests/test_workflow_send_slack_action.py)

### Testing
- Ran `pytest -q backend/tests/test_workflow_send_slack_action.py` and all tests passed (`3 passed`).
- Ran `python -m py_compile backend/workers/tasks/workflows.py backend/agents/tools.py` to validate syntax and byte-compile the modified modules, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5504b63d0832195159d336472ef41)