### PR TITLE
Pass Slack channel context into orchestrator prompts

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -37,7 +37,11 @@ logger = logging.getLogger(__name__)
 _TOOL_EXECUTION_TIMEOUT_SECONDS: float = 600.0  # 10 minutes
 
 
-def _format_slack_scope_context(slack_channel_id: str | None, slack_thread_ts: str | None) -> str:
+def _format_slack_scope_context(
+    slack_channel_id: str | None,
+    slack_thread_ts: str | None,
+    slack_channel_name: str | None = None,
+) -> str:
     """Build prompt guidance for Slack channel/thread query scoping."""
     if not slack_channel_id:
         return ""
@@ -53,10 +57,17 @@ def _format_slack_scope_context(slack_channel_id: str | None, slack_thread_ts: s
         else "AND custom_fields->>'thread_ts' = '<thread_ts>'"
     )
 
+    channel_name_line: str = (
+        f"This conversation is happening in Slack channel name: #{slack_channel_name}\n"
+        if slack_channel_name
+        else ""
+    )
+
     return f"""
 
 ## Slack Channel Context
 This conversation is happening in Slack channel ID: {slack_channel_id}
+{channel_name_line}
 {thread_line}
 When users refer to Slack scope, distinguish **thread/chat** vs **channel**:
 - "this chat", "this thread", "this conversation" → scope to the current thread when `thread_ts` is available.
@@ -980,7 +991,14 @@ class ChatOrchestrator:
 
         slack_channel_id: str | None = (self.workflow_context or {}).get("slack_channel_id")
         slack_thread_ts: str | None = (self.workflow_context or {}).get("slack_thread_ts")
-        system_prompt_parts.append(_format_slack_scope_context(slack_channel_id=slack_channel_id, slack_thread_ts=slack_thread_ts))
+        slack_channel_name: str | None = (self.workflow_context or {}).get("slack_channel_name")
+        system_prompt_parts.append(
+            _format_slack_scope_context(
+                slack_channel_id=slack_channel_id,
+                slack_thread_ts=slack_thread_ts,
+                slack_channel_name=slack_channel_name,
+            )
+        )
 
         # 4. Connected connectors (trimmed preamble)
         if self.organization_id:

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -92,6 +92,28 @@ def _merge_participating_user_ids(
     return current
 
 
+def _build_workflow_context_for_message(
+    platform_slug: str,
+    ctx: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Build workflow_context for orchestrator from inbound messenger context."""
+    workflow_context: dict[str, Any] = dict(ctx.get("workflow_context") or {})
+
+    if platform_slug == "slack":
+        slack_channel_id: str | None = ctx.get("channel_id")
+        slack_thread_ts: str | None = ctx.get("thread_id") or ctx.get("thread_ts")
+        slack_channel_name: str | None = ctx.get("channel_name")
+
+        if slack_channel_id and not workflow_context.get("slack_channel_id"):
+            workflow_context["slack_channel_id"] = slack_channel_id
+        if slack_thread_ts and not workflow_context.get("slack_thread_ts"):
+            workflow_context["slack_thread_ts"] = slack_thread_ts
+        if slack_channel_name and not workflow_context.get("slack_channel_name"):
+            workflow_context["slack_channel_name"] = slack_channel_name
+
+    return workflow_context or None
+
+
 
 # ===========================================================================
 # WorkspaceMessenger
@@ -745,6 +767,10 @@ class WorkspaceMessenger(BaseMessenger):
 
         ctx: dict[str, Any] = message.messenger_context
         slack_user_email: str | None = ctx.get("user_email")
+        workflow_context: dict[str, Any] | None = _build_workflow_context_for_message(
+            platform_slug=self.meta.slug,
+            ctx=ctx,
+        )
 
         orchestrator = ChatOrchestrator(
             user_id=str(user.id),
@@ -753,7 +779,7 @@ class WorkspaceMessenger(BaseMessenger):
             user_email=user.email,
             source_user_id=message.external_user_id,
             source_user_email=slack_user_email or user.email,
-            workflow_context=ctx.get("workflow_context"),
+            workflow_context=workflow_context,
             source=self.meta.slug,
             timezone=ctx.get("timezone"),
             local_time=ctx.get("local_time"),

--- a/backend/tests/test_workspace_workflow_context.py
+++ b/backend/tests/test_workspace_workflow_context.py
@@ -1,0 +1,39 @@
+from messengers._workspace import _build_workflow_context_for_message
+
+
+def test_build_workflow_context_for_slack_includes_channel_fields() -> None:
+    ctx = {
+        "channel_id": "C123",
+        "thread_ts": "1700000000.001",
+        "channel_name": "sales-team",
+    }
+
+    workflow_context = _build_workflow_context_for_message("slack", ctx)
+
+    assert workflow_context is not None
+    assert workflow_context["slack_channel_id"] == "C123"
+    assert workflow_context["slack_thread_ts"] == "1700000000.001"
+    assert workflow_context["slack_channel_name"] == "sales-team"
+
+
+def test_build_workflow_context_preserves_existing_values() -> None:
+    ctx = {
+        "channel_id": "C999",
+        "thread_ts": "1700000000.999",
+        "channel_name": "engineering",
+        "workflow_context": {
+            "workflow_id": "wf_1",
+            "slack_channel_id": "C123",
+            "slack_thread_ts": "1700000000.001",
+            "slack_channel_name": "sales",
+        },
+    }
+
+    workflow_context = _build_workflow_context_for_message("slack", ctx)
+
+    assert workflow_context == {
+        "workflow_id": "wf_1",
+        "slack_channel_id": "C123",
+        "slack_thread_ts": "1700000000.001",
+        "slack_channel_name": "sales",
+    }


### PR DESCRIPTION
### Motivation
- Ensure inbound Slack messages reliably surface channel/thread metadata to the orchestrator so prompts and tools can scope queries correctly.

### Description
- Add helper ` _build_workflow_context_for_message` to normalize and merge Slack fields (`slack_channel_id`, `slack_thread_ts`, `slack_channel_name`) into `workflow_context` when present.  
- Wire the helper into `WorkspaceMessenger.process_inbound` so `ChatOrchestrator` receives the normalized `workflow_context` instead of raw `ctx["workflow_context"]`.  
- Extend `_format_slack_scope_context` in `agents.orchestrator` to optionally include a human-readable channel name when available and include it in system prompt assembly.  
- Add unit tests in `backend/tests/test_workspace_workflow_context.py` validating injection and preservation of existing workflow context values.

### Testing
- Ran `pytest -q backend/tests/test_workspace_workflow_context.py`, which passed (2 tests).
- An attempted additional orchestrator formatting test that imported `agents.orchestrator` was removed after discovery of an unrelated circular-import issue during test collection, so it was not included in the final test set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5749a345c832183fb69d0a9b9a1f6)