### PR TITLE
Fix attachment viewer missing org context

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4,7 +4,7 @@
  * Uses centralized API configuration from lib/api.ts
  */
 
-import { API_BASE, apiRequest, type ApiResponse } from "../lib/api";
+import { API_BASE, apiRequest, getAuthenticatedRequestHeaders, type ApiResponse } from "../lib/api";
 
 // Re-export for backwards compatibility
 export { API_BASE, apiRequest };
@@ -340,23 +340,22 @@ export interface UploadResponse {
 export async function uploadChatFile(
   file: File,
 ): Promise<ApiResponse<UploadResponse>> {
-  const { supabase } = await import("../lib/supabase");
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const token: string | undefined = session?.access_token;
-
-  if (!token) {
+  const authHeaders = await getAuthenticatedRequestHeaders();
+  if (!authHeaders.Authorization) {
     return { data: null, error: "Not authenticated" };
   }
 
   const formData = new FormData();
   formData.append("file", file);
 
+  // Remove Content-Type so browser sets multipart boundary automatically
+  const { "Content-Type": _contentType, ...uploadHeaders } = authHeaders as Record<string, string>;
+  void _contentType;
+
   try {
     const response = await fetch(`${API_BASE}/chat/upload`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${token}` },
+      headers: uploadHeaders,
       body: formData,
     });
 

--- a/frontend/src/components/ArtifactViewer.tsx
+++ b/frontend/src/components/ArtifactViewer.tsx
@@ -18,7 +18,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { apiRequest, API_BASE, getAuthenticatedRequestHeaders } from "../lib/api";
 import { formatDateOnly } from "../lib/dates";
-import { supabase } from "../lib/supabase";
+
 
 // New file-based artifact format
 interface FileArtifact {
@@ -176,15 +176,10 @@ export function ArtifactViewer({
     setShowDownloadMenu(false);
 
     try {
-      // Get auth token for download request
-      const { data: { session } } = await supabase.auth.getSession();
-      const token = session?.access_token;
-      
+      const dlHeaders = await getAuthenticatedRequestHeaders();
       const response = await fetch(
         `${API_BASE}/artifacts/${artifact.id}/download?format=${format}`,
-        {
-          headers: token ? { Authorization: `Bearer ${token}` } : {},
-        }
+        { headers: dlHeaders },
       );
       if (!response.ok) {
         throw new Error("Failed to download artifact");

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -24,8 +24,8 @@ import { ScopeLockIcon } from './ScopeVisibilityIcons';
 import { getConversation, updateConversation, uploadChatFile, type UploadResponse } from '../api/client';
 import { useIsMobile } from '../hooks';
 import { useTeamMembers, type TeamMember } from '../hooks/useOrganization';
-import { API_BASE, apiRequest } from '../lib/api';
-import { supabase } from '../lib/supabase';
+import { API_BASE, apiRequest, getAuthenticatedRequestHeaders } from '../lib/api';
+
 import { crossTab } from '../lib/crossTab';
 import { APP_NAME, LOGO_PATH } from '../lib/brand';
 import {
@@ -3789,11 +3789,10 @@ function ChatAttachmentImageThumbnail({
     let cancelled = false;
     void (async () => {
       try {
-        const { data: { session } } = await supabase.auth.getSession();
-        const token: string | undefined = session?.access_token ?? undefined;
+        const hdrs = await getAuthenticatedRequestHeaders();
         const response: Response = await fetch(
           `${API_BASE}/chat/attachments/${encodeURIComponent(attachmentId)}`,
-          { headers: token ? { Authorization: `Bearer ${token}` } : {} },
+          { headers: hdrs },
         );
         if (!response.ok || cancelled) throw new Error('attachment fetch failed');
         const blob: Blob = await response.blob();


### PR DESCRIPTION
## Summary
- Attachment preview showed "Organization context required" error for all users
- The `ArtifactViewer` fetched attachments with raw `fetch()` using only the JWT token, missing the `X-Organization-Id` header the backend requires
- Replaced with `getAuthenticatedRequestHeaders()` which includes org context, masquerade, and admin headers — consistent with all other API calls

## Test plan
- [ ] Open a shared conversation containing an image attachment
- [ ] Click the attachment — should render the image instead of showing "Organization context required"

🤖 Generated with [Claude Code](https://claude.com/claude-code)