### PR TITLE
Fix artifact downloads broken by leftover debug logging

### DIFF
--- a/backend/api/routes/artifacts.py
+++ b/backend/api/routes/artifacts.py
@@ -198,13 +198,6 @@ async def download_artifact(
 
         content_type: str = artifact.content_type or "text"
         filename: str = artifact.filename or f"artifact.{_get_extension(content_type)}"
-        
-        # #region agent log
-        import json as _json, time as _time
-        _log_path = "/Users/teg/Documents/basebase/basebase/.cursor/debug-fc2f88.log"
-        with open(_log_path, "a") as _f:
-            _f.write(_json.dumps({"sessionId":"fc2f88","hypothesisId":"H1","location":"artifacts.py:download","message":"download_artifact called","data":{"artifact_id":str(artifact.id),"stored_content_type":content_type,"requested_format":format,"filename":filename,"content_length":len(artifact.content) if artifact.content else 0},"timestamp":int(_time.time()*1000),"runId":"post-fix"}) + "\n")
-        # #endregion
 
         # When format=pdf is requested, generate PDF from any text-based content
         if format == "pdf" and content_type in ("markdown", "text", "pdf"):
@@ -212,10 +205,6 @@ async def download_artifact(
             pdf_filename: str = artifact.filename or "artifact.pdf"
             if not pdf_filename.endswith(".pdf"):
                 pdf_filename = pdf_filename.rsplit(".", 1)[0] + ".pdf"
-            # #region agent log
-            with open(_log_path, "a") as _f:
-                _f.write(_json.dumps({"sessionId":"fc2f88","hypothesisId":"H1_fix","location":"artifacts.py:format_pdf_branch","message":"PDF generated via format param","data":{"pdf_size":len(pdf_bytes),"starts_with_percent_pdf":pdf_bytes[:5] == b"%PDF-","pdf_filename":pdf_filename},"timestamp":int(_time.time()*1000),"runId":"post-fix"}) + "\n")
-            # #endregion
             return Response(
                 content=pdf_bytes,
                 media_type="application/pdf",

--- a/frontend/src/components/ArtifactViewer.tsx
+++ b/frontend/src/components/ArtifactViewer.tsx
@@ -186,9 +186,6 @@ export function ArtifactViewer({
       }
 
       const blob = await response.blob();
-      // #region agent log
-      fetch('http://127.0.0.1:7249/ingest/bbad8696-7c16-4021-b7f0-8afa9db11c4a',{method:'POST',headers:{'Content-Type':'application/json','X-Debug-Session-Id':'fc2f88'},body:JSON.stringify({sessionId:'fc2f88',hypothesisId:'H1_H4',location:'ArtifactViewer.tsx:handleDownload',message:'Download response received',data:{requestedFormat:format,responseContentType:response.headers.get('content-type'),blobSize:blob.size,blobType:blob.type,responseStatus:response.status},timestamp:Date.now()})}).catch(()=>{});
-      // #endregion
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;


### PR DESCRIPTION
## Summary
- Artifact downloads (both native markdown and PDF) were failing with 500 errors
- Root cause: Cursor debug instrumentation left in `artifacts.py` that writes to a hardcoded local path (`/Users/teg/...`) — throws `FileNotFoundError` on any machine except the original developer's
- Also removed a matching frontend debug `fetch()` call to `127.0.0.1:7249` in `ArtifactViewer.tsx` (this one was silently caught but shouldn't be in prod)

## What was removed
- **Backend** (`artifacts.py`): Three `#region agent log` blocks that wrote to a local file on every download request
- **Frontend** (`ArtifactViewer.tsx`): One debug fetch POST to localhost after blob download

## Test plan
- [ ] Open an artifact in the viewer → click Download → Native format — should download the `.md` file
- [ ] Same artifact → click Download → PDF — should download a `.pdf` file
- [ ] Verify no 500 errors in Railway logs for `/artifacts/{id}/download`

🤖 Generated with [Claude Code](https://claude.com/claude-code)