### PR TITLE
Rename global admin sidebar Sources tab to "Sources & Health"

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -609,7 +609,7 @@ const GLOBAL_ADMIN_NAV_ITEMS: ReadonlyArray<{
   },
   {
     id: 'sources',
-    label: 'Sources',
+    label: 'Sources & Health',
     icon: (
       <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4" />


### PR DESCRIPTION
### Motivation
- Clarify the global admin navigation to indicate the tab covers both data sources and health information by renaming the label to `Sources & Health`.

### Description
- Updated the admin sidebar label in `GLOBAL_ADMIN_NAV_ITEMS` inside `frontend/src/components/Sidebar.tsx` from `Sources` to `Sources & Health` and preserved the underlying tab `id: 'sources'` and routing.

### Testing
- No automated tests were run for this copy-only UI label change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6b5d8bd048321ac7aa0a1ab699be4)