### PR TITLE
Add automated-agent signature footer for outbound email, SMS, and created issues

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -96,6 +96,23 @@ class PendingOperationData(TypedDict):
 # In-memory store for pending operations (will be replaced by database in Phase 6)
 _pending_operations: dict[str, PendingOperationData] = {}
 
+_AUTOMATED_AGENT_FOOTER: str = "Done by an automated agent via Basebase."
+_AUTOMATED_AGENT_FOOTER_MARKER: re.Pattern[str] = re.compile(
+    r"done\s+by\s+an\s+automated\s+agent",
+    flags=re.IGNORECASE,
+)
+
+
+def _ensure_automated_agent_footer(content: str | None) -> str:
+    """Ensure outbound user-authored messages/issues include an automation signature footer."""
+    base_text: str = (content or "").rstrip()
+    if _AUTOMATED_AGENT_FOOTER_MARKER.search(base_text):
+        return base_text
+    footer_line: str = f"— {_AUTOMATED_AGENT_FOOTER}"
+    if not base_text:
+        return footer_line
+    return f"{base_text}\n\n{footer_line}"
+
 def store_pending_operation(
     operation_id: str,
     tool_name: str,
@@ -2451,10 +2468,15 @@ async def _execute_linear_create(
         team_key,
         title,
     )
+    signed_description: str = _ensure_automated_agent_footer(record.get("description"))
+    logger.info(
+        "[Tools._execute_linear_create] Applying automated-agent footer for Linear issue team_key=%s",
+        team_key,
+    )
     issue: dict[str, Any] = await connector.create_issue(
         team_key=team_key,
         title=title,
-        description=record.get("description"),
+        description=signed_description,
         priority=record.get("priority"),
         assignee_name=record.get("assignee_name"),
         project_name=record.get("project_name"),
@@ -2565,7 +2587,14 @@ async def _handle_github_write(
 
     for i, record in enumerate(records):
         try:
-            result: dict[str, Any] = await connector.write(resolved_op, record)
+            record_payload: dict[str, Any] = dict(record)
+            if resolved_op == "create_issue":
+                record_payload["body"] = _ensure_automated_agent_footer(record.get("body"))
+                logger.info(
+                    "[Tools._handle_github_write] Applying automated-agent footer for GitHub issue repo=%s",
+                    record.get("repo_full_name", ""),
+                )
+            result: dict[str, Any] = await connector.write(resolved_op, record_payload)
             results.append(result)
         except Exception as exc:
             error_msg: str = f"Record {i + 1}: {exc}"
@@ -4743,11 +4772,17 @@ async def execute_send_email_from(
                 user_id=user_id,
             )
         
+        body_with_footer: str = _ensure_automated_agent_footer(body)
+        logger.info(
+            "[Tools.execute_send_email_from] Applying automated-agent footer for email to %s",
+            to,
+        )
+
         # Send the email
         result = await connector.send_email(
             to=to,
             subject=subject,
-            body=body,
+            body=body_with_footer,
             cc=cc if cc else None,
             bcc=bcc if bcc else None,
         )
@@ -4977,7 +5012,9 @@ async def _send_sms(
     if len(digits_only) < 7 or len(digits_only) > 15:
         return {"error": f"Invalid phone number '{to}'. Expected E.164 format, e.g. +14155551234."}
 
-    result: dict[str, str | bool] = await send_sms(to=to, body=body)
+    body_with_footer: str = _ensure_automated_agent_footer(body)
+    logger.info("[Tools._send_sms] Applying automated-agent footer for SMS to %s", to)
+    result: dict[str, str | bool] = await send_sms(to=to, body=body_with_footer)
 
     if result.get("success"):
         return {

--- a/backend/tests/test_tools_automated_agent_footer.py
+++ b/backend/tests/test_tools_automated_agent_footer.py
@@ -1,0 +1,66 @@
+import asyncio
+from typing import Any
+
+from agents import tools
+
+
+def test_ensure_automated_agent_footer_appends_once() -> None:
+    signed = tools._ensure_automated_agent_footer("Hello there")
+    assert "Done by an automated agent" in signed
+    assert signed.startswith("Hello there")
+
+    signed_again = tools._ensure_automated_agent_footer(signed)
+    assert signed_again == signed
+
+
+def test_ensure_automated_agent_footer_handles_empty() -> None:
+    signed = tools._ensure_automated_agent_footer("")
+    assert signed.startswith("— Done by an automated agent")
+
+
+def test_execute_linear_create_adds_footer() -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeLinearConnector:
+        async def create_issue(self, **kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"identifier": "ENG-1", "title": kwargs["title"]}
+
+    record = {"team_key": "ENG", "title": "Need fix", "description": "Please investigate"}
+    result = asyncio.run(tools._execute_linear_create(FakeLinearConnector(), record))
+
+    assert result["identifier"] == "ENG-1"
+    assert "Done by an automated agent" in captured["description"]
+
+
+def test_handle_github_write_create_issue_adds_footer(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeGitHubConnector:
+        def __init__(self, organization_id: str) -> None:
+            self.organization_id = organization_id
+
+        async def write(self, operation: str, data: dict[str, Any]) -> dict[str, Any]:
+            captured["operation"] = operation
+            captured["data"] = data
+            return {"number": 1, "title": data.get("title", "")}
+
+    monkeypatch.setattr("connectors.github.GitHubConnector", FakeGitHubConnector)
+
+    result = asyncio.run(
+        tools._handle_github_write(
+            records=[
+                {
+                    "repo_full_name": "acme/repo",
+                    "title": "Agent-created issue",
+                    "body": "Issue details",
+                }
+            ],
+            organization_id="00000000-0000-0000-0000-000000000001",
+            operation="create",
+        )
+    )
+
+    assert result["status"] == "completed"
+    assert captured["operation"] == "create_issue"
+    assert "Done by an automated agent" in captured["data"]["body"]


### PR DESCRIPTION
### Motivation
- Ensure any action that appears to be sent "as a user" from the app includes an explicit automation disclosure so recipients know the outbound content was produced or sent by an automated agent.

### Description
- Added a centralized helper ` _ensure_automated_agent_footer(...)` to append a single, idempotent footer (`— Done by an automated agent via Basebase.`) to outbound user-authored content.
- Applied the footer to user email sends by updating `execute_send_email_from` to pass `body_with_footer` to connectors and added a log statement for traceability.
- Applied the footer to SMS sends by updating `_send_sms` to sign the `body` before calling `send_sms` and added a log statement.
- Applied the footer to issue creation flows by signing Linear `description` in `_execute_linear_create` and signing GitHub issue `body` in `_handle_github_write`, with logging at each signing site.
- Added unit tests in `backend/tests/test_tools_automated_agent_footer.py` that verify the footer is appended once, handles empty content, and is applied to Linear and GitHub issue creation paths.

### Testing
- Ran `pytest -q backend/tests/test_tools_automated_agent_footer.py backend/tests/test_tools_write_to_system_of_record.py`, which failed at collection due to an existing circular import chain in this environment (`agents.tools -> connectors.fireflies -> api.websockets -> agents.orchestrator -> agents.tools`).
- Ran `python -m compileall backend/agents/tools.py backend/tests/test_tools_automated_agent_footer.py`, which completed successfully and shows the new code and tests are syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6b7dd149c832181fd108da01bf5e2)