### PR TITLE
Fix scope toggle: persist after sending, fix Safari click

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2261,32 +2261,47 @@ export function Chat({
               </button>
             );
 
-            const scopeToggle: JSX.Element | null = (!chatId && !localConversationId) ? (
+            // Scope toggle: shown for new conversations and existing ones the user owns
+            const isNewConversation: boolean = !chatId && !localConversationId;
+            const activeScope: 'private' | 'shared' = isNewConversation ? newConversationScope : conversationScope;
+            const showScopeToggle: boolean = isNewConversation || canToggleChatScope;
+            const scopeToggle: JSX.Element | null = showScopeToggle ? (
               <div
                 className="flex shrink-0 rounded border border-surface-600 p-px gap-px bg-surface-900"
                 role="group"
-                aria-label="New conversation visibility"
+                aria-label="Conversation visibility"
+                onMouseDown={(e) => e.preventDefault()} // Prevent blur stealing click in Safari
               >
                 <button
                   type="button"
-                  onClick={() => setNewConversationScope('shared')}
+                  disabled={scopeToggleSaving || activeScope === 'shared'}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => {
+                    if (isNewConversation) { setNewConversationScope('shared'); }
+                    else { void handleMakeShared(); }
+                  }}
                   className={`flex items-center justify-center gap-0.5 px-1.5 py-0.5 rounded-l-[3px] text-[11px] font-medium transition-colors ${
-                    newConversationScope === 'shared'
+                    activeScope === 'shared'
                       ? 'bg-primary-500/20 text-primary-400'
                       : 'text-surface-500 hover:bg-surface-800 hover:text-surface-300'
-                  }`}
+                  } disabled:opacity-40`}
                   title="Shared: teammates can join this conversation"
                 >
                   Shared
                 </button>
                 <button
                   type="button"
-                  onClick={() => setNewConversationScope('private')}
+                  disabled={scopeToggleSaving || activeScope === 'private'}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => {
+                    if (isNewConversation) { setNewConversationScope('private'); }
+                    else { void handleMakePrivate(); }
+                  }}
                   className={`flex items-center justify-center gap-0.5 px-1.5 py-0.5 rounded-r-[3px] text-[11px] font-medium transition-colors ${
-                    newConversationScope === 'private'
+                    activeScope === 'private'
                       ? 'bg-primary-500/20 text-primary-400'
                       : 'text-surface-500 hover:bg-surface-800 hover:text-surface-300'
-                  }`}
+                  } disabled:opacity-40`}
                   title="Private: only you can see this conversation"
                 >
                   <ScopeLockIcon className="w-3 h-3 shrink-0" />


### PR DESCRIPTION
## Summary
Two bugs with the Private/Shared toggle in the chat composer:

1. **Toggle disappeared after first message** — it only rendered when `(!chatId && !localConversationId)`, so it vanished the moment a conversation was created. Now persists for existing conversations the user owns, using the same `canToggleChatScope` gate as the ⋮ menu.

2. **Safari click not registering** — the composer div's `onBlur` handler fires before `click` on buttons inside it (Safari doesn't reliably set `relatedTarget`). Added `onMouseDown={e => e.preventDefault()}` on the toggle to prevent blur from stealing the click event.

For existing conversations, clicking Shared/Private calls `handleMakeShared`/`handleMakePrivate` (same PATCH endpoint as the ⋮ menu). For new conversations, it sets `newConversationScope` as before.

## Test plan
- [ ] New chat: toggle between Shared/Private before sending — verify it works
- [ ] Send a message — verify toggle persists (shows current scope)
- [ ] Toggle scope on existing conversation — verify it changes (check header badge)
- [ ] Test in Safari — verify clicks register on both buttons
- [ ] Non-owner viewing shared chat — verify toggle does NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)