### PR TITLE
Fix search: Slack fallback was ignoring search filter

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -328,6 +328,29 @@ async def list_conversations(
                 if scope in ("shared", "private"):
                     slack_query = slack_query.where(Conversation.scope == scope)
 
+                # Apply same search filter to Slack fallback
+                if search and search.strip():
+                    slack_search = f"%{search.strip()}%"
+                    slack_msg_subq = (
+                        select(ChatMessage.conversation_id)
+                        .where(
+                            or_(
+                                ChatMessage.content.ilike(slack_search),
+                                ChatMessage.content_blocks.cast(String).ilike(slack_search),
+                            )
+                        )
+                        .distinct()
+                        .correlate(None)
+                    )
+                    slack_query = slack_query.where(
+                        or_(
+                            Conversation.title.ilike(slack_search),
+                            Conversation.summary.ilike(slack_search),
+                            Conversation.last_message_preview.ilike(slack_search),
+                            Conversation.id.in_(slack_msg_subq),
+                        )
+                    )
+
                 slack_result = await session.execute(
                     slack_query.order_by(Conversation.updated_at.desc()).limit(limit)
                 )


### PR DESCRIPTION
## Summary
Search appeared broken because the Slack conversation fallback path ignored the `search` parameter entirely. 

When searching for a term with few/no matches:
1. Main query correctly returned 0 filtered results
2. Slack fallback saw `len(conversations) < limit` and ran an **unfiltered** query
3. Padded results back to 30 conversations, making search appear to do nothing

Now applies the same search filter (title, summary, preview, message content) to the Slack fallback query.

## Test plan
- [ ] Search "jabberwocky" → should return "No matching chats"
- [ ] Search "cookie" → should return only conversations containing "cookie"
- [ ] Search a Slack conversation term → should find it

🤖 Generated with [Claude Code](https://claude.com/claude-code)