### PR TITLE
Slack: gate agent on @-mentions (match web chat)

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -326,8 +326,8 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
                 "[slack_events] Processing direct message type=%s from %s in %s thread=%s: %s (files=%d)",
                 channel_type, user_id, channel_id, thread_ts, text[:50], len(files),
             )
-            message: InboundMessage = _build_inbound_message(
-                event, team_id, MessageType.DIRECT,
+            message = _build_inbound_message(
+                event, team_id, MessageType.DIRECT, bot_user_ids=bot_user_ids,
             )
             await messenger.process_inbound(message)
             return
@@ -358,7 +358,11 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
                 lock_key: str = SlackThreadLockManager.build_lock_key(team_id, channel_id, thread_ts)
                 async with _thread_lock_manager.thread_lock(lock_key):
                     message = _build_inbound_message(
-                        event, team_id, MessageType.MENTION, text_override=normalized_text,
+                        event,
+                        team_id,
+                        MessageType.MENTION,
+                        text_override=normalized_text,
+                        bot_user_ids=bot_user_ids,
                     )
                     await messenger.process_inbound(message)
                 return
@@ -377,7 +381,7 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
             lock_key = SlackThreadLockManager.build_lock_key(team_id, channel_id, thread_ts)
             async with _thread_lock_manager.thread_lock(lock_key):
                 message = _build_inbound_message(
-                    event, team_id, MessageType.THREAD_REPLY,
+                    event, team_id, MessageType.THREAD_REPLY, bot_user_ids=bot_user_ids,
                 )
                 await messenger.process_inbound(message)
             return
@@ -405,9 +409,12 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
         lock_key = SlackThreadLockManager.build_lock_key(team_id, channel_id, lock_thread_ts)
         async with _thread_lock_manager.thread_lock(lock_key):
             message = _build_inbound_message(
-                event, team_id, MessageType.MENTION,
+                event,
+                team_id,
+                MessageType.MENTION,
                 text_override=text,
                 thread_ts_override=lock_thread_ts,
+                bot_user_ids=bot_user_ids,
             )
             await messenger.process_inbound(message)
 
@@ -419,6 +426,7 @@ def _build_inbound_message(
     *,
     text_override: str | None = None,
     thread_ts_override: str | None = None,
+    bot_user_ids: set[str] | None = None,
 ) -> InboundMessage:
     """Build an :class:`InboundMessage` from a Slack event payload."""
     channel_id: str = event.get("channel", "")
@@ -428,6 +436,12 @@ def _build_inbound_message(
     message_ts: str = event.get("ts", "") or event_ts
     thread_ts: str | None = thread_ts_override or event.get("thread_ts")
     files: list[dict[str, Any]] = event.get("files", [])
+    raw_text: str = event.get("text", "") or ""
+    mentions: list[dict[str, Any]] = (
+        _extract_mentions_from_slack_text(raw_text, bot_user_ids)
+        if bot_user_ids is not None
+        else []
+    )
 
     return InboundMessage(
         external_user_id=user_id,
@@ -442,6 +456,7 @@ def _build_inbound_message(
             "event_ts": event_ts,
         },
         message_id=message_ts,
+        mentions=mentions,
     )
 
 
@@ -457,6 +472,32 @@ async def _persist_activity(
             await messenger.persist_channel_activity(message, org_id)
     except Exception as exc:
         logger.error("[slack_events] Failed to persist activity: %s", exc)
+
+
+# Slack encodes @-mentions as ``<@USERID>`` or ``<@USERID|display>`` in message text.
+_SLACK_USER_MENTION_RE = re.compile(r"<@([A-Z0-9]+)(?:\|[^>]+)?>")
+
+
+def _extract_mentions_from_slack_text(
+    text: str,
+    bot_user_ids: set[str],
+) -> list[dict[str, Any]]:
+    """
+    Parse Slack ``<@…>`` tokens and classify each as agent (this bot) or user.
+
+    When ``bot_user_ids`` is empty we cannot distinguish the bot from humans, so
+    we return no structured mentions (plain messages still rely on conversation state).
+    """
+    if not text.strip() or not bot_user_ids:
+        return []
+    mentions: list[dict[str, Any]] = []
+    for match in _SLACK_USER_MENTION_RE.finditer(text):
+        slack_uid: str = match.group(1)
+        if slack_uid in bot_user_ids:
+            mentions.append({"type": "agent"})
+        else:
+            mentions.append({"type": "user", "external_user_id": slack_uid})
+    return mentions
 
 
 def _extract_bot_user_ids(payload: dict[str, Any]) -> set[str]:

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -23,7 +23,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import and_, or_, select, text
+from sqlalchemy import and_, case, or_, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from config import settings
@@ -445,6 +445,94 @@ class WorkspaceMessenger(BaseMessenger):
             )
             return result.first() is not None
 
+    async def _mentions_payload_for_resolve_agent(
+        self,
+        message: InboundMessage,
+        organization_id: str,
+    ) -> list[dict[str, Any]]:
+        """Normalize ``message.mentions`` for :func:`resolve_agent_responding`."""
+        if not message.mentions:
+            return []
+        if self.meta.slug == "slack":
+            return await self._slack_mentions_to_resolve_payload(message, organization_id)
+        resolved: list[dict[str, Any]] = []
+        for raw in message.mentions:
+            if raw.get("type") == "agent":
+                resolved.append({"type": "agent"})
+            elif raw.get("type") == "user":
+                uid_any: Any = raw.get("user_id")
+                if uid_any is not None and str(uid_any).strip():
+                    resolved.append({"type": "user", "user_id": str(uid_any)})
+                else:
+                    resolved.append({"type": "user"})
+        return resolved
+
+    async def _slack_mentions_to_resolve_payload(
+        self,
+        message: InboundMessage,
+        organization_id: str,
+    ) -> list[dict[str, Any]]:
+        """Map Slack ``external_user_id`` mentions to internal ``user_id`` when possible."""
+        ctx: dict[str, Any] = message.messenger_context
+        workspace_id: str | None = ctx.get("workspace_id")
+        org_uuid: UUID = UUID(organization_id)
+
+        external_ids_ordered: list[str] = []
+        for raw in message.mentions:
+            if raw.get("type") != "user":
+                continue
+            ext: Any = raw.get("external_user_id")
+            if isinstance(ext, str) and ext.strip():
+                if ext not in external_ids_ordered:
+                    external_ids_ordered.append(ext)
+
+        id_by_external: dict[str, UUID] = {}
+        if external_ids_ordered and workspace_id is not None and workspace_id != "":
+            async with get_admin_session() as session:
+                stmt = (
+                    select(
+                        MessengerUserMapping.external_user_id,
+                        MessengerUserMapping.user_id,
+                        MessengerUserMapping.workspace_id,
+                    )
+                    .where(MessengerUserMapping.platform == "slack")
+                    .where(MessengerUserMapping.organization_id == org_uuid)
+                    .where(MessengerUserMapping.external_user_id.in_(external_ids_ordered))
+                    .where(
+                        or_(
+                            MessengerUserMapping.workspace_id == workspace_id,
+                            MessengerUserMapping.workspace_id.is_(None),
+                        )
+                    )
+                    .order_by(
+                        case(
+                            (MessengerUserMapping.workspace_id == workspace_id, 0),
+                            else_=1,
+                        ),
+                        MessengerUserMapping.external_user_id,
+                    )
+                )
+                rows: list[Any] = list((await session.execute(stmt)).all())
+                for row in rows:
+                    ext_uid: str = str(row[0])
+                    user_uuid: UUID = row[1]
+                    if ext_uid not in id_by_external:
+                        id_by_external[ext_uid] = user_uuid
+
+        out: list[dict[str, Any]] = []
+        for raw in message.mentions:
+            if raw.get("type") == "agent":
+                out.append({"type": "agent"})
+                continue
+            if raw.get("type") != "user":
+                continue
+            ext_any: Any = raw.get("external_user_id")
+            if isinstance(ext_any, str) and ext_any in id_by_external:
+                out.append({"type": "user", "user_id": str(id_by_external[ext_any])})
+            else:
+                out.append({"type": "user"})
+        return out
+
     async def find_or_create_conversation(
         self,
         organization_id: str,
@@ -801,11 +889,39 @@ class WorkspaceMessenger(BaseMessenger):
             organization_id, user, message,
         )
 
+        ctx: dict[str, Any] = message.messenger_context
+        slack_user_email: str | None = ctx.get("user_email")
+
+        from services.chat_messages import resolve_agent_responding, save_user_message
+
+        should_invoke_agent: bool = True
+        if self.meta.slug == "slack" or message.mentions:
+            mentions_for_resolve: list[dict[str, Any]] = await self._mentions_payload_for_resolve_agent(
+                message,
+                organization_id,
+            )
+            should_invoke_agent = await resolve_agent_responding(
+                conversation_id=str(conversation.id),
+                organization_id=organization_id,
+                mentions=mentions_for_resolve,
+            )
+
         attachment_ids: list[str] = await self.download_attachments(message)
         message_text: str = message.text or ("(see attached files)" if attachment_ids else "")
 
-        ctx: dict[str, Any] = message.messenger_context
-        slack_user_email: str | None = ctx.get("user_email")
+        if not should_invoke_agent:
+            await save_user_message(
+                conversation_id=str(conversation.id),
+                user_id=str(user.id),
+                organization_id=organization_id,
+                message_text=message_text,
+                attachment_ids=attachment_ids or None,
+                sender_name=user.name,
+                sender_email=slack_user_email or user.email,
+            )
+            await self.remove_typing_indicator(message)
+            return {"status": "human_only", "conversation_id": str(conversation.id)}
+
         workflow_context: dict[str, Any] | None = _build_workflow_context_for_message(
             platform_slug=self.meta.slug,
             ctx=ctx,

--- a/backend/messengers/base.py
+++ b/backend/messengers/base.py
@@ -78,6 +78,8 @@ class InboundMessage:
     raw_attachments: list[dict[str, Any]] = field(default_factory=list)
     messenger_context: dict[str, Any] = field(default_factory=dict)
     message_id: str = ""
+    # Structured at-mentions from the platform (e.g. Slack <@U…>).
+    mentions: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass

--- a/backend/services/chat_messages.py
+++ b/backend/services/chat_messages.py
@@ -26,8 +26,9 @@ async def resolve_agent_responding(
     """
     Determine whether the agent should respond and update conversation state.
 
-    - Any {"type": "user", "user_id": "..."} is merged into participating_user_ids (invite-by-mention),
-      including when combined with @agent so mixed messages still add participants.
+    - {"type": "user", "user_id": "<uuid>"} with a valid UUID is merged into participating_user_ids
+      (invite-by-mention), including when combined with @agent. User mentions without ``user_id``
+      still disable the agent but do not add participants.
     - If mentions contains {"type": "agent"} -> set agent_responding=True, return True.
     - Else if any user mention -> set agent_responding=False, return False.
     - If no mentions -> return current conversation.agent_responding.
@@ -39,7 +40,7 @@ async def resolve_agent_responding(
     mentions = mentions or []
 
     has_agent_mention = any(m.get("type") == "agent" for m in mentions)
-    user_mentions = [m for m in mentions if m.get("type") == "user" and m.get("user_id")]
+    user_mentions = [m for m in mentions if m.get("type") == "user"]
 
     async with get_session(organization_id=organization_id) as session:
         row = await session.execute(
@@ -54,9 +55,19 @@ async def resolve_agent_responding(
         current_agent_responding: bool = conv_row[0]
         participating: list[UUID] = list(conv_row[1] or [])
 
-        mentioned_ids: list[UUID] = [
-            UUID(m["user_id"]) for m in user_mentions if m.get("user_id")
-        ]
+        mentioned_ids: list[UUID] = []
+        for m in user_mentions:
+            uid_raw: Any = m.get("user_id")
+            if not uid_raw or not isinstance(uid_raw, str):
+                continue
+            try:
+                mentioned_ids.append(UUID(uid_raw))
+            except (ValueError, TypeError):
+                logger.warning(
+                    "Skipping non-UUID user_id in mentions for conversation %s: %r",
+                    conversation_id,
+                    uid_raw,
+                )
         for uid in mentioned_ids:
             if uid not in participating:
                 participating.append(uid)


### PR DESCRIPTION
## Summary
Aligns Slack inbound handling with the web app: `resolve_agent_responding` now runs for Slack (and any messenger that sets `InboundMessage.mentions`). Slack `<@USERID>` tokens are parsed from raw event text, classified as bot (agent) vs human using payload `bot_user_ids`, mapped to internal users via `messenger_user_mappings` when possible, then the same rules as the web socket apply (agent mention re-enables; user-only mention human-only; both → agent wins; no mentions → unchanged `agent_responding`).

## Implementation
- `InboundMessage.mentions` on [`messengers/base.py`](backend/messengers/base.py)
- [`slack_events.py`](backend/api/routes/slack_events.py): `_extract_mentions_from_slack_text`, wired through DM / app_mention / thread / in-thread bot mention paths
- [`chat_messages.py`](backend/services/chat_messages.py): user mentions without UUID `user_id` still flip human-only; invalid UUIDs skipped for `participating_user_ids`
- [`_workspace.py`](backend/messengers/_workspace.py): resolve Slack externals, call `resolve_agent_responding`, `save_user_message` + early return when agent should not respond

## Checks
- `npm run build` (frontend): **passed**
- `pytest` (backend): not run in this environment (deps/venv unavailable); please run `pytest -q tests` from `backend/` with your usual venv before merge.

## Note
Unrelated local edits (`connectors/base.py`, `Chat.tsx`) were stashed and are **not** in this branch.

Made with [Cursor](https://cursor.com)