### PR TITLE
fix(sync): robust status, unified initial sync, org-scoped connector pick

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -4251,99 +4251,57 @@ async def run_initial_sync(
 ) -> None:
     """
     Run initial data sync after OAuth connection.
-    
-    This runs in the background so the user isn't blocked waiting.
-    
-    Args:
-        organization_id: UUID of the organization
-        provider: Provider name (e.g., "gmail", "hubspot")
-        user_id: UUID of the user (required for user-scoped integrations)
+
+    Uses the same pipeline as periodic/API-triggered sync (``_sync_integration``):
+    clear stale errors, ``mark_sync_started``, ``sync_all``, ``update_last_sync`` /
+    ``record_error``, and ``sync.completed`` / ``sync.failed`` events.
+
+    Runs in a background task so the user is not blocked.
     """
-    from connectors.hubspot import HubSpotConnector
-    from connectors.salesforce import SalesforceConnector
-    from connectors.slack import SlackConnector
-    from connectors.google_calendar import GoogleCalendarConnector
-    from connectors.gmail import GmailConnector
-    from connectors.microsoft_calendar import MicrosoftCalendarConnector
-    from connectors.microsoft_mail import MicrosoftMailConnector
-    from connectors.fireflies import FirefliesConnector
-    from connectors.zoom import ZoomConnector
-    from connectors.github import GitHubConnector
-    from connectors.linear import LinearConnector
-    from connectors.asana import AsanaConnector
-    from connectors.granola import GranolaConnector
+    from workers.tasks.sync import _sync_integration
 
-    # Google Drive uses a different sync pattern (not BaseConnector)
-    if provider == "google_drive":
-        await _run_initial_drive_sync(organization_id, user_id)
-        return
+    owner_user_id: str | None = (
+        user_id.strip() if user_id and user_id.strip() else None
+    )
 
-    connectors = {
-        "hubspot": HubSpotConnector,
-        "salesforce": SalesforceConnector,
-        "slack": SlackConnector,
-        "google_calendar": GoogleCalendarConnector,
-        "gmail": GmailConnector,
-        "microsoft_calendar": MicrosoftCalendarConnector,
-        "microsoft_mail": MicrosoftMailConnector,
-        "fireflies": FirefliesConnector,
-        "zoom": ZoomConnector,
-        "github": GitHubConnector,
-        "linear": LinearConnector,
-        "asana": AsanaConnector,
-        "granola": GranolaConnector,
-    }
-
-    connector_class = connectors.get(provider)
-    if not connector_class:
-        print(f"No connector for provider: {provider}")
-        return
-
-    try:
-        print(f"Starting initial sync for {provider} (org: {organization_id}, user: {user_id})")
-        connector = connector_class(organization_id, user_id=user_id)
-        counts = await connector.sync_all()
-        await connector.update_last_sync(counts)
-        print(f"Initial sync complete for {provider}: {counts}")
-    except Exception as e:
-        print(f"Initial sync failed for {provider}: {str(e)}")
-        # Record the error
-        try:
-            connector = connector_class(organization_id, user_id=user_id)
-            await connector.record_error(str(e))
-        except Exception:
-            pass  # Ignore errors while recording error
-
-
-async def _run_initial_drive_sync(organization_id: str, user_id: Optional[str]) -> None:
-    """Run initial Google Drive metadata sync after OAuth."""
-    if not user_id:
-        print("[GoogleDrive] Skipping initial sync: user_id required")
-        return
-
-    try:
-        from connectors.google_drive import GoogleDriveConnector
-
-        print(f"Starting initial Google Drive sync (org: {organization_id}, user: {user_id})")
-        connector = GoogleDriveConnector(organization_id, user_id)
-        counts: dict[str, int] = await connector.sync_file_metadata()
-        total: int = sum(counts.values())
-
-        # Update integration sync stats
-        async with get_session(organization_id=organization_id) as session:
-            result = await session.execute(
-                select(Integration).where(
-                    Integration.organization_id == UUID(organization_id),
-                    Integration.connector == "google_drive",
-                    Integration.user_id == UUID(user_id),
-                )
-            )
-            integration: Optional[Integration] = result.scalar_one_or_none()
-            if integration:
-                integration.last_sync_at = datetime.utcnow()
-                integration.sync_stats = {"total_files": total, **counts}
-                await session.commit()
-
-        print(f"Initial Google Drive sync complete: {total} files ({counts})")
-    except Exception as e:
-        print(f"Initial Google Drive sync failed: {str(e)}")
+    logger.info(
+        "Starting initial sync for provider=%s org=%s user=%s",
+        provider,
+        organization_id,
+        owner_user_id,
+    )
+    result: dict[str, Any] = await _sync_integration(
+        organization_id,
+        provider,
+        user_id=owner_user_id,
+        sync_since_override_iso=None,
+    )
+    status: str = str(result.get("status", "unknown"))
+    if status == "completed":
+        logger.info(
+            "Initial sync completed for provider=%s org=%s counts=%s",
+            provider,
+            organization_id,
+            result.get("counts"),
+        )
+    elif status == "skipped":
+        logger.info(
+            "Initial sync skipped (no SYNC capability) provider=%s org=%s",
+            provider,
+            organization_id,
+        )
+    elif status == "cancelled":
+        logger.info(
+            "Initial sync cancelled provider=%s org=%s error=%s",
+            provider,
+            organization_id,
+            result.get("error"),
+        )
+    else:
+        logger.warning(
+            "Initial sync finished with status=%s provider=%s org=%s error=%s",
+            status,
+            provider,
+            organization_id,
+            result.get("error"),
+        )

--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -59,7 +59,10 @@ def parse_sync_since_param(since: str | None) -> datetime | None:
     return parsed
 
 class SyncStatusResponse(BaseModel):
-    """Response model for sync status."""
+    """Response model for sync status.
+
+    ``status`` is one of: ``syncing``, ``failed``, ``completed``, ``never_synced``.
+    """
 
     organization_id: str
     provider: str
@@ -820,7 +823,11 @@ async def trigger_sync(
 
 @router.get("/{organization_id}/{provider}/status", response_model=SyncStatusResponse)
 async def get_sync_status(organization_id: str, provider: str) -> SyncStatusResponse:
-    """Get sync status for a specific integration."""
+    """Get sync status for a specific integration.
+
+    Resolution order: ``syncing`` (in-flight, fresh) → ``failed`` (``last_error`` set) →
+    ``completed`` (successful sync, no error) → ``never_synced``.
+    """
     try:
         UUID(organization_id)
     except ValueError:
@@ -859,7 +866,21 @@ async def get_sync_status(organization_id: str, provider: str) -> SyncStatusResp
             except (ValueError, TypeError):
                 pass
 
-    # Use DB last_sync_at / never_synced
+        last_err: str | None = integration.last_error
+        if last_err and last_err.strip():
+            completed_at: str | None = None
+            if integration.last_sync_at:
+                completed_at = f"{integration.last_sync_at.isoformat()}Z"
+            return SyncStatusResponse(
+                organization_id=organization_id,
+                provider=provider,
+                status="failed",
+                started_at=None,
+                completed_at=completed_at,
+                error=last_err,
+                counts=None,
+            )
+
     if integration and integration.last_sync_at:
         return SyncStatusResponse(
             organization_id=organization_id,
@@ -867,7 +888,7 @@ async def get_sync_status(organization_id: str, provider: str) -> SyncStatusResp
             status="completed",
             started_at=None,
             completed_at=f"{integration.last_sync_at.isoformat()}Z",
-            error=integration.last_error,
+            error=None,
             counts=None,
         )
 

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -3,6 +3,41 @@ Base connector class that all connectors inherit from.
 
 Uses Nango for OAuth token management - tokens are fetched from Nango
 on demand and automatically refreshed.
+
+Sync status contract (all SYNC-capable connectors)
+--------------------------------------------------
+The worker and API use a single pipeline (``workers.tasks.sync._sync_integration``)
+for periodic, manual, and post-OAuth initial sync. Connectors do **not** set
+success/failure on the integration row themselves except via the helpers below.
+
+**Integration row fields**
+
+- ``last_sync_at`` — time of the last *successful* full sync (set by
+  ``update_last_sync``).
+- ``last_error`` — truncated error message from the last failed run (set by
+  ``record_error``); cleared on the next successful ``update_last_sync`` or when
+  errors are cleared at sync start.
+- ``sync_stats`` — JSON object: entity counts from the last successful sync, plus
+  optional ``sync_started_at`` (ISO string) while a sync is in flight.
+- ``is_active`` — if false, ``ensure_sync_active`` raises ``SyncCancelledError``.
+
+**Lifecycle** (handled by ``_sync_integration``, not by connector code)
+
+1. Clear prior ``last_error`` for the matching integration row(s).
+2. ``mark_sync_started()`` — sets ``sync_stats["sync_started_at"]``.
+3. ``sync_all()`` — connector implementation; must raise on unrecoverable failure
+   so the worker can record it. Per-record ``try``/log/continue inside a stage is
+   OK; do not catch and swallow exceptions that mean the whole sync failed.
+4. On success: ``update_last_sync(counts)`` — sets ``last_sync_at``, clears
+   ``last_error``, replaces ``sync_stats`` with counts.
+5. On failure: ``clear_sync_started()`` + ``record_error(msg)``.
+
+**Multi-stage syncs** — call ``await self.ensure_sync_active("stage_name")`` between
+long steps (e.g. teams → projects → issues) so disconnect/deactivate is honored
+promptly.
+
+**HTTP sync status** — ``GET /api/sync/{org}/{provider}/status`` maps the DB to
+``syncing`` | ``failed`` | ``completed`` | ``never_synced`` (see that route).
 """
 
 from abc import ABC, abstractmethod
@@ -11,7 +46,7 @@ import logging
 from typing import Any, Optional
 from uuid import UUID
 
-from sqlalchemy import select, update
+from sqlalchemy import case, select, update
 
 from config import get_nango_integration_id
 from connectors.registry import ConnectorMeta  # noqa: F401 – re-export for convenience
@@ -80,6 +115,10 @@ class BaseConnector(ABC):
     Subclasses should set a class-level ``meta`` attribute
     (:class:`ConnectorMeta`) that describes the connector's identity,
     capabilities, auth requirements, and available operations.
+
+    **Implementing SYNC:** Override ``sync_*`` methods and/or ``sync_all``. See the
+    module docstring above for how success and errors are persisted on
+    ``Integration`` and how ``ensure_sync_active`` fits in.
     """
 
     # Override in subclasses - must match our provider names
@@ -332,11 +371,11 @@ class BaseConnector(ABC):
     ) -> Integration | None:
         """Return the best matching integration row for this connector context.
 
-        When ``user_id`` is omitted, an org can have multiple user-scoped rows for a
-        provider. In that case, prefer the most recently updated connection and log a
-        warning to aid cleanup of ambiguous call sites.
+        When ``user_id`` is set, filters to that user's row.
+        When ``user_id`` is omitted, prefers org-scoped rows (``user_id IS NULL``)
+        and falls back to user-scoped rows only if no org-scoped row exists.
         """
-        conditions = [
+        conditions: list[Any] = [
             Integration.organization_id == UUID(self.organization_id),
             Integration.connector == self.source_system,
         ]
@@ -345,19 +384,27 @@ class BaseConnector(ABC):
         if self.user_id:
             conditions.append(Integration.user_id == UUID(self.user_id))
 
+        order_clauses: list[Any] = []
+        if not self.user_id:
+            order_clauses.append(
+                case((Integration.user_id.is_(None), 0), else_=1)
+            )
+        order_clauses.extend([
+            Integration.updated_at.desc().nullslast(),
+            Integration.created_at.desc().nullslast(),
+        ])
+
         result = await session.execute(
             select(Integration)
             .where(*conditions)
-            .order_by(
-                Integration.updated_at.desc().nullslast(),
-                Integration.created_at.desc().nullslast(),
-            )
+            .order_by(*order_clauses)
             .limit(2)
         )
         candidates = result.scalars().all()
         if len(candidates) > 1 and not self.user_id:
             logger.warning(
-                "Multiple active %s integrations found for org=%s with no user_id; using integration=%s",
+                "Multiple %s integrations found for org=%s with no user_id; "
+                "preferring org-scoped integration=%s",
                 self.source_system,
                 self.organization_id,
                 candidates[0].id,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -111,13 +111,22 @@ export interface ConnectUrlResponse {
 // Sync Types
 // =============================================================================
 
+/** Matches GET /sync/{organization_id}/{provider}/status */
 export interface SyncStatusResponse {
-  status: "idle" | "syncing" | "completed" | "failed";
+  organization_id: string;
   provider: string;
+  status: "syncing" | "failed" | "completed" | "never_synced";
   started_at: string | null;
   completed_at: string | null;
   error: string | null;
-  records_synced: number;
+  counts: Record<string, number> | null;
+}
+
+/** Matches POST /sync/{organization_id}/{provider} */
+export interface SyncTriggerResponse {
+  status: string;
+  organization_id: string;
+  provider: string;
 }
 
 // =============================================================================
@@ -283,8 +292,8 @@ export async function disconnectIntegration(
 export async function triggerSync(
   organizationId: string,
   provider: string,
-): Promise<ApiResponse<SyncStatusResponse>> {
-  return apiRequest<SyncStatusResponse>(`/sync/${organizationId}/${provider}`, {
+): Promise<ApiResponse<SyncTriggerResponse>> {
+  return apiRequest<SyncTriggerResponse>(`/sync/${organizationId}/${provider}`, {
     method: "POST",
   });
 }


### PR DESCRIPTION
## Summary

Unifies how sync success/failure is exposed and fixes org-scoped integrations (e.g. Linear) being skipped when user-scoped rows exist for the same org and provider.

## Changes

### Sync status API
- `GET /api/sync/{org}/{provider}/status` now returns `failed` when `last_error` is set (after checking for in-flight `syncing`). `completed` is only returned when there is a `last_sync_at` and no error. This matches what `DataSources.tsx` already polls for.

### Initial sync after OAuth
- `run_initial_sync` now calls `_sync_integration` so post-OAuth runs use the same path as Celery/manual sync: clear errors, `mark_sync_started`, `sync_all`, `update_last_sync` / `record_error`, and `sync.completed` / `sync.failed` events. Google Drive is included (no separate `_run_initial_drive_sync`).

### Documentation
- Extended `backend/connectors/base.py` module docstring describing DB fields, lifecycle, and HTTP status mapping for new connector authors.

### Org-scoped vs user-scoped selection
- `BaseConnector._select_integration`: when `user_id` is omitted, prefer rows with `user_id IS NULL` (org-scoped), then fall back to user-scoped by recency. Fixes periodic `user_id=None` syncs updating the wrong integration when both org- and user-scoped Linear (or other) rows exist.

### Frontend
- `SyncStatusResponse` and `SyncTriggerResponse` in `client.ts` aligned with the API.

## Testing
- `npm run build` (frontend)
- `pytest -q tests` (backend, 264 passed)


Made with [Cursor](https://cursor.com)