### PR TITLE
Align chat pill timestamp with title in All Chats list

### DIFF
--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -356,6 +356,9 @@ function ChatRow({
             }`}>
               {chat.scope}
             </span>
+            <span className="ml-auto text-xs text-surface-500 whitespace-nowrap leading-none">
+              {formatDate(chat.lastMessageAt)}
+            </span>
           </div>
           <div className="flex items-center gap-2 mt-1">
             {chat.participants && chat.participants.length > 0 && (
@@ -374,8 +377,7 @@ function ChatRow({
           </div>
         </div>
 
-        <div className="flex flex-col items-end gap-2 flex-shrink-0">
-          <div className="text-xs text-surface-500 whitespace-nowrap">{formatDate(chat.lastMessageAt)}</div>
+        <div className="flex items-center flex-shrink-0">
           <button
             onClick={(e) => { e.stopPropagation(); onTogglePin(chat.id); }}
             className={`p-1.5 rounded ${


### PR DESCRIPTION
### Motivation
- The "last edited" timestamp in each chat pill was vertically misaligned relative to the chat title on both mobile and desktop, causing a visual inconsistency in the All Chats UI.

### Description
- Moved the timestamp into the top title row and anchored it with `ml-auto` so it sits on the same horizontal line as the chat title and badges in `frontend/src/components/ChatsList.tsx`.
- Simplified the right-side column to only contain the pin action so the timestamp no longer sits stacked above the button and can align consistently.
- Preserved existing metadata rendering, row interactions, and date formatting via `formatDate`.

### Testing
- Ran linting: `cd frontend && npx eslint src/components/ChatsList.tsx`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8084fa2e88321b1c8ed7e83a1f8cc)