### PR TITLE
Align last-edited timestamp with chat title in All Chats

### DIFF
--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -356,6 +356,7 @@ function ChatRow({
             }`}>
               {chat.scope}
             </span>
+            <div className="text-xs text-surface-500 whitespace-nowrap ml-auto">{formatDate(chat.lastMessageAt)}</div>
           </div>
           <div className="flex items-center gap-2 mt-1">
             {chat.participants && chat.participants.length > 0 && (
@@ -375,7 +376,6 @@ function ChatRow({
         </div>
 
         <div className="flex flex-col items-end gap-2 flex-shrink-0">
-          <div className="text-xs text-surface-500 whitespace-nowrap">{formatDate(chat.lastMessageAt)}</div>
           <button
             onClick={(e) => { e.stopPropagation(); onTogglePin(chat.id); }}
             className={`p-1.5 rounded ${


### PR DESCRIPTION
### Motivation
- Fix a visual misalignment where the "last edited" timestamp in the All Chats chat pill rendered in a separate right column and appeared slightly higher than the chat title on both mobile and desktop.
- Preserve the existing pin button placement and behavior while improving the timestamp alignment.

### Description
- Move the timestamp into the title row by adding a `div` with `text-xs text-surface-500 whitespace-nowrap ml-auto` next to the chat title and badges in `frontend/src/components/ChatsList.tsx`.
- Remove the duplicate timestamp from the right-side action column so the pin action column remains unchanged.
- The layout change uses existing Tailwind utility classes and only updates `ChatRow` in `frontend/src/components/ChatsList.tsx`.

### Testing
- Ran `npm run lint` (from `frontend/`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8084fa2e88321b1c8ed7e83a1f8cc)