### PR TITLE
Improve chat search responsiveness and progress visibility

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -259,6 +259,8 @@ async def list_conversations(
         search: Optional text search across title, summary, preview, and message content.
     """
     org_id = auth.organization_id_str
+    request_started_at = datetime.utcnow()
+    normalized_search = (search or "").strip()
 
     async with get_session(organization_id=org_id) as session:
         # Fast path: query without Slack filter first
@@ -274,8 +276,8 @@ async def list_conversations(
         if mine and auth.user_id:
             query = query.where(Conversation.user_id == auth.user_id)
 
-        if search and search.strip():
-            search_term = f"%{search.strip()}%"
+        if normalized_search:
+            search_term = f"%{normalized_search}%"
             # Search conversation title, summary, preview, AND message content
             message_match_subq = (
                 select(ChatMessage.conversation_id)
@@ -285,6 +287,7 @@ async def list_conversations(
                         ChatMessage.content_blocks.cast(String).ilike(search_term),
                     )
                 )
+                .where(ChatMessage.organization_id == auth.organization_id)
                 .distinct()
                 .correlate(None)
             )
@@ -329,8 +332,8 @@ async def list_conversations(
                     slack_query = slack_query.where(Conversation.scope == scope)
 
                 # Apply same search filter to Slack fallback
-                if search and search.strip():
-                    slack_search = f"%{search.strip()}%"
+                if normalized_search:
+                    slack_search = f"%{normalized_search}%"
                     slack_msg_subq = (
                         select(ChatMessage.conversation_id)
                         .where(
@@ -339,6 +342,7 @@ async def list_conversations(
                                 ChatMessage.content_blocks.cast(String).ilike(slack_search),
                             )
                         )
+                        .where(ChatMessage.organization_id == auth.organization_id)
                         .distinct()
                         .correlate(None)
                     )
@@ -421,6 +425,20 @@ async def list_conversations(
                 agent_responding=getattr(conv, "agent_responding", True),
                 participants=participants,
             ))
+
+        duration_ms = int((datetime.utcnow() - request_started_at).total_seconds() * 1000)
+        logger.info(
+            "[chat] list_conversations org=%s user=%s scope=%s mine=%s search_len=%s offset=%s limit=%s returned=%s duration_ms=%s",
+            auth.organization_id_str,
+            auth.user_id_str,
+            scope,
+            mine,
+            len(normalized_search),
+            offset,
+            limit,
+            len(response_items),
+            duration_ms,
+        )
 
         return ConversationListResponse(
             conversations=response_items,

--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -42,9 +42,11 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
   const [scopeFilter, setScopeFilter] = useState<ScopeFilter>('all');
   const [allChats, setAllChats] = useState<ChatSummary[]>([]);
   const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false);
+  const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
   const [hasMore, setHasMore] = useState<boolean>(true);
   const [initialLoaded, setInitialLoaded] = useState<boolean>(false);
   const offsetRef = useRef<number>(0);
+  const latestRequestIdRef = useRef<number>(0);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 
@@ -64,12 +66,20 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
   }, []);
 
   const loadPage = useCallback(async (reset: boolean = false): Promise<void> => {
-    if (isLoadingMore) return;
-    setIsLoadingMore(true);
+    if ((reset && isRefreshing) || (!reset && isLoadingMore)) return;
+    if (reset) {
+      setIsRefreshing(true);
+    } else {
+      setIsLoadingMore(true);
+    }
+
+    const requestId = latestRequestIdRef.current + 1;
+    latestRequestIdRef.current = requestId;
     const offset = reset ? 0 : offsetRef.current;
     const apiScope = scopeFilter === 'all' ? undefined : scopeFilter;
     try {
       const { data, error } = await listConversations(PAGE_SIZE, offset, apiScope, debouncedSearch);
+      if (requestId !== latestRequestIdRef.current) return;
       if (error || !data) {
         setHasMore(false);
         return;
@@ -88,10 +98,13 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
       }
       setHasMore(mapped.length >= PAGE_SIZE);
     } finally {
-      setIsLoadingMore(false);
-      setInitialLoaded(true);
+      if (requestId === latestRequestIdRef.current) {
+        setIsLoadingMore(false);
+        setIsRefreshing(false);
+        setInitialLoaded(true);
+      }
     }
-  }, [isLoadingMore, scopeFilter, debouncedSearch]);
+  }, [isLoadingMore, isRefreshing, scopeFilter, debouncedSearch]);
 
   // Initial load + reload on filter/search change
   useEffect(() => {
@@ -119,6 +132,8 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
   // Merge sidebar chats with loaded chats (skip sidebar merge when searching
   // since sidebar chats aren't filtered by the search query)
   const isSearching: boolean = debouncedSearch.trim().length > 0;
+  const isDebouncingSearch = searchQuery.trim() !== debouncedSearch.trim();
+  const isSearchBusy = isDebouncingSearch || isRefreshing;
   const mergedChats = useMemo((): ChatSummary[] => {
     if (isSearching) {
       return allChats.sort(
@@ -216,6 +231,12 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
               className="input-field pl-10 w-full"
               autoFocus
             />
+            {isSearchBusy && (
+              <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2 text-surface-400">
+                <div className="w-4 h-4 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
+                <span className="text-xs">Searching…</span>
+              </div>
+            )}
           </div>
         </div>
       </header>
@@ -265,6 +286,12 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
             </div>
           ) : (
             <div className="space-y-2">
+              {isRefreshing && (
+                <div className="flex items-center gap-2 text-xs text-surface-400 px-1">
+                  <div className="w-3.5 h-3.5 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
+                  Updating chat results…
+                </div>
+              )}
               {orderedChats.map((chat) => (
                 <ChatRow
                   key={chat.id}


### PR DESCRIPTION
### Motivation
- Users experienced slow chat search with no clear feedback and stale slow responses could overwrite newer results.
- Backend message-content search was scanning across orgs and lacked request-level telemetry for diagnosing slow queries.

### Description
- Frontend: added `isRefreshing` + `latestRequestIdRef` and request-id checking in `loadPage` to prevent out-of-order responses from replacing newer results and to surface an updating state in `frontend/src/components/ChatsList.tsx`.
- Frontend: show inline `Searching…` spinner in the search input while debounce/API refresh is pending and an `Updating chat results…` row above results during refresh in `ChatsList.tsx`.
- Backend: scope message-content search subqueries to the requesting organization by adding `WHERE ChatMessage.organization_id == auth.organization_id` to reduce cross-org scanning in `backend/api/routes/chat.py`.
- Backend: add request timing and structured `logger.info` for `list_conversations` to record `duration_ms`, search length, offset, and returned count for observability.

### Testing
- Built the frontend with `cd frontend && npm run build`, which completed successfully.
- Sanity-checked backend syntax with `python -m py_compile backend/api/routes/chat.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8330cb2ec832192d632dfa80662a0)