### PR TITLE
Add 1px vertical spacer to Chat History in left sidebar

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -996,7 +996,7 @@ function ChatAccordion({
   };
   
   return (
-    <div className="flex-1 flex flex-col min-h-0 px-1.5">
+    <div className="flex-1 flex flex-col min-h-0 px-1.5 py-px">
       {/* Chat History header with View All link */}
       <div className="flex-shrink-0 flex items-center justify-between px-2 py-0.5">
         <span className="text-xs font-semibold text-surface-200 uppercase tracking-wider">Chat History</span>


### PR DESCRIPTION
### Motivation
- Add a 1px vertical spacer above and below the Chat History block in the left sidebar to match requested UI spacing while preserving existing layout.

### Description
- Update the ChatAccordion container in `frontend/src/components/Sidebar.tsx` to include `py-px` so the wrapper's class changes from `px-1.5` to `px-1.5 py-px`, adding 1px top/bottom padding without altering horizontal spacing or behavior.

### Testing
- Ran `git diff --check` with no issues reported.
- Verified repository status shows the intended single-file change in `frontend/src/components/Sidebar.tsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8365bd6e88321ba36aa2ca9785588)