### PR TITLE
Remove updating chat results spinner from All Chats view

### DIFF
--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -286,12 +286,6 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
             </div>
           ) : (
             <div className="space-y-2">
-              {isRefreshing && (
-                <div className="flex items-center gap-2 text-xs text-surface-400 px-1">
-                  <div className="w-3.5 h-3.5 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
-                  Updating chat results…
-                </div>
-              )}
               {orderedChats.map((chat) => (
                 <ChatRow
                   key={chat.id}


### PR DESCRIPTION
### Motivation
- Reduce visual noise in the All Chats full-page view by removing the transient inline "Updating chat results…" indicator that appears above the chat list during refreshes.
- Keep existing pagination and bottom loading indicators unchanged so background loading behavior and infinite scroll remain visible to users.

### Description
- Deleted the inline refresh status block from `frontend/src/components/ChatsList.tsx` that rendered the "Updating chat results…" spinner and text.
- Left the existing bottom infinite-scroll spinner (`isLoadingMore`) and other loading states intact so UX for loading additional pages is unchanged.

### Testing
- Ran `cd frontend && npm run lint`, which completed successfully with no lint errors.
- Attempted `cd frontend && npm run typecheck` but the project has no `typecheck` script, so no typecheck was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c838488bb08321aaa5cc129bdd3a48)