### PR TITLE
Make chat pin icon always visible on mobile in All Chats list

### DIFF
--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -391,8 +391,10 @@ function ChatRow({
             <button
               onClick={(e) => { e.stopPropagation(); onTogglePin(chat.id); }}
               className={`p-1.5 rounded ${
-                isPinned ? 'opacity-100 text-primary-400' : 'opacity-0 text-surface-500'
-              } group-hover:opacity-100 hover:bg-surface-700 hover:text-surface-200 transition-all`}
+                isPinned
+                  ? 'opacity-100 text-primary-400'
+                  : 'opacity-100 md:opacity-0 text-surface-500'
+              } md:group-hover:opacity-100 hover:bg-surface-700 hover:text-surface-200 transition-all`}
               title={isPinned ? 'Unpin conversation' : 'Pin conversation'}
               aria-label={isPinned ? 'Unpin conversation' : 'Pin conversation'}
             >


### PR DESCRIPTION
### Motivation
- Ensure the pin (bookmark) control is always visible on mobile devices while preserving the existing desktop hover-to-reveal behavior so mobile users can pin/unpin conversations without needing hover.

### Description
- Adjusted pin button classes in `frontend/src/components/ChatsList.tsx` so the icon uses `opacity-100` on small screens and `md:opacity-0` with `md:group-hover:opacity-100` on larger screens, and kept the pinned visual state (`text-primary-400`) unchanged.

### Testing
- Ran `npm run lint -- frontend/src/components/ChatsList.tsx` which failed due to the repo lint script pattern usage, and then ran `npx eslint src/components/ChatsList.tsx` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8395d07048321bb91ce0909b2a8e1)