### PR TITLE
Match count badges and browser-style Find navigation

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -181,6 +181,7 @@ class ConversationResponse(BaseModel):
     agent_responding: bool = True
     participants: list[ParticipantResponse] = []
     match_snippet: Optional[str] = None  # Context around search match
+    match_count: int = 0  # Number of times search term appears in conversation
 
 
 class ConversationListResponse(BaseModel):
@@ -379,8 +380,9 @@ async def list_conversations(
             for user in users_result.scalars().all():
                 participants_by_id[user.id] = user
 
-        # When searching, fetch a matching snippet per conversation
+        # When searching, fetch a matching snippet and count per conversation
         snippet_by_conv_id: dict[UUID, str] = {}
+        count_by_conv_id: dict[UUID, int] = {}
         if normalized_search and conversations:
             search_lower = normalized_search.lower()
             conv_ids = [c.id for c in conversations]
@@ -391,8 +393,6 @@ async def list_conversations(
             )
             for row in snippet_result:
                 cid = row.conversation_id
-                if cid in snippet_by_conv_id:
-                    continue  # Take first match per conversation
                 # Collect all text: legacy content + all text blocks
                 candidates: list[str] = []
                 if row.content:
@@ -401,19 +401,25 @@ async def list_conversations(
                     for block in (row.content_blocks or []):
                         if isinstance(block, dict) and block.get("type") == "text":
                             candidates.append(block.get("text", ""))
-                # Find the first candidate containing the search term
+                # Count occurrences across all text in this message
                 for text_content in candidates:
-                    idx = text_content.lower().find(search_lower)
-                    if idx >= 0:
-                        start = max(0, idx - 40)
-                        end = min(len(text_content), idx + len(search_lower) + 40)
-                        snippet = text_content[start:end].strip()
-                        if start > 0:
-                            snippet = "..." + snippet
-                        if end < len(text_content):
-                            snippet = snippet + "..."
-                        snippet_by_conv_id[cid] = snippet
-                        break
+                    occurrences = text_content.lower().count(search_lower)
+                    if occurrences > 0:
+                        count_by_conv_id[cid] = count_by_conv_id.get(cid, 0) + occurrences
+                # Extract snippet from first match (once per conversation)
+                if cid not in snippet_by_conv_id:
+                    for text_content in candidates:
+                        idx = text_content.lower().find(search_lower)
+                        if idx >= 0:
+                            start = max(0, idx - 40)
+                            end = min(len(text_content), idx + len(search_lower) + 40)
+                            snippet = text_content[start:end].strip()
+                            if start > 0:
+                                snippet = "..." + snippet
+                            if end < len(text_content):
+                                snippet = snippet + "..."
+                            snippet_by_conv_id[cid] = snippet
+                            break
 
         # Build response using cached fields
         response_items: list[ConversationResponse] = []
@@ -459,6 +465,7 @@ async def list_conversations(
                 agent_responding=getattr(conv, "agent_responding", True),
                 participants=participants,
                 match_snippet=snippet_by_conv_id.get(conv.id),
+                match_count=count_by_conv_id.get(conv.id, 0),
             ))
 
         return ConversationListResponse(

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -55,6 +55,7 @@ export interface ConversationSummary {
   scope?: "private" | "shared";
   participants?: Array<{ id: string; name: string | null; email: string; avatar_url?: string | null }>;
   match_snippet?: string | null;
+  match_count?: number;
 }
 
 export interface ConversationListResponse {

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1592,11 +1592,35 @@ export function Chat({
     }
   }, [chatId, conversationScope, conversationParticipants]);
 
+  // Search navigation state
+  const [searchMatchTotal, setSearchMatchTotal] = useState<number>(0);
+  const [searchMatchIndex, setSearchMatchIndex] = useState<number>(0);
+
+  const scrollToSearchMatch = useCallback((idx: number) => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+    const marks = container.querySelectorAll('mark[data-search-highlight]');
+    if (marks.length === 0) return;
+    // Clamp and wrap
+    const wrappedIdx = ((idx % marks.length) + marks.length) % marks.length;
+    setSearchMatchIndex(wrappedIdx);
+    // Style: dim all, highlight active
+    marks.forEach((m, i) => {
+      (m as HTMLElement).className = i === wrappedIdx
+        ? 'bg-yellow-400/60 text-yellow-50 rounded-sm ring-2 ring-yellow-400/80'
+        : 'bg-yellow-500/30 text-yellow-200 rounded-sm';
+    });
+    marks[wrappedIdx]?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, []);
+
   // Highlight search term in message content via DOM TreeWalker.
-  // Runs after React paints (requestAnimationFrame) to ensure DOM is ready.
   useEffect(() => {
     const container = messagesContainerRef.current;
-    if (!container || !chatSearchTerm?.trim()) return;
+    if (!container || !chatSearchTerm?.trim()) {
+      setSearchMatchTotal(0);
+      setSearchMatchIndex(0);
+      return;
+    }
 
     const applyHighlights = (): void => {
       const term = chatSearchTerm.trim().toLowerCase();
@@ -1610,38 +1634,53 @@ export function Chat({
         }
       });
 
-      // Walk text nodes and wrap matches
+      // Walk text nodes and wrap ALL matches (not just first per node)
       const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
-      const matches: { node: Text; index: number }[] = [];
+      const allMatches: { node: Text; index: number }[] = [];
       let textNode: Text | null;
       while ((textNode = walker.nextNode() as Text | null)) {
-        const idx = textNode.textContent?.toLowerCase().indexOf(term) ?? -1;
-        if (idx >= 0) matches.push({ node: textNode, index: idx });
+        const text = textNode.textContent?.toLowerCase() ?? '';
+        let searchFrom = 0;
+        let idx: number;
+        while ((idx = text.indexOf(term, searchFrom)) >= 0) {
+          allMatches.push({ node: textNode, index: idx });
+          searchFrom = idx + term.length;
+        }
       }
-      for (const { node: matchNode, index } of matches) {
+
+      // Apply marks in reverse order (so earlier indices don't shift)
+      for (let i = allMatches.length - 1; i >= 0; i--) {
+        const match = allMatches[i];
+        if (!match) continue;
+        const { node: matchNode, index } = match;
         try {
           const range = document.createRange();
           range.setStart(matchNode, index);
           range.setEnd(matchNode, index + term.length);
           const mark = document.createElement('mark');
           mark.setAttribute('data-search-highlight', '');
-          mark.className = 'bg-yellow-500/40 text-yellow-100 rounded-sm';
+          mark.className = 'bg-yellow-500/30 text-yellow-200 rounded-sm';
           range.surroundContents(mark);
         } catch {
           // surroundContents can fail if range crosses element boundaries
         }
       }
 
-      // Scroll to first match
-      const firstMark = container.querySelector('mark[data-search-highlight]');
-      if (firstMark) {
-        firstMark.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      const totalMarks = container.querySelectorAll('mark[data-search-highlight]').length;
+      setSearchMatchTotal(totalMarks);
+      if (totalMarks > 0) {
+        setSearchMatchIndex(0);
+        // Highlight first match as active
+        const firstMark = container.querySelector('mark[data-search-highlight]');
+        if (firstMark) {
+          (firstMark as HTMLElement).className = 'bg-yellow-400/60 text-yellow-50 rounded-sm ring-2 ring-yellow-400/80';
+          firstMark.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
       }
     };
 
     // Wait for React to paint, then apply highlights
     const rafId = requestAnimationFrame(() => {
-      // Double-RAF to ensure layout is complete
       requestAnimationFrame(applyHighlights);
     });
     return () => cancelAnimationFrame(rafId);
@@ -1700,27 +1739,68 @@ export function Chat({
 
   return (
     <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
-      {/* Search result banner */}
+      {/* Search navigation bar (browser-style Find) */}
       {chatSearchTerm && (
-        <div className="hidden md:flex h-9 bg-primary-500/10 border-b border-primary-500/20 items-center px-4 md:px-6 gap-2 flex-shrink-0">
-          <svg className="w-4 h-4 text-primary-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-          </svg>
-          <span className="text-xs text-primary-300">
-            Showing results for <strong>&ldquo;{chatSearchTerm}&rdquo;</strong>
-          </span>
+        <div className="hidden md:flex h-10 bg-surface-900 border-b border-surface-700 items-center px-4 md:px-6 gap-3 flex-shrink-0">
           <button
             type="button"
             onClick={() => {
               useChatStore.setState({ chatSearchTerm: null });
               useAppStore.getState().setCurrentView('chats');
             }}
-            className="ml-auto flex items-center gap-1 text-xs text-primary-400 hover:text-primary-300 font-medium"
+            className="flex items-center gap-1 text-xs text-surface-400 hover:text-surface-200 font-medium"
+            title="Back to search results"
           >
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
             </svg>
-            Back to search
+          </button>
+          <div className="flex items-center gap-1 px-2 py-1 rounded bg-surface-800 border border-surface-700">
+            <svg className="w-3.5 h-3.5 text-yellow-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+            <span className="text-xs text-surface-200 font-medium">{chatSearchTerm}</span>
+          </div>
+          {searchMatchTotal > 0 ? (
+            <span className="text-xs text-surface-400 tabular-nums">
+              {searchMatchIndex + 1} of {searchMatchTotal}
+            </span>
+          ) : (
+            <span className="text-xs text-surface-500">No matches</span>
+          )}
+          <div className="flex items-center gap-0.5">
+            <button
+              type="button"
+              onClick={() => scrollToSearchMatch(searchMatchIndex - 1)}
+              disabled={searchMatchTotal === 0}
+              className="p-1 rounded hover:bg-surface-700 text-surface-400 hover:text-surface-200 disabled:opacity-30 disabled:cursor-not-allowed"
+              title="Previous match"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+              </svg>
+            </button>
+            <button
+              type="button"
+              onClick={() => scrollToSearchMatch(searchMatchIndex + 1)}
+              disabled={searchMatchTotal === 0}
+              className="p-1 rounded hover:bg-surface-700 text-surface-400 hover:text-surface-200 disabled:opacity-30 disabled:cursor-not-allowed"
+              title="Next match"
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => useChatStore.setState({ chatSearchTerm: null })}
+            className="ml-auto p-1 rounded hover:bg-surface-700 text-surface-400 hover:text-surface-200"
+            title="Close search"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
           </button>
         </div>
       )}

--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -33,6 +33,7 @@ function apiConvToChatSummary(conv: ConversationSummary): ChatSummary {
       avatarUrl: p.avatar_url,
     })),
     matchSnippet: conv.match_snippet,
+    matchCount: conv.match_count ?? 0,
   };
 }
 
@@ -404,6 +405,11 @@ function ChatRow({
             }`}>
               {chat.scope}
             </span>
+            {isSearching && (chat.matchCount ?? 0) > 0 && (
+              <span className="flex-shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium bg-yellow-500/20 text-yellow-400">
+                {chat.matchCount} {chat.matchCount === 1 ? 'match' : 'matches'}
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-2 mt-1">
             {chat.participants && chat.participants.length > 0 && (

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -125,6 +125,7 @@ export interface ChatSummary {
   userId?: string; // Creator's user ID
   participants?: Participant[];
   matchSnippet?: string | null; // Search match context snippet
+  matchCount?: number; // Number of occurrences in conversation
 }
 
 // Workstream (semantic Home) types


### PR DESCRIPTION
## Summary

### Search results list
- Yellow **"N matches" badge** on each result showing how many times the term appears
- Match count computed server-side across all text blocks

### Chat view — browser-style Find bar
- **"X of Y" counter** with up/down arrow buttons
- Active match highlighted bright yellow with ring, others dimmed
- **Cycles through matches** with wrapping (like Cmd+F in Chrome/Safari)
- Back arrow returns to search results
- X button closes the find bar
- Finds ALL occurrences per text node (not just first)

## Test plan
- [ ] Search a term → results show "N matches" badges
- [ ] Click a result → Find bar shows "1 of Y"
- [ ] Click down arrow → scrolls to next match, counter updates
- [ ] Click up arrow → goes to previous, wraps around
- [ ] Active match visually distinct from others
- [ ] X closes find bar, back arrow returns to All Chats

🤖 Generated with [Claude Code](https://claude.com/claude-code)