### PR TITLE
Use backend match count, fix back arrow

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1620,9 +1620,9 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
     return () => window.removeEventListener('navigate', handleNavigate);
   }, [setCurrentView]);
 
-  const handleSelectChat = useCallback((chatId: string, searchTerm?: string): void => {
+  const handleSelectChat = useCallback((chatId: string, searchTerm?: string, matchCount?: number): void => {
     setCurrentChatId(chatId);
-    useChatStore.setState({ chatSearchTerm: searchTerm ?? null });
+    useChatStore.setState({ chatSearchTerm: searchTerm ?? null, chatSearchMatchCount: matchCount ?? 0 });
     setCurrentView('chat');
   }, [setCurrentChatId, setCurrentView]);
 

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1457,6 +1457,7 @@ export function Chat({
   const deleteConversation = useAppStore((s) => s.deleteConversation);
   const isCurrentChatUnread = useChatStore((s) => Boolean(chatId && s.unreadConversationIds.has(chatId)));
   const chatSearchTerm = useChatStore((s) => s.chatSearchTerm);
+  const chatSearchMatchCount = useChatStore((s) => s.chatSearchMatchCount);
   const isCurrentChatPinned: boolean = Boolean(chatId && pinnedChatIds.includes(chatId));
 
   const startEditingHeaderTitle = useCallback(() => {
@@ -1592,8 +1593,8 @@ export function Chat({
     }
   }, [chatId, conversationScope, conversationParticipants]);
 
-  // Search navigation state
-  const [searchMatchTotal, setSearchMatchTotal] = useState<number>(0);
+  // Search navigation state — use backend count, not DOM mark count
+  const searchMatchTotal: number = chatSearchTerm ? chatSearchMatchCount : 0;
   const [searchMatchIndex, setSearchMatchIndex] = useState<number>(0);
 
   const scrollToSearchMatch = useCallback((idx: number) => {
@@ -1617,7 +1618,6 @@ export function Chat({
   useEffect(() => {
     const container = messagesContainerRef.current;
     if (!container || !chatSearchTerm?.trim()) {
-      setSearchMatchTotal(0);
       setSearchMatchIndex(0);
       return;
     }
@@ -1667,7 +1667,6 @@ export function Chat({
       }
 
       const totalMarks = container.querySelectorAll('mark[data-search-highlight]').length;
-      setSearchMatchTotal(totalMarks);
       if (totalMarks > 0) {
         setSearchMatchIndex(0);
         // Highlight first match as active
@@ -1745,7 +1744,7 @@ export function Chat({
           <button
             type="button"
             onClick={() => {
-              useChatStore.setState({ chatSearchTerm: null });
+              // Keep chatSearchTerm so ChatsList restores search results
               useAppStore.getState().setCurrentView('chats');
             }}
             className="flex items-center gap-1 text-xs text-surface-400 hover:text-surface-200 font-medium"

--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -6,13 +6,13 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ChatSummary } from '../store/types';
-import { useActiveTasksByConversation, useAppStore } from '../store';
+import { useActiveTasksByConversation, useAppStore, useChatStore } from '../store';
 import { listConversations, type ConversationSummary } from '../api/client';
 import { Avatar } from './Avatar';
 
 interface ChatsListProps {
   chats: ChatSummary[];
-  onSelectChat: (id: string, searchTerm?: string) => void;
+  onSelectChat: (id: string, searchTerm?: string, matchCount?: number) => void;
   onNewChat: () => void;
 }
 
@@ -58,7 +58,8 @@ function HighlightText({ text, term }: { text: string; term: string }): JSX.Elem
 type ScopeFilter = 'all' | 'shared' | 'private' | 'mine';
 
 export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: ChatsListProps): JSX.Element {
-  const [searchQuery, setSearchQuery] = useState<string>('');
+  const storedSearchTerm = useChatStore((s) => s.chatSearchTerm);
+  const [searchQuery, setSearchQuery] = useState<string>(storedSearchTerm ?? '');
   const [scopeFilter, setScopeFilter] = useState<ScopeFilter>('all');
   const [allChats, setAllChats] = useState<ChatSummary[]>([]);
   const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false);
@@ -73,7 +74,7 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
   const togglePinChat = useAppStore((state) => state.togglePinChat);
   const currentUserId = useAppStore((state) => state.user?.id);
 
-  const [committedSearch, setCommittedSearch] = useState<string>('');
+  const [committedSearch, setCommittedSearch] = useState<string>(storedSearchTerm ?? '');
   const searchVersionRef = useRef<number>(0);
 
   const handleSearchSubmit = useCallback(() => {
@@ -83,6 +84,7 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
   const handleSearchClear = useCallback(() => {
     setSearchQuery('');
     setCommittedSearch('');
+    useChatStore.setState({ chatSearchTerm: null, chatSearchMatchCount: 0 });
   }, []);
 
   const loadPage = useCallback(async (reset: boolean = false): Promise<void> => {
@@ -354,13 +356,13 @@ function ChatRow({
   searchTerm: string;
   hasActiveTask: boolean;
   isPinned: boolean;
-  onSelect: (id: string, searchTerm?: string) => void;
+  onSelect: (id: string, searchTerm?: string, matchCount?: number) => void;
   onTogglePin: (id: string) => void;
 }): JSX.Element {
   const isSearching = searchTerm.trim().length > 0;
   return (
     <button
-      onClick={() => onSelect(chat.id, isSearching ? searchTerm : undefined)}
+      onClick={() => onSelect(chat.id, isSearching ? searchTerm : undefined, isSearching ? chat.matchCount : undefined)}
       className="relative w-full text-left p-4 rounded-xl bg-surface-900 hover:bg-surface-800 border border-surface-800 hover:border-surface-700 transition-colors group"
     >
       <div className="flex items-start justify-between gap-4">

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -63,6 +63,7 @@ export interface ChatState {
   recentChats: ChatSummary[];
   currentChatId: string | null;
   chatSearchTerm: string | null; // Active search term for highlighting in chat
+  chatSearchMatchCount: number; // Backend-provided total match count
   pendingChatInput: string | null;
   pendingChatAutoSend: boolean;
 
@@ -205,6 +206,7 @@ export const useChatStore = create<ChatState>()(
     recentChats: [],
     currentChatId: null,
     chatSearchTerm: null,
+    chatSearchMatchCount: 0,
     pendingChatInput: null,
     pendingChatAutoSend: false,
     conversations: {},

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -99,7 +99,7 @@ export const useUIStore = create<UIState>()(
         set({ currentAppId: appId, currentView: "app-view" as View }),
       startNewChat: () => {
         set({ currentView: "chat" });
-        useChatStore.setState({ currentChatId: null, chatSearchTerm: null });
+        useChatStore.setState({ currentChatId: null, chatSearchTerm: null, chatSearchMatchCount: 0 });
       },
       togglePinChat: (id) => {
         const { pinnedChatIds } = get();


### PR DESCRIPTION
## Summary
Two persistent bugs fixed:

1. **"0 matches" on landing** — was counting DOM marks, but text in tool results
   isn't rendered as visible DOM text. Now uses the backend's `match_count`
   directly — shows "8 matches" immediately on click-through.

2. **Back arrow restarted search** — was clearing `chatSearchTerm` before
   navigating to All Chats, so ChatsList mounted with no search. Now preserves
   the term; ChatsList initializes from store on mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)