### PR TITLE
Auto-load all messages when opening from search

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1460,6 +1460,24 @@ export function Chat({
   const chatSearchMatchCount = useChatStore((s) => s.chatSearchMatchCount);
   const isCurrentChatPinned: boolean = Boolean(chatId && pinnedChatIds.includes(chatId));
 
+  // When opened from search, auto-load ALL older messages so all matches are navigable
+  const autoLoadedForChatRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!chatSearchTerm || !chatId || isLoading) return;
+    if (autoLoadedForChatRef.current === chatId) return;
+    autoLoadedForChatRef.current = chatId;
+    if (!hasMoreMessages) return;
+    const loadAll = async (): Promise<void> => {
+      let more = true;
+      let safety = 0;
+      while (more && safety < 50) {
+        safety++;
+        more = await fetchOlderMessages(chatId);
+      }
+    };
+    void loadAll();
+  }, [chatSearchTerm, chatId, isLoading, hasMoreMessages, fetchOlderMessages]);
+
   const startEditingHeaderTitle = useCallback(() => {
     if (!canRenameHeader) return;
     setHeaderTitleDraft(chatTitle);


### PR DESCRIPTION
When clicking a search result, automatically loads all older messages
so the find bar arrows can navigate to every match. Previously older
messages stayed behind "Load earlier messages" making most matches
unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)