### PR TITLE
Back arrow in chat header, clickable Chat History

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1838,6 +1838,23 @@ export function Chat({
       {/* Header - hidden on mobile since AppLayout has mobile header */}
       <header className="hidden md:flex h-14 border-b border-surface-800 items-center justify-between px-4 md:px-6 flex-shrink-0">
         <div className="flex items-center gap-3 min-w-0">
+          {/* Back to All Chats */}
+          <button
+            type="button"
+            onClick={() => {
+              if (chatSearchTerm) {
+                useAppStore.getState().setCurrentView('chats');
+              } else {
+                useAppStore.getState().setCurrentView('chats');
+              }
+            }}
+            className="p-1 -ml-1 rounded-md text-surface-500 hover:text-surface-200 hover:bg-surface-800 transition-colors flex-shrink-0"
+            title="All Chats"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
           {isEditingHeaderTitle ? (
             <input
               ref={headerTitleInputRef}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -997,16 +997,20 @@ function ChatAccordion({
   
   return (
     <div className="flex-1 flex flex-col min-h-0 px-1.5 py-px">
-      {/* Chat History header with View All link */}
-      <div className="flex-shrink-0 flex items-center justify-between px-2 py-0.5">
-        <span className="text-xs font-semibold text-surface-200 uppercase tracking-wider">Chat History</span>
-        <button
-          onClick={onViewAll}
-          className="text-xs font-medium text-amber-400 hover:text-amber-300 transition-colors"
-        >
+      {/* Chat History header — whole row is clickable to open All Chats (with search) */}
+      <button
+        type="button"
+        onClick={onViewAll}
+        className="flex-shrink-0 flex items-center justify-between w-full px-2 py-1.5 rounded-md hover:bg-surface-800 transition-colors group"
+      >
+        <span className="text-xs font-semibold text-surface-200 uppercase tracking-wider group-hover:text-surface-100">Chat History</span>
+        <span className="flex items-center gap-1 text-xs font-medium text-primary-400 group-hover:text-primary-300">
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
           View All
-        </button>
-      </div>
+        </span>
+      </button>
 
       <div className="flex-1 overflow-y-auto scrollbar-thin space-y-0 min-h-0">
         {recentSidebarChats.length > 0 ? (


### PR DESCRIPTION
## Summary
1. **Back chevron** in chat header — always visible, returns to All Chats
2. **Chat History row** in sidebar is now a full-width clickable button with
   hover state and search icon — makes it more discoverable as the search entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)