### PR TITLE
Combine scope and timestamp into single metadata pill in Chats list

### DIFF
--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -400,13 +400,16 @@ function ChatRow({
                 Active
               </span>
             )}
-            <span className={`flex-shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide ${
+            <div className={`ml-auto min-w-[9rem] flex-shrink-0 flex items-center gap-2 px-2 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wide ${
               chat.scope === 'shared'
                 ? 'bg-primary-500/20 text-primary-400'
                 : 'bg-surface-700 text-surface-400'
             }`}>
-              {chat.scope}
-            </span>
+              <span>{chat.scope}</span>
+              <span className="ml-auto normal-case tracking-normal text-xs text-surface-300 whitespace-nowrap">
+                {formatDate(chat.lastMessageAt)}
+              </span>
+            </div>
             {isSearching && (chat.matchCount ?? 0) > 0 && (
               <span className="flex-shrink-0 px-1.5 py-0.5 rounded text-[10px] font-bold bg-amber-300 text-black">
                 {chat.matchCount} {chat.matchCount === 1 ? 'match' : 'matches'}
@@ -437,9 +440,7 @@ function ChatRow({
             </p>
           </div>
         </div>
-
         <div className="flex flex-col items-end gap-2 flex-shrink-0">
-          <div className="text-xs text-surface-500 whitespace-nowrap">{formatDate(chat.lastMessageAt)}</div>
           <button
             onClick={(e) => { e.stopPropagation(); onTogglePin(chat.id); }}
             className={`p-1.5 rounded ${


### PR DESCRIPTION
### Motivation
- Consolidate conversation metadata by combining the `scope` label and last-edited time into a single pill in the All Chats row header, and place the time at the right edge of that pill for clearer, more compact UI.

### Description
- Updated `ChatRow` in `frontend/src/components/ChatsList.tsx` to replace the separate `scope` span and the standalone timestamp with a single pill container using `ml-auto` and a second span for the time.
- The new pill uses `min-w-[9rem] flex items-center gap-2 px-2 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wide` and conditionally applies the existing color styles for `shared` vs other scopes.
- Added an inner time span with `ml-auto normal-case tracking-normal text-xs text-surface-300 whitespace-nowrap` that renders `formatDate(chat.lastMessageAt)`.
- Removed the previous separate timestamp element on the far-right column so the metadata is consolidated within the header pill.

### Testing
- Ran `npm --prefix frontend run lint`, which completed successfully.
- No additional automated tests were present for this component in the change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c949568fe08321acd94eb3e4e87ff7)