### PR TITLE
Adjust all-chats pill layout for avatars and mobile pin visibility

### DIFF
--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -366,19 +366,18 @@ function ChatRow({
       className="relative w-full text-left p-4 rounded-xl bg-surface-900 hover:bg-surface-800 border border-surface-800 hover:border-surface-700 transition-colors group"
     >
       <div className="flex items-start justify-between gap-4">
-        <div className="flex-shrink-0 mt-0.5">
-          {chat.scope === 'private' ? (
-            <svg className="w-5 h-5 text-surface-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-            </svg>
-          ) : (
-            <svg className="w-5 h-5 text-surface-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-            </svg>
-          )}
-        </div>
-
-        <div className="flex-1 min-w-0">
+        <div className="flex-1 min-w-0 grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1">
+          <div className="flex-shrink-0 mt-0.5">
+            {chat.scope === 'private' ? (
+              <svg className="w-5 h-5 text-surface-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+              </svg>
+            ) : (
+              <svg className="w-5 h-5 text-surface-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+              </svg>
+            )}
+          </div>
           <div className="flex items-center gap-2">
             <h3 className="font-medium text-surface-100 truncate group-hover:text-white transition-colors">
               {isSearching ? <HighlightText text={chat.title} term={searchTerm} /> : chat.title}
@@ -413,7 +412,7 @@ function ChatRow({
               </span>
             )}
           </div>
-          <div className="flex items-center gap-2 mt-1">
+          <div className="flex min-h-[1.25rem] items-center">
             {chat.participants && chat.participants.length > 0 && (
               <div className="flex -space-x-1.5">
                 {chat.participants.slice(0, 3).map((p, idx) => (
@@ -426,6 +425,8 @@ function ChatRow({
                 )}
               </div>
             )}
+          </div>
+          <div className="flex items-center gap-2 min-w-0">
             <p className="text-sm text-surface-400 truncate">
               {isSearching && chat.matchSnippet ? (
                 <HighlightText text={chat.matchSnippet} term={searchTerm} />
@@ -443,8 +444,10 @@ function ChatRow({
           <button
             onClick={(e) => { e.stopPropagation(); onTogglePin(chat.id); }}
             className={`p-1.5 rounded ${
-              isPinned ? 'opacity-100 text-primary-400' : 'opacity-0 text-surface-500'
-            } group-hover:opacity-100 hover:bg-surface-700 hover:text-surface-200 transition-all`}
+              isPinned
+                ? 'opacity-100 text-primary-400'
+                : 'opacity-100 md:opacity-0 text-surface-500'
+            } md:group-hover:opacity-100 hover:bg-surface-700 hover:text-surface-200 transition-all`}
             title={isPinned ? 'Unpin conversation' : 'Pin conversation'}
           >
             <svg className={`w-4 h-4 ${isPinned ? 'text-primary-400' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
### Motivation
- Ensure participant avatars in the All Chats view appear left-most in the chat pill, directly under the top-row chat-type icon for clearer visual alignment. 
- On mobile, make the pin control always visible while preserving hover-to-reveal on larger screens for discoverability and consistent UX.

### Description
- Reworked the `ChatRow` content area in `frontend/src/components/ChatsList.tsx` into a 2-column grid using `grid-cols-[auto_minmax(0,1fr)]` so the icon/avatar stack occupies the left column and title/preview live in the right column. 
- Moved the participant avatar stack into the left column and added a stable row for the preview text in the second column to preserve truncation and alignment (`min-w-0` / truncate-safe layout). 
- Updated the pin button visibility logic so it is always visible on mobile by changing the Tailwind classes from `opacity-0` to `opacity-100 md:opacity-0` and keeping `md:group-hover:opacity-100` for medium+ screens. 
- Small spacing/height adjustments (`gap-x/gap-y`, `min-h-[1.25rem]`) to keep the layout visually consistent across breakpoints.

### Testing
- Ran the frontend linter with `cd frontend && npm run -s lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c948abe01483219ad3463063df5235)