### PR TITLE
Adjust all chats scope pill placement

### DIFF
--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -378,27 +378,39 @@ function ChatRow({
               </svg>
             )}
           </div>
-          <div className="flex items-center gap-2">
-            <h3 className="font-medium text-surface-100 truncate group-hover:text-white transition-colors">
-              {isSearching ? <HighlightText text={chat.title} term={searchTerm} /> : chat.title}
-            </h3>
-            {chat.type === 'workflow' && (
-              <span className="flex-shrink-0 px-1.5 py-0.5 rounded text-xs bg-amber-500/20 text-amber-400">Workflow</span>
-            )}
-            {hasActiveTask && (
-              <span className="flex-shrink-0 flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-primary-500/20 text-primary-400 text-xs">
-                <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                </svg>
-                Active
+          <div className="flex items-start gap-2 min-w-0">
+            <div className="flex items-center gap-2 min-w-0 flex-1">
+              <h3 className="font-medium text-surface-100 truncate group-hover:text-white transition-colors">
+                {isSearching ? <HighlightText text={chat.title} term={searchTerm} /> : chat.title}
+              </h3>
+              {chat.type === 'workflow' && (
+                <span className="flex-shrink-0 px-1.5 py-0.5 rounded text-xs bg-amber-500/20 text-amber-400">Workflow</span>
+              )}
+              {hasActiveTask && (
+                <span className="flex-shrink-0 flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-primary-500/20 text-primary-400 text-xs">
+                  <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                  </svg>
+                  Active
+                </span>
+              )}
+              {isSearching && (chat.matchCount ?? 0) > 0 && (
+                <span className="flex-shrink-0 px-1.5 py-0.5 rounded text-[10px] font-bold bg-amber-300 text-black">
+                  {chat.matchCount} {chat.matchCount === 1 ? 'match' : 'matches'}
+                </span>
+              )}
+            </div>
+            <div className={`flex-shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wide ${
+              chat.scope === 'shared'
+                ? 'bg-primary-500/20 text-primary-400'
+                : 'bg-surface-700 text-surface-400'
+            }`}>
+              <span>{chat.scope}</span>
+              <span className="normal-case tracking-normal text-xs text-surface-300 whitespace-nowrap">
+                {formatDate(chat.lastMessageAt)}
               </span>
-            )}
-            {isSearching && (chat.matchCount ?? 0) > 0 && (
-              <span className="flex-shrink-0 px-1.5 py-0.5 rounded text-[10px] font-bold bg-amber-300 text-black">
-                {chat.matchCount} {chat.matchCount === 1 ? 'match' : 'matches'}
-              </span>
-            )}
+            </div>
           </div>
           <div className="flex min-h-[1.25rem] items-center">
             {chat.participants && chat.participants.length > 0 && (
@@ -438,16 +450,6 @@ function ChatRow({
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
                 </svg>
               </button>
-              <div className={`min-w-[8rem] flex-shrink-0 flex items-center justify-end gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wide ${
-                chat.scope === 'shared'
-                  ? 'bg-primary-500/20 text-primary-400'
-                  : 'bg-surface-700 text-surface-400'
-              }`}>
-                <span>{chat.scope}</span>
-                <span className="normal-case tracking-normal text-xs text-surface-300 whitespace-nowrap">
-                  {formatDate(chat.lastMessageAt)}
-                </span>
-              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Reduce the spare colored-pill buffer and surface the conversation scope/last-edited info more prominently by moving it into the top title row of each All Chats list item.
- Preserve existing interactions (pin action and participants) while tightening visual spacing and avoiding large fixed-width colored areas.

### Description
- Updated `frontend/src/components/ChatsList.tsx` to move the scope/date pill from the lower preview/metadata row into the top title row next to the title/status badges.
- Reworked the title row layout to use a compact `inline-flex` pill with reduced horizontal padding (`px-1.5`) and removed the previous fixed minimum width to eliminate excess colored space.
- Kept the pin control and preview text in the lower metadata area so interaction behavior is unchanged.
- This is a visual/layout-only change; no API or data-model changes were made.

### Testing
- Ran frontend linting via `npm run lint` in `frontend/` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c959b082a483219754f36928bf57ea)