### PR TITLE
Ensure automated-agent disclosure footer for workflow `send_email_from`

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -86,6 +86,8 @@ if _configured_openai_research_model and not _configured_openai_research_model.s
 from datetime import datetime as dt
 from typing import TypedDict
 
+from services.automated_agent_footer import ensure_automated_agent_footer
+
 class PendingOperationData(TypedDict):
     tool_name: str
     params: dict[str, Any]
@@ -96,22 +98,9 @@ class PendingOperationData(TypedDict):
 # In-memory store for pending operations (will be replaced by database in Phase 6)
 _pending_operations: dict[str, PendingOperationData] = {}
 
-_AUTOMATED_AGENT_FOOTER: str = "Done by an automated agent via Basebase."
-_AUTOMATED_AGENT_FOOTER_MARKER: re.Pattern[str] = re.compile(
-    r"done\s+by\s+an\s+automated\s+agent",
-    flags=re.IGNORECASE,
-)
-
-
 def _ensure_automated_agent_footer(content: str | None) -> str:
     """Ensure outbound user-authored messages/issues include an automation signature footer."""
-    base_text: str = (content or "").rstrip()
-    if _AUTOMATED_AGENT_FOOTER_MARKER.search(base_text):
-        return base_text
-    footer_line: str = f"— {_AUTOMATED_AGENT_FOOTER}"
-    if not base_text:
-        return footer_line
-    return f"{base_text}\n\n{footer_line}"
+    return ensure_automated_agent_footer(content)
 
 def store_pending_operation(
     operation_id: str,

--- a/backend/services/automated_agent_footer.py
+++ b/backend/services/automated_agent_footer.py
@@ -1,0 +1,22 @@
+"""Utilities for applying an automated-agent disclosure footer to outbound content."""
+
+from __future__ import annotations
+
+import re
+
+AUTOMATED_AGENT_FOOTER: str = "Done by an automated agent via Basebase."
+_AUTOMATED_AGENT_FOOTER_MARKER: re.Pattern[str] = re.compile(
+    r"done\s+by\s+an\s+automated\s+agent",
+    flags=re.IGNORECASE,
+)
+
+
+def ensure_automated_agent_footer(content: str | None) -> str:
+    """Ensure outbound user-authored content includes an automation signature footer."""
+    base_text: str = (content or "").rstrip()
+    if _AUTOMATED_AGENT_FOOTER_MARKER.search(base_text):
+        return base_text
+    footer_line: str = f"— {AUTOMATED_AGENT_FOOTER}"
+    if not base_text:
+        return footer_line
+    return f"{base_text}\n\n{footer_line}"

--- a/backend/tests/test_automated_agent_footer.py
+++ b/backend/tests/test_automated_agent_footer.py
@@ -1,0 +1,15 @@
+from services.automated_agent_footer import ensure_automated_agent_footer
+
+
+def test_ensure_automated_agent_footer_adds_footer_once() -> None:
+    signed = ensure_automated_agent_footer("Hello there")
+    assert "Done by an automated agent" in signed
+    assert signed.startswith("Hello there")
+
+    signed_again = ensure_automated_agent_footer(signed)
+    assert signed_again == signed
+
+
+def test_ensure_automated_agent_footer_handles_empty_text() -> None:
+    signed = ensure_automated_agent_footer("")
+    assert signed.startswith("— Done by an automated agent")

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -25,6 +25,7 @@ from typing import Any
 from uuid import UUID
 
 from workers.celery_app import celery_app
+from services.automated_agent_footer import ensure_automated_agent_footer
 from services.anthropic_health import report_anthropic_call_failure, report_anthropic_call_success
 
 logger = logging.getLogger(__name__)
@@ -1802,10 +1803,16 @@ async def _action_send_email_from(
                 nango_connection_id=integration.nango_connection_id,
             )
         
+        body_with_footer = ensure_automated_agent_footer(body)
+        logger.info(
+            "[workflows._action_send_email_from] Applying automated-agent footer for email to %s",
+            to,
+        )
+
         result = await connector.send_email(
             to=to,
             subject=subject,
-            body=body,
+            body=body_with_footer,
             cc=cc if cc else None,
             bcc=bcc if bcc else None,
         )


### PR DESCRIPTION
### Motivation
- Workflow-triggered email sends used a different code path than agent tools, so emails sent via workflows could omit the AI disclosure footer even after prior fixes to agent tool paths. 
- Make the disclosure behavior consistent across both agent tools and workflow-driven sends.

### Description
- Add shared helper `backend/services/automated_agent_footer.py` exposing `ensure_automated_agent_footer` for consistent footer application.  
- Update `workers.tasks.workflows._action_send_email_from` to call `ensure_automated_agent_footer(body)` and send the resulting `body_with_footer` before invoking the connector.  
- Keep `agents.tools._ensure_automated_agent_footer` as a thin wrapper that delegates to the shared helper to preserve existing call sites.  
- Add focused unit tests in `backend/tests/test_automated_agent_footer.py` validating footer addition and idempotence.

### Testing
- Ran `pytest -q backend/tests/test_automated_agent_footer.py` which passed (`2 passed`).
- Attempted `pytest -q backend/tests/test_tools_automated_agent_footer.py backend/tests/test_automated_agent_footer.py` but test collection failed due to a pre-existing circular import (`agents.tools` <-> `agents.orchestrator`) in this environment, so the broader combined run could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95bbc825c8321beb10354fc351a78)