### PR TITLE
Add automated-agent disclosure footer to workflow email actions

### DIFF
--- a/backend/tests/test_workflow_automated_agent_footer.py
+++ b/backend/tests/test_workflow_automated_agent_footer.py
@@ -1,0 +1,15 @@
+from workers.tasks import workflows
+
+
+def test_workflow_footer_appends_once() -> None:
+    signed = workflows._ensure_automated_agent_footer("Hello from workflow")
+    assert "Done by an automated agent" in signed
+    assert signed.endswith("Done by an automated agent via Basebase.")
+
+    signed_again = workflows._ensure_automated_agent_footer(signed)
+    assert signed_again == signed
+
+
+def test_workflow_footer_handles_empty_body() -> None:
+    signed = workflows._ensure_automated_agent_footer("")
+    assert signed == "— Done by an automated agent via Basebase."

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -20,6 +20,7 @@ if str(_backend_dir) not in sys.path:
 
 import json
 import logging
+import re
 from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
@@ -36,6 +37,23 @@ WORKFLOW_NESTING_GUARDRAIL = (
     "the total created across this execution tree at 5 or fewer. Prefer "
     "completing the task in this workflow directly."
 )
+
+_AUTOMATED_AGENT_FOOTER: str = "Done by an automated agent via Basebase."
+_AUTOMATED_AGENT_FOOTER_MARKER: re.Pattern[str] = re.compile(
+    r"done\s+by\s+an\s+automated\s+agent",
+    flags=re.IGNORECASE,
+)
+
+
+def _ensure_automated_agent_footer(content: str | None) -> str:
+    """Ensure workflow outbound messages include an automation signature footer."""
+    base_text: str = (content or "").rstrip()
+    if _AUTOMATED_AGENT_FOOTER_MARKER.search(base_text):
+        return base_text
+    footer_line: str = f"— {_AUTOMATED_AGENT_FOOTER}"
+    if not base_text:
+        return footer_line
+    return f"{base_text}\n\n{footer_line}"
 
 
 def _extract_allowed_slack_channels(workflow: Any) -> list[str]:
@@ -1442,7 +1460,7 @@ async def _action_send_email(
         prev_output = context.get("step_0_output", {}).get("output", "")
         body = body.replace("{previous_output}", prev_output)
     
-    success = await send_email(to, subject, body)
+    success = await send_email(to, subject, _ensure_automated_agent_footer(body))
     
     return {
         "status": "completed" if success else "failed",
@@ -1692,7 +1710,12 @@ async def _action_send_system_email(
             subject = subject.replace(f"{{{key}}}", output_str)
             body = body.replace(f"{{{key}}}", output_str)
     
-    success = await send_email(to, subject, body, reply_to=reply_to)
+    success = await send_email(
+        to,
+        subject,
+        _ensure_automated_agent_footer(body),
+        reply_to=reply_to,
+    )
     
     return {
         "status": "completed" if success else "failed",
@@ -1805,7 +1828,7 @@ async def _action_send_email_from(
         result = await connector.send_email(
             to=to,
             subject=subject,
-            body=body,
+            body=_ensure_automated_agent_footer(body),
             cc=cc if cc else None,
             bcc=bcc if bcc else None,
         )


### PR DESCRIPTION
### Motivation
- Workflow-triggered emails were not including the automated-agent disclosure that is applied in the agent tool path, so workflow emails could be sent without the AI disclosure footer.
- Ensure consistent AI disclosure across both agent tool email sends and workflow-driven email actions.

### Description
- Add `_ensure_automated_agent_footer` helper to `backend/workers/tasks/workflows.py` (imports `re`) that appends the footer `— Done by an automated agent via Basebase.` and is idempotent when the marker already exists.
- Apply the helper to workflow email paths by updating `_action_send_email` to call `send_email(to, subject, _ensure_automated_agent_footer(body))`.
- Apply the helper to `_action_send_system_email` by adding the footer to the `send_email(..., reply_to=...)` call.
- Apply the helper to `_action_send_email_from` by passing `body=_ensure_automated_agent_footer(body)` to the Gmail/Outlook connectors.
- Add focused tests in `backend/tests/test_workflow_automated_agent_footer.py` verifying footer append and idempotency.

### Testing
- Ran the workflow-focused tests with `pytest -q backend/tests/test_workflow_automated_agent_footer.py` which passed (`2 passed`).
- Attempted `pytest -q backend/tests/test_tools_automated_agent_footer.py backend/tests/test_workflow_automated_agent_footer.py` which failed during collection due to an existing circular import in the test environment (`ImportError` between `agents.orchestrator` and `agents.tools`), unrelated to the workflow changes.
- The new workflow tests exercise the footer logic and confirm correct append and idempotency; they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95bbc825c8321beb10354fc351a78)