### PR TITLE
Enforce automated-agent footer at final email/SMS send step

### DIFF
--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -10,6 +10,7 @@ from typing import Any, Optional
 import httpx
 
 from config import settings
+from services.automated_agent_footer import AUTOMATED_AGENT_FOOTER, ensure_automated_agent_footer
 
 
 def _resend_request_succeeded(status_code: int) -> bool:
@@ -45,6 +46,12 @@ async def send_email(
 
     # Ensure to is a list
     to_list = [to] if isinstance(to, str) else to
+
+    # Apply footer at the final send boundary so user-authored content cannot
+    # remove or mutate the disclosure in earlier prompt/editing steps.
+    body_with_footer: str = ensure_automated_agent_footer(body)
+    if body_with_footer != body:
+        print(f"[Email] Applied automated-agent footer before send to {to_list}")
     
     # Generate simple HTML if not provided
     if not html:
@@ -53,17 +60,19 @@ async def send_email(
         <html>
         <head><meta charset="utf-8"></head>
         <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-            {body.replace(chr(10), '<br>')}
+            {body_with_footer.replace(chr(10), '<br>')}
         </body>
         </html>
         """
+    elif body_with_footer != body:
+        html = f"{html}<br><br>— {AUTOMATED_AGENT_FOOTER}"
 
     payload: dict[str, Any] = {
         "from": from_address or settings.EMAIL_FROM or "Basebase <hello@basebase.com>",
         "to": to_list,
         "subject": subject,
         "html": html,
-        "text": body,
+        "text": body_with_footer,
     }
     
     if reply_to:

--- a/backend/services/sms.py
+++ b/backend/services/sms.py
@@ -14,6 +14,7 @@ from urllib.parse import urlencode
 import httpx
 
 from config import settings
+from services.automated_agent_footer import ensure_automated_agent_footer
 
 # #region agent log
 _DEBUG_LOG_PATH: str = "/Users/teg/Documents/basebase/basebase/.cursor/debug-f1ce5e.log"
@@ -100,9 +101,14 @@ async def send_sms(
         pass
     # #endregion
 
+    # Apply footer at the final send boundary so user text cannot remove it.
+    body_with_footer: str = ensure_automated_agent_footer(body)
+    if body_with_footer != body:
+        print(f"[SMS] Applied automated-agent footer before send to {to}")
+
     # Truncate body if too long
-    if len(body) > 1600:
-        body = body[:1597] + "..."
+    if len(body_with_footer) > 1600:
+        body_with_footer = body_with_footer[:1597] + "..."
     
     # Build auth header
     credentials = base64.b64encode(f"{account_sid}:{auth_token}".encode()).decode()
@@ -118,7 +124,7 @@ async def send_sms(
             params: list[tuple[str, str]] = [
                 ("To", to_value),
                 ("From", from_value),
-                ("Body", body),
+                ("Body", body_with_footer),
             ]
             # Twilio accepts up to 10 repeated MediaUrl params for MMS
             if media_urls:

--- a/backend/tests/test_service_footer_enforcement.py
+++ b/backend/tests/test_service_footer_enforcement.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from urllib.parse import parse_qs
+
+import pytest
+
+from services.automated_agent_footer import AUTOMATED_AGENT_FOOTER
+from services.email import send_email
+from services.sms import send_sms
+
+
+@pytest.mark.asyncio
+async def test_send_email_applies_footer_right_before_send(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_payload: dict[str, object] = {}
+
+    class _MockResponse:
+        status_code = 200
+        text = "ok"
+
+    class _MockClient:
+        async def __aenter__(self) -> _MockClient:
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url: str, headers: dict[str, str], json: dict[str, object], timeout: float) -> _MockResponse:
+            captured_payload.update(json)
+            return _MockResponse()
+
+    monkeypatch.setattr("services.email.settings.RESEND_API_KEY", "test-key")
+    monkeypatch.setattr("services.email.httpx.AsyncClient", _MockClient)
+
+    success = await send_email(
+        to="test@example.com",
+        subject="subject",
+        body="Hello there",
+    )
+
+    assert success is True
+    sent_text = str(captured_payload["text"])
+    sent_html = str(captured_payload["html"])
+    assert AUTOMATED_AGENT_FOOTER in sent_text
+    assert AUTOMATED_AGENT_FOOTER in sent_html
+
+
+@pytest.mark.asyncio
+async def test_send_sms_applies_footer_right_before_send(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_content: str = ""
+
+    class _MockResponse:
+        status_code = 201
+
+        @staticmethod
+        def json() -> dict[str, str]:
+            return {"sid": "SM123", "status": "queued"}
+
+    class _MockClient:
+        async def __aenter__(self) -> _MockClient:
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url: str, headers: dict[str, str], content: str, timeout: float) -> _MockResponse:
+            nonlocal captured_content
+            captured_content = content
+            return _MockResponse()
+
+    monkeypatch.setattr("services.sms.settings.TWILIO_ACCOUNT_SID", "AC123")
+    monkeypatch.setattr("services.sms.settings.TWILIO_AUTH_TOKEN", "tok")
+    monkeypatch.setattr("services.sms.settings.TWILIO_PHONE_NUMBER", "+15550001111")
+    monkeypatch.setattr("services.sms.httpx.AsyncClient", _MockClient)
+
+    result = await send_sms(
+        to="+15550002222",
+        body="Hello via SMS",
+        allow_unverified=True,
+    )
+
+    assert result["success"] is True
+    body_values = parse_qs(captured_content).get("Body", [])
+    assert body_values, "Body should be present in Twilio form payload"
+    assert AUTOMATED_AGENT_FOOTER in body_values[0]


### PR DESCRIPTION
### Motivation
- Ensure the automated-agent disclosure is always present on outbound email and SMS by applying it at the final delivery boundary so user-edits or prompt-level transformations cannot remove or alter the footer.

### Description
- Apply `ensure_automated_agent_footer(...)` inside `services.email.send_email` before payload assembly and replace the `text` body with the footer-enforced text, and append the footer to provided HTML using `AUTOMATED_AGENT_FOOTER` when necessary.
- Apply `ensure_automated_agent_footer(...)` inside `services.sms.send_sms` immediately before building the Twilio form payload and use the footered text as the `Body` parameter, preserving truncation behavior.
- Add informational logs when the footer is applied at send-time and add a focused unit test file `backend/tests/test_service_footer_enforcement.py` that verifies the footer appears in the outgoing Resend JSON payload and Twilio form payload.
- Modified files: `backend/services/email.py`, `backend/services/sms.py`, and added `backend/tests/test_service_footer_enforcement.py`.

### Testing
- Ran `pytest -q backend/tests/test_service_footer_enforcement.py backend/tests/test_automated_agent_footer.py backend/tests/test_email_status_codes.py` and observed all tests passed (`6 passed`).
- Attempted a broader collection with `pytest -q backend/tests/test_service_footer_enforcement.py backend/tests/test_automated_agent_footer.py backend/tests/test_tools_automated_agent_footer.py` which failed during test collection due to an existing unrelated circular import between `agents.tools` and `agents.orchestrator` (this issue is outside the scope of these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95d78d0188321b066dcd729c1c6cb)