### PR TITLE
Enforce exact automated-agent footer when sending outbound content

### DIFF
--- a/backend/services/automated_agent_footer.py
+++ b/backend/services/automated_agent_footer.py
@@ -6,7 +6,7 @@ import re
 
 AUTOMATED_AGENT_FOOTER: str = "Done by an automated agent via Basebase."
 _AUTOMATED_AGENT_FOOTER_MARKER: re.Pattern[str] = re.compile(
-    r"done\s+by\s+an\s+automated\s+agent",
+    re.escape(AUTOMATED_AGENT_FOOTER),
     flags=re.IGNORECASE,
 )
 

--- a/backend/tests/test_automated_agent_footer.py
+++ b/backend/tests/test_automated_agent_footer.py
@@ -13,3 +13,9 @@ def test_ensure_automated_agent_footer_adds_footer_once() -> None:
 def test_ensure_automated_agent_footer_handles_empty_text() -> None:
     signed = ensure_automated_agent_footer("")
     assert signed.startswith("— Done by an automated agent")
+
+
+def test_ensure_automated_agent_footer_does_not_accept_partial_phrase() -> None:
+    signed = ensure_automated_agent_footer("Done by an automated agent")
+    assert signed.count("Done by an automated agent") == 2
+    assert "via Basebase." in signed


### PR DESCRIPTION
### Motivation
- Outbound emails and other agent-generated content were skipping the standardized disclosure when text included a partial phrase like "Done by an automated agent", allowing a bypass of the required canonical footer.

### Description
- Tightened footer detection by matching the full canonical footer text (`Done by an automated agent via Basebase.`) using `re.escape(AUTOMATED_AGENT_FOOTER)` in `backend/services/automated_agent_footer.py` to avoid false positives from partial phrases.
- Added a regression test `test_ensure_automated_agent_footer_does_not_accept_partial_phrase` in `backend/tests/test_automated_agent_footer.py` to ensure partial footer-like text does not prevent the canonical footer from being appended.
- Change preserves idempotency for content that already contains the exact canonical footer.

### Testing
- Ran `pytest -q backend/tests/test_automated_agent_footer.py backend/tests/test_service_footer_enforcement.py` and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95fe3d9b48321b1f94da468f901f1)