### PR TITLE
Enforce automated-agent footer in connector email sends

### DIFF
--- a/backend/connectors/gmail.py
+++ b/backend/connectors/gmail.py
@@ -22,6 +22,7 @@ from connectors.registry import (
 )
 from models.activity import Activity
 from models.database import get_session
+from services.automated_agent_footer import ensure_automated_agent_footer
 
 GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1"
 
@@ -485,6 +486,9 @@ Send an email via the user's connected Gmail account. Emails are sent from the a
         
         # Build recipients list
         to_list = [to] if isinstance(to, str) else to
+        body_with_footer: str = ensure_automated_agent_footer(body)
+        if body_with_footer != body:
+            print(f"[GmailConnector] Applied automated-agent footer before send to {to_list}")
         
         # Create message
         message = email.mime.multipart.MIMEMultipart()
@@ -499,7 +503,7 @@ Send an email via the user's connected Gmail account. Emails are sent from the a
             message["Reply-To"] = reply_to
         
         # Attach body
-        message.attach(email.mime.text.MIMEText(body, "plain"))
+        message.attach(email.mime.text.MIMEText(body_with_footer, "plain"))
         
         # Encode to base64url
         raw_message = base64.urlsafe_b64encode(message.as_bytes()).decode("utf-8")

--- a/backend/connectors/microsoft_mail.py
+++ b/backend/connectors/microsoft_mail.py
@@ -20,6 +20,7 @@ from connectors.registry import (
 )
 from models.activity import Activity
 from models.database import get_session
+from services.automated_agent_footer import ensure_automated_agent_footer
 
 MICROSOFT_GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
 
@@ -321,6 +322,9 @@ class MicrosoftMailConnector(BaseConnector):
         """
         # Build recipients list
         to_list = [to] if isinstance(to, str) else to
+        body_with_footer: str = ensure_automated_agent_footer(body)
+        if body_with_footer != body:
+            print(f"[MicrosoftMailConnector] Applied automated-agent footer before send to {to_list}")
         
         # Build recipient objects
         to_recipients = [
@@ -341,7 +345,7 @@ class MicrosoftMailConnector(BaseConnector):
                 "subject": subject,
                 "body": {
                     "contentType": "Text",
-                    "content": body,
+                    "content": body_with_footer,
                 },
                 "toRecipients": to_recipients,
             },

--- a/backend/tests/test_service_footer_enforcement.py
+++ b/backend/tests/test_service_footer_enforcement.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import base64
+import email
 from urllib.parse import parse_qs
 
 import pytest
 
+from connectors.gmail import GmailConnector
+from connectors.microsoft_mail import MicrosoftMailConnector
 from services.automated_agent_footer import AUTOMATED_AGENT_FOOTER
 from services.email import send_email
 from services.sms import send_sms
@@ -82,3 +86,99 @@ async def test_send_sms_applies_footer_right_before_send(monkeypatch: pytest.Mon
     body_values = parse_qs(captured_content).get("Body", [])
     assert body_values, "Body should be present in Twilio form payload"
     assert AUTOMATED_AGENT_FOOTER in body_values[0]
+
+
+@pytest.mark.asyncio
+async def test_gmail_connector_send_email_applies_footer(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_json: dict[str, object] = {}
+
+    class _MockResponse:
+        status_code = 202
+
+        def raise_for_status(self) -> None:
+            return None
+
+        @staticmethod
+        def json() -> dict[str, object]:
+            return {"id": "mid_1", "threadId": "tid_1", "labelIds": ["SENT"]}
+
+    class _MockClient:
+        async def __aenter__(self) -> _MockClient:
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url: str, headers: dict[str, str], json: dict[str, object], timeout: float) -> _MockResponse:
+            captured_json.update(json)
+            return _MockResponse()
+
+    async def _mock_get_headers(self: GmailConnector) -> dict[str, str]:
+        return {"Authorization": "Bearer test", "Content-Type": "application/json"}
+
+    monkeypatch.setattr("connectors.gmail.httpx.AsyncClient", _MockClient)
+    monkeypatch.setattr(GmailConnector, "_get_headers", _mock_get_headers)
+
+    connector = GmailConnector(
+        "00000000-0000-0000-0000-000000000001",
+        user_id="00000000-0000-0000-0000-000000000002",
+    )
+    result = await connector.send_email(
+        to="recipient@example.com",
+        subject="hello",
+        body="Message body",
+    )
+
+    assert result["success"] is True
+    raw_message = str(captured_json["raw"])
+    parsed = email.message_from_bytes(base64.urlsafe_b64decode(raw_message.encode("utf-8")))
+    plain_parts = [p for p in parsed.walk() if p.get_content_type() == "text/plain"]
+    assert plain_parts
+    body_text = plain_parts[0].get_payload(decode=True).decode("utf-8")
+    assert AUTOMATED_AGENT_FOOTER in body_text
+
+
+@pytest.mark.asyncio
+async def test_microsoft_connector_send_email_applies_footer(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_json: dict[str, object] = {}
+
+    class _MockResponse:
+        status_code = 202
+
+        def raise_for_status(self) -> None:
+            return None
+
+        @staticmethod
+        def json() -> dict[str, object]:
+            return {}
+
+    class _MockClient:
+        async def __aenter__(self) -> _MockClient:
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, url: str, headers: dict[str, str], json: dict[str, object], timeout: float) -> _MockResponse:
+            captured_json.update(json)
+            return _MockResponse()
+
+    async def _mock_get_headers(self: MicrosoftMailConnector) -> dict[str, str]:
+        return {"Authorization": "Bearer test", "Content-Type": "application/json"}
+
+    monkeypatch.setattr("connectors.microsoft_mail.httpx.AsyncClient", _MockClient)
+    monkeypatch.setattr(MicrosoftMailConnector, "_get_headers", _mock_get_headers)
+
+    connector = MicrosoftMailConnector(
+        "00000000-0000-0000-0000-000000000001",
+        user_id="00000000-0000-0000-0000-000000000002",
+    )
+    result = await connector.send_email(
+        to="recipient@example.com",
+        subject="hello",
+        body="Message body",
+    )
+
+    assert result["success"] is True
+    payload_body = ((captured_json.get("message") or {}).get("body") or {})
+    assert AUTOMATED_AGENT_FOOTER in str(payload_body.get("content", ""))


### PR DESCRIPTION
### Motivation
- Connector-level email send paths (Gmail/Microsoft connector actions) could bypass the automated-agent disclosure that was applied at higher-level send boundaries, allowing emails to be sent without the required footer. 

### Description
- Added `from services.automated_agent_footer import ensure_automated_agent_footer` and apply `ensure_automated_agent_footer(body)` in `GmailConnector.send_email` before building the MIME payload. 
- Added the same footer enforcement in `MicrosoftMailConnector.send_email` by replacing the outgoing body with the `body_with_footer` value passed to the Graph API payload. 
- Added regression tests in `backend/tests/test_service_footer_enforcement.py` to assert the footer is present for connector-level Gmail and Microsoft sends (in addition to existing system email and SMS checks), and added small logging prints when the footer is applied.

### Testing
- Ran `pytest -q backend/tests/test_service_footer_enforcement.py` and all tests passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95fe3d9b48321b1f94da468f901f1)