### PR TITLE
Fix automated footer tests to match current disclosure text

### DIFF
--- a/backend/tests/test_automated_agent_footer.py
+++ b/backend/tests/test_automated_agent_footer.py
@@ -1,9 +1,9 @@
-from services.automated_agent_footer import ensure_automated_agent_footer
+from services.automated_agent_footer import AUTOMATED_AGENT_FOOTER, ensure_automated_agent_footer
 
 
 def test_ensure_automated_agent_footer_adds_footer_once() -> None:
     signed = ensure_automated_agent_footer("Hello there")
-    assert "Done by an automated agent" in signed
+    assert AUTOMATED_AGENT_FOOTER in signed
     assert signed.startswith("Hello there")
 
     signed_again = ensure_automated_agent_footer(signed)
@@ -12,4 +12,4 @@ def test_ensure_automated_agent_footer_adds_footer_once() -> None:
 
 def test_ensure_automated_agent_footer_handles_empty_text() -> None:
     signed = ensure_automated_agent_footer("")
-    assert signed.startswith("— Done by an automated agent")
+    assert signed == f"— {AUTOMATED_AGENT_FOOTER}"

--- a/backend/tests/test_tools_automated_agent_footer.py
+++ b/backend/tests/test_tools_automated_agent_footer.py
@@ -2,11 +2,12 @@ import asyncio
 from typing import Any
 
 from agents import tools
+from services.automated_agent_footer import AUTOMATED_AGENT_FOOTER
 
 
 def test_ensure_automated_agent_footer_appends_once() -> None:
     signed = tools._ensure_automated_agent_footer("Hello there")
-    assert "Done by an automated agent" in signed
+    assert AUTOMATED_AGENT_FOOTER in signed
     assert signed.startswith("Hello there")
 
     signed_again = tools._ensure_automated_agent_footer(signed)
@@ -15,7 +16,7 @@ def test_ensure_automated_agent_footer_appends_once() -> None:
 
 def test_ensure_automated_agent_footer_handles_empty() -> None:
     signed = tools._ensure_automated_agent_footer("")
-    assert signed.startswith("— Done by an automated agent")
+    assert signed == f"— {AUTOMATED_AGENT_FOOTER}"
 
 
 def test_execute_linear_create_adds_footer() -> None:
@@ -30,7 +31,7 @@ def test_execute_linear_create_adds_footer() -> None:
     result = asyncio.run(tools._execute_linear_create(FakeLinearConnector(), record))
 
     assert result["identifier"] == "ENG-1"
-    assert "Done by an automated agent" in captured["description"]
+    assert AUTOMATED_AGENT_FOOTER in captured["description"]
 
 
 def test_handle_github_write_create_issue_adds_footer(monkeypatch) -> None:
@@ -63,4 +64,4 @@ def test_handle_github_write_create_issue_adds_footer(monkeypatch) -> None:
 
     assert result["status"] == "completed"
     assert captured["operation"] == "create_issue"
-    assert "Done by an automated agent" in captured["data"]["body"]
+    assert AUTOMATED_AGENT_FOOTER in captured["data"]["body"]


### PR DESCRIPTION
### Motivation
- The tests expected the legacy hard-coded phrase but the code now exposes the canonical footer via `AUTOMATED_AGENT_FOOTER`, so tests needed to be updated to validate the current disclosure text.

### Description
- Updated `backend/tests/test_automated_agent_footer.py` to import `AUTOMATED_AGENT_FOOTER` and assert against that constant instead of a hard-coded string.
- Updated `backend/tests/test_tools_automated_agent_footer.py` to import `AUTOMATED_AGENT_FOOTER` and replace all legacy assertions with checks against the constant, including exact empty-message footer formatting (`— {AUTOMATED_AGENT_FOOTER}`).
- Adjusted payload assertions for Linear and GitHub tool tests to check for `AUTOMATED_AGENT_FOOTER` in outgoing content.

### Testing
- Ran `pytest -q backend/tests/test_automated_agent_footer.py`, which passed (`2 passed`).
- Ran `pytest -q backend/tests/test_tools_automated_agent_footer.py`, which failed during collection due to an existing circular import between `agents.tools` and `agents.orchestrator` (import error), unrelated to the assertions changed.
- A combined test run earlier also surfaced the same import-cycle error during collection which blocks running the tool-level tests end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c96f8914008321a9d1747905231b4b)