### PR TITLE
Harden action ledger access controls and add retention pruning

### DIFF
--- a/backend/api/routes/action_ledger.py
+++ b/backend/api/routes/action_ledger.py
@@ -8,8 +8,10 @@ from pydantic import BaseModel
 from sqlalchemy import func, select
 
 from api.auth_middleware import AuthContext, get_current_auth
+from api.routes.auth import _can_administer_org
 from models.action_ledger import ActionLedgerEntry
-from models.database import get_session
+from models.database import get_admin_session, get_session
+from models.user import User
 
 router = APIRouter(prefix="/action-ledger", tags=["action-ledger"])
 logger = logging.getLogger(__name__)
@@ -35,7 +37,25 @@ async def list_action_ledger(
     if not auth.organization_id or str(auth.organization_id) != org_id:
         raise HTTPException(status_code=403, detail="Organization mismatch")
 
-    filters = [ActionLedgerEntry.organization_id == UUID(org_id)]
+    try:
+        org_uuid = UUID(org_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid organization id") from None
+
+    can_view_org_wide = False
+    async with get_admin_session() as admin_session:
+        requester: User | None = await admin_session.get(User, auth.user_id)
+        can_view_org_wide = await _can_administer_org(admin_session, requester, org_uuid)
+    logger.info(
+        "action_ledger list request org=%s user=%s org_wide=%s",
+        org_id,
+        auth.user_id,
+        can_view_org_wide,
+    )
+
+    filters = [ActionLedgerEntry.organization_id == org_uuid]
+    if not can_view_org_wide:
+        filters.append(ActionLedgerEntry.user_id == auth.user_id)
     if conversation_id:
         filters.append(ActionLedgerEntry.conversation_id == UUID(conversation_id))
     if connector:

--- a/backend/db/migrations/versions/119_ledger_limits.py
+++ b/backend/db/migrations/versions/119_ledger_limits.py
@@ -1,0 +1,27 @@
+"""Add index for user-scoped action ledger reads.
+
+Revision ID: 119_ledger_limits
+Revises: 118_create_action_ledger
+Create Date: 2026-03-30
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "119_ledger_limits"
+down_revision: Union[str, None] = "118_create_action_ledger"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_action_ledger_org_user_created",
+        "action_ledger",
+        ["organization_id", "user_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_action_ledger_org_user_created", table_name="action_ledger")

--- a/backend/tests/test_action_ledger.py
+++ b/backend/tests/test_action_ledger.py
@@ -349,6 +349,87 @@ class TestActionLedgerAPI:
         matching = [p for p in paths if "action-ledger" in p]
         assert len(matching) > 0, "action-ledger route not found in OpenAPI schema"
 
+    def test_non_admin_route_scopes_results_to_requesting_user(self) -> None:
+        from api.auth_middleware import AuthContext
+        from api.routes import action_ledger as route
+
+        org_id = "00000000-0000-0000-0000-000000000001"
+        user_id = uuid.UUID("00000000-0000-0000-0000-0000000000aa")
+        captured_sql: list[str] = []
+
+        class _ExecResult:
+            def __init__(self, *, count: int = 0, rows: list[ActionLedgerEntry] | None = None):
+                self._count = count
+                self._rows = rows or []
+
+            def scalar_one(self) -> int:
+                return self._count
+
+            def scalars(self):
+                class _Scalars:
+                    def __init__(self, rows: list[ActionLedgerEntry]):
+                        self._rows = rows
+
+                    def all(self) -> list[ActionLedgerEntry]:
+                        return self._rows
+
+                return _Scalars(self._rows)
+
+        class _UserScopedSession:
+            async def execute(self, stmt):
+                captured_sql.append(str(stmt))
+                if "count(" in str(stmt):
+                    return _ExecResult(count=1)
+                row = ActionLedgerEntry(
+                    id=uuid.uuid4(),
+                    organization_id=uuid.UUID(org_id),
+                    user_id=user_id,
+                    connector="hubspot",
+                    dispatch_type="write",
+                    operation="update_deal",
+                    intent={"x": 1},
+                    reversible=False,
+                    created_at=datetime(2026, 3, 30, 0, 0, 0),
+                )
+                return _ExecResult(rows=[row])
+
+        @asynccontextmanager
+        async def _fake_admin_session():
+            admin = MagicMock()
+            admin.get = AsyncMock(return_value=MagicMock())
+            yield admin
+
+        @asynccontextmanager
+        async def _fake_user_session(_org_id: str):
+            yield _UserScopedSession()
+
+        auth = AuthContext(
+            user_id=user_id,
+            organization_id=uuid.UUID(org_id),
+            email="user@example.com",
+            role="member",
+            is_global_admin=False,
+        )
+
+        with patch.object(route, "get_admin_session", _fake_admin_session), \
+             patch.object(route, "get_session", _fake_user_session), \
+             patch.object(route, "_can_administer_org", new=AsyncMock(return_value=False)):
+            response = asyncio.run(
+                route.list_action_ledger(
+                    org_id=org_id,
+                    auth=auth,
+                    conversation_id=None,
+                    connector=None,
+                    entity_type=None,
+                    entity_id=None,
+                    limit=50,
+                    offset=0,
+                )
+            )
+
+        assert response.total == 1
+        assert any("action_ledger.user_id" in sql for sql in captured_sql)
+
 
 # ---------------------------------------------------------------------------
 # Connector: capture_before_state default

--- a/backend/tests/test_monitoring_prune_action_ledger.py
+++ b/backend/tests/test_monitoring_prune_action_ledger.py
@@ -1,0 +1,35 @@
+from unittest.mock import AsyncMock, patch
+
+from workers.tasks import monitoring
+
+def test_prune_action_ledger_deletes_old_rows_and_stops_when_under_target() -> None:
+    # First loop (retention): delete 3, then 0.
+    # Size loop: starts above max, delete 2 rows, drops below target.
+    delete_side_effects = [3, 0, 2]
+    size_side_effects = [
+        monitoring._ACTION_LEDGER_MAX_BYTES + 10,
+        monitoring._ACTION_LEDGER_TARGET_BYTES - 10,
+        monitoring._ACTION_LEDGER_TARGET_BYTES - 10,
+    ]
+
+    with patch("workers.tasks.monitoring._delete_action_ledger_batch", new=AsyncMock(side_effect=delete_side_effects)), \
+         patch("workers.tasks.monitoring._action_ledger_total_bytes", new=AsyncMock(side_effect=size_side_effects)):
+        result = monitoring.prune_action_ledger.run()
+
+    assert result["status"] == "ok"
+    assert result["deleted_for_age"] == 3
+    assert result["deleted_for_size"] == 2
+    assert result["final_size_bytes"] == monitoring._ACTION_LEDGER_TARGET_BYTES - 10
+
+
+def test_prune_action_ledger_stops_size_loop_when_nothing_deleted() -> None:
+    with patch("workers.tasks.monitoring._delete_action_ledger_batch", new=AsyncMock(side_effect=[0, 0])), \
+         patch("workers.tasks.monitoring._action_ledger_total_bytes", new=AsyncMock(side_effect=[
+             monitoring._ACTION_LEDGER_MAX_BYTES + 1,
+             monitoring._ACTION_LEDGER_MAX_BYTES + 1,
+         ])):
+        result = monitoring.prune_action_ledger.run()
+
+    assert result["status"] == "ok"
+    assert result["deleted_for_age"] == 0
+    assert result["deleted_for_size"] == 0

--- a/backend/workers/celery_app.py
+++ b/backend/workers/celery_app.py
@@ -151,6 +151,10 @@ if _ENABLE_BEAT:
             "task": "workers.tasks.monitoring.monitoring_heartbeat_watchdog",
             "schedule": timedelta(minutes=5),
         },
+        "prune-action-ledger": {
+            "task": "workers.tasks.monitoring.prune_action_ledger",
+            "schedule": crontab(hour=2, minute=17),
+        },
     }
 else:
     celery_app.conf.beat_schedule = {}

--- a/backend/workers/tasks/monitoring.py
+++ b/backend/workers/tasks/monitoring.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 
 import logging
 import time
+from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass
 from typing import Any
 
 import httpx
+from sqlalchemy import text
 
 from config import get_redis_connection_kwargs, settings
+from models.database import get_admin_session
 from services.incident_throttling import clear_incident_failure, evaluate_incident_creation
 from services.pagerduty import create_pagerduty_incident
 from workers.celery_app import celery_app
@@ -17,6 +20,10 @@ logger = logging.getLogger(__name__)
 
 _HEARTBEAT_KEY = "monitoring:dependency_checks:last_completed_at"
 _HEARTBEAT_STALE_AFTER_SECONDS = 30 * 60
+_ACTION_LEDGER_MAX_BYTES = 10 * 1024 * 1024 * 1024
+_ACTION_LEDGER_TARGET_BYTES = 9 * 1024 * 1024 * 1024
+_ACTION_LEDGER_RETENTION_DAYS = 100
+_ACTION_LEDGER_DELETE_BATCH_SIZE = 1000
 
 
 @dataclass(frozen=True)
@@ -302,5 +309,115 @@ def monitoring_heartbeat_watchdog(self: Any) -> dict[str, Any]:
             _HEARTBEAT_STALE_AFTER_SECONDS,
         )
         return {"status": "ok", "age_seconds": age_seconds}
+
+    return run_async(_run())
+
+
+async def _action_ledger_total_bytes() -> int:
+    """Return total bytes occupied by action_ledger table (+indexes)."""
+    async with get_admin_session() as session:
+        result = await session.execute(
+            text("SELECT pg_total_relation_size('action_ledger')")
+        )
+        size_bytes = int(result.scalar_one() or 0)
+    return size_bytes
+
+
+async def _delete_action_ledger_batch(*, cutoff: datetime | None) -> int:
+    """Delete oldest action_ledger rows in bounded batches."""
+    clause = "WHERE created_at < :cutoff" if cutoff is not None else ""
+    params: dict[str, Any] = {"batch_size": _ACTION_LEDGER_DELETE_BATCH_SIZE}
+    if cutoff is not None:
+        params["cutoff"] = cutoff
+
+    async with get_admin_session() as session:
+        result = await session.execute(
+            text(
+                f"""
+                WITH doomed AS (
+                    SELECT id
+                    FROM action_ledger
+                    {clause}
+                    ORDER BY created_at ASC
+                    LIMIT :batch_size
+                    FOR UPDATE SKIP LOCKED
+                )
+                DELETE FROM action_ledger a
+                USING doomed d
+                WHERE a.id = d.id
+                RETURNING a.id
+                """
+            ),
+            params,
+        )
+        deleted = len(result.fetchall())
+        await session.commit()
+    return deleted
+
+
+@celery_app.task(bind=True, name="workers.tasks.monitoring.prune_action_ledger")
+def prune_action_ledger(self: Any) -> dict[str, Any]:
+    """Apply time and size retention limits to action_ledger."""
+    from workers.run_async import run_async
+
+    logger.info("Task %s: Starting action_ledger pruning run", self.request.id)
+
+    async def _run() -> dict[str, Any]:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=_ACTION_LEDGER_RETENTION_DAYS)
+        deleted_for_age = 0
+        deleted_for_size = 0
+
+        # 1) Always enforce retention window first.
+        while True:
+            deleted = await _delete_action_ledger_batch(cutoff=cutoff)
+            if deleted == 0:
+                break
+            deleted_for_age += deleted
+            logger.info(
+                "action_ledger retention batch deleted=%s cutoff=%s",
+                deleted,
+                cutoff.isoformat(),
+            )
+
+        # 2) Enforce max size by trimming oldest rows.
+        current_size = await _action_ledger_total_bytes()
+        logger.info(
+            "action_ledger size check bytes=%s max_bytes=%s target_bytes=%s",
+            current_size,
+            _ACTION_LEDGER_MAX_BYTES,
+            _ACTION_LEDGER_TARGET_BYTES,
+        )
+        while current_size > _ACTION_LEDGER_MAX_BYTES:
+            deleted = await _delete_action_ledger_batch(cutoff=None)
+            if deleted == 0:
+                logger.warning(
+                    "action_ledger exceeded max size but no rows were deleted; stopping prune loop"
+                )
+                break
+            deleted_for_size += deleted
+            current_size = await _action_ledger_total_bytes()
+            logger.info(
+                "action_ledger size-prune batch deleted=%s remaining_bytes=%s",
+                deleted,
+                current_size,
+            )
+            if current_size <= _ACTION_LEDGER_TARGET_BYTES:
+                break
+
+        final_size = await _action_ledger_total_bytes()
+        logger.info(
+            "action_ledger prune complete deleted_for_age=%s deleted_for_size=%s final_bytes=%s",
+            deleted_for_age,
+            deleted_for_size,
+            final_size,
+        )
+        return {
+            "status": "ok",
+            "deleted_for_age": deleted_for_age,
+            "deleted_for_size": deleted_for_size,
+            "final_size_bytes": final_size,
+            "retention_days": _ACTION_LEDGER_RETENTION_DAYS,
+            "max_size_bytes": _ACTION_LEDGER_MAX_BYTES,
+        }
 
     return run_async(_run())


### PR DESCRIPTION
### Motivation
- Prevent non-admin users from seeing other users' action-ledger rows by scoping reads to the authenticated user unless they are org/global admins. 
- Prevent unbounded growth of the `action_ledger` table by applying reasonable time- and size-based retention limits and automated pruning.

### Description
- Scope API reads in `list_action_ledger` so the route validates `org_id`, checks org-admin/global-admin capability via an admin session and `_can_administer_org`, and if not admin adds `ActionLedgerEntry.user_id == auth.user_id` to the query filters (file: `backend/api/routes/action_ledger.py`).
- Added size/age retention and pruning helpers in the monitoring worker: `_action_ledger_total_bytes`, `_delete_action_ledger_batch` (batched deletes using `FOR UPDATE SKIP LOCKED`), and a `prune_action_ledger` Celery task that first deletes rows older than 100 days and then trims by size when table+indexes exceed 10 GiB down toward a 9 GiB target (file: `backend/workers/tasks/monitoring.py`).
- Registered the prune task in Celery beat schedule (`prune-action-ledger` at 02:17) so pruning runs automatically when beat is enabled (file: `backend/workers/celery_app.py`).
- Added an Alembic migration `119_ledger_limits` to create `ix_action_ledger_org_user_created` to support user-scoped queries (file: `backend/db/migrations/versions/119_ledger_limits.py`).
- Added tests that verify non-admin API scoping and pruning task behavior, and added extra request logging for traceability (tests: `backend/tests/test_action_ledger.py`, `backend/tests/test_monitoring_prune_action_ledger.py`).

### Testing
- Ran unit tests: `cd backend && pytest -q tests/test_action_ledger.py tests/test_monitoring_prune_action_ledger.py`, which passed (34 tests passed, 2 warnings).
- Verified migration metadata and preflight assertions with a small script that confirmed `revision`/`down_revision` lengths meet the migration safety rules (`len(revision) <= 32` and `len(down_revision) <= 32`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cad5f7d9d08321ac5513f4332616f2)