### PR TITLE
Scope action-ledger visibility and add retention enforcement

### DIFF
--- a/backend/api/routes/action_ledger.py
+++ b/backend/api/routes/action_ledger.py
@@ -8,11 +8,27 @@ from pydantic import BaseModel
 from sqlalchemy import func, select
 
 from api.auth_middleware import AuthContext, get_current_auth
+from models.org_member import OrgMember
 from models.action_ledger import ActionLedgerEntry
-from models.database import get_session
+from models.database import get_admin_session, get_session
 
 router = APIRouter(prefix="/action-ledger", tags=["action-ledger"])
 logger = logging.getLogger(__name__)
+
+
+async def _is_org_admin(*, user_id: UUID, organization_id: UUID) -> bool:
+    """Return True when the user is an active org admin for the organization."""
+    async with get_admin_session() as session:
+        membership = (
+            await session.execute(
+                select(OrgMember).where(
+                    OrgMember.user_id == user_id,
+                    OrgMember.organization_id == organization_id,
+                    OrgMember.status.in_(("active", "onboarding", "invited")),
+                )
+            )
+        ).scalar_one_or_none()
+    return bool(membership and membership.role == "admin")
 
 
 class ActionLedgerResponse(BaseModel):
@@ -35,7 +51,15 @@ async def list_action_ledger(
     if not auth.organization_id or str(auth.organization_id) != org_id:
         raise HTTPException(status_code=403, detail="Organization mismatch")
 
-    filters = [ActionLedgerEntry.organization_id == UUID(org_id)]
+    org_uuid = UUID(org_id)
+    is_org_admin = auth.is_global_admin or await _is_org_admin(
+        user_id=auth.user_id,
+        organization_id=org_uuid,
+    )
+
+    filters = [ActionLedgerEntry.organization_id == org_uuid]
+    if not is_org_admin:
+        filters.append(ActionLedgerEntry.user_id == auth.user_id)
     if conversation_id:
         filters.append(ActionLedgerEntry.conversation_id == UUID(conversation_id))
     if connector:

--- a/backend/api/routes/billing.py
+++ b/backend/api/routes/billing.py
@@ -18,16 +18,33 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
+from sqlalchemy import select
 
 from api.auth_middleware import AuthContext, require_organization
 from config import settings
 from models.database import get_admin_session
+from models.org_member import OrgMember
 from models.organization import Organization
 from services.credits import ACTIVE_SUBSCRIPTION_STATUSES
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+async def _is_org_admin(*, user_id: UUID, organization_id: UUID) -> bool:
+    """Return True when the user is an active organization admin."""
+    async with get_admin_session() as session:
+        membership = (
+            await session.execute(
+                select(OrgMember).where(
+                    OrgMember.user_id == user_id,
+                    OrgMember.organization_id == organization_id,
+                    OrgMember.status.in_(("active", "onboarding", "invited")),
+                )
+            )
+        ).scalar_one_or_none()
+    return bool(membership and membership.role == "admin")
+
 
 # Tier config: name, price_cents, credits_included
 # "free" tier requires no credit card; "partner" tier is hidden and assigned manually
@@ -470,6 +487,17 @@ async def get_credit_details(
     if not org_id:
         raise HTTPException(status_code=403, detail="Organization required")
     
+    is_org_admin = auth.is_global_admin or await _is_org_admin(
+        user_id=auth.user_id,
+        organization_id=org_id,
+    )
+    if not is_org_admin:
+        logger.info(
+            "Scoping credit transaction details to requesting user org=%s user=%s",
+            org_id,
+            auth.user_id,
+        )
+
     async with get_admin_session() as session:
         from sqlalchemy import select, func
         from models.credit_transaction import CreditTransaction
@@ -495,6 +523,8 @@ async def get_credit_details(
                 .where(CreditTransaction.organization_id == org_id)
                 .order_by(CreditTransaction.created_at.asc())
             )
+            if not is_org_admin:
+                q = q.where(CreditTransaction.user_id == auth.user_id)
             if filter_start:
                 q = q.where(CreditTransaction.created_at >= filter_start)
             return q
@@ -513,6 +543,8 @@ async def get_credit_details(
                 .group_by(CreditTransaction.user_id, User.email, User.name)
                 .order_by(func.sum(func.abs(CreditTransaction.amount)).desc())
             )
+            if not is_org_admin:
+                q = q.where(CreditTransaction.user_id == auth.user_id)
             if filter_start:
                 q = q.where(CreditTransaction.created_at >= filter_start)
             return q
@@ -574,6 +606,10 @@ async def get_credit_details(
                 .where(CreditTransaction.reference_type == "conversation")
                 .where(CreditTransaction.amount < 0)
             )
+            if not is_org_admin:
+                conv_usage_query = conv_usage_query.where(
+                    CreditTransaction.user_id == auth.user_id
+                )
             if effective_period_start:
                 conv_usage_query = conv_usage_query.where(
                     CreditTransaction.created_at >= effective_period_start

--- a/backend/db/migrations/versions/119_audit_retention.py
+++ b/backend/db/migrations/versions/119_audit_retention.py
@@ -1,0 +1,31 @@
+"""Add action_ledger retention indexes.
+
+Revision ID: 119_audit_retention
+Revises: 118_create_action_ledger
+Create Date: 2026-03-31
+"""
+from alembic import op
+
+
+revision = "119_audit_retention"
+down_revision = "118_create_action_ledger"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_action_ledger_created_at",
+        "action_ledger",
+        ["created_at"],
+    )
+    op.create_index(
+        "ix_action_ledger_org_user_created",
+        "action_ledger",
+        ["organization_id", "user_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_action_ledger_org_user_created", table_name="action_ledger")
+    op.drop_index("ix_action_ledger_created_at", table_name="action_ledger")

--- a/backend/tests/test_action_ledger.py
+++ b/backend/tests/test_action_ledger.py
@@ -349,6 +349,120 @@ class TestActionLedgerAPI:
         matching = [p for p in paths if "action-ledger" in p]
         assert len(matching) > 0, "action-ledger route not found in OpenAPI schema"
 
+    def test_non_admin_listing_is_scoped_to_requesting_user(self) -> None:
+        from api.auth_middleware import AuthContext
+        from api.routes import action_ledger as route
+
+        org_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        captured_queries: list[Any] = []
+
+        class _ExecResult:
+            def scalar_one(self) -> int:
+                return 0
+
+            def scalars(self) -> "_ExecResult":
+                return self
+
+            def all(self) -> list[Any]:
+                return []
+
+        @asynccontextmanager
+        async def _fake_session(*_a: object, **_kw: object):
+            mock = MagicMock()
+
+            async def _execute(query: Any) -> _ExecResult:
+                captured_queries.append(query)
+                return _ExecResult()
+
+            mock.execute = AsyncMock(side_effect=_execute)
+            yield mock
+
+        async def _run() -> None:
+            with patch.object(route, "_is_org_admin", new=AsyncMock(return_value=False)), patch.object(
+                route,
+                "get_session",
+                _fake_session,
+            ):
+                response = await route.list_action_ledger(
+                    org_id=str(org_id),
+                    auth=AuthContext(
+                        user_id=user_id,
+                        organization_id=org_id,
+                        email="user@example.com",
+                        role="member",
+                        is_global_admin=False,
+                    ),
+                    conversation_id=None,
+                    connector=None,
+                    entity_type=None,
+                    entity_id=None,
+                    limit=50,
+                    offset=0,
+                )
+                assert response.total == 0
+
+        asyncio.run(_run())
+        rendered_queries = " ".join(str(q) for q in captured_queries)
+        assert "action_ledger.user_id = :user_id_1" in rendered_queries
+
+    def test_org_admin_listing_is_not_scoped_to_user_id(self) -> None:
+        from api.auth_middleware import AuthContext
+        from api.routes import action_ledger as route
+
+        org_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        captured_queries: list[Any] = []
+
+        class _ExecResult:
+            def scalar_one(self) -> int:
+                return 0
+
+            def scalars(self) -> "_ExecResult":
+                return self
+
+            def all(self) -> list[Any]:
+                return []
+
+        @asynccontextmanager
+        async def _fake_session(*_a: object, **_kw: object):
+            mock = MagicMock()
+
+            async def _execute(query: Any) -> _ExecResult:
+                captured_queries.append(query)
+                return _ExecResult()
+
+            mock.execute = AsyncMock(side_effect=_execute)
+            yield mock
+
+        async def _run() -> None:
+            with patch.object(route, "_is_org_admin", new=AsyncMock(return_value=True)), patch.object(
+                route,
+                "get_session",
+                _fake_session,
+            ):
+                response = await route.list_action_ledger(
+                    org_id=str(org_id),
+                    auth=AuthContext(
+                        user_id=user_id,
+                        organization_id=org_id,
+                        email="admin@example.com",
+                        role="admin",
+                        is_global_admin=False,
+                    ),
+                    conversation_id=None,
+                    connector=None,
+                    entity_type=None,
+                    entity_id=None,
+                    limit=50,
+                    offset=0,
+                )
+                assert response.total == 0
+
+        asyncio.run(_run())
+        rendered_queries = " ".join(str(q) for q in captured_queries)
+        assert "action_ledger.user_id = :user_id_1" not in rendered_queries
+
 
 # ---------------------------------------------------------------------------
 # Connector: capture_before_state default

--- a/backend/tests/test_billing_credit_details_scope.py
+++ b/backend/tests/test_billing_credit_details_scope.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from api.auth_middleware import AuthContext
+from api.routes import billing
+
+
+class _Result:
+    def __init__(self, *, scalar: Any = None, rows: list[tuple[Any, ...]] | None = None) -> None:
+        self._scalar = scalar
+        self._rows = rows or []
+
+    def scalar_one_or_none(self) -> Any:
+        return self._scalar
+
+    def all(self) -> list[tuple[Any, ...]]:
+        return self._rows
+
+
+def test_credit_details_non_admin_scopes_queries_to_requesting_user() -> None:
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    captured_queries: list[str] = []
+
+    org = MagicMock()
+    org.current_period_start = datetime(2026, 3, 1, tzinfo=timezone.utc)
+    org.current_period_end = datetime(2026, 4, 1, tzinfo=timezone.utc)
+    org.credits_included = 500
+
+    @asynccontextmanager
+    async def _fake_admin_session(*_a: object, **_kw: object):
+        mock = MagicMock()
+
+        async def _execute(query: Any) -> _Result:
+            sql = str(query)
+            captured_queries.append(sql)
+            if "FROM organizations" in sql:
+                return _Result(scalar=org)
+            return _Result(rows=[])
+
+        mock.execute = AsyncMock(side_effect=_execute)
+        yield mock
+
+    async def _run() -> None:
+        with patch.object(billing, "_is_org_admin", new=AsyncMock(return_value=False)), patch.object(
+            billing,
+            "get_admin_session",
+            _fake_admin_session,
+        ):
+            response = await billing.get_credit_details(
+                auth=AuthContext(
+                    user_id=user_id,
+                    organization_id=org_id,
+                    email="user@example.com",
+                    role="member",
+                    is_global_admin=False,
+                )
+            )
+
+            assert response.transactions == []
+
+    asyncio.run(_run())
+
+    joined = "\n".join(captured_queries)
+    assert "credit_transactions.user_id" in joined

--- a/backend/tests/test_monitoring_task.py
+++ b/backend/tests/test_monitoring_task.py
@@ -276,6 +276,33 @@ def test_monitor_dependencies_suppresses_repeated_incident_for_same_failure(monk
     assert created_incidents == []
 
 
+def test_enforce_action_ledger_retention_deletes_when_limits_exceeded(monkeypatch: Any) -> None:
+    sizes = [12_000_000_000, 11_000_000_000, 9_000_000_000, 9_000_000_000]
+    deletes = [2000]
+
+    async def _fake_size() -> int:
+        return sizes.pop(0)
+
+    async def _fake_delete_oldest_action_ledger_batch(*, created_before: Any) -> int:
+        return deletes.pop(0)
+
+    monkeypatch.setattr(monitoring, "_action_ledger_table_bytes", _fake_size)
+    monkeypatch.setattr(
+        monitoring,
+        "_delete_oldest_action_ledger_batch",
+        _fake_delete_oldest_action_ledger_batch,
+    )
+
+    import asyncio
+
+    result = asyncio.run(monitoring._enforce_action_ledger_retention())
+
+    assert result["deleted_rows"] == 2000
+    assert result["batches_run"] == 1
+    assert result["size_before_bytes"] == 12_000_000_000
+    assert result["size_after_bytes"] == 9_000_000_000
+
+
 def test_monitor_dependencies_allows_incident_when_different_check_fails(monkeypatch: Any) -> None:
     async def _fake_run_dependency_checks() -> list[monitoring.CheckResult]:
         return [

--- a/backend/workers/celery_app.py
+++ b/backend/workers/celery_app.py
@@ -151,6 +151,10 @@ if _ENABLE_BEAT:
             "task": "workers.tasks.monitoring.monitoring_heartbeat_watchdog",
             "schedule": timedelta(minutes=5),
         },
+        "enforce-action-ledger-retention": {
+            "task": "workers.tasks.monitoring.enforce_action_ledger_retention",
+            "schedule": crontab(minute=15, hour=2),
+        },
     }
 else:
     celery_app.conf.beat_schedule = {}

--- a/backend/workers/tasks/monitoring.py
+++ b/backend/workers/tasks/monitoring.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import httpx
+from sqlalchemy import text
 
 from config import get_redis_connection_kwargs, settings
+from models.database import get_admin_session
 from services.incident_throttling import clear_incident_failure, evaluate_incident_creation
 from services.pagerduty import create_pagerduty_incident
 from workers.celery_app import celery_app
@@ -17,6 +20,10 @@ logger = logging.getLogger(__name__)
 
 _HEARTBEAT_KEY = "monitoring:dependency_checks:last_completed_at"
 _HEARTBEAT_STALE_AFTER_SECONDS = 30 * 60
+_AUDIT_RETENTION_DAYS = 100
+_AUDIT_MAX_TABLE_BYTES = 10 * 1024 * 1024 * 1024
+_AUDIT_DELETE_BATCH_SIZE = 2_000
+_AUDIT_DELETE_MAX_BATCHES = 50
 
 
 @dataclass(frozen=True)
@@ -32,6 +39,97 @@ def _api_healthcheck_url() -> str:
     """Resolve API health endpoint URL for ASGI process monitoring."""
     base_url = settings.BACKEND_PUBLIC_URL or "https://api.basebase.com"
     return f"{base_url.rstrip('/')}/health"
+
+
+async def _action_ledger_table_bytes() -> int:
+    """Return total on-disk bytes (table + indexes) used by action_ledger."""
+    async with get_admin_session() as session:
+        result = await session.execute(
+            text("SELECT COALESCE(pg_total_relation_size('action_ledger'), 0)")
+        )
+        return int(result.scalar_one() or 0)
+
+
+async def _delete_oldest_action_ledger_batch(*, created_before: datetime) -> int:
+    """Delete one ordered batch of action_ledger rows to avoid long-running locks."""
+    async with get_admin_session() as session:
+        result = await session.execute(
+            text(
+                """
+                WITH rows_to_delete AS (
+                    SELECT id
+                    FROM action_ledger
+                    WHERE created_at < :created_before
+                    ORDER BY created_at ASC
+                    LIMIT :batch_size
+                    FOR UPDATE SKIP LOCKED
+                )
+                DELETE FROM action_ledger a
+                USING rows_to_delete r
+                WHERE a.id = r.id
+                """
+            ),
+            {
+                "created_before": created_before,
+                "batch_size": _AUDIT_DELETE_BATCH_SIZE,
+            },
+        )
+        await session.commit()
+        return int(result.rowcount or 0)
+
+
+async def _enforce_action_ledger_retention() -> dict[str, Any]:
+    """Apply time- and size-based retention limits for action_ledger."""
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=_AUDIT_RETENTION_DAYS)
+    deleted_rows = 0
+    batches_run = 0
+
+    size_before = await _action_ledger_table_bytes()
+    logger.info(
+        "Action ledger retention start size_bytes=%s cutoff=%s",
+        size_before,
+        cutoff.isoformat(),
+    )
+
+    for _ in range(_AUDIT_DELETE_MAX_BATCHES):
+        size_bytes = await _action_ledger_table_bytes()
+        if size_bytes <= _AUDIT_MAX_TABLE_BYTES and batches_run > 0:
+            break
+
+        removed = await _delete_oldest_action_ledger_batch(created_before=cutoff)
+        batches_run += 1
+        deleted_rows += removed
+        if removed == 0:
+            break
+
+    size_after = await _action_ledger_table_bytes()
+    logger.info(
+        "Action ledger retention complete deleted_rows=%s batches=%s size_before=%s size_after=%s",
+        deleted_rows,
+        batches_run,
+        size_before,
+        size_after,
+    )
+
+    if deleted_rows > 0:
+        logger.warning(
+            "Deleted %s action_ledger rows during retention enforcement (size_before=%s size_after=%s cutoff_days=%s max_bytes=%s)",
+            deleted_rows,
+            size_before,
+            size_after,
+            _AUDIT_RETENTION_DAYS,
+            _AUDIT_MAX_TABLE_BYTES,
+        )
+
+    return {
+        "deleted_rows": deleted_rows,
+        "batches_run": batches_run,
+        "size_before_bytes": size_before,
+        "size_after_bytes": size_after,
+        "cutoff_iso": cutoff.isoformat(),
+        "max_bytes": _AUDIT_MAX_TABLE_BYTES,
+    }
 
 
 async def _check_http_endpoint(name: str, url: str, timeout_s: float = 10.0) -> CheckResult:
@@ -304,3 +402,12 @@ def monitoring_heartbeat_watchdog(self: Any) -> dict[str, Any]:
         return {"status": "ok", "age_seconds": age_seconds}
 
     return run_async(_run())
+
+
+@celery_app.task(bind=True, name="workers.tasks.monitoring.enforce_action_ledger_retention")
+def enforce_action_ledger_retention(self: Any) -> dict[str, Any]:
+    """Periodic task: keep action_ledger bounded by age and total table size."""
+    from workers.run_async import run_async
+
+    logger.info("Task %s: enforcing action_ledger retention", self.request.id)
+    return run_async(_enforce_action_ledger_retention())


### PR DESCRIPTION
### Motivation
- Prevent non-admin users from seeing other users' audit actions in the action ledger while preserving org-wide visibility for org admins and global admins.
- Prevent the `action_ledger` table from growing without bound by applying reasonable time- and size-based retention limits.

### Description
- Scoped `GET /api/action-ledger/{org_id}` so non-admin users only see rows where `action_ledger.user_id == auth.user_id`, and org admins/global admins retain org-wide visibility by way of a new `_is_org_admin` helper using `get_admin_session` and `OrgMember` membership checks.
- Scoped billing `GET /credit-details` queries so non-admins only see their own `credit_transactions` and usage rollups, with an informational log when scoping is applied.
- Added retention enforcement in `workers.tasks.monitoring` that: computes `action_ledger` table size via `pg_total_relation_size`, deletes oldest rows in batched increments using `FOR UPDATE SKIP LOCKED`, and stops when size and age thresholds are satisfied (defaults: 100 days and 10 GiB).
- Scheduled the retention task in Celery beat and added migration `119_audit_retention` that creates indexes (`created_at` and `(organization_id, user_id, created_at)`) to support efficient retention deletes and user-scoped lookups; revision IDs respect the <=32 char constraint.
- Added unit tests covering action-ledger scoping, billing scoping, and retention enforcement behavior, and updated tests to assert SQL contains the expected user-scoped predicate.

### Testing
- Migration preflight: loaded `backend/db/migrations/versions/119_audit_retention.py` and asserted `len(revision) <= 32` and `len(down_revision) <= 32`; check passed.
- Ran the focused test suite: `cd backend && pytest -q tests/test_action_ledger.py tests/test_monitoring_task.py tests/test_billing_credit_details_scope.py`, and the tests completed successfully (all tests in those files passed).
- Verified retention task logging and that deletion uses batched `FOR UPDATE SKIP LOCKED` to reduce lock contention.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb53ade1c88321a28104d7d5023ed0)