### PR TITLE
Fix action_ledger retention when table is oversized with only recent rows

### DIFF
--- a/backend/tests/test_monitoring_task.py
+++ b/backend/tests/test_monitoring_task.py
@@ -303,6 +303,38 @@ def test_enforce_action_ledger_retention_deletes_when_limits_exceeded(monkeypatc
     assert result["size_after_bytes"] == 9_000_000_000
 
 
+def test_enforce_action_ledger_retention_falls_back_when_no_rows_older_than_cutoff(monkeypatch: Any) -> None:
+    sizes = [12_000_000_000, 11_000_000_000, 9_000_000_000, 9_000_000_000]
+    delete_calls: list[Any] = []
+
+    async def _fake_size() -> int:
+        return sizes.pop(0)
+
+    async def _fake_delete_oldest_action_ledger_batch(*, created_before: Any) -> int:
+        delete_calls.append(created_before)
+        if created_before is None:
+            return 2000
+        return 0
+
+    monkeypatch.setattr(monitoring, "_action_ledger_table_bytes", _fake_size)
+    monkeypatch.setattr(
+        monitoring,
+        "_delete_oldest_action_ledger_batch",
+        _fake_delete_oldest_action_ledger_batch,
+    )
+
+    import asyncio
+
+    result = asyncio.run(monitoring._enforce_action_ledger_retention())
+
+    assert result["deleted_rows"] == 2000
+    assert result["batches_run"] == 1
+    assert result["size_before_bytes"] == 12_000_000_000
+    assert result["size_after_bytes"] == 9_000_000_000
+    assert delete_calls[0] is not None
+    assert delete_calls[1] is None
+
+
 def test_monitor_dependencies_allows_incident_when_different_check_fails(monkeypatch: Any) -> None:
     async def _fake_run_dependency_checks() -> list[monitoring.CheckResult]:
         return [

--- a/backend/workers/tasks/monitoring.py
+++ b/backend/workers/tasks/monitoring.py
@@ -50,8 +50,16 @@ async def _action_ledger_table_bytes() -> int:
         return int(result.scalar_one() or 0)
 
 
-async def _delete_oldest_action_ledger_batch(*, created_before: datetime) -> int:
+async def _delete_oldest_action_ledger_batch(*, created_before: datetime | None) -> int:
     """Delete one ordered batch of action_ledger rows to avoid long-running locks."""
+    cutoff_filter = ""
+    params: dict[str, Any] = {
+        "batch_size": _AUDIT_DELETE_BATCH_SIZE,
+    }
+    if created_before is not None:
+        cutoff_filter = "WHERE created_at < :created_before"
+        params["created_before"] = created_before
+
     async with get_admin_session() as session:
         result = await session.execute(
             text(
@@ -59,7 +67,7 @@ async def _delete_oldest_action_ledger_batch(*, created_before: datetime) -> int
                 WITH rows_to_delete AS (
                     SELECT id
                     FROM action_ledger
-                    WHERE created_at < :created_before
+                    {cutoff_filter}
                     ORDER BY created_at ASC
                     LIMIT :batch_size
                     FOR UPDATE SKIP LOCKED
@@ -68,11 +76,9 @@ async def _delete_oldest_action_ledger_batch(*, created_before: datetime) -> int
                 USING rows_to_delete r
                 WHERE a.id = r.id
                 """
+                .format(cutoff_filter=cutoff_filter)
             ),
-            {
-                "created_before": created_before,
-                "batch_size": _AUDIT_DELETE_BATCH_SIZE,
-            },
+            params,
         )
         await session.commit()
         return int(result.rowcount or 0)
@@ -98,6 +104,14 @@ async def _enforce_action_ledger_retention() -> dict[str, Any]:
             break
 
         removed = await _delete_oldest_action_ledger_batch(created_before=cutoff)
+        if removed == 0 and size_bytes > _AUDIT_MAX_TABLE_BYTES:
+            logger.warning(
+                "No rows older than cutoff could be deleted while action_ledger is oversized; "
+                "falling back to deleting oldest rows regardless of age size_bytes=%s cutoff=%s",
+                size_bytes,
+                cutoff.isoformat(),
+            )
+            removed = await _delete_oldest_action_ledger_batch(created_before=None)
         batches_run += 1
         deleted_rows += removed
         if removed == 0:


### PR DESCRIPTION
### Motivation
- The retention loop used `created_before` to limit deletes, so if the table exceeded `_AUDIT_MAX_TABLE_BYTES` but only contained rows newer than the cutoff, `_delete_oldest_action_ledger_batch` returned `0` and the loop exited leaving the table oversized.  
- This caused the size-based retention guarantee to fail when recent rows alone pushed the table over the limit.

### Description
- Updated `backend/workers/tasks/monitoring.py` to allow `_delete_oldest_action_ledger_batch` to be called with `created_before=None` and to dynamically omit the age filter from the SQL when `None` is passed.  
- Modified `_enforce_action_ledger_retention` to fall back to a second delete attempt with `created_before=None` when a cutoff-scoped delete returned `0` but the table size remains above `_AUDIT_MAX_TABLE_BYTES`.  
- Added a warning log when the fallback path is used so operators can see when recent rows were removed due to size pressure.  
- Added a unit test `test_enforce_action_ledger_retention_falls_back_when_no_rows_older_than_cutoff` in `backend/tests/test_monitoring_task.py` that simulates the failure mode and verifies the fallback deletion happens.

### Testing
- Ran the retention-focused tests: `pytest -q backend/tests/test_monitoring_task.py -k retention`, and they passed (`2 passed, 12 deselected`).
- The new unit test covers the oversized-with-only-recent-rows scenario and verifies the fallback is invoked and reduces reported size.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb5c5261988321a8e16dcca2fe8732)