### PR TITLE
Enforce shared_files RLS with team-sharing access

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -5420,8 +5420,9 @@ async def _search_cloud_files(
 
     try:
         from uuid import UUID as _UUID
-        from sqlalchemy import select, and_
+        from sqlalchemy import select, and_, or_, exists
         from models.shared_file import SharedFile
+        from models.integration import Integration
         from models.database import get_session
 
         org_uuid: _UUID = _UUID(organization_id)
@@ -5432,7 +5433,18 @@ async def _search_cloud_files(
 
         filters: list[Any] = [
             SharedFile.organization_id == org_uuid,
-            SharedFile.user_id == user_uuid,
+            or_(
+                SharedFile.user_id == user_uuid,
+                exists(
+                    select(1).where(
+                        Integration.organization_id == SharedFile.organization_id,
+                        Integration.user_id == SharedFile.user_id,
+                        Integration.connector == SharedFile.source,
+                        Integration.is_active == True,  # noqa: E712
+                        Integration.share_synced_data == True,  # noqa: E712
+                    )
+                ),
+            ),
             SharedFile.mime_type != "application/vnd.google-apps.folder",
         ]
 
@@ -5494,8 +5506,9 @@ async def _read_cloud_file(
 
     try:
         from uuid import UUID as _UUID
-        from sqlalchemy import select, and_
+        from sqlalchemy import select, and_, or_, exists
         from models.shared_file import SharedFile
+        from models.integration import Integration
         from models.database import get_session
 
         org_uuid: _UUID = _UUID(organization_id)
@@ -5506,7 +5519,18 @@ async def _read_cloud_file(
                 select(SharedFile).where(
                     and_(
                         SharedFile.organization_id == org_uuid,
-                        SharedFile.user_id == user_uuid,
+                        or_(
+                            SharedFile.user_id == user_uuid,
+                            exists(
+                                select(1).where(
+                                    Integration.organization_id == SharedFile.organization_id,
+                                    Integration.user_id == SharedFile.user_id,
+                                    Integration.connector == SharedFile.source,
+                                    Integration.is_active == True,  # noqa: E712
+                                    Integration.share_synced_data == True,  # noqa: E712
+                                )
+                            ),
+                        ),
                         SharedFile.external_id == external_id,
                     )
                 )

--- a/backend/db/migrations/versions/120_shared_files_rls.py
+++ b/backend/db/migrations/versions/120_shared_files_rls.py
@@ -1,0 +1,97 @@
+"""Enable RLS on shared_files with org + owner/team visibility.
+
+Revision ID: 120_shared_files_rls
+Revises: 119_audit_retention
+Create Date: 2026-03-31
+"""
+from alembic import op
+from sqlalchemy import text
+
+
+revision = "120_shared_files_rls"
+down_revision = "119_audit_retention"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(text("ALTER TABLE shared_files ENABLE ROW LEVEL SECURITY"))
+    conn.execute(text("ALTER TABLE shared_files FORCE ROW LEVEL SECURITY"))
+
+    conn.execute(text("DROP POLICY IF EXISTS shared_files_select_access ON shared_files"))
+    conn.execute(text("DROP POLICY IF EXISTS shared_files_owner_write ON shared_files"))
+
+    # SELECT policy:
+    # - Always constrained to current org
+    # - Owner can read their rows
+    # - Teammates can read rows only when the corresponding integration has
+    #   share_synced_data=true (preserves connector sharing behavior)
+    conn.execute(
+        text(
+            """
+            CREATE POLICY shared_files_select_access ON shared_files
+            FOR SELECT
+            USING (
+                organization_id::text = COALESCE(
+                    NULLIF(current_setting('app.current_org_id', true), ''),
+                    '00000000-0000-0000-0000-000000000000'
+                )
+                AND (
+                    user_id::text = COALESCE(
+                        NULLIF(current_setting('app.current_user_id', true), ''),
+                        '00000000-0000-0000-0000-000000000000'
+                    )
+                    OR EXISTS (
+                        SELECT 1
+                        FROM integrations i
+                        WHERE i.organization_id = shared_files.organization_id
+                          AND i.user_id = shared_files.user_id
+                          AND i.connector = shared_files.source
+                          AND i.is_active = true
+                          AND i.share_synced_data = true
+                    )
+                )
+            )
+            """
+        )
+    )
+
+    # Write policy:
+    # - Only file owner in current org can insert/update/delete their rows
+    conn.execute(
+        text(
+            """
+            CREATE POLICY shared_files_owner_write ON shared_files
+            FOR ALL
+            USING (
+                organization_id::text = COALESCE(
+                    NULLIF(current_setting('app.current_org_id', true), ''),
+                    '00000000-0000-0000-0000-000000000000'
+                )
+                AND user_id::text = COALESCE(
+                    NULLIF(current_setting('app.current_user_id', true), ''),
+                    '00000000-0000-0000-0000-000000000000'
+                )
+            )
+            WITH CHECK (
+                organization_id::text = COALESCE(
+                    NULLIF(current_setting('app.current_org_id', true), ''),
+                    '00000000-0000-0000-0000-000000000000'
+                )
+                AND user_id::text = COALESCE(
+                    NULLIF(current_setting('app.current_user_id', true), ''),
+                    '00000000-0000-0000-0000-000000000000'
+                )
+            )
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(text("DROP POLICY IF EXISTS shared_files_owner_write ON shared_files"))
+    conn.execute(text("DROP POLICY IF EXISTS shared_files_select_access ON shared_files"))
+    conn.execute(text("ALTER TABLE shared_files DISABLE ROW LEVEL SECURITY"))


### PR DESCRIPTION
### Motivation
- Prevent cross-org and cross-user enumeration of synced cloud files by enforcing DB-level isolation on the `shared_files` table while preserving existing connector sharing semantics.
- Ensure team-shared connectors (when `share_synced_data=true`) continue to allow teammates to read an owner's synced files.

### Description
- Add Alembic migration `120_shared_files_rls` to `backend/db/migrations/versions` that enables and forces Row-Level Security on `shared_files` and creates a `SELECT` policy that requires `app.current_org_id` and allows rows when either the current user is the owner or an active `integrations` row for the owner/source has `share_synced_data = true`.
- Add a write policy `shared_files_owner_write` that restricts insert/update/delete to the row owner within the active org context.
- Update `_search_cloud_files` in `backend/agents/tools.py` to return files that belong to the requesting user or to teammates whose matching integration has `share_synced_data=true`, while still filtering by organization and excluding folder MIME types.
- Update `_read_cloud_file` in `backend/agents/tools.py` to mirror the same owner-or-shared access logic before dispatching to the connector for content fetch.

### Testing
- Ran an Alembic revision preflight import/assertion to verify `revision` and `down_revision` lengths with: `python - <<'PY' ...` which asserted `len(revision) <= 32` and `len(down_revision) <= 32`, and it succeeded.
- Compiled changed Python modules with `python -m compileall backend/agents/tools.py backend/db/migrations/versions/120_shared_files_rls.py` and the compilation succeeded.
- Static import of the new migration module was performed to validate metadata and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc037e6c2c8321869e064481a936d7)