### PR TITLE
Warn when websocket messages are rejected without organization context

### DIFF
--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -332,6 +332,21 @@ def _generate_title(message: str) -> str:
 logger = logging.getLogger(__name__)
 
 
+def _warn_org_required_rejection(
+    *,
+    user_id: str,
+    message_type: str,
+    conversation_id: str | None = None,
+) -> None:
+    """Emit a warning when a websocket message is rejected due to missing org context."""
+    logger.warning(
+        "[WebSocket] Rejected %s message: no organization context (user_id=%s, conversation_id=%s)",
+        message_type,
+        user_id,
+        conversation_id or "none",
+    )
+
+
 async def _collect_running_workflow_tool_updates(organization_id: str) -> list[dict]:
     """
     Collect running workflow tool states from persisted chat messages.
@@ -664,7 +679,14 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
 
             if message_type == "typing":
                 ty_conv_id = data.get("conversation_id")
-                if not ty_conv_id or not organization_id:
+                if not ty_conv_id:
+                    continue
+                if not organization_id:
+                    _warn_org_required_rejection(
+                        user_id=user_id_str,
+                        message_type=message_type,
+                        conversation_id=str(ty_conv_id),
+                    )
                     continue
                 try:
                     ty_conv_uuid = UUID(str(ty_conv_id))
@@ -711,6 +733,11 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                     continue
 
                 if not organization_id:
+                    _warn_org_required_rejection(
+                        user_id=user_id_str,
+                        message_type=message_type,
+                        conversation_id=str(conversation_id) if conversation_id else None,
+                    )
                     await websocket.send_text(
                         json.dumps(
                             {


### PR DESCRIPTION
### Motivation
- WebSocket handlers sometimes reject client messages when the organization context is not yet known, and those rejections should be surfaced in logs to aid debugging. 

### Description
- Add a helper `_warn_org_required_rejection` in `backend/api/websockets.py` and invoke it in the `typing` and `send_message`/`chat` branches to emit a `logger.warning` containing the message type, `user_id`, and `conversation_id` (if present) before the existing rejection behavior.

### Testing
- Ran `pytest -q backend/tests/test_websocket_fanout.py` which completed successfully (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc95826d048321b25747127b7a1e35)