### PR TITLE
Deduplicate consecutive tool status messages in workspace messenger

### DIFF
--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -774,6 +774,17 @@ class WorkspaceMessenger(BaseMessenger):
             return
         normalized_status_text: str = status_text.strip()
         tool_status: str = data.get("status") if isinstance(data.get("status"), str) else "running"
+        global_dedup_key: str = "__last_tool_status_message__"
+        if posted_tool_statuses is not None:
+            last_global_status: tuple[str, str] | None = posted_tool_statuses.get(global_dedup_key)
+            if last_global_status == (tool_status, normalized_status_text):
+                logger.info(
+                    "[%s] Skipping consecutive duplicate tool status message status=%s text=%s",
+                    self.meta.slug,
+                    tool_status,
+                    normalized_status_text,
+                )
+                return
         dedup_key: str = (
             data.get("tool_id")
             if isinstance(data.get("tool_id"), str) and data.get("tool_id")
@@ -796,6 +807,7 @@ class WorkspaceMessenger(BaseMessenger):
         message: str = self.format_tool_status_for_display(normalized_status_text)
         if posted_tool_statuses is not None:
             posted_tool_statuses[dedup_key] = (tool_status, normalized_status_text)
+            posted_tool_statuses[global_dedup_key] = (tool_status, normalized_status_text)
 
         async def _post() -> None:
             try:

--- a/backend/tests/test_workspace_tool_status_dedup.py
+++ b/backend/tests/test_workspace_tool_status_dedup.py
@@ -142,3 +142,52 @@ def test_handle_json_chunk_allows_same_status_text_after_status_change() -> None
         "Reading Linear docs",
         "Reading Linear docs",
     ]
+
+
+def test_handle_json_chunk_skips_consecutive_duplicate_messages_across_tool_ids() -> None:
+    messenger = _TestWorkspaceMessenger()
+    posted_tool_statuses: dict[str, tuple[str, str]] = {}
+    first_chunk = json.dumps(
+        {
+            "type": "tool_call",
+            "tool_id": "tool-aaa",
+            "tool_name": "execute_sql",
+            "status": "running",
+            "status_text": "Querying your database",
+        }
+    )
+    second_chunk = json.dumps(
+        {
+            "type": "tool_call",
+            "tool_id": "tool-bbb",
+            "tool_name": "execute_sql",
+            "status": "running",
+            "status_text": "Querying your database",
+        }
+    )
+
+    async def _run() -> None:
+        await messenger._handle_json_chunk(
+            first_chunk,
+            channel_id="C123",
+            thread_id="thread-1",
+            workspace_id="T123",
+            organization_id="org-1",
+            posted_tool_statuses=posted_tool_statuses,
+        )
+        await asyncio.sleep(0)
+        await messenger._handle_json_chunk(
+            second_chunk,
+            channel_id="C123",
+            thread_id="thread-1",
+            workspace_id="T123",
+            organization_id="org-1",
+            posted_tool_statuses=posted_tool_statuses,
+        )
+        await asyncio.sleep(0)
+
+    asyncio.run(_run())
+
+    assert [message["text"] for message in messenger.posted_messages] == [
+        "Querying your database",
+    ]


### PR DESCRIPTION
### Motivation
- Prevent repeated identical progress status messages (for example, "Querying your database") from being posted back-to-back to Slack when they come from different tool IDs.

### Description
- Add a global consecutive-status dedup key (`"__last_tool_status_message__

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdb3854bb48321b374b84307ed1023)