### PR TITLE
Allow SQL read access to conversations and chat_messages with user-scoped RLS

### DIFF
--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -125,6 +125,8 @@ Available tables (use these exact column names):
 - users: Team members (email, name, role, phone_number in E.164 format e.g. +14155551234)
 - user_mappings_for_identity: Slack identity links (external_userid, external_email, match_source)
 - organizations: User's company info (name, logo_url)
+- conversations: Conversation threads visible to the current user (their own conversations plus org-shared conversations). Columns include id, user_id, title, summary, scope, source, participating_user_ids, created_at, updated_at.
+- chat_messages: Messages from conversations visible to the current user. Columns include id, conversation_id, role, content_blocks (JSONB), user_id, created_at.
 - workflows: Workflow definitions (name, trigger_type, prompt, is_enabled, auto_approve_tools). Useful for listing and inspecting workflows.
 - workflow_runs: Workflow execution history (workflow_id, status, started_at, completed_at, output, workflow_notes). Useful for querying past run outcomes and notes.
 - github_repositories: Tracked GitHub repos (full_name, owner, name, is_tracked, last_sync_at). Join to commits/PRs via repository_id.

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -188,6 +188,7 @@ class ToolProgressUpdater:
 ALLOWED_TABLES: set[str] = {
     "deals", "accounts", "contacts", "activities", "meetings", "integrations", "users", "organizations",
     "org_members", "apps",
+    "conversations", "chat_messages",
     "pipelines", "pipeline_stages", "goals", "workflows", "workflow_runs", "user_mappings_for_identity",
     "github_repositories", "github_commits", "github_pull_requests",
     "shared_files",

--- a/backend/db/migrations/versions/124_convo_msg_visibility.py
+++ b/backend/db/migrations/versions/124_convo_msg_visibility.py
@@ -1,0 +1,123 @@
+"""Restrict conversations/chat_messages RLS to user-visible rows.
+
+Revision ID: 124_convo_msg_visibility
+Revises: 123_rls_with_check_writables
+Create Date: 2026-04-02
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "124_convo_msg_visibility"
+down_revision: Union[str, None] = "123_rls_with_check_writables"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_ORG_MATCH: str = """
+organization_id::text = COALESCE(
+    NULLIF(current_setting('app.current_org_id', true), ''),
+    '00000000-0000-0000-0000-000000000000'
+)
+"""
+
+_USER_ID_TEXT: str = """
+COALESCE(
+    NULLIF(current_setting('app.current_user_id', true), ''),
+    '00000000-0000-0000-0000-000000000000'
+)
+"""
+
+_CONVERSATION_VISIBILITY: str = f"""
+(
+    scope = 'shared'
+    OR user_id::text = ({_USER_ID_TEXT.strip()})
+    OR EXISTS (
+        SELECT 1
+        FROM unnest(COALESCE(participating_user_ids, ARRAY[]::uuid[])) AS pu(uid)
+        WHERE pu.uid::text = ({_USER_ID_TEXT.strip()})
+    )
+)
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    bind.execute(sa.text("DROP POLICY IF EXISTS org_isolation ON conversations"))
+    bind.execute(
+        sa.text(
+            f"""
+            CREATE POLICY org_isolation ON conversations
+            FOR ALL
+            USING ({_ORG_MATCH.strip()} AND {_CONVERSATION_VISIBILITY.strip()})
+            WITH CHECK ({_ORG_MATCH.strip()} AND {_CONVERSATION_VISIBILITY.strip()})
+            """
+        )
+    )
+
+    bind.execute(sa.text("DROP POLICY IF EXISTS org_isolation ON chat_messages"))
+    bind.execute(
+        sa.text(
+            f"""
+            CREATE POLICY org_isolation ON chat_messages
+            FOR ALL
+            USING (
+                {_ORG_MATCH.strip()}
+                AND EXISTS (
+                    SELECT 1
+                    FROM conversations c
+                    WHERE c.id = chat_messages.conversation_id
+                      AND c.organization_id::text = COALESCE(
+                        NULLIF(current_setting('app.current_org_id', true), ''),
+                        '00000000-0000-0000-0000-000000000000'
+                      )
+                      AND {_CONVERSATION_VISIBILITY.strip()}
+                )
+            )
+            WITH CHECK (
+                {_ORG_MATCH.strip()}
+                AND EXISTS (
+                    SELECT 1
+                    FROM conversations c
+                    WHERE c.id = chat_messages.conversation_id
+                      AND c.organization_id::text = COALESCE(
+                        NULLIF(current_setting('app.current_org_id', true), ''),
+                        '00000000-0000-0000-0000-000000000000'
+                      )
+                      AND {_CONVERSATION_VISIBILITY.strip()}
+                )
+            )
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    bind.execute(sa.text("DROP POLICY IF EXISTS org_isolation ON chat_messages"))
+    bind.execute(
+        sa.text(
+            f"""
+            CREATE POLICY org_isolation ON chat_messages
+            FOR ALL
+            USING ({_ORG_MATCH.strip()})
+            WITH CHECK ({_ORG_MATCH.strip()})
+            """
+        )
+    )
+
+    bind.execute(sa.text("DROP POLICY IF EXISTS org_isolation ON conversations"))
+    bind.execute(
+        sa.text(
+            f"""
+            CREATE POLICY org_isolation ON conversations
+            FOR ALL
+            USING ({_ORG_MATCH.strip()})
+            WITH CHECK ({_ORG_MATCH.strip()})
+            """
+        )
+    )

--- a/backend/tests/test_tool_visibility.py
+++ b/backend/tests/test_tool_visibility.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from agents.registry import get_tools_for_claude, requires_approval
 
 
@@ -19,3 +21,15 @@ def test_run_sql_query_documents_workflow_runs_table() -> None:
     run_sql_query_tool = next(tool for tool in get_tools_for_claude(in_workflow=True) if tool["name"] == "run_sql_query")
     description = run_sql_query_tool["description"]
     assert "- workflow_runs:" in description
+
+
+def test_run_sql_query_documents_conversation_tables() -> None:
+    run_sql_query_tool = next(tool for tool in get_tools_for_claude(in_workflow=True) if tool["name"] == "run_sql_query")
+    description = run_sql_query_tool["description"]
+    assert "- conversations:" in description
+    assert "- chat_messages:" in description
+
+
+def test_run_sql_query_allows_conversation_tables() -> None:
+    tools_source = (Path(__file__).resolve().parents[1] / "agents" / "tools.py").read_text()
+    assert '"conversations", "chat_messages"' in tools_source


### PR DESCRIPTION
### Motivation
- Enable agents to run read-only SQL queries against conversation data while ensuring tenants and per-user visibility remain enforced by RLS.
- Document the availability of `conversations` and `chat_messages` for `run_sql_query` so users know which columns and semantics are supported.

### Description
- Added `conversations` and `chat_messages` to the `ALLOWED_TABLES` allowlist used by the `run_sql_query` tool (`backend/agents/tools.py`).
- Updated the `run_sql_query` tool documentation to explicitly list `conversations` and `chat_messages` and describe their intended visibility (`backend/agents/registry.py`).
- Added Alembic migration `124_convo_msg_visibility` to tighten RLS policies so `conversations` are visible only when `scope = 'shared'` or the current user is the owner or a participant, and `chat_messages` are visible only when their parent conversation is visible to the user (`backend/db/migrations/versions/124_convo_msg_visibility.py`).
- Added/updated tests to verify the tool description mentions the conversation tables and to assert the allowlist entry is present in the tools source while avoiding import-time circular imports (`backend/tests/test_tool_visibility.py`).

### Testing
- Ran migration preflight assertions to ensure `revision` and `down_revision` lengths meet constraints (both checks succeeded).
- Ran the test subset `cd backend && pytest -q tests/test_tool_visibility.py tests/test_alembic_migration_numbering.py`, which completed successfully with all tests passing (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdb75cd7a88321a2a4197b8cfdbf05)