### PR TITLE
Fix PendingRollbackError during session RLS cleanup

### DIFF
--- a/backend/models/database.py
+++ b/backend/models/database.py
@@ -301,6 +301,10 @@ async def get_session(
             # Reset role AND org context before returning connection to pool.
             # Without this, a pooled connection could leak one org's RLS context to another.
             try:
+                # Always rollback first so cleanup SQL doesn't fail with
+                # PendingRollbackError when prior work left the transaction in
+                # a failed state.
+                await session.rollback()
                 logger.debug("Session cleanup: resetting RLS context (set_config + RESET ROLE)")
                 # Batch both set_config resets into one round trip
                 await session.execute(


### PR DESCRIPTION
### Motivation
- Prevent `PendingRollbackError` raised during session finalization when prior work left the transaction invalid and cleanup SQL (`set_config` / `RESET ROLE`) is executed. 

### Description
- Call `await session.rollback()` in the `get_session()` finalizer before executing RLS reset SQL to ensure the transaction is clean. 
- Added an explanatory comment above the rollback to document why the rollback is required. 
- Modified file `backend/models/database.py` to perform the rollback prior to `SELECT set_config(...)` and `RESET ROLE`.

### Testing
- Ran `python -m compileall backend/models/database.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdd9891e248321bae5cc50b1abd6dc)