### PR TITLE
Expunge Integration before returning to avoid DetachedInstanceError

### DIFF
--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -409,7 +409,12 @@ class BaseConnector(ABC):
                 self.organization_id,
                 candidates[0].id,
             )
-        return candidates[0] if candidates else None
+        selected = candidates[0] if candidates else None
+        if selected is not None:
+            # Detach so callers can safely access scalar attributes after the
+            # session context exits (e.g., nango_connection_id in write paths).
+            session.expunge(selected)
+        return selected
 
     @abstractmethod
     async def sync_deals(self) -> int:

--- a/backend/tests/test_base_connector_integration_selection.py
+++ b/backend/tests/test_base_connector_integration_selection.py
@@ -42,9 +42,15 @@ class _FakeExecuteResult:
 class _FakeSession:
     def __init__(self, rows):
         self._rows = rows
+        self.expunge_calls = []
 
     async def execute(self, _query):
         return _FakeExecuteResult(self._rows)
+
+    def expunge(self, row):
+        self.expunge_calls.append(row)
+        if hasattr(row, "_expunged"):
+            row._expunged = True
 
 
 class _FakeSessionContext:
@@ -67,6 +73,19 @@ class _FakeNango:
         return "token-123"
 
 
+class _ExpungeRequiredIntegration:
+    def __init__(self, integration_id: str, connection_id: str):
+        self.id = integration_id
+        self._connection_id = connection_id
+        self._expunged = False
+
+    @property
+    def nango_connection_id(self):
+        if not self._expunged:
+            raise RuntimeError("simulated detached instance attribute refresh")
+        return self._connection_id
+
+
 def test_get_oauth_token_handles_multiple_integrations_without_user_id(monkeypatch):
     first = SimpleNamespace(id="int-new", nango_connection_id="conn-new")
     second = SimpleNamespace(id="int-old", nango_connection_id="conn-old")
@@ -85,4 +104,23 @@ def test_get_oauth_token_handles_multiple_integrations_without_user_id(monkeypat
 
     assert token == "token-123"
     assert instance == ""
+    assert fake_nango.calls == [("nango-slack", "conn-new")]
+
+
+def test_get_oauth_token_uses_expunged_integration_instance(monkeypatch):
+    row = _ExpungeRequiredIntegration("int-new", "conn-new")
+
+    monkeypatch.setattr(
+        "connectors.base.get_session",
+        lambda organization_id: _FakeSessionContext([row]),
+    )
+
+    fake_nango = _FakeNango()
+    monkeypatch.setattr("connectors.base.get_nango_client", lambda: fake_nango)
+    monkeypatch.setattr("connectors.base.get_nango_integration_id", lambda _source: "nango-slack")
+
+    connector = _DummyConnector(organization_id="11111111-1111-1111-1111-111111111111")
+    token, _ = asyncio.run(connector.get_oauth_token())
+
+    assert token == "token-123"
     assert fake_nango.calls == [("nango-slack", "conn-new")]


### PR DESCRIPTION
### Motivation
- Reading `Integration` scalar attributes (e.g. `nango_connection_id`) after a short-lived DB session can trigger SQLAlchemy to refresh expired attributes, causing `DetachedInstanceError` as seen in the provided stack trace. 
- The change ensures connector code that stores `self._integration` can safely access its scalar fields outside the session scope.

### Description
- In `BaseConnector._select_integration` the selected `Integration` row is now `expunge()`d from the session before being returned so scalar attribute access does not attempt a refresh on a detached instance. 
- Tests were updated to simulate the detached-attribute refresh failure and to verify the connector path continues to work when the integration instance is expunged by adding `._ExpungeRequiredIntegration`, a fake `expunge` on the fake session, and the test `test_get_oauth_token_uses_expunged_integration_instance` in `tests/test_base_connector_integration_selection.py`.

### Testing
- Ran `pytest -q tests/test_base_connector_integration_selection.py` and observed `2 passed` indicating the existing and new regression test both succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea5f4de608321b09dd12a2e3b91da)