### PR TITLE
Fix DetachedInstanceError for messenger Conversation instances

### DIFF
--- a/backend/messengers/_twilio_phone.py
+++ b/backend/messengers/_twilio_phone.py
@@ -550,6 +550,10 @@ class TwilioPhoneMessenger(BaseMessenger):
                 if user.id and conversation.user_id is None:
                     conversation.user_id = user.id
                     await session.commit()
+                # get_session() cleanup issues rollback before close; detach
+                # instance so scalar attribute reads don't trigger refresh on a
+                # closed session.
+                session.expunge(conversation)
                 return conversation
 
             display_name: str = user.name or phone
@@ -573,6 +577,8 @@ class TwilioPhoneMessenger(BaseMessenger):
                 phone,
                 organization_id,
             )
+            # Detach before get_session() cleanup rollback.
+            session.expunge(conversation)
             return conversation
 
     # ------------------------------------------------------------------

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -576,6 +576,10 @@ class WorkspaceMessenger(BaseMessenger):
 
                 if changed:
                     await session.commit()
+                # get_session() cleanup always rolls back before close to clear
+                # transaction state/RLS context; expunge the ORM object so
+                # attribute access remains safe after the session scope exits.
+                session.expunge(conversation)
                 return conversation
 
             source_label: str = {
@@ -604,6 +608,8 @@ class WorkspaceMessenger(BaseMessenger):
                 "[%s] Created conversation %s channel=%s user=%s",
                 source, conversation.id, source_channel_id, revtops_user_id,
             )
+            # See note above: detach before get_session() cleanup rollback.
+            session.expunge(conversation)
             return conversation
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- `get_session()` cleanup now performs a `rollback()` and RLS-reset before closing the session, which can expire ORM state and cause `DetachedInstanceError` when callers access attributes of returned ORM objects after the context exits.
- The same pattern was previously addressed for `Integration` objects, indicating `Conversation` return paths were a similar regression vector. 
- Returning attached ORM instances from session-scoped contexts is fragile; detaching preserves already-loaded scalar attributes and avoids refresh attempts on closed sessions.

### Description
- Detached returned `Conversation` instances in messenger flows by calling `session.expunge(conversation)` before returning in both `backend/messengers/_workspace.py` and `backend/messengers/_twilio_phone.py` for existing and newly-created conversation code paths.
- Added explanatory comments noting the `get_session()` cleanup/rollback behavior and why detaching is required.
- No changes were made to `get_session()` semantics or broader session lifecycle behavior.

### Testing
- Compiled modified modules with `python -m compileall backend/messengers/_workspace.py backend/messengers/_twilio_phone.py`, which succeeded. 
- Ran unit tests `pytest -q backend/tests/test_base_connector_integration_selection.py`, which passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea9d04e2c8321a413182a423ad47a)