### PR TITLE
Avoid returning detached Conversation ORM instances from messenger flow

### DIFF
--- a/backend/messengers/_twilio_phone.py
+++ b/backend/messengers/_twilio_phone.py
@@ -533,7 +533,7 @@ class TwilioPhoneMessenger(BaseMessenger):
         organization_id: str,
         user: User,
         message: InboundMessage,
-    ) -> Conversation:
+    ) -> str:
         phone: str = message.external_user_id
         source: str = self.meta.slug
 
@@ -550,7 +550,7 @@ class TwilioPhoneMessenger(BaseMessenger):
                 if user.id and conversation.user_id is None:
                     conversation.user_id = user.id
                     await session.commit()
-                return conversation
+                return str(conversation.id)
 
             display_name: str = user.name or phone
             conversation = Conversation(
@@ -573,7 +573,7 @@ class TwilioPhoneMessenger(BaseMessenger):
                 phone,
                 organization_id,
             )
-            return conversation
+            return str(conversation.id)
 
     # ------------------------------------------------------------------
     # Attachments

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -539,7 +539,7 @@ class WorkspaceMessenger(BaseMessenger):
         organization_id: str,
         user: User,
         message: InboundMessage,
-    ) -> Conversation:
+    ) -> str:
         ctx: dict[str, Any] = message.messenger_context
         channel_id: str = ctx.get("channel_id", "")
         thread_id: str | None = ctx.get("thread_id") or ctx.get("thread_ts")
@@ -576,7 +576,7 @@ class WorkspaceMessenger(BaseMessenger):
 
                 if changed:
                     await session.commit()
-                return conversation
+                return str(conversation.id)
 
             source_label: str = {
                 "direct": f"{self.meta.name} DM",
@@ -604,7 +604,7 @@ class WorkspaceMessenger(BaseMessenger):
                 "[%s] Created conversation %s channel=%s user=%s",
                 source, conversation.id, source_channel_id, revtops_user_id,
             )
-            return conversation
+            return str(conversation.id)
 
     # ------------------------------------------------------------------
     # Attachments
@@ -898,7 +898,7 @@ class WorkspaceMessenger(BaseMessenger):
             await self.remove_typing_indicator(message)
             return {"status": "error", "error": "insufficient_credits"}
 
-        conversation: Conversation = await self.find_or_create_conversation(
+        conversation_id: str = await self.find_or_create_conversation(
             organization_id, user, message,
         )
 
@@ -914,7 +914,7 @@ class WorkspaceMessenger(BaseMessenger):
                 organization_id,
             )
             should_invoke_agent = await resolve_agent_responding(
-                conversation_id=str(conversation.id),
+                conversation_id=conversation_id,
                 organization_id=organization_id,
                 mentions=mentions_for_resolve,
             )
@@ -924,7 +924,7 @@ class WorkspaceMessenger(BaseMessenger):
 
         if not should_invoke_agent:
             await save_user_message(
-                conversation_id=str(conversation.id),
+                conversation_id=conversation_id,
                 user_id=str(user.id),
                 organization_id=organization_id,
                 message_text=message_text,
@@ -933,7 +933,7 @@ class WorkspaceMessenger(BaseMessenger):
                 sender_email=slack_user_email or user.email,
             )
             await self.remove_typing_indicator(message)
-            return {"status": "human_only", "conversation_id": str(conversation.id)}
+            return {"status": "human_only", "conversation_id": conversation_id}
 
         workflow_context: dict[str, Any] | None = _build_workflow_context_for_message(
             platform_slug=self.meta.slug,
@@ -943,7 +943,7 @@ class WorkspaceMessenger(BaseMessenger):
         orchestrator = ChatOrchestrator(
             user_id=str(user.id),
             organization_id=organization_id,
-            conversation_id=str(conversation.id),
+            conversation_id=conversation_id,
             user_email=user.email,
             source_user_id=message.external_user_id,
             source_user_email=slack_user_email or user.email,
@@ -978,7 +978,7 @@ class WorkspaceMessenger(BaseMessenger):
                 await self.remove_typing_indicator(message)
                 return {
                     "status": "success",
-                    "conversation_id": str(conversation.id),
+                    "conversation_id": conversation_id,
                     "response_length": total,
                 }
 
@@ -991,7 +991,7 @@ class WorkspaceMessenger(BaseMessenger):
                 await self.remove_typing_indicator(message)
                 return {
                     "status": "success",
-                    "conversation_id": str(conversation.id),
+                    "conversation_id": conversation_id,
                     "response_length": total,
                 }
 
@@ -1016,7 +1016,7 @@ class WorkspaceMessenger(BaseMessenger):
                     await self.remove_typing_indicator(message)
 
             asyncio.create_task(_finish())
-            return {"status": "timeout_continuing", "conversation_id": str(conversation.id)}
+            return {"status": "timeout_continuing", "conversation_id": conversation_id}
 
         # Batch mode (fallback — workspace messengers are usually streaming)
         return await super().process_inbound(message)

--- a/backend/messengers/base.py
+++ b/backend/messengers/base.py
@@ -22,7 +22,6 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, ClassVar
 
-from models.conversation import Conversation
 from models.user import User
 from services.anthropic_health import user_message_for_agent_stream_failure
 
@@ -181,8 +180,8 @@ class BaseMessenger(ABC):
         organization_id: str,
         user: User,
         message: InboundMessage,
-    ) -> Conversation:
-        """Find or create the :class:`Conversation` for this message."""
+    ) -> str:
+        """Find or create the conversation and return its UUID string."""
 
     # ------------------------------------------------------------------
     # Attachments
@@ -301,7 +300,7 @@ class BaseMessenger(ABC):
             return {"status": "error", "error": "insufficient_credits"}
 
         # 4. Find / create conversation
-        conversation: Conversation = await self.find_or_create_conversation(
+        conversation_id: str = await self.find_or_create_conversation(
             organization_id, user, message
         )
 
@@ -319,7 +318,7 @@ class BaseMessenger(ABC):
         orchestrator = ChatOrchestrator(
             user_id=user_id,
             organization_id=organization_id,
-            conversation_id=str(conversation.id),
+            conversation_id=conversation_id,
             user_email=user_email,
             source_user_id=message.external_user_id,
             source_user_email=user_email,
@@ -344,7 +343,7 @@ class BaseMessenger(ABC):
             logger.exception(
                 "[%s] Orchestrator error conversation=%s",
                 self.meta.slug,
-                conversation.id,
+                conversation_id,
             )
             full_response += user_message_for_agent_stream_failure(exc)
 

--- a/backend/messengers/web.py
+++ b/backend/messengers/web.py
@@ -17,7 +17,6 @@ from messengers.base import (
     OutboundResponse,
     ResponseMode,
 )
-from models.conversation import Conversation
 from models.user import User
 
 
@@ -36,7 +35,7 @@ class WebMessenger(BaseMessenger):
 
     async def find_or_create_conversation(
         self, organization_id: str, user: User, message: InboundMessage,
-    ) -> Conversation:
+    ) -> str:
         raise NotImplementedError("Web messenger uses WebSocket flow, not process_inbound()")
 
     async def download_attachments(self, message: InboundMessage) -> list[str]:


### PR DESCRIPTION
### Motivation
- Intermittent `DetachedInstanceError` occurred when `Conversation` ORM objects were created inside `async with get_session(...)` and then used after the session had been closed.
- Recent routing and streaming changes increased the number of code paths that carried `Conversation` objects across async boundaries, making detached-instance refresh attempts more likely.
- The intent is to remove session-coupled ORM objects from the messenger-to-orchestrator boundary so downstream code no longer tries to refresh attributes on detached instances.

### Description
- Changed the `find_or_create_conversation` contract to return a conversation ID string (`str`) instead of a `Conversation` ORM instance in `BaseMessenger` and all messenger implementations (`backend/messengers/base.py`, `backend/messengers/_workspace.py`, `backend/messengers/_twilio_phone.py`, `backend/messengers/web.py`).
- Updated the shared messenger pipeline in `BaseMessenger.process_inbound` to accept and pass `conversation_id` to the `ChatOrchestrator` and to logging/response payloads instead of referencing `conversation` attributes after session teardown.
- Updated workspace and Twilio messenger implementations and their call sites to return `str(conversation.id)` where previously the ORM object was returned, and to use `conversation_id` in calls to `resolve_agent_responding`, `save_user_message`, orchestrator instantiation, and JSON/status payloads.
- Removed now-unnecessary `Conversation` imports from places where only the ID is used and preserved defensive notes about avoiding `session.refresh()` after commit in create paths.

### Testing
- Ran `pytest -q backend/tests/test_workspace_tool_status_dedup.py backend/tests/test_workspace_slow_reply_window.py` and all tests passed (`5 passed`).
- Ran `pytest -q backend/tests/test_slack_connector_actions.py` and all tests passed (`9 passed`).
- Verified diffs and adjusted messenger flows to avoid returning detached ORM instances; no automated tests failed in the exercised subset.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cea9d04e2c8321a413182a423ad47a)