### PR TITLE
Fix detached Integration access in Google Drive connector

### DIFF
--- a/backend/connectors/google_drive.py
+++ b/backend/connectors/google_drive.py
@@ -491,6 +491,18 @@ Call via `run_on_connector(connector='google_drive', action='edit_file', params=
         super().__init__(
             organization_id, user_id=user_id, sync_since_override=sync_since_override
         )
+        self._integration_last_sync_at: datetime | None = None
+        self._nango_connection_id: str | None = None
+
+
+    @property
+    def sync_since(self) -> datetime | None:
+        """Return incremental sync cutoff without relying on an attached ORM instance."""
+        if self._sync_since_override is not None:
+            return self._sync_since_override
+        if self._integration_last_sync_at is not None:
+            return self._integration_last_sync_at - self._SYNC_SINCE_BUFFER
+        return None
 
     # -------------------------------------------------------------------------
     # OAuth – overrides BaseConnector to handle legacy connection-id format
@@ -504,25 +516,28 @@ Call via `run_on_connector(connector='google_drive', action='edit_file', params=
         async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
             connection_id: str = f"{self.organization_id}:user:{self.user_id}"
             result = await session.execute(
-                select(Integration).where(
+                select(Integration.nango_connection_id, Integration.last_sync_at).where(
                     Integration.organization_id == UUID(self.organization_id),
                     Integration.connector == "google_drive",
                     Integration.user_id == UUID(self.user_id),
                 )
             )
-            self._integration = result.scalar_one_or_none()
+            integration_row = result.one_or_none()
 
-            if not self._integration:
+            if integration_row is None:
                 raise ValueError(
                     "Google Drive integration not found. Please connect first."
                 )
+
+            self._nango_connection_id = integration_row.nango_connection_id
+            self._integration_last_sync_at = integration_row.last_sync_at
 
         nango = get_nango_client()
         nango_integration_id: str = get_nango_integration_id("google_drive")
 
         self._token = await nango.get_token(
             nango_integration_id,
-            self._integration.nango_connection_id or connection_id,
+            self._nango_connection_id or connection_id,
         )
         return self._token, ""
 


### PR DESCRIPTION
### Motivation
- Background syncs could raise "Instance <Integration ...> is not bound to a Session; attribute refresh operation cannot proceed" when `sync_since` accessed `self._integration.last_sync_at` after the DB session closed. 
- The connector should not retain a session-bound ORM object across an async session boundary to prevent detached-session attribute refreshes.

### Description
- Stop storing a session-bound `Integration` ORM instance in `GoogleDriveConnector.get_oauth_token` and instead select only `Integration.nango_connection_id` and `Integration.last_sync_at` from the DB. 
- Cache the selected scalars on the connector as `self._nango_connection_id` and `self._integration_last_sync_at` to be used after the session closes. 
- Add a `GoogleDriveConnector.sync_since` override that computes the incremental cutoff from `self._integration_last_sync_at` (or `self._sync_since_override`) to avoid touching a detached ORM object. 
- Use the cached `self._nango_connection_id` when requesting a token from Nango instead of `self._integration.nango_connection_id`.

### Testing
- Compiled the modified module with `python -m py_compile backend/connectors/google_drive.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cebad2c6a083218c1b286e52352651)