### PR TITLE
Handle non-streaming chat turn exceptions gracefully

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -1120,8 +1120,19 @@ async def send_message(
 
         # Collect all chunks into a single response
         response_content = ""
-        async for chunk in orchestrator.process_message(request.content):
-            response_content += chunk
+        try:
+            async for chunk in orchestrator.process_message(request.content):
+                response_content += chunk
+        except Exception as exc:
+            logger.exception(
+                "send_message turn processing failed conversation_id=%s user_id=%s",
+                conv_uuid,
+                auth.user_id,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to process message: {exc}",
+            ) from exc
 
         # Get the message IDs from the database
         result = await session.execute(


### PR DESCRIPTION
### Motivation
- Ensure the non-streaming `POST /api/chat/message` endpoint returns a controlled error payload instead of allowing unexpected exceptions from turn processing to bubble up.

### Description
- Wrapped the `ChatOrchestrator.process_message(...)` loop in `backend/api/routes/chat.py` with a `try/except` that logs conversation and user identifiers and raises an `HTTPException(500)` with a clear detail when processing fails.

### Testing
- Ran `python -m py_compile backend/api/routes/chat.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d59d477efc83219039f6c3bf833f7a)