### PR TITLE
Fix private chat RLS context for message writes

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -130,6 +130,7 @@ async def update_tool_result(
     result: dict[str, Any],
     status: str = "running",
     organization_id: str | None = None,
+    user_id: str | None = None,
 ) -> bool:
     """
     Update a tool call's result in an existing conversation message.
@@ -143,6 +144,7 @@ async def update_tool_result(
         result: The new result dict (can be partial progress or final)
         status: "running" for progress updates, "complete" when done
         organization_id: Organization ID for RLS context
+        user_id: User ID for RLS visibility context
         
     Returns:
         True if update succeeded, False otherwise
@@ -154,7 +156,7 @@ async def update_tool_result(
         status,
     )
     try:
-        async with get_session(organization_id=organization_id) as session:
+        async with get_session(organization_id=organization_id, user_id=user_id) as session:
             # Find the latest assistant message in this conversation
             query = (
                 select(ChatMessage)
@@ -538,7 +540,7 @@ class ChatOrchestrator:
         from models.user import User
 
         try:
-            async with get_session(organization_id=self.organization_id) as session:
+            async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
                 if self.user_id and (not self.user_name or not self.user_email):
                     result = await session.execute(
                         select(
@@ -584,7 +586,7 @@ class ChatOrchestrator:
         from models.integration import Integration
 
         try:
-            async with get_session(organization_id=self.organization_id) as session:
+            async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
                 result = await session.execute(
                     select(
                         Integration.connector,
@@ -710,7 +712,7 @@ class ChatOrchestrator:
         }
 
         try:
-            async with get_session(organization_id=self.organization_id) as session:
+            async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
                 # Load all memories for this org in one query, then split by entity_type
                 result = await session.execute(
                     select(Memory)
@@ -852,7 +854,7 @@ class ChatOrchestrator:
         from models.workflow import WorkflowRun
 
         try:
-            async with get_session(organization_id=self.organization_id) as session:
+            async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
                 result = await session.execute(
                     select(WorkflowRun.workflow_notes)
                     .where(WorkflowRun.workflow_id == UUID(workflow_id))
@@ -894,7 +896,7 @@ class ChatOrchestrator:
             return []
 
         try:
-            async with get_session(organization_id=self.organization_id) as session:
+            async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
                 query = (
                     select(Conversation)
                     .where(Conversation.organization_id == UUID(self.organization_id))
@@ -996,7 +998,7 @@ class ChatOrchestrator:
             conv_uuid = UUID(self.conversation_id) if self.conversation_id else None
             org_uuid = UUID(self.organization_id) if self.organization_id else None
             if conv_uuid and org_uuid:
-                async with get_session(organization_id=self.organization_id) as session:
+                async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
                     for aid in attachment_ids:
                         sf: StoredFile | None = retrieve_file(aid)
                         if sf is not None:
@@ -1613,6 +1615,8 @@ class ChatOrchestrator:
                     per_tool_ctx.update(self.workflow_context)
                 if self.conversation_id:
                     per_tool_ctx["conversation_id"] = self.conversation_id
+                if self.user_id:
+                    per_tool_ctx["user_id"] = self.user_id
                 if self._current_message_id:
                     per_tool_ctx["message_id"] = str(self._current_message_id)
                 per_tool_ctx["tool_id"] = tool_use["id"]
@@ -1802,7 +1806,7 @@ class ChatOrchestrator:
             user_uuid: UUID | None = UUID(self.user_id) if self.user_id else None
             org_uuid: UUID | None = UUID(self.organization_id) if self.organization_id else None
 
-            async with get_session(organization_id=self.organization_id) as session:
+            async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
                 session.add(
                     ChatMessage(
                         id=message_id,
@@ -1823,14 +1827,21 @@ class ChatOrchestrator:
     ) -> None:
         """Fire-and-forget wrapper for update_tool_result. Logs errors instead of raising."""
         try:
-            await update_tool_result(conversation_id, tool_id, result, "complete", org_id)
+            await update_tool_result(
+                conversation_id=conversation_id,
+                tool_id=tool_id,
+                result=result,
+                status="complete",
+                organization_id=org_id,
+                user_id=self.user_id,
+            )
         except Exception as e:
             logger.warning("[Orchestrator] Background tool result save failed: %s", e)
 
     async def _create_conversation(self) -> str:
         """Create a new conversation and return its ID."""
         user_uuid = UUID(self.user_id) if self.user_id else None
-        async with get_session(organization_id=self.organization_id) as session:
+        async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
             conversation = Conversation(
                 user_id=user_uuid,
                 organization_id=UUID(self.organization_id) if self.organization_id else None,
@@ -1853,7 +1864,7 @@ class ChatOrchestrator:
         if not self.conversation_id:
             return []
 
-        async with get_session(organization_id=self.organization_id) as session:
+        async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
             result = await session.execute(
                 select(ChatMessage)
                 .where(ChatMessage.conversation_id == UUID(self.conversation_id))
@@ -2060,7 +2071,7 @@ class ChatOrchestrator:
         blocks.append({"type": "text", "text": user_msg})
 
         message_id: UUID = pre_generated_message_id if pre_generated_message_id is not None else uuid4()
-        async with get_session(organization_id=self.organization_id) as session:
+        async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
             message = ChatMessage(
                 id=message_id,
                 conversation_id=conv_uuid,
@@ -2158,7 +2169,7 @@ class ChatOrchestrator:
             conv_uuid,
         )
 
-        async with get_session(organization_id=self.organization_id) as session:
+        async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
             if self._assistant_message_saved and self._current_message_id is not None:
                 # UPDATE the specific message we inserted during the early save.
                 # Using the exact ID avoids the old bug where "find latest assistant
@@ -2235,7 +2246,7 @@ class ChatOrchestrator:
         if not self.conversation_id:
             return
 
-        async with get_session(organization_id=self.organization_id) as session:
+        async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
             await session.execute(
                 update(Conversation)
                 .where(Conversation.id == UUID(self.conversation_id))

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -150,6 +150,7 @@ class ToolProgressUpdater:
     ) -> None:
         self.conversation_id: str | None = context.get("conversation_id") if context else None
         self.tool_id: str | None = context.get("tool_id") if context else None
+        self.user_id: str | None = context.get("user_id") if context else None
         self.organization_id = organization_id
         
     @property
@@ -180,6 +181,7 @@ class ToolProgressUpdater:
             result,
             status,
             self.organization_id,
+            self.user_id,
         )
 
 

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -59,6 +59,7 @@ class TaskManager:
         
         # Organization ID per task (for RLS context)
         self._task_org_ids: dict[str, str] = {}
+        self._task_user_ids: dict[str, str] = {}
         
         # WebSocket subscriptions: task_id -> set of websockets
         self._subscriptions: dict[str, set[WebSocket]] = {}
@@ -157,7 +158,7 @@ class TaskManager:
         task_id = str(uuid4())
         
         # Create database record (with RLS context)
-        async with get_session(organization_id=organization_id) as session:
+        async with get_session(organization_id=organization_id, user_id=user_id) as session:
             agent_task = AgentTask(
                 id=UUID(task_id),
                 conversation_id=UUID(conversation_id),
@@ -193,6 +194,7 @@ class TaskManager:
         
         self._running_tasks[task_id] = asyncio_task
         self._task_org_ids[task_id] = organization_id
+        self._task_user_ids[task_id] = user_id
         
         return task_id
     
@@ -318,6 +320,7 @@ class TaskManager:
             # Clean up
             self._running_tasks.pop(task_id, None)
             self._task_org_ids.pop(task_id, None)
+            self._task_user_ids.pop(task_id, None)
     
     async def _append_chunk_safe(self, task_id: str, chunk: dict[str, Any]) -> None:
         """Fire-and-forget wrapper for _append_chunk that logs errors instead of raising."""
@@ -329,7 +332,8 @@ class TaskManager:
     async def _append_chunk(self, task_id: str, chunk: dict[str, Any]) -> None:
         """Append a chunk to the task's output_chunks in the database."""
         org_id = self._task_org_ids.get(task_id)
-        async with get_session(organization_id=org_id) as session:
+        user_id = self._task_user_ids.get(task_id)
+        async with get_session(organization_id=org_id, user_id=user_id) as session:
             # Use raw SQL for atomic append to JSONB array
             await session.execute(
                 update(AgentTask)
@@ -349,7 +353,8 @@ class TaskManager:
     ) -> None:
         """Mark a task as completed/failed/cancelled in the database."""
         org_id = self._task_org_ids.get(task_id)
-        async with get_session(organization_id=org_id) as session:
+        user_id = self._task_user_ids.get(task_id)
+        async with get_session(organization_id=org_id, user_id=user_id) as session:
             values: dict[str, Any] = {
                 "status": status,
                 "completed_at": datetime.utcnow(),
@@ -375,7 +380,7 @@ class TaskManager:
         try:
             from api.websockets import broadcast_conversation_message
 
-            async with get_session(organization_id=organization_id) as session:
+            async with get_session(organization_id=organization_id, user_id=exclude_user_id) as session:
                 conv_row = await session.execute(
                     select(Conversation.scope, Conversation.participating_user_ids).where(
                         Conversation.id == UUID(conversation_id)
@@ -387,7 +392,7 @@ class TaskManager:
             scope: str = row[0]
             participant_ids: list[str] = [str(uid) for uid in row[1]]
 
-            async with get_session(organization_id=organization_id) as session:
+            async with get_session(organization_id=organization_id, user_id=exclude_user_id) as session:
                 msg_result = await session.execute(
                     select(ChatMessage)
                     .where(
@@ -526,7 +531,7 @@ class TaskManager:
         Returns:
             List of task state dictionaries
         """
-        async with get_session(organization_id=organization_id) as session:
+        async with get_session(organization_id=organization_id, user_id=user_id) as session:
             result = await session.execute(
                 select(AgentTask)
                 .join(Conversation, AgentTask.conversation_id == Conversation.id)
@@ -558,7 +563,8 @@ class TaskManager:
         """
         # Use cached org_id if not provided
         org_id = organization_id or self._task_org_ids.get(task_id)
-        async with get_session(organization_id=org_id) as session:
+        user_id = self._task_user_ids.get(task_id)
+        async with get_session(organization_id=org_id, user_id=user_id) as session:
             task = await session.get(AgentTask, UUID(task_id))
             if task:
                 return task.to_state_dict()
@@ -585,7 +591,8 @@ class TaskManager:
         """
         # Use cached org_id if not provided
         org_id = organization_id or self._task_org_ids.get(task_id)
-        async with get_session(organization_id=org_id) as session:
+        user_id = self._task_user_ids.get(task_id)
+        async with get_session(organization_id=org_id, user_id=user_id) as session:
             task = await session.get(AgentTask, UUID(task_id))
             if not task or not task.output_chunks:
                 return []
@@ -634,6 +641,7 @@ class TaskManager:
                         asyncio_task.cancel()
                     self._running_tasks.pop(task_id_str, None)
                     self._task_org_ids.pop(task_id_str, None)
+                    self._task_user_ids.pop(task_id_str, None)
                     await self._broadcast(
                         task_id_str,
                         {


### PR DESCRIPTION
### Motivation
- Private-chat writes and updates were failing RLS checks because DB sessions set only `app.current_org_id` and not `app.current_user_id`, causing row-level security violations on `chat_messages` and related reads/writes.

### Description
- Propagate `user_id` into orchestrator DB sessions by calling `get_session(..., user_id=...)` across chat read/write paths in `backend/agents/orchestrator.py` so `app.current_user_id` is set for visibility policies.
- Extend `update_tool_result(...)` to accept a `user_id` parameter and thread that user context through progress update callsites so tool-progress updates use the same RLS visibility context.
- Include `user_id` in per-tool execution context so tools and their progress updates in private chats can correctly update assistant messages (`backend/agents/orchestrator.py`).
- Track the task-level `user_id` in `TaskManager` and use it for subsequent DB session operations, chunk persistence, task completion, and participant broadcast lookups (`backend/services/task_manager.py`).
- Update `ToolProgressUpdater` to carry `user_id` from tool context and pass it into `update_tool_result` (`backend/agents/tools.py`).

### Testing
- Ran static compile check with `python -m py_compile backend/agents/orchestrator.py backend/agents/tools.py backend/services/task_manager.py` which succeeded.
- Ran unit tests `pytest -q backend/tests/test_tool_progress_dedup.py` which passed (2 tests, 2 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d59f03237483218bfa8997fe37224f)