### PR TITLE
Handle duplicate users when matching by email to avoid Slack background crash

### DIFF
--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -314,7 +314,12 @@ class WorkspaceMessenger(BaseMessenger):
         organization_id: str,
         email: str,
     ) -> User | None:
-        """Find an org user whose email matches."""
+        """Find an org user whose email matches.
+
+        Historical data can contain duplicate email rows (for example a guest
+        plus a member record), so this method resolves deterministically instead
+        of using ``scalar_one_or_none()``.
+        """
         async with get_admin_session() as session:
             org_uuid: UUID = UUID(organization_id)
             membership_subq = (
@@ -334,8 +339,20 @@ class WorkspaceMessenger(BaseMessenger):
                     )
                 )
                 .where(User.email == email)
+                .order_by(User.is_guest.asc(), User.id.asc())
+                .limit(2)
             )
-            return result.scalar_one_or_none()
+            matched_users: list[User] = list(result.scalars().all())
+            if len(matched_users) > 1:
+                logger.warning(
+                    "[%s] Multiple users matched email=%s org=%s; choosing user=%s and ignoring %d additional match(es)",
+                    self.meta.slug,
+                    email,
+                    organization_id,
+                    matched_users[0].id,
+                    len(matched_users) - 1,
+                )
+            return matched_users[0] if matched_users else None
 
     async def _resolve_guest_user(self, organization_id: str) -> User | None:
         """Fall back to the org's guest user if configured."""

--- a/backend/tests/test_workspace_email_match.py
+++ b/backend/tests/test_workspace_email_match.py
@@ -1,0 +1,91 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID
+
+from messengers._workspace import WorkspaceMessenger
+from messengers.base import MessengerMeta, ResponseMode
+
+
+class _TestWorkspaceMessenger(WorkspaceMessenger):
+    meta = MessengerMeta(name="Test", slug="test", response_mode=ResponseMode.STREAMING)
+
+    async def resolve_organization(self, user, message):  # type: ignore[override]
+        raise NotImplementedError
+
+    async def find_or_create_conversation(self, organization_id, user, message):  # type: ignore[override]
+        raise NotImplementedError
+
+    async def download_attachments(self, message):  # type: ignore[override]
+        raise NotImplementedError
+
+    def format_text(self, markdown: str) -> str:
+        return markdown
+
+    async def post_message(
+        self,
+        channel_id: str,
+        text: str,
+        thread_id: str | None = None,
+        *,
+        workspace_id: str | None = None,
+        organization_id: str | None = None,
+    ) -> str | None:
+        raise NotImplementedError
+
+
+class _FakeScalarResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeExecuteResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return _FakeScalarResult(self._rows)
+
+
+class _FakeSession:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def execute(self, _query):
+        return _FakeExecuteResult(self._rows)
+
+
+class _FakeAdminSessionContext:
+    def __init__(self, rows):
+        self._session = _FakeSession(rows)
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_match_user_by_email_handles_duplicate_rows_without_error(monkeypatch):
+    org_id = "11111111-1111-1111-1111-111111111111"
+    member_user = SimpleNamespace(
+        id=UUID("22222222-2222-2222-2222-222222222222"),
+        is_guest=False,
+    )
+    guest_user = SimpleNamespace(
+        id=UUID("33333333-3333-3333-3333-333333333333"),
+        is_guest=True,
+    )
+
+    monkeypatch.setattr(
+        "messengers._workspace.get_admin_session",
+        lambda: _FakeAdminSessionContext([member_user, guest_user]),
+    )
+
+    messenger = _TestWorkspaceMessenger()
+    resolved = asyncio.run(messenger._match_user_by_email(org_id, "person@example.com"))
+
+    assert resolved is not None
+    assert resolved.id == member_user.id


### PR DESCRIPTION
### Motivation
- Prevent background Slack event processing from crashing with `Multiple rows were found when one or none was required` when historical data contains duplicate user rows for the same org+email.

### Description
- Replace `scalar_one_or_none()` in `WorkspaceMessenger._match_user_by_email` with a deterministic selection that orders results and limits the query to `limit(2)`, then returns the first match.
- Order results by `User.is_guest.asc(), User.id.asc()` so non-guest (member) rows are preferred when duplicates exist.
- Add a warning log when multiple matches are found so data-quality issues are visible without breaking processing.
- Add a unit test `tests/test_workspace_email_match.py` that simulates duplicate rows (member + guest) and asserts the member row is chosen.

### Testing
- Ran `cd backend && pytest -q tests/test_workspace_email_match.py tests/test_slack_events_thread_locking.py` and observed all tests pass (5 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5a97296388321a31dd7502b508ee8)