### PR TITLE
Fix Slack event duplicate conversation lookup failures

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -326,10 +326,16 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
                 "[slack_events] Processing direct message type=%s from %s in %s thread=%s: %s (files=%d)",
                 channel_type, user_id, channel_id, thread_ts, text[:50], len(files),
             )
-            message = _build_inbound_message(
-                event, team_id, MessageType.DIRECT, bot_user_ids=bot_user_ids,
+            lock_key: str = SlackThreadLockManager.build_lock_key(
+                team_id,
+                channel_id,
+                thread_ts,
             )
-            await messenger.process_inbound(message)
+            async with _thread_lock_manager.thread_lock(lock_key):
+                message = _build_inbound_message(
+                    event, team_id, MessageType.DIRECT, bot_user_ids=bot_user_ids,
+                )
+                await messenger.process_inbound(message)
             return
 
         thread_ts = event.get("thread_ts")

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -571,8 +571,19 @@ class WorkspaceMessenger(BaseMessenger):
                 .where(Conversation.organization_id == UUID(organization_id))
                 .where(Conversation.source == source)
                 .where(Conversation.source_channel_id == source_channel_id)
+                .order_by(Conversation.updated_at.desc(), Conversation.id.desc())
+                .limit(2)
             )
-            conversation: Conversation | None = result.scalar_one_or_none()
+            conversations: list[Conversation] = list(result.scalars().all())
+            if len(conversations) > 1:
+                logger.warning(
+                    "[%s] Multiple conversations found for org=%s source_channel_id=%s ids=%s; using latest",
+                    source,
+                    organization_id,
+                    source_channel_id,
+                    [str(conv.id) for conv in conversations],
+                )
+            conversation: Conversation | None = conversations[0] if conversations else None
 
             if conversation is not None:
                 changed: bool = False


### PR DESCRIPTION
### Motivation

- Background Slack event processing could race when handling direct messages, creating duplicate `conversations` rows and triggering `MultipleResultsFound` from `scalar_one_or_none()` during lookups. 
- The change prevents intermittent failures observed as `Background processing failed: Multiple rows were found when one or none was required` by avoiding the race and making lookups tolerant of historical duplicates.

### Description

- Serialize Slack direct-message handling by acquiring the existing per-thread lock (`SlackThreadLockManager.thread_lock`) before building and processing the `InboundMessage` so concurrent DM events for the same channel/thread cannot race conversation creation. 
- Harden `WorkspaceMessenger.find_or_create_conversation` to select deterministically when duplicates already exist by adding `order_by(Conversation.updated_at.desc(), Conversation.id.desc()).limit(2)` and choosing the latest row; when multiple rows are found a warning is logged and the latest is used instead of raising. 
- Add a clear warning log to surface duplicate conversation IDs when this fallback is exercised to aid future debugging.

### Testing

- Ran `pytest -q backend/tests/test_slack_events_thread_locking.py backend/tests/test_slack_events_direct_messages.py`. 
- All tests passed: `6 passed` (completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5afb7e844832182912213e2342627)