### PR TITLE
Fix DetachedInstanceError in widgets listing endpoint

### DIFF
--- a/backend/api/routes/apps.py
+++ b/backend/api/routes/apps.py
@@ -473,9 +473,8 @@ async def list_widgets(
             .order_by(App.updated_at.desc().nullslast())
         )
         apps = list(result.scalars().all())
-
-    return {
-        "widgets": [
+        # Build response inside the session context to avoid DetachedInstanceError
+        widgets = [
             {
                 "id": str(a.id),
                 "title": a.title,
@@ -483,7 +482,8 @@ async def list_widgets(
             }
             for a in apps
         ]
-    }
+
+    return {"widgets": widgets}
 
 
 @router.get("/widgets/{app_id}/screenshot")


### PR DESCRIPTION
### Motivation
- Prevent `sqlalchemy.orm.exc.DetachedInstanceError` when serializing `App` ORM objects by ensuring attributes are accessed while the DB session is still active.

### Description
- Build the widgets response inside the `get_session` context in `backend/api/routes/apps.py` so `App` fields are read before the SQLAlchemy session is torn down, preserving the existing query, ordering, and response shape.

### Testing
- Ran `python -m compileall backend/api/routes/apps.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5cb06cb888321bd902985f57103d3)