### PR TITLE
Fix private conversation creation RLS failures in websocket chat

### DIFF
--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -761,7 +761,10 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                     if conv_scope not in ("private", "shared"):
                         conv_scope = "shared"
                     
-                    async with get_session(organization_id=organization_id) as session:
+                    async with get_session(
+                        organization_id=organization_id,
+                        user_id=user_id_str,
+                    ) as session:
                         conversation = Conversation(
                             id=conv_uuid,
                             user_id=UUID(user_id_str),
@@ -810,7 +813,10 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                         attachment_ids=attachment_ids,
                         sender_email=user_email,
                     )
-                    async with get_session(organization_id=organization_id) as session:
+                    async with get_session(
+                        organization_id=organization_id,
+                        user_id=user_id_str,
+                    ) as session:
                         conv_row = await session.execute(
                             select(Conversation.participating_user_ids).where(
                                 Conversation.id == UUID(conversation_id)


### PR DESCRIPTION
### Motivation
- Fix an `InsufficientPrivilegeError` when creating `scope="private"` conversations over WebSocket caused by RLS policy `124_convo_msg_visibility` requiring `app.current_user_id` to be set during inserts.

### Description
- Pass `user_id` into `get_session(...)` calls in `backend/api/websockets.py` (used when creating a new conversation and when looking up participating users for mention notifications) so `app.current_user_id` is populated for RLS `WITH CHECK` enforcement.

### Testing
- Ran `python -m py_compile backend/api/websockets.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5cb9c8e1c8321a12c126190f4b7eb)