### PR TITLE
Increase query outcome window to 30 minutes and treat empty window as 100% success

### DIFF
--- a/backend/api/routes/admin_dashboard.py
+++ b/backend/api/routes/admin_dashboard.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 async def get_query_outcome_rate(
     auth: AuthContext = Depends(require_global_admin),
 ) -> dict[str, float | int]:
-    """Return rolling query success/failure counts for the last 15 minutes."""
+    """Return rolling query success/failure counts for the last 30 minutes."""
     return await get_query_outcome_window_stats()
 
 

--- a/backend/services/query_outcome_metrics.py
+++ b/backend/services/query_outcome_metrics.py
@@ -10,13 +10,13 @@ from config import get_redis_connection_kwargs, settings
 
 logger = logging.getLogger(__name__)
 
-_WINDOW_SECONDS = 15 * 60
+_WINDOW_SECONDS = 30 * 60
 _SUCCESS_KEY = "monitoring:query_outcomes:success"
 _FAILURE_KEY = "monitoring:query_outcomes:failure"
 
 
 async def get_query_outcome_window_stats() -> dict[str, float | int]:
-    """Return rolling 15-minute query outcome stats from Redis."""
+    """Return rolling 30-minute query outcome stats from Redis."""
     timestamp = int(time.time())
     window_start = timestamp - _WINDOW_SECONDS
     redis_client = aioredis.from_url(
@@ -35,7 +35,7 @@ async def get_query_outcome_window_stats() -> dict[str, float | int]:
     success_total = int(success_count or 0)
     failure_total = int(failure_count or 0)
     total = success_total + failure_total
-    success_pct = ((success_total / total) * 100.0) if total else 0.0
+    success_pct = ((success_total / total) * 100.0) if total else 100.0
     return {
         "window_seconds": _WINDOW_SECONDS,
         "success_count": success_total,
@@ -46,7 +46,7 @@ async def get_query_outcome_window_stats() -> dict[str, float | int]:
 
 
 async def record_query_outcome(*, platform: str, was_success: bool) -> None:
-    """Record one query outcome and maintain a rolling 15-minute success pct."""
+    """Record one query outcome and maintain a rolling 30-minute success pct."""
     timestamp = int(time.time())
     score = float(timestamp)
     bucket_key = _SUCCESS_KEY if was_success else _FAILURE_KEY

--- a/backend/tests/test_query_outcome_metrics.py
+++ b/backend/tests/test_query_outcome_metrics.py
@@ -62,8 +62,43 @@ def test_get_query_outcome_window_stats() -> None:
     finally:
         query_outcome_metrics.aioredis.from_url = original_from_url
 
-    assert stats["window_seconds"] == 900
+    assert stats["window_seconds"] == 1800
     assert stats["success_count"] == 9
     assert stats["failure_count"] == 1
     assert stats["total_count"] == 10
     assert stats["success_rate_pct"] == 90.0
+
+
+def test_get_query_outcome_window_stats_defaults_to_full_success_for_empty_window() -> None:
+    class _FakePipeline:
+        def zremrangebyscore(self, *_args, **_kwargs) -> None:
+            return None
+
+        def zcard(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def execute(self) -> list[int]:
+            return [0, 0, 0, 0]
+
+    class _FakeRedis:
+        def pipeline(self) -> _FakePipeline:
+            return _FakePipeline()
+
+        async def __aenter__(self) -> "_FakeRedis":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    original_from_url = query_outcome_metrics.aioredis.from_url
+    query_outcome_metrics.aioredis.from_url = lambda *_args, **_kwargs: _FakeRedis()
+    try:
+        stats = asyncio.run(query_outcome_metrics.get_query_outcome_window_stats())
+    finally:
+        query_outcome_metrics.aioredis.from_url = original_from_url
+
+    assert stats["window_seconds"] == 1800
+    assert stats["success_count"] == 0
+    assert stats["failure_count"] == 0
+    assert stats["total_count"] == 0
+    assert stats["success_rate_pct"] == 100.0

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -2227,7 +2227,7 @@ export function AdminPanel(): JSX.Element {
           <div className="space-y-6">
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
               <div className="rounded-xl border border-surface-800 bg-surface-900 p-4">
-                <div className="text-xs uppercase tracking-wide text-surface-500">Rolling success rate (15m)</div>
+                <div className="text-xs uppercase tracking-wide text-surface-500">Rolling success rate (30m)</div>
                 <div className="mt-2 text-2xl font-semibold text-surface-100">
                   {queryOutcomeRateLoading ? '…' : `${(queryOutcomeRate?.success_rate_pct ?? 0).toFixed(1)}%`}
                 </div>
@@ -2245,7 +2245,7 @@ export function AdminPanel(): JSX.Element {
                 </div>
               </div>
               <div className="rounded-xl border border-surface-800 bg-surface-900 p-4">
-                <div className="text-xs uppercase tracking-wide text-surface-500">Total queries (15m)</div>
+                <div className="text-xs uppercase tracking-wide text-surface-500">Total queries (30m)</div>
                 <div className="mt-2 text-2xl font-semibold text-surface-100">
                   {queryOutcomeRateLoading ? '…' : (queryOutcomeRate?.total_count ?? 0).toLocaleString()}
                 </div>


### PR DESCRIPTION
### Motivation
- Make rolling query outcome metrics less noisy by lengthening the monitoring window from 15 minutes to 30 minutes.
- Avoid misleading 0% success when there are no queries in the window by treating an empty window as fully successful.
- Keep the admin UI and API documentation consistent with the updated window semantics.

### Description
- Updated `_WINDOW_SECONDS` from `15 * 60` to `30 * 60` in `backend/services/query_outcome_metrics.py` and adjusted related docstrings and expiry usage accordingly.
- Changed the success-rate calculation in `get_query_outcome_window_stats()` to return `100.0` when `total == 0` instead of `0.0` to treat zero queries as 100% success.
- Updated the admin dashboard API docstring in `backend/api/routes/admin_dashboard.py` and the UI labels in `frontend/src/components/AdminPanel.tsx` from `(15m)` to `(30m)` to reflect the new window.
- Updated tests in `backend/tests/test_query_outcome_metrics.py` to expect `window_seconds == 1800` and added a new test `test_get_query_outcome_window_stats_defaults_to_full_success_for_empty_window()` that validates the empty-window behavior.

### Testing
- Ran `pytest -q backend/tests/test_query_outcome_metrics.py`, and all tests passed (`4 passed`).
- The added unit test verifies that an empty Redis window yields `success_rate_pct == 100.0` and the existing test was updated to assert the new `window_seconds == 1800`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5d38d816c83219db0eaf997fa1563)