### PR TITLE
Add throttled PagerDuty incident for low rolling query success

### DIFF
--- a/backend/services/query_outcome_metrics.py
+++ b/backend/services/query_outcome_metrics.py
@@ -7,12 +7,16 @@ import time
 import redis.asyncio as aioredis
 
 from config import get_redis_connection_kwargs, settings
+from services.incident_throttling import clear_incident_failure, evaluate_incident_creation
+from services.pagerduty import create_pagerduty_incident
 
 logger = logging.getLogger(__name__)
 
 _WINDOW_SECONDS = 30 * 60
 _SUCCESS_KEY = "monitoring:query_outcomes:success"
 _FAILURE_KEY = "monitoring:query_outcomes:failure"
+_QUERY_SUCCESS_CHECK_NAME = "Rolling Query Success"
+_QUERY_SUCCESS_INCIDENT_THRESHOLD_PCT = 25.0
 
 
 async def get_query_outcome_window_stats() -> dict[str, float | int]:
@@ -74,4 +78,48 @@ async def record_query_outcome(*, platform: str, was_success: bool) -> None:
         stats["success_count"],
         stats["failure_count"],
         stats["success_rate_pct"],
+    )
+    await _maybe_raise_query_success_incident(platform=platform, stats=stats)
+
+
+async def _maybe_raise_query_success_incident(
+    *,
+    platform: str,
+    stats: dict[str, float | int],
+) -> None:
+    """Raise/suppress incident when rolling success percentage crosses threshold."""
+    success_rate_pct = float(stats["success_rate_pct"])
+    if success_rate_pct > _QUERY_SUCCESS_INCIDENT_THRESHOLD_PCT:
+        logger.info(
+            "Rolling query success recovered platform=%s success_pct=%.2f threshold_pct=%.2f",
+            platform,
+            success_rate_pct,
+            _QUERY_SUCCESS_INCIDENT_THRESHOLD_PCT,
+        )
+        await clear_incident_failure(_QUERY_SUCCESS_CHECK_NAME)
+        return
+
+    should_create, reason = await evaluate_incident_creation(_QUERY_SUCCESS_CHECK_NAME)
+    logger.warning(
+        "Rolling query success degraded platform=%s success_pct=%.2f threshold_pct=%.2f "
+        "total_count=%s should_create_incident=%s reason=%s",
+        platform,
+        success_rate_pct,
+        _QUERY_SUCCESS_INCIDENT_THRESHOLD_PCT,
+        stats["total_count"],
+        should_create,
+        reason,
+    )
+    if not should_create:
+        return
+
+    await create_pagerduty_incident(
+        title="Rolling query success dropped to 25% or below",
+        details=(
+            f"Rolling 30-minute query success dropped to {success_rate_pct:.2f}% "
+            f"(threshold={_QUERY_SUCCESS_INCIDENT_THRESHOLD_PCT:.2f}%). "
+            f"platform={platform}, success_count={stats['success_count']}, "
+            f"failure_count={stats['failure_count']}, total_count={stats['total_count']}, "
+            f"incident_reason={reason}"
+        ),
     )

--- a/backend/tests/test_query_outcome_metrics.py
+++ b/backend/tests/test_query_outcome_metrics.py
@@ -102,3 +102,124 @@ def test_get_query_outcome_window_stats_defaults_to_full_success_for_empty_windo
     assert stats["failure_count"] == 0
     assert stats["total_count"] == 0
     assert stats["success_rate_pct"] == 100.0
+
+
+def test_record_query_outcome_raises_incident_when_success_rate_at_or_below_25(
+    monkeypatch,
+) -> None:
+    class _FakePipeline:
+        def __init__(self) -> None:
+            self._zcard_results = [1, 3]
+
+        def zadd(self, *_args, **_kwargs) -> None:
+            return None
+
+        def expire(self, *_args, **_kwargs) -> None:
+            return None
+
+        def zremrangebyscore(self, *_args, **_kwargs) -> None:
+            return None
+
+        def zcard(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def execute(self):
+            if self._zcard_results:
+                return [0, 0, self._zcard_results.pop(0), self._zcard_results.pop(0)]
+            return [1, True]
+
+    class _FakeRedis:
+        def pipeline(self) -> _FakePipeline:
+            return _FakePipeline()
+
+        async def __aenter__(self) -> "_FakeRedis":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    incidents: list[dict[str, str]] = []
+    evaluate_calls: list[str] = []
+    clear_calls: list[str] = []
+
+    async def _fake_evaluate(check_name: str) -> tuple[bool, str]:
+        evaluate_calls.append(check_name)
+        return True, "new_failure"
+
+    async def _fake_incident(*, title: str, details: str) -> bool:
+        incidents.append({"title": title, "details": details})
+        return True
+
+    async def _fake_clear(check_name: str) -> None:
+        clear_calls.append(check_name)
+
+    monkeypatch.setattr(query_outcome_metrics.aioredis, "from_url", lambda *_args, **_kwargs: _FakeRedis())
+    monkeypatch.setattr(query_outcome_metrics, "evaluate_incident_creation", _fake_evaluate)
+    monkeypatch.setattr(query_outcome_metrics, "create_pagerduty_incident", _fake_incident)
+    monkeypatch.setattr(query_outcome_metrics, "clear_incident_failure", _fake_clear)
+
+    asyncio.run(query_outcome_metrics.record_query_outcome(platform="slack", was_success=True))
+
+    assert evaluate_calls == ["Rolling Query Success"]
+    assert clear_calls == []
+    assert len(incidents) == 1
+    assert incidents[0]["title"] == "Rolling query success dropped to 25% or below"
+
+
+def test_record_query_outcome_clears_throttle_when_success_rate_recovers(monkeypatch) -> None:
+    class _FakePipeline:
+        def __init__(self) -> None:
+            self._zcard_results = [3, 1]
+
+        def zadd(self, *_args, **_kwargs) -> None:
+            return None
+
+        def expire(self, *_args, **_kwargs) -> None:
+            return None
+
+        def zremrangebyscore(self, *_args, **_kwargs) -> None:
+            return None
+
+        def zcard(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def execute(self):
+            if self._zcard_results:
+                return [0, 0, self._zcard_results.pop(0), self._zcard_results.pop(0)]
+            return [1, True]
+
+    class _FakeRedis:
+        def pipeline(self) -> _FakePipeline:
+            return _FakePipeline()
+
+        async def __aenter__(self) -> "_FakeRedis":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    evaluate_calls: list[str] = []
+    incident_calls: list[str] = []
+    clear_calls: list[str] = []
+
+    async def _fake_evaluate(check_name: str) -> tuple[bool, str]:
+        evaluate_calls.append(check_name)
+        return True, "new_failure"
+
+    async def _fake_incident(*, title: str, details: str) -> bool:
+        incident_calls.append(title)
+        return True
+
+    async def _fake_clear(check_name: str) -> None:
+        clear_calls.append(check_name)
+
+    monkeypatch.setattr(query_outcome_metrics.aioredis, "from_url", lambda *_args, **_kwargs: _FakeRedis())
+    monkeypatch.setattr(query_outcome_metrics, "evaluate_incident_creation", _fake_evaluate)
+    monkeypatch.setattr(query_outcome_metrics, "create_pagerduty_incident", _fake_incident)
+    monkeypatch.setattr(query_outcome_metrics, "clear_incident_failure", _fake_clear)
+
+    asyncio.run(query_outcome_metrics.record_query_outcome(platform="slack", was_success=True))
+
+    assert evaluate_calls == []
+    assert incident_calls == []
+    assert clear_calls == ["Rolling Query Success"]


### PR DESCRIPTION
### Motivation
- Raise an automated PagerDuty incident when the 30-minute rolling query success rate for messenger-originated turns falls to 25% or below. 
- Reuse the existing Redis-based incident throttling to avoid noisy repeats and allow a new incident at most once every 3 hours.

### Description
- Added imports and constants to `services/query_outcome_metrics.py` and wired in `clear_incident_failure`, `evaluate_incident_creation`, and `create_pagerduty_incident` to support throttled incidenting. 
- Implemented `_maybe_raise_query_success_incident` which logs degraded/recovered states, clears throttle on recovery, evaluates throttle on degradation, and triggers a PagerDuty incident when allowed. 
- Invoked the new check from `record_query_outcome` so every recorded outcome updates rolling stats and may raise/clear incidents. 
- Added unit tests in `backend/tests/test_query_outcome_metrics.py` covering incident creation when success rate is at-or-below 25% and throttle clearing on recovery.

### Testing
- Ran `pytest -q backend/tests/test_query_outcome_metrics.py` and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5d9512e948321bf360188733321dd)