### PR TITLE
Harden code sandbox package manager blocking

### DIFF
--- a/backend/connectors/code_sandbox.py
+++ b/backend/connectors/code_sandbox.py
@@ -27,20 +27,21 @@ _COMMAND_TIMEOUT_SECONDS: float = 120
 _MAX_OUTPUT_LENGTH: int = 50_000
 
 _PACKAGE_INSTALL_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"(^|[;&|()\s])npm\s+(?:install|i)\b", re.IGNORECASE), "npm install"),
+    (re.compile(r"(^|[;&|()\s])npm\b", re.IGNORECASE), "npm"),
     (re.compile(r"(^|[;&|()\s])yarn\s+(?:global\s+add|add|install)\b", re.IGNORECASE), "yarn add/install"),
     (re.compile(r"(^|[;&|()\s])pnpm\s+(?:add|install)\b", re.IGNORECASE), "pnpm add/install"),
     (re.compile(r"(^|[;&|()\s])bun\s+(?:add|install)\b", re.IGNORECASE), "bun add/install"),
-    (re.compile(r"(^|[;&|()\s])pip(?:3)?\s+install\b", re.IGNORECASE), "pip install"),
+    (re.compile(r"(^|[;&|()\s])pip(?:3)?\b", re.IGNORECASE), "pip"),
     (re.compile(r"(^|[;&|()\s])python(?:3)?\s+-m\s+pip\s+install\b", re.IGNORECASE), "python -m pip install"),
     (re.compile(r"(^|[;&|()\s])uv\s+(?:pip\s+install|add)\b", re.IGNORECASE), "uv pip install/add"),
     (re.compile(r"(^|[;&|()\s])poetry\s+(?:add|install)\b", re.IGNORECASE), "poetry add/install"),
     (re.compile(r"(^|[;&|()\s])pipx\s+install\b", re.IGNORECASE), "pipx install"),
-    (re.compile(r"(^|[;&|()\s])apt(?:-get)?\s+install\b", re.IGNORECASE), "apt install"),
+    (re.compile(r"(^|[;&|()\s])apt-get\b", re.IGNORECASE), "apt-get"),
+    (re.compile(r"(^|[;&|()\s])yum\b", re.IGNORECASE), "yum"),
+    (re.compile(r"(^|[;&|()\s])brew\b", re.IGNORECASE), "brew"),
+    (re.compile(r"(^|[;&|()\s])apt\s+install\b", re.IGNORECASE), "apt install"),
     (re.compile(r"(^|[;&|()\s])apk\s+add\b", re.IGNORECASE), "apk add"),
-    (re.compile(r"(^|[;&|()\s])yum\s+install\b", re.IGNORECASE), "yum install"),
     (re.compile(r"(^|[;&|()\s])dnf\s+install\b", re.IGNORECASE), "dnf install"),
-    (re.compile(r"(^|[;&|()\s])brew\s+install\b", re.IGNORECASE), "brew install"),
     (re.compile(r"(^|[;&|()\s])pacman\s+-S\b", re.IGNORECASE), "pacman -S"),
 )
 

--- a/backend/tests/test_code_sandbox_command_policy.py
+++ b/backend/tests/test_code_sandbox_command_policy.py
@@ -5,22 +5,27 @@ from connectors.code_sandbox import CodeSandboxConnector, get_blocked_package_in
 
 def test_get_blocked_package_install_reason_allows_non_install_commands() -> None:
     assert get_blocked_package_install_reason("python3 -c 'print(1)'") is None
-    assert get_blocked_package_install_reason("npm run build") is None
+    assert get_blocked_package_install_reason("node -e 'console.log(1)'") is None
 
 
 def test_get_blocked_package_install_reason_blocks_common_package_managers() -> None:
     commands = [
         "npm install lodash",
+        "npm run build",
         "yarn add react",
         "pnpm install zod",
         "bun add hono",
         "pip install pandas",
+        "pip --version",
         "python3 -m pip install numpy",
         "uv pip install polars",
         "poetry add requests",
         "apt-get install jq",
+        "apt-get update",
         "apk add curl",
+        "yum update -y",
         "brew install wget",
+        "brew update",
     ]
 
     for command in commands:
@@ -48,7 +53,7 @@ async def test_execute_action_rejects_package_install_before_sandbox_use() -> No
         "error": (
             "Installing packages inside the code sandbox is disabled. "
             "Use the preinstalled runtimes and libraries only. "
-            "Blocked command pattern: npm install."
+            "Blocked command pattern: npm."
         )
     }
 


### PR DESCRIPTION
### Motivation

- Prevent users from invoking package managers and privilege escalation inside the code sandbox by rejecting those commands before any sandbox is provisioned.  
- Enforce the project policy to disallow `pip`, `npm`, `apt-get`, `yum`, and `brew` usage in sandboxed commands while preserving existing behavior for other installers and the sudo block.

### Description

- Broadened the command-policy regexes in `backend/connectors/code_sandbox.py` to match direct invocations of `npm`, `pip`, `apt-get`, `yum`, and `brew` (not just their `install` subcommands) and kept existing rules for other package managers.  
- Added separate patterns for `apt-get`, `yum`, and `brew` and preserved `apt install`/other installers like `yarn`, `pnpm`, `bun`, `apk`, `dnf`, and `pacman`.  
- Updated tests in `backend/tests/test_code_sandbox_command_policy.py` to cover the newly-blocked forms (e.g. `npm run build`, `pip --version`, `apt-get update`, `yum update`, `brew update`) and adjusted the expected blocked-pattern label for `npm`.

### Testing

- Ran the focused test suite with `cd backend && pytest -q tests/test_code_sandbox_command_policy.py`, and all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5ddccf82c832185c35e9165a8ca3b)