### PR TITLE
Add failed-query reason visibility to global admin query metrics

### DIFF
--- a/backend/api/routes/admin_dashboard.py
+++ b/backend/api/routes/admin_dashboard.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 @router.get("/query-outcome-rate")
 async def get_query_outcome_rate(
     auth: AuthContext = Depends(require_global_admin),
-) -> dict[str, float | int]:
+) -> dict[str, Any]:
     """Return rolling query success/failure counts for the last 30 minutes."""
     return await get_query_outcome_window_stats()
 

--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -107,21 +107,27 @@ async def _get_slack_user_ids(
 async def _record_web_query_outcome(
     *,
     was_success: bool,
+    failure_reason: str | None,
     conversation_id: str | None,
     user_id: str,
 ) -> None:
     """Best-effort metric recording for web-app turns."""
-    from services.query_outcome_metrics import record_query_outcome
+    from services.query_outcome_metrics import normalize_failure_reason, record_query_outcome
 
     try:
-        await record_query_outcome(platform=_WEB_PLATFORM_SLUG, was_success=was_success)
+        await record_query_outcome(
+            platform=_WEB_PLATFORM_SLUG,
+            was_success=was_success,
+            failure_reason=normalize_failure_reason(failure_reason) if not was_success else None,
+        )
     except Exception:
         logger.exception(
-            "[chat] Failed to record query outcome platform=%s was_success=%s conversation_id=%s user_id=%s",
+            "[chat] Failed to record query outcome platform=%s was_success=%s conversation_id=%s user_id=%s failure_reason=%s",
             _WEB_PLATFORM_SLUG,
             was_success,
             conversation_id,
             user_id,
+            failure_reason,
         )
 
 
@@ -1143,11 +1149,13 @@ async def send_message(
         # Collect all chunks into a single response
         response_content = ""
         was_success = False
+        failure_reason: str | None = None
         try:
             async for chunk in orchestrator.process_message(request.content):
                 response_content += chunk
             was_success = True
         except Exception as exc:
+            failure_reason = str(exc)
             logger.exception(
                 "send_message turn processing failed conversation_id=%s user_id=%s",
                 conv_uuid,
@@ -1160,6 +1168,7 @@ async def send_message(
         finally:
             await _record_web_query_outcome(
                 was_success=was_success,
+                failure_reason=failure_reason,
                 conversation_id=str(conv_uuid) if conv_uuid else None,
                 user_id=auth.user_id_str,
             )

--- a/backend/messengers/base.py
+++ b/backend/messengers/base.py
@@ -396,17 +396,23 @@ class BaseMessenger(ABC):
         error: Exception | None,
     ) -> None:
         """Persist query success/failure for rolling monitoring windows."""
-        from services.query_outcome_metrics import record_query_outcome
+        from services.query_outcome_metrics import normalize_failure_reason, record_query_outcome
 
         was_success = self._is_successful_query_outcome(result=result, error=error)
+        failure_reason = self._derive_failed_query_reason(result=result, error=error)
         try:
-            await record_query_outcome(platform=self.meta.slug, was_success=was_success)
+            await record_query_outcome(
+                platform=self.meta.slug,
+                was_success=was_success,
+                failure_reason=normalize_failure_reason(failure_reason) if not was_success else None,
+            )
         except Exception:
             logger.exception(
-                "[%s] Failed to record query outcome was_success=%s result=%s",
+                "[%s] Failed to record query outcome was_success=%s result=%s failure_reason=%s",
                 self.meta.slug,
                 was_success,
                 result,
+                failure_reason,
             )
 
     @staticmethod
@@ -428,6 +434,26 @@ class BaseMessenger(ABC):
         if status == "error" and result.get("error") == "insufficient_credits":
             return True
         return False
+
+    @staticmethod
+    def _derive_failed_query_reason(
+        *,
+        result: dict[str, Any] | None,
+        error: Exception | None,
+    ) -> str | None:
+        """Extract a short reason describing why a query failed."""
+        if error is not None:
+            return str(error)
+        if not result:
+            return "empty_result"
+
+        if isinstance(result.get("error"), str) and result.get("error"):
+            return str(result["error"])
+        if isinstance(result.get("reason"), str) and result.get("reason"):
+            return str(result["reason"])
+        if isinstance(result.get("status"), str) and result.get("status"):
+            return str(result["status"])
+        return "unknown_error"
 
     # ------------------------------------------------------------------
     # Helpers

--- a/backend/services/query_outcome_metrics.py
+++ b/backend/services/query_outcome_metrics.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections import Counter
 
 import redis.asyncio as aioredis
 
@@ -15,8 +16,28 @@ logger = logging.getLogger(__name__)
 _WINDOW_SECONDS = 30 * 60
 _SUCCESS_KEY = "monitoring:query_outcomes:success"
 _FAILURE_KEY = "monitoring:query_outcomes:failure"
+_FAILURE_REASON_KEY = "monitoring:query_outcomes:failure_reasons"
 _QUERY_SUCCESS_CHECK_NAME = "Rolling Query Success"
 _QUERY_SUCCESS_INCIDENT_THRESHOLD_PCT = 25.0
+_MAX_REASON_LENGTH = 80
+_DEFAULT_FAILURE_REASON = "unknown_error"
+_MAX_REASON_RESULTS = 20
+
+
+def normalize_failure_reason(raw_reason: str | None) -> str:
+    """Normalize noisy error text to a short, dashboard-safe reason string."""
+    reason = (raw_reason or "").strip().lower()
+    if not reason:
+        return _DEFAULT_FAILURE_REASON
+
+    compact = " ".join(reason.split())
+    for separator in (":", "\n"):
+        if separator in compact:
+            compact = compact.split(separator, 1)[0].strip()
+            break
+    if len(compact) > _MAX_REASON_LENGTH:
+        compact = compact[:_MAX_REASON_LENGTH].rstrip(" .,:;") + "…"
+    return compact or _DEFAULT_FAILURE_REASON
 
 
 async def get_query_outcome_window_stats() -> dict[str, float | int]:
@@ -32,29 +53,57 @@ async def get_query_outcome_window_stats() -> dict[str, float | int]:
         pipe = redis_client.pipeline()
         pipe.zremrangebyscore(_SUCCESS_KEY, "-inf", window_start)
         pipe.zremrangebyscore(_FAILURE_KEY, "-inf", window_start)
+        pipe.zremrangebyscore(_FAILURE_REASON_KEY, "-inf", window_start)
         pipe.zcard(_SUCCESS_KEY)
         pipe.zcard(_FAILURE_KEY)
-        _, _, success_count, failure_count = await pipe.execute()
+        pipe.zrangebyscore(
+            _FAILURE_REASON_KEY,
+            window_start,
+            "+inf",
+        )
+        _, _, _, success_count, failure_count, failure_reason_members = await pipe.execute()
 
     success_total = int(success_count or 0)
     failure_total = int(failure_count or 0)
     total = success_total + failure_total
     success_pct = ((success_total / total) * 100.0) if total else 100.0
+    reason_counts: Counter[str] = Counter()
+    for raw_member in failure_reason_members or []:
+        member = raw_member.decode("utf-8") if isinstance(raw_member, bytes) else str(raw_member)
+        # member format: "{timestamp}:{platform}:{reason}:{time_ns}"
+        parts = member.split(":", 3)
+        if len(parts) < 4:
+            continue
+        reason = parts[2].strip()
+        if reason:
+            reason_counts[reason] += 1
+
+    top_failure_reasons = [
+        {"reason": reason, "count": count}
+        for reason, count in reason_counts.most_common(_MAX_REASON_RESULTS)
+    ]
     return {
         "window_seconds": _WINDOW_SECONDS,
         "success_count": success_total,
         "failure_count": failure_total,
         "total_count": total,
         "success_rate_pct": success_pct,
+        "top_failure_reasons": top_failure_reasons,
     }
 
 
-async def record_query_outcome(*, platform: str, was_success: bool) -> None:
+async def record_query_outcome(
+    *,
+    platform: str,
+    was_success: bool,
+    failure_reason: str | None = None,
+) -> None:
     """Record one query outcome and maintain a rolling 30-minute success pct."""
     timestamp = int(time.time())
     score = float(timestamp)
     bucket_key = _SUCCESS_KEY if was_success else _FAILURE_KEY
     member = f"{timestamp}:{platform}:{'ok' if was_success else 'fail'}:{time.time_ns()}"
+    normalized_reason = normalize_failure_reason(failure_reason) if not was_success else None
 
     redis_client = aioredis.from_url(
         settings.REDIS_URL,
@@ -65,19 +114,24 @@ async def record_query_outcome(*, platform: str, was_success: bool) -> None:
         pipe = redis_client.pipeline()
         pipe.zadd(bucket_key, {member: score})
         pipe.expire(bucket_key, _WINDOW_SECONDS * 2)
+        if normalized_reason:
+            reason_member = f"{timestamp}:{platform}:{normalized_reason}:{time.time_ns()}"
+            pipe.zadd(_FAILURE_REASON_KEY, {reason_member: score})
+            pipe.expire(_FAILURE_REASON_KEY, _WINDOW_SECONDS * 2)
         await pipe.execute()
 
     stats = await get_query_outcome_window_stats()
 
     logger.info(
         "Rolling query outcomes window_seconds=%s platform=%s was_success=%s "
-        "success_count=%s failure_count=%s success_pct=%.2f",
+        "success_count=%s failure_count=%s success_pct=%.2f failure_reason=%s",
         stats["window_seconds"],
         platform,
         was_success,
         stats["success_count"],
         stats["failure_count"],
         stats["success_rate_pct"],
+        normalized_reason,
     )
     await _maybe_raise_query_success_incident(platform=platform, stats=stats)
 

--- a/backend/tests/test_query_outcome_metrics.py
+++ b/backend/tests/test_query_outcome_metrics.py
@@ -42,8 +42,11 @@ def test_get_query_outcome_window_stats() -> None:
         def zcard(self, *_args, **_kwargs) -> None:
             return None
 
+        def zrangebyscore(self, *_args, **_kwargs) -> None:
+            return None
+
         async def execute(self) -> list[int]:
-            return [0, 0, 9, 1]
+            return [0, 0, 0, 9, 1, []]
 
     class _FakeRedis:
         def pipeline(self) -> _FakePipeline:
@@ -67,6 +70,7 @@ def test_get_query_outcome_window_stats() -> None:
     assert stats["failure_count"] == 1
     assert stats["total_count"] == 10
     assert stats["success_rate_pct"] == 90.0
+    assert stats["top_failure_reasons"] == []
 
 
 def test_get_query_outcome_window_stats_defaults_to_full_success_for_empty_window() -> None:
@@ -77,8 +81,11 @@ def test_get_query_outcome_window_stats_defaults_to_full_success_for_empty_windo
         def zcard(self, *_args, **_kwargs) -> None:
             return None
 
+        def zrangebyscore(self, *_args, **_kwargs) -> None:
+            return None
+
         async def execute(self) -> list[int]:
-            return [0, 0, 0, 0]
+            return [0, 0, 0, 0, 0, []]
 
     class _FakeRedis:
         def pipeline(self) -> _FakePipeline:
@@ -102,6 +109,7 @@ def test_get_query_outcome_window_stats_defaults_to_full_success_for_empty_windo
     assert stats["failure_count"] == 0
     assert stats["total_count"] == 0
     assert stats["success_rate_pct"] == 100.0
+    assert stats["top_failure_reasons"] == []
 
 
 def test_record_query_outcome_raises_incident_when_success_rate_at_or_below_25(
@@ -123,9 +131,12 @@ def test_record_query_outcome_raises_incident_when_success_rate_at_or_below_25(
         def zcard(self, *_args, **_kwargs) -> None:
             return None
 
+        def zrangebyscore(self, *_args, **_kwargs) -> None:
+            return None
+
         async def execute(self):
             if self._zcard_results:
-                return [0, 0, self._zcard_results.pop(0), self._zcard_results.pop(0)]
+                return [0, 0, 0, self._zcard_results.pop(0), self._zcard_results.pop(0), []]
             return [1, True]
 
     class _FakeRedis:
@@ -183,9 +194,12 @@ def test_record_query_outcome_clears_throttle_when_success_rate_recovers(monkeyp
         def zcard(self, *_args, **_kwargs) -> None:
             return None
 
+        def zrangebyscore(self, *_args, **_kwargs) -> None:
+            return None
+
         async def execute(self):
             if self._zcard_results:
-                return [0, 0, self._zcard_results.pop(0), self._zcard_results.pop(0)]
+                return [0, 0, 0, self._zcard_results.pop(0), self._zcard_results.pop(0), []]
             return [1, True]
 
     class _FakeRedis:
@@ -223,3 +237,8 @@ def test_record_query_outcome_clears_throttle_when_success_rate_recovers(monkeyp
     assert evaluate_calls == []
     assert incident_calls == []
     assert clear_calls == ["Rolling Query Success"]
+
+
+def test_normalize_failure_reason() -> None:
+    assert query_outcome_metrics.normalize_failure_reason(None) == "unknown_error"
+    assert query_outcome_metrics.normalize_failure_reason("  Timeout while calling provider: request id 123  ") == "timeout while calling provider"

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -54,6 +54,10 @@ interface QueryOutcomeRateResponse {
   failure_count: number;
   total_count: number;
   success_rate_pct: number;
+  top_failure_reasons: Array<{
+    reason: string;
+    count: number;
+  }>;
 }
 
 function formatRelativeTime(iso: string): string {
@@ -500,6 +504,7 @@ export function AdminPanel(): JSX.Element {
   const [queryOutcomeRate, setQueryOutcomeRate] = useState<QueryOutcomeRateResponse | null>(null);
   const [queryOutcomeRateLoading, setQueryOutcomeRateLoading] = useState<boolean>(true);
   const [queryOutcomeRateError, setQueryOutcomeRateError] = useState<string | null>(null);
+  const [showFailureReasons, setShowFailureReasons] = useState<boolean>(false);
 
   // Global sync state
   const [syncing, setSyncing] = useState<boolean>(false);
@@ -2256,6 +2261,43 @@ export function AdminPanel(): JSX.Element {
                 {queryOutcomeRateError}
               </div>
             )}
+            <div className="rounded-xl border border-surface-800 bg-surface-900 p-4">
+              <button
+                type="button"
+                onClick={() => setShowFailureReasons((prev) => !prev)}
+                className="flex w-full items-center justify-between text-left"
+              >
+                <div>
+                  <div className="text-xs uppercase tracking-wide text-surface-500">Failed query reasons (30m)</div>
+                  <div className="mt-1 text-sm text-surface-300">
+                    {queryOutcomeRateLoading
+                      ? 'Loading…'
+                      : `${queryOutcomeRate?.top_failure_reasons?.length ?? 0} reason${(queryOutcomeRate?.top_failure_reasons?.length ?? 0) === 1 ? '' : 's'} captured`}
+                  </div>
+                </div>
+                <svg className={`h-4 w-4 text-surface-400 transition-transform ${showFailureReasons ? 'rotate-180' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              {showFailureReasons && (
+                <div className="mt-4 rounded-lg border border-surface-800 bg-surface-950/60">
+                  {queryOutcomeRateLoading ? (
+                    <div className="p-3 text-sm text-surface-400">Loading failure reasons…</div>
+                  ) : (queryOutcomeRate?.top_failure_reasons?.length ?? 0) === 0 ? (
+                    <div className="p-3 text-sm text-surface-400">No failed query reasons in the last 30 minutes.</div>
+                  ) : (
+                    <ul className="divide-y divide-surface-800">
+                      {(queryOutcomeRate?.top_failure_reasons ?? []).map((entry) => (
+                        <li key={entry.reason} className="flex items-center justify-between gap-4 p-3 text-sm">
+                          <span className="truncate text-surface-200" title={entry.reason}>{entry.reason}</span>
+                          <span className="rounded bg-surface-800 px-2 py-0.5 text-xs text-surface-300">{entry.count.toLocaleString()}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              )}
+            </div>
             {/* Search & Actions */}
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="relative w-full flex-1 sm:max-w-md">


### PR DESCRIPTION
### Motivation
- Surface short, human-friendly reasons for failed queries in the Global Admin Sources tab so admins can quickly triage query health and see an expandable list of common failure causes.
- Persist normalized failure reasons alongside existing rolling success/failure metrics to enable low-cardinality aggregation without blowing up monitoring storage.

### Description
- Extend `services/query_outcome_metrics` to normalize failure text (`normalize_failure_reason`), persist normalized reasons to a new Redis sorted-set key `monitoring:query_outcomes:failure_reasons`, and return `top_failure_reasons` in `get_query_outcome_window_stats` (capped to top 20, normalized/truncated to 80 chars, default `unknown_error`).
- Add an optional `failure_reason` parameter to `record_query_outcome` and store a timestamped reason-member into the failure reasons zset when a query fails.
- Thread failure-reason capture through code paths that record outcomes by: deriving a short failure label in `messengers/base.BaseMessenger._derive_failed_query_reason` and passing it to `record_query_outcome`, and plumbing a `failure_reason` through the web chat path in `api/routes/chat.py`.
- Update the global admin API route typing in `api/routes/admin_dashboard.py` to reflect the richer response shape and add an expandable UI block in `frontend/src/components/AdminPanel.tsx` that shows a collapsible list of `Failed query reasons (30m)` with loading/empty states.
- Add/adjust unit tests in `backend/tests/test_query_outcome_metrics.py` to cover the new response shape and `normalize_failure_reason` behavior.

### Testing
- Ran `pytest -q backend/tests/test_query_outcome_metrics.py` and all tests passed (`7 passed`).
- Built the frontend with `npm run build` inside `frontend/` and the build completed successfully (Vite emitted chunk-size warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d67632d2a88321ba7f4985017903a4)