### PR TITLE
Include source conversation IDs in admin-panel failure reasons

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -119,6 +119,7 @@ async def _record_web_query_outcome(
             platform=_WEB_PLATFORM_SLUG,
             was_success=was_success,
             failure_reason=normalize_failure_reason(failure_reason) if not was_success else None,
+            conversation_id=conversation_id,
         )
     except Exception:
         logger.exception(

--- a/backend/messengers/base.py
+++ b/backend/messengers/base.py
@@ -405,6 +405,7 @@ class BaseMessenger(ABC):
                 platform=self.meta.slug,
                 was_success=was_success,
                 failure_reason=normalize_failure_reason(failure_reason) if not was_success else None,
+                conversation_id=str(result.get("conversation_id")) if result and result.get("conversation_id") else None,
             )
         except Exception:
             logger.exception(

--- a/backend/services/query_outcome_metrics.py
+++ b/backend/services/query_outcome_metrics.py
@@ -22,6 +22,7 @@ _QUERY_SUCCESS_INCIDENT_THRESHOLD_PCT = 25.0
 _MAX_REASON_LENGTH = 80
 _DEFAULT_FAILURE_REASON = "unknown_error"
 _MAX_REASON_RESULTS = 20
+_MAX_REASON_CONVERSATIONS = 5
 
 
 def normalize_failure_reason(raw_reason: str | None) -> str:
@@ -40,7 +41,7 @@ def normalize_failure_reason(raw_reason: str | None) -> str:
     return compact or _DEFAULT_FAILURE_REASON
 
 
-async def get_query_outcome_window_stats() -> dict[str, float | int]:
+async def get_query_outcome_window_stats() -> dict[str, object]:
     """Return rolling 30-minute query outcome stats from Redis."""
     timestamp = int(time.time())
     window_start = timestamp - _WINDOW_SECONDS
@@ -68,18 +69,29 @@ async def get_query_outcome_window_stats() -> dict[str, float | int]:
     total = success_total + failure_total
     success_pct = ((success_total / total) * 100.0) if total else 100.0
     reason_counts: Counter[str] = Counter()
+    reason_conversations: dict[str, list[str]] = {}
     for raw_member in failure_reason_members or []:
         member = raw_member.decode("utf-8") if isinstance(raw_member, bytes) else str(raw_member)
-        # member format: "{timestamp}:{platform}:{reason}:{time_ns}"
-        parts = member.split(":", 3)
+        # member format:
+        # "{timestamp}:{platform}:{reason}:{conversation_id}:{time_ns}".
+        # Older members may omit conversation_id:
+        # "{timestamp}:{platform}:{reason}:{time_ns}".
+        parts = member.split(":")
         if len(parts) < 4:
             continue
         reason = parts[2].strip()
+        conversation_id = ""
+        if len(parts) >= 5:
+            conversation_id = parts[3].strip()
         if reason:
             reason_counts[reason] += 1
+            if conversation_id and conversation_id != "unknown":
+                existing = reason_conversations.setdefault(reason, [])
+                if conversation_id not in existing and len(existing) < _MAX_REASON_CONVERSATIONS:
+                    existing.append(conversation_id)
 
     top_failure_reasons = [
-        {"reason": reason, "count": count}
+        {"reason": reason, "count": count, "conversation_ids": reason_conversations.get(reason, [])}
         for reason, count in reason_counts.most_common(_MAX_REASON_RESULTS)
     ]
     return {
@@ -97,6 +109,7 @@ async def record_query_outcome(
     platform: str,
     was_success: bool,
     failure_reason: str | None = None,
+    conversation_id: str | None = None,
 ) -> None:
     """Record one query outcome and maintain a rolling 30-minute success pct."""
     timestamp = int(time.time())
@@ -104,6 +117,7 @@ async def record_query_outcome(
     bucket_key = _SUCCESS_KEY if was_success else _FAILURE_KEY
     member = f"{timestamp}:{platform}:{'ok' if was_success else 'fail'}:{time.time_ns()}"
     normalized_reason = normalize_failure_reason(failure_reason) if not was_success else None
+    normalized_conversation_id = (conversation_id or "unknown").strip() or "unknown"
 
     redis_client = aioredis.from_url(
         settings.REDIS_URL,
@@ -115,7 +129,9 @@ async def record_query_outcome(
         pipe.zadd(bucket_key, {member: score})
         pipe.expire(bucket_key, _WINDOW_SECONDS * 2)
         if normalized_reason:
-            reason_member = f"{timestamp}:{platform}:{normalized_reason}:{time.time_ns()}"
+            reason_member = (
+                f"{timestamp}:{platform}:{normalized_reason}:{normalized_conversation_id}:{time.time_ns()}"
+            )
             pipe.zadd(_FAILURE_REASON_KEY, {reason_member: score})
             pipe.expire(_FAILURE_REASON_KEY, _WINDOW_SECONDS * 2)
         await pipe.execute()
@@ -124,7 +140,7 @@ async def record_query_outcome(
 
     logger.info(
         "Rolling query outcomes window_seconds=%s platform=%s was_success=%s "
-        "success_count=%s failure_count=%s success_pct=%.2f failure_reason=%s",
+        "success_count=%s failure_count=%s success_pct=%.2f failure_reason=%s conversation_id=%s",
         stats["window_seconds"],
         platform,
         was_success,
@@ -132,6 +148,7 @@ async def record_query_outcome(
         stats["failure_count"],
         stats["success_rate_pct"],
         normalized_reason,
+        normalized_conversation_id,
     )
     await _maybe_raise_query_success_incident(platform=platform, stats=stats)
 
@@ -139,7 +156,7 @@ async def record_query_outcome(
 async def _maybe_raise_query_success_incident(
     *,
     platform: str,
-    stats: dict[str, float | int],
+    stats: dict[str, object],
 ) -> None:
     """Raise/suppress incident when rolling success percentage crosses threshold."""
     success_rate_pct = float(stats["success_rate_pct"])

--- a/backend/tests/test_query_outcome_metrics.py
+++ b/backend/tests/test_query_outcome_metrics.py
@@ -112,6 +112,57 @@ def test_get_query_outcome_window_stats_defaults_to_full_success_for_empty_windo
     assert stats["top_failure_reasons"] == []
 
 
+def test_get_query_outcome_window_stats_includes_source_conversation_ids() -> None:
+    class _FakePipeline:
+        def zremrangebyscore(self, *_args, **_kwargs) -> None:
+            return None
+
+        def zcard(self, *_args, **_kwargs) -> None:
+            return None
+
+        def zrangebyscore(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def execute(self) -> list[object]:
+            return [
+                0,
+                0,
+                0,
+                8,
+                2,
+                [
+                    b"100:web:provider timeout:conv-1:9001",
+                    b"101:web:provider timeout:conv-2:9002",
+                    b"102:web:provider timeout:9003",  # legacy format without conversation_id
+                ],
+            ]
+
+    class _FakeRedis:
+        def pipeline(self) -> _FakePipeline:
+            return _FakePipeline()
+
+        async def __aenter__(self) -> "_FakeRedis":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    original_from_url = query_outcome_metrics.aioredis.from_url
+    query_outcome_metrics.aioredis.from_url = lambda *_args, **_kwargs: _FakeRedis()
+    try:
+        stats = asyncio.run(query_outcome_metrics.get_query_outcome_window_stats())
+    finally:
+        query_outcome_metrics.aioredis.from_url = original_from_url
+
+    assert stats["top_failure_reasons"] == [
+        {
+            "reason": "provider timeout",
+            "count": 3,
+            "conversation_ids": ["conv-1", "conv-2"],
+        }
+    ]
+
+
 def test_record_query_outcome_raises_incident_when_success_rate_at_or_below_25(
     monkeypatch,
 ) -> None:

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -57,6 +57,7 @@ interface QueryOutcomeRateResponse {
   top_failure_reasons: Array<{
     reason: string;
     count: number;
+    conversation_ids: string[];
   }>;
 }
 
@@ -2288,8 +2289,15 @@ export function AdminPanel(): JSX.Element {
                   ) : (
                     <ul className="divide-y divide-surface-800">
                       {(queryOutcomeRate?.top_failure_reasons ?? []).map((entry) => (
-                        <li key={entry.reason} className="flex items-center justify-between gap-4 p-3 text-sm">
-                          <span className="truncate text-surface-200" title={entry.reason}>{entry.reason}</span>
+                        <li key={entry.reason} className="flex items-start justify-between gap-4 p-3 text-sm">
+                          <div className="min-w-0 flex-1">
+                            <span className="block truncate text-surface-200" title={entry.reason}>{entry.reason}</span>
+                            {(entry.conversation_ids?.length ?? 0) > 0 && (
+                              <div className="mt-1 text-xs text-surface-400">
+                                Conversations: {entry.conversation_ids.join(', ')}
+                              </div>
+                            )}
+                          </div>
                           <span className="rounded bg-surface-800 px-2 py-0.5 text-xs text-surface-300">{entry.count.toLocaleString()}</span>
                         </li>
                       ))}


### PR DESCRIPTION
### Motivation
- Provide admins with the originating conversation context for failed queries so failure reasons in the admin panel are actionable and easier to debug.
- Preserve backward compatibility with existing Redis failure-reason entries while surfacing conversation IDs when available.

### Description
- Extend `record_query_outcome` to accept an optional `conversation_id` and write failure-reason Redis members in the format `"{timestamp}:{platform}:{reason}:{conversation_id}:{time_ns}"` when available. 
- Update `get_query_outcome_window_stats` to parse both the new and legacy member formats and return per-reason `conversation_ids` capped at 5 unique IDs. 
- Thread `conversation_id` into the two recording paths by passing it from messenger outcomes (`backend/messengers/base.py`) and web chat outcomes (`backend/api/routes/chat.py`).
- Update the admin UI typing and display in `frontend/src/components/AdminPanel.tsx` to show `conversation_ids` under each failure reason, and add a regression test covering parsing/exposure of conversation IDs.

### Testing
- Ran the backend metric tests with `pytest -q backend/tests/test_query_outcome_metrics.py` and all tests passed (`8 passed`).
- The new unit test verifies parsing both new-format members (with conversation ids) and legacy-format members (without conversation ids) and asserts the returned payload shape includes `conversation_ids`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6847207bc8321921ee3bcb8a120a9)