### PR TITLE
Add diagnostics for ignored thread replies and notification fallback targeting

### DIFF
--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -908,6 +908,13 @@ class WorkspaceMessenger(BaseMessenger):
                 has_conversation: bool = await self._has_existing_conversation(message)
                 if not has_conversation:
                     logger.info(
+                        "[%s] no_existing_thread_conversation channel=%s thread=%s workspace=%s",
+                        self.meta.slug,
+                        message.messenger_context.get("channel_id"),
+                        message.messenger_context.get("thread_id") or message.messenger_context.get("thread_ts"),
+                        message.messenger_context.get("workspace_id"),
+                    )
+                    logger.info(
                         "[%s] Ignoring thread reply — no existing conversation for thread",
                         self.meta.slug,
                     )

--- a/backend/services/notifications.py
+++ b/backend/services/notifications.py
@@ -35,8 +35,21 @@ async def create_mention_notifications(
 
     if user_mentions:
         target_ids: list[str] = list({m["user_id"] for m in user_mentions})
+        logger.info(
+            "Creating mention notifications from explicit mentions conversation_id=%s actor_user_id=%s targets=%s",
+            conversation_id,
+            actor_user_id,
+            target_ids,
+        )
     else:
         target_ids = [uid for uid in participant_user_ids if uid != actor_user_id]
+        logger.info(
+            "Creating mention notifications from participants fallback conversation_id=%s actor_user_id=%s participants=%s targets=%s",
+            conversation_id,
+            actor_user_id,
+            participant_user_ids,
+            target_ids,
+        )
 
     if not target_ids:
         return


### PR DESCRIPTION
### Motivation
- Improve observability to debug why users sometimes receive notification badges when they weren't explicitly mentioned by logging context where thread replies are ignored and whether notifications were created from explicit mentions or from participant fallback.

### Description
- Add a structured `logger.info` entry in `WorkspaceMessenger.process_inbound` to emit `channel_id`, `thread_id`/`thread_ts`, and `workspace_id` when returning `no_existing_thread_conversation`.
- Add `logger.info` statements in `create_mention_notifications` to record whether targets were derived from explicit user mentions or from the participant fallback, and to show the resolved `targets`/`participants`.
- No logic or routing behavior was changed; these are observability-only additions.

### Testing
- Ran `python -m py_compile backend/messengers/_workspace.py backend/services/notifications.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d694383e50832197ab5e12f87de921)