### PR TITLE
Exclude no-thread ignores from query outcome metrics

### DIFF
--- a/backend/messengers/base.py
+++ b/backend/messengers/base.py
@@ -398,6 +398,17 @@ class BaseMessenger(ABC):
         """Persist query success/failure for rolling monitoring windows."""
         from services.query_outcome_metrics import normalize_failure_reason, record_query_outcome
 
+        if (
+            result
+            and result.get("status") == "ignored"
+            and result.get("reason") == "no_existing_thread_conversation"
+        ):
+            logger.info(
+                "[%s] Skipping query outcome metrics for ignored no_existing_thread_conversation",
+                self.meta.slug,
+            )
+            return
+
         was_success = self._is_successful_query_outcome(result=result, error=error)
         failure_reason = self._derive_failed_query_reason(result=result, error=error)
         try:


### PR DESCRIPTION
### Motivation
- Do not count thread-reply ignores for missing bot participation (i.e. `"status": "ignored", "reason": "no_existing_thread_conversation"`) toward rolling conversation success/failure metrics to avoid skewing alerts and dashboards.

### Description
- Add an early-return guard in `backend/messengers/base.py` inside `_record_query_outcome` to skip recording metrics when `result` is `{"status": "ignored", "reason": "no_existing_thread_conversation"}`, and emit an info log when this path is taken.

### Testing
- Ran `python -m compileall backend/messengers/base.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69697d6cc83218e5c6b00bb40b23d)