### PR TITLE
Exclude timeout_continuing from query outcome metrics

### DIFF
--- a/backend/messengers/base.py
+++ b/backend/messengers/base.py
@@ -409,6 +409,14 @@ class BaseMessenger(ABC):
             )
             return
 
+        if self._should_skip_query_outcome(result=result):
+            logger.info(
+                "[%s] Skipping query outcome metrics for intermediate status=%s",
+                self.meta.slug,
+                result.get("status") if result else None,
+            )
+            return
+
         was_success = self._is_successful_query_outcome(result=result, error=error)
         failure_reason = self._derive_failed_query_reason(result=result, error=error)
         try:
@@ -446,6 +454,16 @@ class BaseMessenger(ABC):
         if status == "error" and result.get("error") == "insufficient_credits":
             return True
         return False
+
+    @staticmethod
+    def _should_skip_query_outcome(
+        *,
+        result: dict[str, Any] | None,
+    ) -> bool:
+        """Identify intermediate states that should not affect success/failure metrics."""
+        if not result:
+            return False
+        return result.get("status") == "timeout_continuing"
 
     @staticmethod
     def _derive_failed_query_reason(

--- a/backend/tests/test_query_outcome_metrics.py
+++ b/backend/tests/test_query_outcome_metrics.py
@@ -34,6 +34,12 @@ def test_failed_query_outcome_classification() -> None:
     )
 
 
+def test_timeout_continuing_is_excluded_from_query_outcome_consideration() -> None:
+    assert BaseMessenger._should_skip_query_outcome(result={"status": "timeout_continuing"})
+    assert not BaseMessenger._should_skip_query_outcome(result={"status": "success"})
+    assert not BaseMessenger._should_skip_query_outcome(result=None)
+
+
 def test_get_query_outcome_window_stats() -> None:
     class _FakePipeline:
         def zremrangebyscore(self, *_args, **_kwargs) -> None:


### PR DESCRIPTION
### Motivation
- Intermediate slow-path states like `timeout_continuing` should not be counted as a final turn success or failure when recording rolling query outcome metrics.
- Recording intermediate states skews monitoring and incident detection that should be based on final results only.

### Description
- Add `BaseMessenger._should_skip_query_outcome` to centralize the rule for excluding intermediate statuses from metric recording, currently excluding `timeout_continuing`.
- Short-circuit `_record_query_outcome` to skip recording when `_should_skip_query_outcome` is true and emit an info log identifying the skipped intermediate status.
- Add unit test `test_timeout_continuing_is_excluded_from_query_outcome_consideration` to assert the new helper behavior.
- Change files: `backend/messengers/base.py` and `backend/tests/test_query_outcome_metrics.py`.

### Testing
- Ran `pytest -q backend/tests/test_query_outcome_metrics.py`, and all tests passed: `9 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69a4095c083218422f95984522d44)