### PR TITLE
Include websocket web chat turns in rolling success rate; allow system actors access

### DIFF
--- a/backend/api/auth_middleware.py
+++ b/backend/api/auth_middleware.py
@@ -708,6 +708,31 @@ async def require_global_admin(
     return auth
 
 
+async def require_global_admin_or_system_actor(
+    auth: AuthContext = Depends(get_current_auth),
+) -> AuthContext:
+    """
+    Require that the authenticated actor is either global admin or a system actor.
+
+    Usage:
+        @router.get("/admin-or-system-only")
+        async def route(auth: AuthContext = Depends(require_global_admin_or_system_actor)):
+            # Global admins and internal system actors can access
+    """
+    if auth.is_global_admin:
+        return auth
+
+    # Internal service actors can be represented by role/roles metadata.
+    actor_role = (auth.role or "").strip().lower()
+    if actor_role == "system":
+        return auth
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Global admin or system actor access required",
+    )
+
+
 async def verify_websocket_token(websocket: WebSocket) -> AuthContext:
     """
     Verify JWT for WebSocket connections.

--- a/backend/api/routes/admin_dashboard.py
+++ b/backend/api/routes/admin_dashboard.py
@@ -15,7 +15,11 @@ from uuid import UUID
 from fastapi import APIRouter, Depends
 from sqlalchemy import cast, Date, desc, func, select
 
-from api.auth_middleware import AuthContext, require_global_admin
+from api.auth_middleware import (
+    AuthContext,
+    require_global_admin,
+    require_global_admin_or_system_actor,
+)
 from models.conversation import Conversation
 from models.credit_transaction import CreditTransaction
 from models.organization import Organization
@@ -29,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 @router.get("/query-outcome-rate")
 async def get_query_outcome_rate(
-    auth: AuthContext = Depends(require_global_admin),
+    auth: AuthContext = Depends(require_global_admin_or_system_actor),
 ) -> dict[str, Any]:
     """Return rolling query success/failure counts for the last 30 minutes."""
     return await get_query_outcome_window_stats()

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -35,6 +35,33 @@ FANOUT_SEND_TIMEOUT_SECONDS = 1.5
 BroadcastCallback = Callable[[str], Coroutine[Any, Any, None]]
 
 
+async def _record_websocket_query_outcome(
+    *,
+    was_success: bool,
+    failure_reason: str | None,
+    conversation_id: str,
+    user_id: str,
+) -> None:
+    """Best-effort rolling success metric recording for web websocket turns."""
+    from services.query_outcome_metrics import normalize_failure_reason, record_query_outcome
+
+    try:
+        await record_query_outcome(
+            platform="web",
+            was_success=was_success,
+            failure_reason=normalize_failure_reason(failure_reason) if not was_success else None,
+            conversation_id=conversation_id,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to record websocket query outcome platform=web was_success=%s conversation_id=%s user_id=%s failure_reason=%s",
+            was_success,
+            conversation_id,
+            user_id,
+            failure_reason,
+        )
+
+
 class TaskManager:
     """
     Manages background agent tasks with WebSocket subscriptions.
@@ -217,6 +244,8 @@ class TaskManager:
         Streams output from the orchestrator, persists chunks to database,
         and broadcasts to subscribed WebSockets.
         """
+        was_success = False
+        failure_reason: str | None = None
         try:
             async with self._conversation_execution_lock(conversation_id):
                 orchestrator = ChatOrchestrator(
@@ -284,6 +313,7 @@ class TaskManager:
             })
             
             logger.info("Task %s completed successfully", task_id)
+            was_success = True
 
             # Broadcast final assistant message to other participants in shared conversations
             asyncio.create_task(
@@ -307,6 +337,7 @@ class TaskManager:
             
         except Exception as e:
             logger.exception("Task %s failed with error: %s", task_id, e)
+            failure_reason = str(e)
             await self._complete_task(task_id, "failed", str(e))
             await self._broadcast(task_id, {
                 "type": "task_complete",
@@ -317,6 +348,12 @@ class TaskManager:
             })
             
         finally:
+            await _record_websocket_query_outcome(
+                was_success=was_success,
+                failure_reason=failure_reason,
+                conversation_id=conversation_id,
+                user_id=user_id,
+            )
             # Clean up
             self._running_tasks.pop(task_id, None)
             self._task_org_ids.pop(task_id, None)


### PR DESCRIPTION
### Motivation
- Websocket-driven web chat turns (the primary web chat flow) were not being counted in the rolling query success metrics, causing the dashboard to under-report web turn outcomes.  
- The admin dashboard rolling-success endpoint needs to be accessible to internal system actors in addition to global admins for internal tooling and monitoring.

### Description
- Record web websocket chat outcomes by adding `_record_websocket_query_outcome` and invoking it from `TaskManager._run_task` so websocket turns are included in the rolling 30-minute metrics (platform set to `web`).  
- Normalize failure reasons and keep metric recording best-effort with defensive logging to avoid impacting task execution.  
- Add a new auth dependency `require_global_admin_or_system_actor` in `backend/api/auth_middleware.py` that allows access when `auth.is_global_admin` or `auth.role == 'system'`.  
- Update `/api/admin-dashboard/query-outcome-rate` to depend on `require_global_admin_or_system_actor` so global admins and system actors can fetch the rolling success rate.

### Testing
- Ran `pytest -q backend/tests/test_query_outcome_metrics.py` which passed (`9 passed`).  
- Ran `pytest -q backend/tests -k task_manager` which passed (`2 passed, 370 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c1e7520c8321b148ac24dbf26833)