### PR TITLE
Shorten incident throttle cooldown to 90 minutes

### DIFF
--- a/backend/services/incident_throttling.py
+++ b/backend/services/incident_throttling.py
@@ -11,7 +11,7 @@ from config import get_redis_connection_kwargs, settings
 
 logger = logging.getLogger(__name__)
 
-_INCIDENT_COOLDOWN_SECONDS = 3 * 60 * 60
+_INCIDENT_COOLDOWN_SECONDS = 90 * 60
 _INCIDENT_KEY_PREFIX = "monitoring:incident_throttle"
 _INCIDENT_KEY_TTL_SECONDS = 7 * 24 * 60 * 60
 
@@ -85,4 +85,3 @@ async def clear_incident_failure(check_name: str) -> None:
             logger.info("Cleared incident throttle state for recovered check=%s", check_name)
     except Exception:
         logger.exception("Failed to clear incident throttle state for check=%s", check_name)
-

--- a/backend/tests/test_incident_throttling.py
+++ b/backend/tests/test_incident_throttling.py
@@ -52,7 +52,7 @@ def test_evaluate_incident_creation_first_failure_allowed(monkeypatch: pytest.Mo
     assert reason == "new_failure"
 
 
-def test_evaluate_incident_creation_suppresses_repeated_failure_within_3h(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_evaluate_incident_creation_suppresses_repeated_failure_within_90m(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(throttling.aioredis, "from_url", lambda *args, **kwargs: _FakeRedis())
 
     import asyncio
@@ -67,7 +67,7 @@ def test_evaluate_incident_creation_suppresses_repeated_failure_within_3h(monkey
     assert reason.startswith("suppressed_for_")
 
 
-def test_evaluate_incident_creation_allows_after_3h(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_evaluate_incident_creation_allows_after_90m(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(throttling.aioredis, "from_url", lambda *args, **kwargs: _FakeRedis())
 
     import asyncio
@@ -75,7 +75,7 @@ def test_evaluate_incident_creation_allows_after_3h(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(throttling.time, "time", lambda: 1000)
     asyncio.run(throttling.evaluate_incident_creation("Auth JWKS"))
 
-    monkeypatch.setattr(throttling.time, "time", lambda: 1000 + (3 * 60 * 60))
+    monkeypatch.setattr(throttling.time, "time", lambda: 1000 + (90 * 60))
     should_create, reason = asyncio.run(throttling.evaluate_incident_creation("Auth JWKS"))
 
     assert should_create is True


### PR DESCRIPTION
### Motivation
- Reduce the maximum suppress window between repeated incidents from 3 hours to 1.5 hours so recurring failures can generate a new PagerDuty incident sooner.

### Description
- Change `_INCIDENT_COOLDOWN_SECONDS` from `3 * 60 * 60` to `90 * 60` in `backend/services/incident_throttling.py` and update related test names and timing assertions in `backend/tests/test_incident_throttling.py` to reflect the 90-minute behavior.

### Testing
- Ran `pytest -q backend/tests/test_incident_throttling.py`, which resulted in `4 passed` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6eae28184832198880564a7716ce3)