### PR TITLE
Handle `vs.` as non-terminal abbreviation in stream message breaks

### DIFF
--- a/backend/messengers/_stream_breaks.py
+++ b/backend/messengers/_stream_breaks.py
@@ -15,6 +15,7 @@ _TITLE_ABBREVIATIONS: set[str] = {
     "dr",
     "prof",
     "st",
+    "vs",
     "saint",
 }
 

--- a/backend/tests/test_workspace_stream_breaks.py
+++ b/backend/tests/test_workspace_stream_breaks.py
@@ -45,6 +45,11 @@ def test_find_safe_stream_break_skips_saint_abbreviation() -> None:
     assert find_safe_break(text, strategy="quickest_safe") == len("They visited St. Louis last week. ")
 
 
+def test_find_safe_stream_break_skips_vs_abbreviation() -> None:
+    text = "This is a Lakers vs. Celtics preview. Tip-off at seven"
+    assert find_safe_break(text, strategy="quickest_safe") == len("This is a Lakers vs. Celtics preview. ")
+
+
 def test_find_safe_stream_break_defers_inside_pipe_table_with_pipes() -> None:
     text = "Here is the data:\n\n| Name | Email |\n| Alice | alice@co.com |"
     assert find_safe_break(text, strategy="quickest_safe") == 0


### PR DESCRIPTION
### Motivation
- Avoid premature sentence splitting in streaming processors by treating `vs.` as a non-terminal abbreviation, matching existing handling for `st.` and `mrs.`.

### Description
- Added `"vs"` to `_TITLE_ABBREVIATIONS` in `backend/messengers/_stream_breaks.py` and added `test_find_safe_stream_break_skips_vs_abbreviation` to `backend/tests/test_workspace_stream_breaks.py` to cover the regression.

### Testing
- Ran `pytest -q backend/tests/test_workspace_stream_breaks.py backend/tests/test_twilio_stream_breaks.py` and all tests passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7fe06eb2483218f837d9ac2e739c7)