### PR TITLE
Add cross-user connector usage warning for non-Slack/Teams actions

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -693,6 +693,62 @@ async def _get_connector_instance(
     return instance, None
 
 
+def _build_cross_user_connector_warning(
+    connector_slug: str,
+    connector_instance: Any,
+    requester_user_id: str | None,
+) -> str | None:
+    """Return a user-facing warning when we used a teammate's connector."""
+    if not requester_user_id:
+        return None
+    if connector_slug in {"slack", "teams"}:
+        return None
+
+    raw_integration_user_id: Any = getattr(connector_instance, "user_id", None)
+    integration_user_id: str | None = (
+        raw_integration_user_id if isinstance(raw_integration_user_id, str) else None
+    )
+    if not integration_user_id or integration_user_id == requester_user_id:
+        return None
+
+    service_name: str = connector_slug.replace("_", " ").title()
+    try:
+        from connectors.registry import resolve_connector
+
+        connector_cls = resolve_connector(connector_slug)
+        if connector_cls is not None and getattr(connector_cls, "meta", None) is not None:
+            service_name = connector_cls.meta.name
+    except Exception:
+        logger.debug(
+            "[Tools] Failed to resolve connector display name for cross-user warning slug=%s",
+            connector_slug,
+            exc_info=True,
+        )
+
+    return (
+        f"To perform this action, we used another teammate's connector for {service_name}. "
+        f"You may want to connect to {service_name} as yourself."
+    )
+
+
+def _attach_cross_user_connector_warning(result: Any, warning: str | None) -> dict[str, Any]:
+    """Attach cross-user connector warning text to tool result payloads."""
+    if not warning:
+        if isinstance(result, dict):
+            return result
+        return {"result": result}
+
+    if isinstance(result, dict):
+        if "warning" in result:
+            existing_warning = result.get("warning")
+            result["warning"] = f"{existing_warning}\n\n{warning}" if existing_warning else warning
+        else:
+            result["warning"] = warning
+        return result
+
+    return {"result": result, "warning": warning}
+
+
 async def _list_connected_connectors(organization_id: str) -> dict[str, Any]:
     """Return the connectors manifest for all connected connectors."""
     from connectors.registry import Capability, ConnectorMeta, discover_connectors, resolve_connector
@@ -940,8 +996,11 @@ async def _query_on_connector(
         return {"error": error}
     assert instance is not None
 
+    cross_user_warning = _build_cross_user_connector_warning(connector, instance, user_id)
+
     try:
-        return await instance.query(query)
+        result = await instance.query(query)
+        return _attach_cross_user_connector_warning(result, cross_user_warning)
     except Exception as exc:
         logger.error("[Tools] query_on_connector(%s) failed: %s", connector, exc, exc_info=True)
         return await _attach_connector_docs(
@@ -1014,10 +1073,12 @@ async def _write_on_connector(
         dispatch_type="write", operation=operation, data=data,
         connector_instance=instance,
     )
+    cross_user_warning = _build_cross_user_connector_warning(connector, instance, user_id)
+
     try:
         result = await instance.write(operation, data)
         await record_outcome(change_id, organization_id, result)
-        return result
+        return _attach_cross_user_connector_warning(result, cross_user_warning)
     except Exception as exc:
         await record_outcome(change_id, organization_id, {"error": str(exc)})
         logger.error("[Tools] write_on_connector(%s, %s) failed: %s", connector, operation, exc, exc_info=True)
@@ -1080,10 +1141,12 @@ async def _run_on_connector(
         dispatch_type="action", operation=action, data=action_params,
         connector_instance=instance,
     )
+    cross_user_warning = _build_cross_user_connector_warning(connector, instance, user_id)
+
     try:
         result = await instance.execute_action(action, action_params)
         await record_outcome(change_id, organization_id, result)
-        return result
+        return _attach_cross_user_connector_warning(result, cross_user_warning)
     except Exception as exc:
         await record_outcome(change_id, organization_id, {"error": str(exc)})
         logger.error("[Tools] run_on_connector(%s, %s) failed: %s", connector, action, exc, exc_info=True)

--- a/backend/tests/test_action_ledger.py
+++ b/backend/tests/test_action_ledger.py
@@ -502,6 +502,7 @@ class TestChokepoints:
         from agents import tools
 
         fake_instance = MagicMock()
+        fake_instance.user_id = "user-1"
         fake_instance.write = AsyncMock(return_value={"id": "99", "status": "ok"})
 
         change_id = uuid.uuid4()
@@ -526,6 +527,32 @@ class TestChokepoints:
         outcome_args = mock_outcome.call_args
         assert outcome_args[0][0] == change_id
         assert outcome_args[0][2] == {"id": "99", "status": "ok"}
+
+    def test_write_on_connector_adds_warning_for_cross_user_non_slack(self) -> None:
+        """Cross-user non-Slack/Teams connector use should add a user-facing warning."""
+        from agents import tools
+
+        fake_instance = MagicMock()
+        fake_instance.user_id = "teammate-1"
+        fake_instance.write = AsyncMock(return_value={"id": "99", "status": "ok"})
+
+        with patch.object(tools, "_get_connector_instance", new=AsyncMock(return_value=(fake_instance, None))), \
+             patch.object(tools, "check_connector_call", new=AsyncMock(return_value=MagicMock(allowed=True))), \
+             patch("services.action_ledger.record_intent", new=AsyncMock(return_value=uuid.uuid4())), \
+             patch("services.action_ledger.record_outcome", new=AsyncMock()):
+
+            result = asyncio.run(tools._write_on_connector(
+                params={"connector": "hubspot", "operation": "update_deal", "data": {"deal_id": "1"}},
+                organization_id="org-1",
+                user_id="user-1",
+                skip_approval=True,
+                context={"conversation_id": "conv-1"},
+            ))
+
+        assert result.get("id") == "99"
+        assert "warning" in result
+        assert "HubSpot" in str(result["warning"])
+        assert "connect to HubSpot as yourself" in str(result["warning"])
 
     def test_write_on_connector_records_error_on_exception(self) -> None:
         """When instance.write raises, record_outcome should still be called with error."""


### PR DESCRIPTION
### Motivation
- Provide a clear, user-facing warning when an agent action uses a teammate's connector (for non-chat connectors) so users know they may want to connect the service themselves.

### Description
- Added helper functions `
_build_cross_user_connector_warning` and `
_attach_cross_user_connector_warning` in `backend/agents/tools.py` to build and attach a human-friendly warning when a connector call uses another user's integration, with Slack/Teams explicitly excluded.
- Wired the warning into the three generic connector dispatch paths by calling the helpers from `
_query_on_connector`, `
_write_on_connector`, and `
_run_on_connector` so successful results include a `warning` field when appropriate.
- Safely handle `connector_instance.user_id` types and attempt to resolve a connector display name via `resolve_connector` for friendlier text.
- Updated tests in `backend/tests/test_action_ledger.py` to set explicit fake connector owner IDs and added a new test verifying the warning for cross-user non-Slack connector calls.

### Testing
- Ran `pytest -q backend/tests/test_action_ledger.py` which includes the new test and existing chokepoint tests; result: all tests passed (`34 passed, 2 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85996b7f883219627ed6fe3a8da26)