### PR TITLE
Add workflow-level model override in Advanced editor settings

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1068,14 +1068,20 @@ class ChatOrchestrator:
         self._llm_config = await resolve_llm_config(self.organization_id)
         self._adapter = get_adapter(self._llm_config)
         is_workflow_run: bool = bool((self.workflow_context or {}).get("is_workflow"))
-        selected_model: str = self._llm_config.workflow_model if is_workflow_run else self._llm_config.primary_model
+        workflow_model_override = (self.workflow_context or {}).get("workflow_model_override")
+        selected_model: str = (
+            str(workflow_model_override)
+            if is_workflow_run and workflow_model_override
+            else (self._llm_config.workflow_model if is_workflow_run else self._llm_config.primary_model)
+        )
 
         logger.info(
-            "[Orchestrator] conversation_id=%s provider=%s selected_model=%s is_workflow=%s",
+            "[Orchestrator] conversation_id=%s provider=%s selected_model=%s is_workflow=%s workflow_model_override=%s",
             self.conversation_id,
             self._llm_config.provider,
             selected_model,
             is_workflow_run,
+            workflow_model_override,
         )
 
         # Keep track of content blocks for saving (preserves interleaving order)

--- a/backend/api/routes/workflows.py
+++ b/backend/api/routes/workflows.py
@@ -17,6 +17,7 @@ from sqlalchemy import select, and_, func, or_
 from models.database import get_session
 from models.workflow import Workflow, WorkflowRun
 from api.auth_middleware import AuthContext, require_organization
+from services.llm_provider import is_model_allowed
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -88,6 +89,7 @@ class CreateWorkflowRequest(BaseModel):
     input_schema: Optional[dict[str, Any]] = None  # JSON Schema for typed inputs
     output_schema: Optional[dict[str, Any]] = None  # JSON Schema for typed outputs
     child_workflows: list[str] = []  # IDs of workflows this can call
+    llm_model: Optional[str] = None  # Optional per-workflow model override
     output_config: Optional[dict[str, Any]] = None
     is_enabled: bool = True
 
@@ -105,6 +107,7 @@ class UpdateWorkflowRequest(BaseModel):
     input_schema: Optional[dict[str, Any]] = None
     output_schema: Optional[dict[str, Any]] = None
     child_workflows: Optional[list[str]] = None
+    llm_model: Optional[str] = None
     output_config: Optional[dict[str, Any]] = None
     is_enabled: Optional[bool] = None
 
@@ -125,6 +128,7 @@ class WorkflowResponse(BaseModel):
     input_schema: Optional[dict[str, Any]]  # JSON Schema for typed inputs
     output_schema: Optional[dict[str, Any]]  # JSON Schema for typed outputs
     child_workflows: list[str]  # IDs of workflows this can call
+    llm_model: Optional[str]  # Optional per-workflow model override
     output_config: Optional[dict[str, Any]]
     archived_at: Optional[str]
     is_enabled: bool
@@ -434,6 +438,8 @@ async def create_workflow(
                 status_code=400,
                 detail=f"Invalid cron expression: {e}",
             )
+    if request.llm_model and not is_model_allowed(request.llm_model):
+        raise HTTPException(status_code=400, detail=f"Model not allowed: {request.llm_model}")
 
     async with get_session(
         organization_id=organization_id,
@@ -452,6 +458,7 @@ async def create_workflow(
             input_schema=request.input_schema,
             output_schema=request.output_schema,
             child_workflows=request.child_workflows,
+            llm_model=request.llm_model or None,
             output_config=request.output_config,
             is_enabled=request.is_enabled,
         )
@@ -514,6 +521,10 @@ async def update_workflow(
             workflow.output_schema = request.output_schema
         if request.child_workflows is not None:
             workflow.child_workflows = request.child_workflows
+        if request.llm_model is not None:
+            if request.llm_model and not is_model_allowed(request.llm_model):
+                raise HTTPException(status_code=400, detail=f"Model not allowed: {request.llm_model}")
+            workflow.llm_model = request.llm_model or None
         if request.output_config is not None:
             workflow.output_config = request.output_config
         if request.is_enabled is not None:

--- a/backend/db/migrations/versions/132_wf_llm_model.py
+++ b/backend/db/migrations/versions/132_wf_llm_model.py
@@ -1,0 +1,28 @@
+"""Add per-workflow LLM model override.
+
+Revision ID: 132_wf_llm_model
+Revises: 131_workflow_model
+Create Date: 2026-04-10
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "132_wf_llm_model"
+down_revision: Union[str, Sequence[str], None] = "131_workflow_model"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workflows",
+        sa.Column("llm_model", sa.String(length=128), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workflows", "llm_model")

--- a/backend/models/workflow.py
+++ b/backend/models/workflow.py
@@ -109,6 +109,10 @@ class Workflow(Base):
         JSONB, nullable=False, default=list
     )
 
+    # Optional model override for this workflow only.
+    # When null, workflow execution uses organization workflow model fallback.
+    llm_model: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+
     # Output configuration (optional, can also be in last step)
     # Example: { "channel": "email", "to": "user@example.com" }
     output_config: Mapped[Optional[dict[str, Any]]] = mapped_column(
@@ -154,6 +158,7 @@ class Workflow(Base):
             "input_schema": self.input_schema,
             "output_schema": self.output_schema,
             "child_workflows": self.child_workflows,
+            "llm_model": self.llm_model,
             "output_config": self.output_config,
             "archived_at": f"{self.archived_at.isoformat()}Z" if self.archived_at else None,
             "is_enabled": self.is_enabled,

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -1113,6 +1113,7 @@ async def _execute_workflow_via_agent(
         "is_workflow": True,
         "workflow_id": str(workflow.id),
         "workflow_run_id": str(run.id),
+        "workflow_model_override": getattr(workflow, "llm_model", None),
         "runtime_context": runtime_context,
         "auto_approve_tools": effective_auto_approve_tools,
         "allowed_slack_channels": _extract_allowed_slack_channels(workflow),

--- a/frontend/src/components/Workflows.tsx
+++ b/frontend/src/components/Workflows.tsx
@@ -41,6 +41,7 @@ interface Workflow {
   input_schema: Record<string, unknown> | null;  // JSON Schema for typed inputs
   output_schema: Record<string, unknown> | null;  // JSON Schema for typed outputs
   child_workflows: string[];  // IDs of workflows this can call
+  llm_model: string | null;  // Optional per-workflow model override
   archived_at: string | null;
   is_enabled: boolean;
   last_run_at: string | null;
@@ -148,6 +149,7 @@ interface CreateWorkflowParams {
   input_schema?: Record<string, unknown> | null;
   output_schema?: Record<string, unknown> | null;
   child_workflows?: string[];
+  llm_model?: string | null;
 }
 
 interface WorkflowDraft {
@@ -161,6 +163,7 @@ interface WorkflowDraft {
   inputSchemaText: string;
   outputSchemaText: string;
   selectedChildWorkflows: string[];
+  llmModel: string;
 }
 
 const WORKFLOW_DRAFT_VERSION = 'v1';
@@ -215,6 +218,7 @@ async function createWorkflow(orgId: string, userId: string, params: CreateWorkf
       input_schema: params.input_schema ?? null,
       output_schema: params.output_schema ?? null,
       child_workflows: params.child_workflows ?? [],
+      llm_model: params.llm_model ?? null,
       is_enabled: true,
     }),
   });
@@ -238,6 +242,7 @@ async function updateWorkflow(orgId: string, workflowId: string, params: CreateW
       input_schema: params.input_schema,
       output_schema: params.output_schema,
       child_workflows: params.child_workflows,
+      llm_model: params.llm_model,
     }),
   });
   if (error || !data) throw new Error(error ?? 'Failed to update workflow');
@@ -705,6 +710,8 @@ function WorkflowModal({
   const [selectedChildWorkflows, setSelectedChildWorkflows] = useState<string[]>(
     workflow?.child_workflows ?? createDraft?.selectedChildWorkflows ?? []
   );
+  const [llmModel, setLlmModel] = useState(workflow?.llm_model ?? createDraft?.llmModel ?? '');
+  const [llmModelMap, setLlmModelMap] = useState<Record<string, string>>({});
 
   useEffect(() => {
     if (isEditMode) return;
@@ -720,6 +727,7 @@ function WorkflowModal({
       inputSchemaText,
       outputSchemaText,
       selectedChildWorkflows,
+      llmModel,
     });
   }, [
     autoApproveTools,
@@ -733,8 +741,20 @@ function WorkflowModal({
     prompt,
     selectedChildWorkflows,
     showAdvanced,
+    llmModel,
     triggerType,
   ]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { data } = await apiRequest<{ models: Record<string, string> }>('/auth/llm-options');
+      if (!cancelled && data?.models) setLlmModelMap(data.models);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Get all workflows for child workflow selection (exclude current workflow)
   const { data: allWorkflows = [] } = useQuery({
@@ -827,6 +847,7 @@ function WorkflowModal({
       input_schema: inputSchema,
       output_schema: outputSchema,
       child_workflows: selectedChildWorkflows.length > 0 ? selectedChildWorkflows : undefined,
+      llm_model: llmModel || '',
     });
   };
 
@@ -1004,7 +1025,7 @@ function WorkflowModal({
             </div>
           )}
 
-          {/* Advanced: Input/Output Schemas */}
+          {/* Advanced: Typed Schemas + Model */}
           <div className="border-t border-surface-800 pt-4">
             <button
               type="button"
@@ -1019,7 +1040,7 @@ function WorkflowModal({
               >
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>
-              Advanced: Typed Input/Output Schemas
+              Advanced: Typed Schema and Model
             </button>
             
             {showAdvanced && (
@@ -1034,6 +1055,25 @@ function WorkflowModal({
                     {schemaError}
                   </div>
                 )}
+
+                <div>
+                  <label className="block text-sm font-medium text-surface-300 mb-1">
+                    Workflow Model Override
+                  </label>
+                  <select
+                    value={llmModel}
+                    onChange={(e) => setLlmModel(e.target.value)}
+                    className="w-full px-3 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                  >
+                    <option value="">Default workflow model</option>
+                    {Object.entries(llmModelMap).map(([model, provider]) => (
+                      <option key={model} value={model}>{model} ({provider})</option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-surface-500 mt-1">
+                    Optional: override the organization workflow model for this workflow only.
+                  </p>
+                </div>
 
                 {/* Input Schema */}
                 <div>


### PR DESCRIPTION
### Motivation

- Provide a per-workflow option to override the organization workflow model so users can pick a specific LLM for a given workflow run. 
- Make the workflow edit UI clearer by renaming the advanced expander to include model selection alongside typed schemas.

### Description

- Added a nullable `llm_model` column to the `Workflow` model and included it in `to_dict()` so API responses now return the field (`backend/models/workflow.py`).
- Added Alembic migration `132_wf_llm_model` to add/drop the `workflows.llm_model` column (`backend/db/migrations/versions/132_wf_llm_model.py`).
- Extended workflow create/update request/response models and handlers to accept and persist `llm_model`, and validate selected models with `is_model_allowed` on the server (`backend/api/routes/workflows.py`).
- Passed the selected workflow model through the run context (`workflow_model_override`) and updated the orchestrator to prefer the override for workflow runs when present (`backend/workers/tasks/workflows.py`, `backend/agents/orchestrator.py`).
- Updated the workflow editor UI (`frontend/src/components/Workflows.tsx`) to rename the advanced expander to `Advanced: Typed Schema and Model`, add a `Workflow Model Override` dropdown populated from `/auth/llm-options`, persist selection to the local draft, and include it in create/update payloads.

### Testing

- Ran a migration preflight assertion to verify revision ID lengths: the `revision='132_wf_llm_model'` and `down_revision='131_workflow_model'` checks passed.
- Ran `pytest -q backend/tests/test_workflow_prompt_guardrails.py` and the suite passed (`2 passed`).
- Attempted frontend typecheck via `npm run typecheck` but the script is not defined in this repository, so a formal frontend typecheck was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85bfacd3483218655177133992667)