### PR TITLE
Update workflow count placement on workflows page

### DIFF
--- a/frontend/src/components/Workflows.tsx
+++ b/frontend/src/components/Workflows.tsx
@@ -1397,9 +1397,6 @@ export function Workflows(): JSX.Element {
             </p>
           </div>
           <div className="flex items-center gap-3">
-            <span className="text-sm text-surface-500">
-              {filteredWorkflows.length} workflow{filteredWorkflows.length !== 1 ? "s" : ""}
-            </span>
             <button
               type="button"
               onClick={openCreateModal}
@@ -1545,7 +1542,7 @@ export function Workflows(): JSX.Element {
             {userWorkflows.length > 0 && (
               <div>
                 <h2 className="text-sm font-medium text-surface-400 uppercase tracking-wider mb-4">
-                  My Workflows
+                  My Workflows ({userWorkflows.length})
                 </h2>
                 <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                   {userWorkflows.map((workflow) => (
@@ -1564,7 +1561,7 @@ export function Workflows(): JSX.Element {
             {otherWorkflows.length > 0 && (
               <div>
                 <h2 className="text-sm font-medium text-surface-400 uppercase tracking-wider mb-4">
-                  Team Workflows
+                  Team Workflows ({otherWorkflows.length})
                 </h2>
                 <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
                   {otherWorkflows.map((workflow) => (
@@ -1593,8 +1590,7 @@ export function Workflows(): JSX.Element {
                 >
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                 </svg>
-                Archived
-                {showArchived ? ` (${archivedWorkflows.length})` : ''}
+                Archived ({archivedWorkflows.length})
               </button>
               {showArchived && (
                 <div className="mt-4 space-y-2">


### PR DESCRIPTION
### Motivation
- Replace the single global workflow count in the header with per-section counts to provide more contextual information at the section level.
- Ensure archived workflows always show their count in the toggle label even when the section is collapsed.

### Description
- Removed the header aggregate count rendering and its pluralization logic from `frontend/src/components/Workflows.tsx`.
- Added inline counts to the section headings: `My Workflows ({userWorkflows.length})` and `Team Workflows ({otherWorkflows.length})` in `frontend/src/components/Workflows.tsx`.
- Changed the archived toggle label to always display `Archived ({archivedWorkflows.length})` instead of showing the count only when expanded.
- Kept UI behavior for creating/searching/view modes unchanged; only label text was adjusted.

### Testing
- Ran `npm --prefix frontend run lint` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85ea7e0e08321b18b7b54b449f5df)