### PR TITLE
Adjust workflows action button sizing and labels

### DIFF
--- a/frontend/src/components/Workflows.tsx
+++ b/frontend/src/components/Workflows.tsx
@@ -628,13 +628,13 @@ function WorkflowDetail({
                   onClick={onArchive}
                   className="w-full min-h-10 px-4 py-2 rounded-lg bg-surface-800 text-sm font-medium text-surface-300 hover:bg-surface-700 hover:text-surface-100 transition-colors whitespace-nowrap sm:min-w-40"
                 >
-                  Archive workflow
+                  Archive Workflow
                 </button>
                 <button
                   onClick={() => setShowDeleteConfirm(true)}
                   className="w-full min-h-10 px-4 py-2 rounded-lg bg-red-600/20 text-sm font-medium text-red-400 hover:bg-red-600/30 hover:text-red-300 transition-colors whitespace-nowrap sm:min-w-40"
                 >
-                  Delete workflow
+                  Delete Workflow
                 </button>
               </div>
             )}
@@ -642,14 +642,14 @@ function WorkflowDetail({
           <div className="grid w-full grid-cols-2 gap-2 sm:w-auto sm:flex sm:items-center">
             <button
               onClick={onEdit}
-              className="w-full min-h-10 px-4 py-2 bg-surface-700 hover:bg-surface-600 text-surface-200 rounded-lg text-sm font-medium transition-colors whitespace-nowrap sm:min-w-40"
+              className="w-full min-h-10 px-4 py-2 bg-surface-700 hover:bg-surface-600 text-sm font-medium text-surface-200 rounded-lg transition-colors whitespace-nowrap sm:min-h-9 sm:px-3 sm:py-1.5 sm:min-w-32"
             >
               Edit
             </button>
             <button
               onClick={onTrigger}
               disabled={!workflow.is_enabled || isTriggering}
-              className="w-full min-h-10 px-4 py-2 bg-primary-600 hover:bg-primary-700 disabled:bg-surface-700 disabled:text-surface-500 text-white rounded-lg text-sm font-medium transition-colors flex items-center justify-center gap-2 whitespace-nowrap sm:min-w-40"
+              className="w-full min-h-10 px-4 py-2 bg-primary-600 hover:bg-primary-700 disabled:bg-surface-700 disabled:text-surface-500 text-sm font-medium text-white rounded-lg transition-colors flex items-center justify-center gap-2 whitespace-nowrap sm:min-h-9 sm:px-3 sm:py-1.5 sm:min-w-32"
             >
               {isTriggering && (
                 <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">


### PR DESCRIPTION
### Motivation
- Make the Workflows details modal copy consistent by capitalizing the word `Workflow` in action labels.
- Reduce the desktop (`sm+`) footprint of the `Edit` and `Run Now` buttons while keeping their current mobile sizing for a more compact workflows UI.

### Description
- Change the modal action labels to `Archive Workflow` and `Delete Workflow` in `frontend/src/components/Workflows.tsx`.
- Update Tailwind class names for the `Edit` and `Run Now` buttons to use smaller `sm`-scale sizing (`sm:min-h-9`, reduced `sm:px`/`sm:py`, and `sm:min-w-32`) while preserving mobile styles in `frontend/src/components/Workflows.tsx`.

### Testing
- Ran `cd frontend && npx eslint src/components/Workflows.tsx` and the lint check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87c7b57bc8321b95f7137daf47099)