### PR TITLE
Narrow workflow pills and enable title wrapping on mobile

### DIFF
--- a/frontend/src/components/Workflows.tsx
+++ b/frontend/src/components/Workflows.tsx
@@ -1722,7 +1722,7 @@ function WorkflowCard({
       }`}
     >
       <div className="flex items-start justify-between mb-2">
-        <h3 className="font-medium text-surface-100 truncate flex-1">{workflow.name}</h3>
+        <h3 className="font-medium text-surface-100 flex-1 min-w-0 break-words leading-snug">{workflow.name}</h3>
         <div className="ml-2 flex items-center gap-2">
           {isActive ? (
             <span className="relative flex h-2.5 w-2.5">
@@ -1746,7 +1746,10 @@ function WorkflowCard({
       
       <div className="flex items-center gap-1 flex-wrap">
         {workflow.steps.slice(0, 3).map((step, idx) => (
-          <span key={idx} className="px-2 py-0.5 bg-surface-800 rounded text-xs text-surface-400">
+          <span
+            key={idx}
+            className="px-2 py-0.5 bg-surface-800 rounded text-xs text-surface-400 max-w-full whitespace-normal break-words"
+          >
             {getActionDisplayName(step.action)}
           </span>
         ))}


### PR DESCRIPTION
### Motivation
- Workflow cards on narrow/mobile screens allowed long titles and step pills to overflow or be truncated, causing poor readability.

### Description
- Updated `frontend/src/components/Workflows.tsx` to allow workflow titles to wrap by replacing the `truncate` behavior with `flex-1 min-w-0 break-words leading-snug` and constrained workflow step pills by adding `max-w-full whitespace-normal break-words` so pills wrap within card boundaries.

### Testing
- Ran `npm --prefix frontend run lint` and the lint pass completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87f222668832180c893c666f5de8b)