### PR TITLE
Truncate Google Drive action-ledger payload strings to 200 chars

### DIFF
--- a/backend/services/action_ledger.py
+++ b/backend/services/action_ledger.py
@@ -15,6 +15,7 @@ from models.action_ledger import ActionLedgerEntry
 from models.database import get_session
 
 logger = logging.getLogger(__name__)
+GOOGLE_DRIVE_LOG_MAX_CHARS = 200
 
 # Best-effort entity extraction from operation name + data dict.
 _ENTITY_HEURISTICS: dict[str, tuple[str, str]] = {
@@ -32,6 +33,22 @@ _ENTITY_HEURISTICS: dict[str, tuple[str, str]] = {
     "create_file": ("file", ""),
     "append_rows": ("sheet", "external_id"),
 }
+
+
+def _truncate_value_for_log(value: Any, max_chars: int = GOOGLE_DRIVE_LOG_MAX_CHARS) -> Any:
+    """Recursively truncate string values for log-safe persistence."""
+    if isinstance(value, str):
+        return value if len(value) <= max_chars else value[:max_chars]
+    if isinstance(value, dict):
+        return {k: _truncate_value_for_log(v, max_chars=max_chars) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_truncate_value_for_log(v, max_chars=max_chars) for v in value]
+    return value
+
+
+def _sanitize_google_drive_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Truncate nested string fields in Google Drive tool payloads."""
+    return _truncate_value_for_log(payload, max_chars=GOOGLE_DRIVE_LOG_MAX_CHARS)
 
 
 def _extract_entity(operation: str, data: dict[str, Any]) -> tuple[Optional[str], Optional[str]]:
@@ -70,6 +87,10 @@ async def record_intent(
         workflow_id = ctx.get("workflow_id")
 
         change_id = uuid.uuid4()
+        sanitized_data: dict[str, Any] = (
+            _sanitize_google_drive_payload(data) if connector == "google_drive" else data
+        )
+
         entry = ActionLedgerEntry(
             id=change_id,
             organization_id=uuid.UUID(organization_id),
@@ -81,7 +102,7 @@ async def record_intent(
             operation=operation,
             entity_type=entity_type,
             entity_id=entity_id,
-            intent={"changes": data, "before_state": before_state},
+            intent={"changes": sanitized_data, "before_state": before_state},
         )
 
         async with get_session(organization_id) as session:
@@ -113,6 +134,8 @@ async def record_outcome(
         async with get_session(organization_id) as session:
             entry: ActionLedgerEntry | None = await session.get(ActionLedgerEntry, change_id)
             if entry:
+                if entry.connector == "google_drive":
+                    outcome = _truncate_value_for_log(outcome)
                 entry.outcome = outcome
                 entry.executed_at = datetime.utcnow()
                 await session.commit()

--- a/backend/tests/test_action_ledger.py
+++ b/backend/tests/test_action_ledger.py
@@ -17,7 +17,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from models.action_ledger import ActionLedgerEntry
-from services.action_ledger import _extract_entity, record_intent, record_outcome
+from services.action_ledger import (
+    _extract_entity,
+    _truncate_value_for_log,
+    record_intent,
+    record_outcome,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -253,6 +258,32 @@ class TestRecordIntentFailureIsolation:
         # Should still succeed — before_state is best-effort
         assert isinstance(result, uuid.UUID)
 
+    def test_google_drive_intent_truncates_long_strings(self) -> None:
+        added_entries: list[ActionLedgerEntry] = []
+
+        @asynccontextmanager
+        async def _fake_session(*_a: object, **_kw: object):
+            mock = MagicMock()
+            mock.add = MagicMock(side_effect=lambda e: added_entries.append(e))
+            mock.commit = AsyncMock()
+            yield mock
+
+        long_text = "x" * 250
+        with patch("services.action_ledger.get_session", _fake_session):
+            result = asyncio.run(record_intent(
+                organization_id="00000000-0000-0000-0000-000000000001",
+                user_id=None,
+                context={},
+                connector="google_drive",
+                dispatch_type="action",
+                operation="insert_text",
+                data={"text": long_text, "external_id": "file-1"},
+            ))
+
+        assert isinstance(result, uuid.UUID)
+        assert len(added_entries) == 1
+        assert len(added_entries[0].intent["changes"]["text"]) == 200
+
 
 class TestRecordOutcomeFailureIsolation:
     """record_outcome must never raise."""
@@ -320,6 +351,36 @@ class TestRecordOutcomeFailureIsolation:
 
         assert mock_entry.outcome["status"] == "error"
         assert mock_entry.outcome["error"] == "Connection refused"
+
+    def test_google_drive_outcome_truncates_long_strings(self) -> None:
+        mock_entry = MagicMock()
+        mock_entry.connector = "google_drive"
+        mock_entry.outcome = None
+        mock_entry.executed_at = None
+
+        @asynccontextmanager
+        async def _fake_session(*_a: object, **_kw: object):
+            mock = MagicMock()
+            mock.get = AsyncMock(return_value=mock_entry)
+            mock.commit = AsyncMock()
+            yield mock
+
+        with patch("services.action_ledger.get_session", _fake_session):
+            asyncio.run(record_outcome(
+                uuid.uuid4(), "00000000-0000-0000-0000-000000000001",
+                {"content": "y" * 500},
+            ))
+
+        assert mock_entry.outcome["status"] == "success"
+        assert len(mock_entry.outcome["response"]["content"]) == 200
+
+
+def test_truncate_value_for_log_truncates_nested_strings() -> None:
+    payload = {"a": "b" * 250, "nested": [{"c": "d" * 205}, "ok"]}
+    truncated = _truncate_value_for_log(payload)
+    assert len(truncated["a"]) == 200
+    assert len(truncated["nested"][0]["c"]) == 200
+    assert truncated["nested"][1] == "ok"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Prevent excessive Google Drive tool-call payloads from being stored in the action ledger by capping string fields to 200 characters to reduce log noise and DB payload size.

### Description
- Add `GOOGLE_DRIVE_LOG_MAX_CHARS = 200` and a recursive helper ` _truncate_value_for_log` to truncate nested string values. 
- Add `_sanitize_google_drive_payload` and apply it in `record_intent` so only `connector == "google_drive"` intent `changes` are truncated before persisting. 
- In `record_outcome`, truncate the outcome payload when the persisted ledger entry has `connector == "google_drive"` before saving. 
- Add tests for intent truncation, outcome truncation, and nested truncation helper behavior; changes are in `backend/services/action_ledger.py` and `backend/tests/test_action_ledger.py`.

### Testing
- Ran `pytest -q backend/tests/test_action_ledger.py` and all tests passed (`37 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a8b698a08321a67da1c5822087cf)