### PR TITLE
Fix PagerDuty incident retries for rolling query success drops

### DIFF
--- a/backend/services/query_outcome_metrics.py
+++ b/backend/services/query_outcome_metrics.py
@@ -184,7 +184,7 @@ async def _maybe_raise_query_success_incident(
     if not should_create:
         return
 
-    await create_pagerduty_incident(
+    incident_created = await create_pagerduty_incident(
         title="Rolling query success dropped to 25% or below",
         details=(
             f"Rolling 30-minute query success dropped to {success_rate_pct:.2f}% "
@@ -194,3 +194,12 @@ async def _maybe_raise_query_success_incident(
             f"incident_reason={reason}"
         ),
     )
+    if not incident_created:
+        logger.warning(
+            "Rolling query success incident request failed; clearing throttle for immediate retry "
+            "platform=%s success_pct=%.2f threshold_pct=%.2f",
+            platform,
+            success_rate_pct,
+            _QUERY_SUCCESS_INCIDENT_THRESHOLD_PCT,
+        )
+        await clear_incident_failure(_QUERY_SUCCESS_CHECK_NAME)

--- a/backend/tests/test_query_outcome_metrics.py
+++ b/backend/tests/test_query_outcome_metrics.py
@@ -234,6 +234,67 @@ def test_record_query_outcome_raises_incident_when_success_rate_at_or_below_25(
     assert incidents[0]["title"] == "Rolling query success dropped to 25% or below"
 
 
+def test_record_query_outcome_raises_incident_when_success_rate_below_25(
+    monkeypatch,
+) -> None:
+    class _FakePipeline:
+        def __init__(self) -> None:
+            self._zcard_results = [1, 4]
+
+        def zadd(self, *_args, **_kwargs) -> None:
+            return None
+
+        def expire(self, *_args, **_kwargs) -> None:
+            return None
+
+        def zremrangebyscore(self, *_args, **_kwargs) -> None:
+            return None
+
+        def zcard(self, *_args, **_kwargs) -> None:
+            return None
+
+        def zrangebyscore(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def execute(self):
+            if self._zcard_results:
+                return [0, 0, 0, self._zcard_results.pop(0), self._zcard_results.pop(0), []]
+            return [1, True]
+
+    class _FakeRedis:
+        def pipeline(self) -> _FakePipeline:
+            return _FakePipeline()
+
+        async def __aenter__(self) -> "_FakeRedis":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    incidents: list[dict[str, str]] = []
+
+    async def _fake_evaluate(_check_name: str) -> tuple[bool, str]:
+        return True, "new_failure"
+
+    async def _fake_incident(*, title: str, details: str) -> bool:
+        incidents.append({"title": title, "details": details})
+        return True
+
+    async def _fake_clear(_check_name: str) -> None:
+        return None
+
+    monkeypatch.setattr(query_outcome_metrics.aioredis, "from_url", lambda *_args, **_kwargs: _FakeRedis())
+    monkeypatch.setattr(query_outcome_metrics, "evaluate_incident_creation", _fake_evaluate)
+    monkeypatch.setattr(query_outcome_metrics, "create_pagerduty_incident", _fake_incident)
+    monkeypatch.setattr(query_outcome_metrics, "clear_incident_failure", _fake_clear)
+
+    asyncio.run(query_outcome_metrics.record_query_outcome(platform="slack", was_success=False))
+
+    assert len(incidents) == 1
+    assert incidents[0]["title"] == "Rolling query success dropped to 25% or below"
+    assert "20.00%" in incidents[0]["details"]
+
+
 def test_record_query_outcome_clears_throttle_when_success_rate_recovers(monkeypatch) -> None:
     class _FakePipeline:
         def __init__(self) -> None:
@@ -293,6 +354,62 @@ def test_record_query_outcome_clears_throttle_when_success_rate_recovers(monkeyp
 
     assert evaluate_calls == []
     assert incident_calls == []
+    assert clear_calls == ["Rolling Query Success"]
+
+
+def test_record_query_outcome_clears_throttle_when_incident_creation_fails(monkeypatch) -> None:
+    class _FakePipeline:
+        def __init__(self) -> None:
+            self._zcard_results = [1, 4]
+
+        def zadd(self, *_args, **_kwargs) -> None:
+            return None
+
+        def expire(self, *_args, **_kwargs) -> None:
+            return None
+
+        def zremrangebyscore(self, *_args, **_kwargs) -> None:
+            return None
+
+        def zcard(self, *_args, **_kwargs) -> None:
+            return None
+
+        def zrangebyscore(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def execute(self):
+            if self._zcard_results:
+                return [0, 0, 0, self._zcard_results.pop(0), self._zcard_results.pop(0), []]
+            return [1, True]
+
+    class _FakeRedis:
+        def pipeline(self) -> _FakePipeline:
+            return _FakePipeline()
+
+        async def __aenter__(self) -> "_FakeRedis":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    clear_calls: list[str] = []
+
+    async def _fake_evaluate(_check_name: str) -> tuple[bool, str]:
+        return True, "new_failure"
+
+    async def _fake_incident(*, title: str, details: str) -> bool:
+        return False
+
+    async def _fake_clear(check_name: str) -> None:
+        clear_calls.append(check_name)
+
+    monkeypatch.setattr(query_outcome_metrics.aioredis, "from_url", lambda *_args, **_kwargs: _FakeRedis())
+    monkeypatch.setattr(query_outcome_metrics, "evaluate_incident_creation", _fake_evaluate)
+    monkeypatch.setattr(query_outcome_metrics, "create_pagerduty_incident", _fake_incident)
+    monkeypatch.setattr(query_outcome_metrics, "clear_incident_failure", _fake_clear)
+
+    asyncio.run(query_outcome_metrics.record_query_outcome(platform="slack", was_success=False))
+
     assert clear_calls == ["Rolling Query Success"]
 
 


### PR DESCRIPTION
### Motivation
- Ensure we actually raise a PagerDuty incident when the rolling 30-minute query success rate is below the configured threshold instead of remaining suppressed by the incident throttle when the PagerDuty request itself fails.
- Make degraded-window incident delivery resilient to transient PagerDuty/API/configuration failures while preserving the existing `<= 25%` degrade / `> 25%` recover semantics.

### Description
- Update `_maybe_raise_query_success_incident` in `services/query_outcome_metrics.py` to capture the boolean result from `create_pagerduty_incident` and call `clear_incident_failure` when incident creation returns `False`, allowing immediate retry on subsequent degraded events.
- Add unit tests in `backend/tests/test_query_outcome_metrics.py` to cover the explicit `<25%` case and to verify that throttle state is cleared when incident creation fails.
- Modified files: `backend/services/query_outcome_metrics.py` and `backend/tests/test_query_outcome_metrics.py`.

### Testing
- Ran `pytest -q backend/tests/test_query_outcome_metrics.py` and the suite passed: `11 passed`.
- The new tests assert that an incident is raised for a 20% success rate and that the throttle is cleared when `create_pagerduty_incident` reports failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a6f728e8832186e809e061468449)