### PR TITLE
Fix PagerDuty incident flag diagnostics and .env discovery

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -28,8 +28,13 @@ def to_iso8601(dt: datetime | date | None) -> str | None:
     # date only - no timezone
     return dt.isoformat()
 
-# Find .env file - check current dir, then parent (for when running from backend/)
-_env_file = Path(".env")
+# Find .env file deterministically from repository layout first, then CWD fallbacks.
+# This avoids silently missing .env when processes start with an unexpected working directory.
+_config_dir = Path(__file__).resolve().parent
+_repo_root = _config_dir.parent
+_env_file = _repo_root / ".env"
+if not _env_file.exists():
+    _env_file = Path(".env")
 if not _env_file.exists():
     _env_file = Path("../.env")
 

--- a/backend/services/pagerduty.py
+++ b/backend/services/pagerduty.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
+
 import httpx
 
 from config import settings
@@ -25,7 +27,10 @@ def _pagerduty_incidents_enabled() -> bool:
         return True
 
     logger.info(
-        "PagerDuty incident skipped: incidenting disabled (PAGERDUTY_INCIDENTS_ENABLED=false)"
+        "PagerDuty incident skipped: incidenting disabled "
+        "(parsed_enabled=%s raw_env=%r)",
+        settings.PAGERDUTY_INCIDENTS_ENABLED,
+        os.getenv("PAGERDUTY_INCIDENTS_ENABLED"),
     )
     return False
 


### PR DESCRIPTION
### Motivation
- Processes starting from an unexpected working directory could miss the project `.env`, causing `PAGERDUTY_INCIDENTS_ENABLED` to fall back to the default `False` and silently disable incidenting. 
- Existing log output did not show the raw environment string, making it hard to tell whether the flag was unset or parsed as false. 

### Description
- Resolve `.env` deterministically from the repository root relative to `backend/config.py` before falling back to CWD-based paths to avoid missing env files (change in `backend/config.py`).
- Improve diagnostics in `backend/services/pagerduty.py` by logging both the parsed `settings.PAGERDUTY_INCIDENTS_ENABLED` value and the raw `os.getenv("PAGERDUTY_INCIDENTS_ENABLED")` string when incidenting is disabled, and add the necessary `import os`.
- Keep existing behavior otherwise (configuration validation and PagerDuty request flow are unchanged).

### Testing
- Ran `pytest -q backend/tests/test_pagerduty_service.py` and all tests passed (5 passed).
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8ac9f3b348321a249f15c1ac94bfa)