### PR TITLE
Start incident throttle only after PagerDuty incident is accepted

### DIFF
--- a/backend/api/auth_middleware.py
+++ b/backend/api/auth_middleware.py
@@ -30,7 +30,7 @@ from sqlalchemy import select
 from config import settings
 from models.org_member import OrgMember, ORG_MEMBER_SCOPING_STATUSES
 from models.user import User
-from services.incident_throttling import evaluate_incident_creation
+from services.incident_throttling import evaluate_incident_creation, mark_incident_created
 from services.pagerduty import create_pagerduty_incident
 
 logger = logging.getLogger(__name__)
@@ -228,13 +228,15 @@ async def _get_jwks() -> dict:
     should_create, reason = await evaluate_incident_creation("Auth JWKS")
     if should_create:
         logger.warning("PagerDuty incident allowed for Auth JWKS reason=%s", reason)
-        await create_pagerduty_incident(
+        incident_created = await create_pagerduty_incident(
             title="Auth JWKS endpoint unreachable",
             details=(
                 "Auth middleware failed to fetch JWKS after 3 attempts and has no cache fallback. "
                 f"JWKS URL: {jwks_url}. Last error: {last_error}"
             ),
         )
+        if incident_created:
+            await mark_incident_created("Auth JWKS")
     else:
         logger.info("PagerDuty incident suppressed for Auth JWKS reason=%s", reason)
     raise HTTPException(

--- a/backend/services/anthropic_health.py
+++ b/backend/services/anthropic_health.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from anthropic import APIStatusError
 
-from services.incident_throttling import clear_incident_failure, evaluate_incident_creation
+from services.incident_throttling import clear_incident_failure, evaluate_incident_creation, mark_incident_created
 from services.pagerduty import create_pagerduty_incident
 
 logger = logging.getLogger(__name__)
@@ -92,10 +92,12 @@ async def report_anthropic_call_failure(*, exc: Exception, source: str) -> None:
         )
         return
 
-    await create_pagerduty_incident(
+    incident_created = await create_pagerduty_incident(
         title="Anthropic credits exhausted",
         details=(
             "Passive Anthropic credit health check observed an out-of-credits response. "
             f"Source={source}. Reason={reason}. Error={exc}"
         ),
     )
+    if incident_created:
+        await mark_incident_created(_ANTHROPIC_CREDITS_CHECK_NAME)

--- a/backend/services/incident_throttling.py
+++ b/backend/services/incident_throttling.py
@@ -38,7 +38,6 @@ async def evaluate_incident_creation(check_name: str) -> tuple[bool, str]:
                     key,
                     mapping={
                         "first_failed_at": str(now),
-                        "last_incident_at": str(now),
                     },
                 )
                 await redis_client.expire(key, _INCIDENT_KEY_TTL_SECONDS)
@@ -56,8 +55,6 @@ async def evaluate_incident_creation(check_name: str) -> tuple[bool, str]:
                 last_incident_at = 0
 
             if now - last_incident_at >= _INCIDENT_COOLDOWN_SECONDS:
-                await redis_client.hset(key, mapping={"last_incident_at": str(now)})
-                await redis_client.expire(key, _INCIDENT_KEY_TTL_SECONDS)
                 return True, "cooldown_elapsed"
 
             suppress_for = _INCIDENT_COOLDOWN_SECONDS - (now - last_incident_at)
@@ -68,6 +65,30 @@ async def evaluate_incident_creation(check_name: str) -> tuple[bool, str]:
             check_name,
         )
         return True, "throttle_unavailable"
+
+
+async def mark_incident_created(check_name: str) -> None:
+    """Persist incident timestamp after PagerDuty accepts incident creation."""
+    now = int(time.time())
+    redis_client = aioredis.from_url(
+        settings.REDIS_URL,
+        **get_redis_connection_kwargs(),
+    )
+    key = _incident_key(check_name)
+
+    try:
+        async with redis_client:
+            await redis_client.hset(
+                key,
+                mapping={
+                    "first_failed_at": str(now),
+                    "last_incident_at": str(now),
+                },
+            )
+            await redis_client.expire(key, _INCIDENT_KEY_TTL_SECONDS)
+        logger.info("Marked incident throttle window start check=%s timestamp=%s", check_name, now)
+    except Exception:
+        logger.exception("Failed to mark incident throttle window start for check=%s", check_name)
 
 
 async def clear_incident_failure(check_name: str) -> None:

--- a/backend/services/query_outcome_metrics.py
+++ b/backend/services/query_outcome_metrics.py
@@ -8,7 +8,7 @@ from collections import Counter
 import redis.asyncio as aioredis
 
 from config import get_redis_connection_kwargs, settings
-from services.incident_throttling import clear_incident_failure, evaluate_incident_creation
+from services.incident_throttling import clear_incident_failure, evaluate_incident_creation, mark_incident_created
 from services.pagerduty import create_pagerduty_incident
 
 logger = logging.getLogger(__name__)
@@ -184,7 +184,7 @@ async def _maybe_raise_query_success_incident(
     if not should_create:
         return
 
-    await create_pagerduty_incident(
+    incident_created = await create_pagerduty_incident(
         title="Rolling query success dropped to 25% or below",
         details=(
             f"Rolling 30-minute query success dropped to {success_rate_pct:.2f}% "
@@ -194,3 +194,5 @@ async def _maybe_raise_query_success_incident(
             f"incident_reason={reason}"
         ),
     )
+    if incident_created:
+        await mark_incident_created(_QUERY_SUCCESS_CHECK_NAME)

--- a/backend/workers/tasks/monitoring.py
+++ b/backend/workers/tasks/monitoring.py
@@ -12,7 +12,7 @@ from sqlalchemy import text
 
 from config import get_redis_connection_kwargs, settings
 from models.database import get_admin_session
-from services.incident_throttling import clear_incident_failure, evaluate_incident_creation
+from services.incident_throttling import clear_incident_failure, evaluate_incident_creation, mark_incident_created
 from services.pagerduty import create_pagerduty_incident
 from workers.celery_app import celery_app
 
@@ -222,15 +222,18 @@ async def _check_redis(timeout_s: float = 10.0) -> CheckResult:
 async def _create_pagerduty_incident(
     *,
     check_result: CheckResult,
-) -> None:
+) -> bool:
     """Create an incident in PagerDuty v2 REST API."""
-    await create_pagerduty_incident(
+    incident_created = await create_pagerduty_incident(
         title=f"{check_result.name} is down",
         details=(
             "Automated Basebase dependency monitor detected an outage. "
             f"Dependency: {check_result.name}. Details: {check_result.details}"
         ),
     )
+    if incident_created:
+        await mark_incident_created(check_result.name)
+    return incident_created
 
 
 async def _run_dependency_checks() -> list[CheckResult]:


### PR DESCRIPTION
### Motivation

- Prevent failed or rejected PagerDuty requests from consuming the incident throttle window so transient transport/HTTP errors do not suppress subsequent, valid alerts.  
- Ensure the throttle window only starts when an incident has actually been accepted by PagerDuty.

### Description

- Changed `evaluate_incident_creation` to stop writing `last_incident_at` (it now only decides whether an incident is allowed) in `backend/services/incident_throttling.py`.  
- Added `mark_incident_created(check_name)` in `backend/services/incident_throttling.py` to persist `last_incident_at` only after PagerDuty reports success.  
- Updated all throttle-aware paths to call `mark_incident_created(...)` only when `create_pagerduty_incident(...)` returns `True`, including `backend/services/anthropic_health.py` (`report_anthropic_call_failure`), `backend/services/query_outcome_metrics.py` (`_maybe_raise_query_success_incident`), and `backend/api/auth_middleware.py` (JWKS fetch failure handling).  
- Modified dependency monitoring in `backend/workers/tasks/monitoring.py` so `_create_pagerduty_incident` returns a boolean and calls `mark_incident_created` on success, and updated imports to include `mark_incident_created` where needed.

### Testing

- Ran targeted test suite: `pytest -q backend/tests/test_incident_throttling.py backend/tests/test_auth_middleware_jwks.py backend/tests/test_anthropic_health.py backend/tests/test_query_outcome_metrics.py backend/tests/test_monitoring_task.py`.  
- Result: `40 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93a8816308321a1894658ad34c0d3)