### PR TITLE
Fix Slack app_mention handling to preserve non-bot user mentions

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -425,7 +425,8 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
     if inner_type == "app_mention":
         channel_id = event.get("channel", "")
         user_id = event.get("user", "")
-        text = re.sub(r"<@[A-Z0-9]+>\s*", "", event.get("text", "")).strip()
+        raw_text: str = event.get("text", "") or ""
+        text = _strip_bot_mentions(raw_text, bot_user_ids) if bot_user_ids else raw_text.strip()
         event_ts: str = event.get("event_ts", "")
         message_ts = event.get("ts", "") or event_ts
         thread_ts = event.get("thread_ts")

--- a/backend/tests/test_slack_events_thread_locking.py
+++ b/backend/tests/test_slack_events_thread_locking.py
@@ -127,3 +127,44 @@ def test_strip_bot_mentions_removes_only_known_bot_mentions() -> None:
     text = "<@UBOT> hi <@UOTHER> and <@UBOT>"
     cleaned = slack_events._strip_bot_mentions(text, {"UBOT"})
     assert cleaned == "hi <@UOTHER> and"
+
+
+def test_app_mention_keeps_non_bot_user_mentions_in_text(monkeypatch) -> None:
+    captured: list[InboundMessage] = []
+
+    async def _fake_is_duplicate_event(_event_id: str) -> bool:
+        return False
+
+    async def _fake_is_duplicate_message(_channel_id: str, _message_ts: str) -> bool:
+        return False
+
+    async def _fake_process_inbound(self, message: InboundMessage):
+        captured.append(message)
+        return {"status": "success"}
+
+    monkeypatch.setattr(slack_events, "is_duplicate_event", _fake_is_duplicate_event)
+    monkeypatch.setattr(slack_events, "is_duplicate_message", _fake_is_duplicate_message)
+    monkeypatch.setattr(SlackMessenger, "process_inbound", _fake_process_inbound)
+
+    payload = {
+        "type": "event_callback",
+        "event_id": "EvAppMention1",
+        "team_id": "T123",
+        "authed_users": ["UBOT"],
+        "event": {
+            "type": "app_mention",
+            "channel_type": "channel",
+            "channel": "C123",
+            "user": "U123",
+            "event_ts": "1700000000.001",
+            "ts": "1700000000.001",
+            "text": "<@UBOT> who is <@UJON123>?",
+        },
+    }
+
+    asyncio.run(slack_events._process_event_callback_impl(payload))
+
+    assert len(captured) == 1
+    msg: InboundMessage = captured[0]
+    assert msg.message_type == MessageType.MENTION
+    assert msg.text == "who is <@UJON123>?"


### PR DESCRIPTION
### Motivation
- The `app_mention` preprocessing was stripping every `<@...>` token which removed non-bot user mentions and prevented downstream resolution via the Slack mapping table (e.g. `"@Basebase who is @Jon"` lost `@Jon`).

### Description
- Replace the unconditional regex removal with a call to `_strip_bot_mentions(raw_text, bot_user_ids)` so only known bot mention tokens are removed in `backend/api/routes/slack_events.py`.
- Introduce a `raw_text` variable and use `bot_user_ids` when available to preserve other `<@...>` tokens.
- Add a regression test `test_app_mention_keeps_non_bot_user_mentions_in_text` in `backend/tests/test_slack_events_thread_locking.py` to assert an `app_mention` like `"<@UBOT> who is <@UJON123>?"` is normalized to `"who is <@UJON123>?"`.

### Testing
- Ran `pytest -q backend/tests/test_slack_events_thread_locking.py` and the suite passed with `5 passed` tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd760ae708321830fb9ccd20030fd)