### PR TITLE
Fix GPT-5 chat completion token parameter handling

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -317,6 +317,23 @@ class OpenAIAdapter:
             kwargs["base_url"] = base_url
         self._client: AsyncOpenAI = AsyncOpenAI(**kwargs)
 
+    def _build_token_limit_kwargs(self, *, model: str, max_tokens: int) -> dict[str, int]:
+        """Map token limit parameter name based on OpenAI model requirements."""
+        # Newer reasoning families (e.g. gpt-5 / o-series) reject `max_tokens`.
+        uses_completion_tokens: bool = model.startswith(("gpt-5", "o"))
+        token_param_name: str = (
+            "max_completion_tokens" if uses_completion_tokens else "max_tokens"
+        )
+        logger.debug(
+            "OpenAI token limit param selected",
+            extra={
+                "model": model,
+                "token_param_name": token_param_name,
+                "token_limit": max_tokens,
+            },
+        )
+        return {token_param_name: max_tokens}
+
     # -- streaming ----------------------------------------------------------
 
     async def stream(
@@ -335,10 +352,10 @@ class OpenAIAdapter:
 
         api_kwargs: dict[str, Any] = {
             "model": model,
-            "max_tokens": max_tokens,
             "messages": api_messages,
             "stream": True,
         }
+        api_kwargs.update(self._build_token_limit_kwargs(model=model, max_tokens=max_tokens))
         if tools:
             api_kwargs["tools"] = self.format_tools(tools)
 
@@ -428,8 +445,8 @@ class OpenAIAdapter:
 
         response = await self._client.chat.completions.create(
             model=model,
-            max_tokens=max_tokens,
             messages=api_messages,
+            **self._build_token_limit_kwargs(model=model, max_tokens=max_tokens),
         )
         blocks: list[ContentBlock] = self.build_completed_content(response)
         usage = response.usage

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -1,0 +1,17 @@
+from services.llm_adapter import OpenAIAdapter
+
+
+def test_openai_gpt5_uses_max_completion_tokens():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    assert adapter._build_token_limit_kwargs(model="gpt-5", max_tokens=1234) == {
+        "max_completion_tokens": 1234
+    }
+
+
+def test_openai_legacy_models_use_max_tokens():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    assert adapter._build_token_limit_kwargs(model="gpt-4o-mini", max_tokens=4321) == {
+        "max_tokens": 4321
+    }


### PR DESCRIPTION
### Motivation
- OpenAI GPT-5 / newer reasoning families reject the `max_tokens` parameter and require `max_completion_tokens`, which caused 400 `unsupported_parameter` errors during streaming. 
- Ensure both streaming and non-streaming OpenAI chat calls use the correct token-limit parameter per model family to avoid API errors.

### Description
- Added `OpenAIAdapter._build_token_limit_kwargs` to select the proper token parameter name based on model family (uses `max_completion_tokens` for `gpt-5`/`o` series, otherwise `max_tokens`).
- Updated the streaming path to merge the token-parameter mapping into `api_kwargs` before calling `self._client.chat.completions.create`.
- Updated the non-streaming `complete` call to pass token-parameter kwargs from the same helper instead of a fixed `max_tokens` argument.
- Added debug logging for the chosen token parameter and its value and added unit tests in `backend/tests/test_llm_adapter_openai_token_params.py` to validate the mapping.

### Testing
- Ran `cd backend && pytest -q tests/test_llm_adapter_openai_token_params.py`, which passed with `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddde710d708321a77ecddc2c4220fa)