### PR TITLE
Default workflow conversations to private scope

### DIFF
--- a/backend/api/routes/workflows.py
+++ b/backend/api/routes/workflows.py
@@ -641,8 +641,16 @@ async def trigger_workflow(
                 user_id=trigger_user_uuid or workflow.created_by_user_id,
                 organization_id=workflow.organization_id,
                 type="workflow",
+                scope="private",
                 workflow_id=workflow.id,
                 title=f"Workflow: {workflow.name}",
+            )
+            logger.info(
+                "[Workflows API] Creating workflow conversation with private default scope",
+                extra={
+                    "workflow_id": str(workflow.id),
+                    "conversation_scope": "private",
+                },
             )
             session.add(conversation)
             await session.commit()

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -960,9 +960,16 @@ async def _execute_workflow_via_agent(
                 user_id=conversation_user_id,
                 organization_id=workflow.organization_id,
                 type="workflow",
+                scope="private",
                 workflow_id=workflow.id,
                 title=f"Workflow: {workflow.name}",
                 parent_conversation_id=parent_conversation_id,
+            )
+            logger.info(
+                "[Workflow] Creating fallback workflow conversation with private scope "
+                "workflow_id=%s parent_conversation_id=%s",
+                workflow.id,
+                parent_conversation_id,
             )
             session.add(conversation)
             await session.flush()
@@ -972,9 +979,16 @@ async def _execute_workflow_via_agent(
             user_id=conversation_user_id,
             organization_id=workflow.organization_id,
             type="workflow",
+            scope="private",
             workflow_id=workflow.id,
             title=f"Workflow: {workflow.name}",
             parent_conversation_id=parent_conversation_id,
+        )
+        logger.info(
+            "[Workflow] Creating workflow conversation with private scope "
+            "workflow_id=%s parent_conversation_id=%s",
+            workflow.id,
+            parent_conversation_id,
         )
         session.add(conversation)
         await session.flush()


### PR DESCRIPTION
### Motivation
- Ensure conversations created by workflows are owner-only by default so automated workflow runs are not exposed org-wide unintentionally.

### Description
- Explicitly set `scope="private"` when creating a `Conversation` for manual prompt-based triggers in `backend/api/routes/workflows.py`.
- Explicitly set `scope="private"` for both fallback and new conversation creation paths in `_execute_workflow_via_agent` within `backend/workers/tasks/workflows.py`.
- Add logging around these creation paths to make the scope and creation events visible for debugging and operational tracing.

### Testing
- Ran `pytest -q backend/tests/test_workflow_permissions.py` and all tests passed (`6 passed`).
- Ran `pytest -q backend/tests/test_workflow_org_scope.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddde057dfc8321bc67992d16d9a474)