### PR TITLE
Add regression tests for workflow child guardrails and conversation privacy

### DIFF
--- a/backend/tests/test_workflow_permissions.py
+++ b/backend/tests/test_workflow_permissions.py
@@ -55,6 +55,15 @@ def test_child_workflow_cannot_escalate_if_parent_has_no_permissions() -> None:
     assert effective == []
 
 
+def test_child_workflow_cannot_gain_more_permissions_than_parent() -> None:
+    effective = compute_effective_auto_approve_tools(
+        workflow_auto_approve_tools=["send_slack", "write_to_system_of_record", "keep_notes"],
+        parent_auto_approve_tools=["send_slack"],
+    )
+
+    assert effective == ["send_slack"]
+
+
 def test_workflow_auto_approve_strips_manage_memory() -> None:
     effective = compute_effective_auto_approve_tools(
         workflow_auto_approve_tools=["manage_memory", "send_slack"],

--- a/backend/tests/test_workflow_sql_write_guards.py
+++ b/backend/tests/test_workflow_sql_write_guards.py
@@ -1,0 +1,53 @@
+import sys
+import types
+
+_fake_websockets = types.ModuleType("api.websockets")
+
+async def _noop_broadcast_sync_progress(*_args: object, **_kwargs: object) -> None:
+    return None
+
+_fake_websockets.broadcast_sync_progress = _noop_broadcast_sync_progress
+sys.modules.setdefault("api.websockets", _fake_websockets)
+
+import asyncio
+
+from agents.tools import _run_sql_write
+
+
+ORG_ID = "00000000-0000-0000-0000-000000000001"
+USER_ID = "00000000-0000-0000-0000-000000000002"
+
+
+def test_workflow_cannot_create_child_workflow_that_runs_automatically() -> None:
+    query = (
+        "INSERT INTO workflows (name, trigger_type, is_enabled) "
+        "VALUES ('Child workflow', 'schedule', true)"
+    )
+
+    result = asyncio.run(
+        _run_sql_write(
+            params={"query": query},
+            organization_id=ORG_ID,
+            user_id=USER_ID,
+            context={"is_workflow": True, "workflow_id": "wf-parent"},
+        )
+    )
+
+    assert "error" in result
+    assert "cannot create enabled schedule/event workflows" in result["error"]
+
+
+def test_workflow_cannot_update_child_workflow_to_run_automatically() -> None:
+    query = "UPDATE workflows SET is_enabled = true, trigger_type = 'event' WHERE id = 'wf-child'"
+
+    result = asyncio.run(
+        _run_sql_write(
+            params={"query": query},
+            organization_id=ORG_ID,
+            user_id=USER_ID,
+            context={"is_workflow": True, "workflow_id": "wf-parent"},
+        )
+    )
+
+    assert "error" in result
+    assert "cannot enable or configure schedule/event triggers" in result["error"]

--- a/backend/tests/test_workflow_trigger_defaults.py
+++ b/backend/tests/test_workflow_trigger_defaults.py
@@ -1,0 +1,105 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID
+
+from api.routes import workflows
+
+
+class _FakeExecuteResult:
+    def __init__(self, workflow: object) -> None:
+        self._workflow = workflow
+
+    def scalar_one_or_none(self) -> object:
+        return self._workflow
+
+
+class _FakeSession:
+    def __init__(self, workflow: object) -> None:
+        self.workflow = workflow
+        self.added: list[object] = []
+        self.committed = 0
+
+    async def execute(self, _query: object) -> _FakeExecuteResult:
+        return _FakeExecuteResult(self.workflow)
+
+    def add(self, obj: object) -> None:
+        self.added.append(obj)
+
+    async def commit(self) -> None:
+        self.committed += 1
+
+    async def refresh(self, _obj: object) -> None:
+        return None
+
+
+class _FakeSessionFactory:
+    def __init__(self, session: _FakeSession) -> None:
+        self.session = session
+
+    async def __aenter__(self) -> _FakeSession:
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class _FakeConversation:
+    def __init__(self, **kwargs) -> None:
+        self.id = UUID("00000000-0000-0000-0000-0000000000c0")
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class _FakeTask:
+    id = "task-123"
+
+
+class _FakeExecuteWorkflowTask:
+    @staticmethod
+    def delay(**_kwargs) -> _FakeTask:
+        return _FakeTask()
+
+
+def test_trigger_workflow_creates_private_conversation_for_owner_by_default(monkeypatch) -> None:
+    org_id = UUID("00000000-0000-0000-0000-0000000000a1")
+    creator_id = UUID("00000000-0000-0000-0000-0000000000b2")
+
+    fake_workflow = SimpleNamespace(
+        id=UUID("00000000-0000-0000-0000-0000000000d3"),
+        organization_id=org_id,
+        created_by_user_id=creator_id,
+        archived_at=None,
+        is_enabled=True,
+        prompt="Do work",
+        name="Parent workflow",
+    )
+    fake_session = _FakeSession(fake_workflow)
+
+    monkeypatch.setattr(workflows, "get_session", lambda **_kwargs: _FakeSessionFactory(fake_session))
+    monkeypatch.setattr("models.conversation.Conversation", _FakeConversation)
+    monkeypatch.setattr("workers.tasks.workflows.execute_workflow", _FakeExecuteWorkflowTask)
+
+    auth = SimpleNamespace(
+        user_id=UUID("00000000-0000-0000-0000-0000000000e4"),
+        organization_id=org_id,
+        is_global_admin=False,
+    )
+
+    response = asyncio.run(
+        workflows.trigger_workflow(
+            organization_id=str(org_id),
+            workflow_id=str(fake_workflow.id),
+            body=workflows.TriggerWorkflowRequest(),
+            user_id=None,
+            auth=auth,
+        )
+    )
+
+    assert response.status == "queued"
+    assert response.conversation_id == "00000000-0000-0000-0000-0000000000c0"
+    assert len(fake_session.added) == 1
+
+    conversation = fake_session.added[0]
+    assert conversation.scope == "private"
+    assert conversation.type == "workflow"
+    assert conversation.user_id == creator_id


### PR DESCRIPTION
### Motivation

- Prevent workflows from escalating child workflow tool permissions beyond their parent and guard against autonomous fan-out that creates auto-running child workflows. 
- Ensure prompt-based workflow runs create conversations that are private by default and owned by the workflow creator when no explicit trigger user is provided.

### Description

- Added a permission regression test to `backend/tests/test_workflow_permissions.py` asserting a child workflow cannot gain auto-approve tools the parent does not have.
- Added `backend/tests/test_workflow_sql_write_guards.py` with tests that assert workflow executions are blocked from `INSERT`ing enabled `schedule`/`event` workflows and from `UPDATE`ing workflows to enable schedule/event triggers.
- Added `backend/tests/test_workflow_trigger_defaults.py` to verify the trigger API creates a `Conversation` with `type="workflow"`, `scope="private"`, and `user_id` bound to the workflow owner when no user is supplied.
- Tests include lightweight stubbing/monkeypatching (fake `api.websockets` and fake session/conversation/task classes) to isolate the behaviors under test.

### Testing

- Ran `pytest -q tests/test_workflow_permissions.py tests/test_workflow_sql_write_guards.py tests/test_workflow_trigger_defaults.py` and all tests passed.
- Test run summary: `10 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dde0bad5ac83219360389d05072a63)