### PR TITLE
Restrict non-admin org_members SQL writes to caller row

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -1564,6 +1564,90 @@ def _parse_sql_string_literal(raw_value: str) -> str | None:
     return None
 
 
+def _sql_literal_matches_user_id(raw_value: str, user_id: str) -> bool:
+    """Return True when a SQL literal token resolves to the provided user id."""
+    candidate = raw_value.strip()
+    match = re.match(r"^'([^']+)'\s*(::\s*uuid)?$", candidate, re.IGNORECASE)
+    if not match:
+        return False
+    return match.group(1).strip().lower() == user_id.strip().lower()
+
+
+def _scope_org_member_write_to_user(
+    *,
+    query: str,
+    operation: str,
+    user_id: str | None,
+) -> tuple[str | None, str | None]:
+    """Restrict non-admin org_members writes to the caller's own membership row."""
+    if not user_id:
+        return None, "Cannot write org_members rows without a user context."
+
+    if operation in {"UPDATE", "DELETE"}:
+        scoped = query.rstrip().rstrip(";")
+        scoped = f"{scoped} AND user_id = '{user_id}'"
+        return scoped, None
+
+    if operation == "INSERT":
+        parsed = _parse_insert_for_injection(query)
+        if parsed is None:
+            return None, "INSERT into org_members must use explicit column and value lists."
+
+        table_name, columns, values = parsed
+        column_names = [c.strip() for c in _split_sql_csv(columns)]
+        raw_values = _split_sql_csv(values)
+        if len(column_names) != len(raw_values):
+            return None, "Could not validate org_members INSERT values."
+
+        column_index = {
+            col.lower(): idx for idx, col in enumerate(column_names)
+        }
+        if "user_id" in column_index:
+            raw_user_value = raw_values[column_index["user_id"]]
+            if not _sql_literal_matches_user_id(raw_user_value, user_id):
+                return None, "Non-admin users can only write their own org_members row."
+            return query, None
+
+        scoped_columns = f"{columns}, user_id"
+        scoped_values = f"{values}, '{user_id}'"
+        scoped_query = f"INSERT INTO {table_name} ({scoped_columns}) VALUES ({scoped_values})"
+        return scoped_query, None
+
+    return None, f"Unsupported org_members operation: {operation}"
+
+
+async def _can_user_manage_other_org_members(organization_id: str, user_id: str | None) -> bool:
+    """Return True when the caller can modify other members in org_members."""
+    if not user_id:
+        return False
+
+    from models.org_member import OrgMember
+
+    try:
+        user_uuid = UUID(user_id)
+        org_uuid = UUID(organization_id)
+    except ValueError:
+        return False
+
+    async with get_admin_session() as session:
+        user: User | None = await session.get(User, user_uuid)
+        if not user:
+            return False
+
+        if user.role == "global_admin" or "global_admin" in (user.roles or []):
+            return True
+
+        membership_result = await session.execute(
+            select(OrgMember.role).where(
+                OrgMember.user_id == user_uuid,
+                OrgMember.organization_id == org_uuid,
+                OrgMember.status.in_(("active", "onboarding")),
+            )
+        )
+        membership_role: str | None = membership_result.scalar_one_or_none()
+        return membership_role == "admin"
+
+
 def _workflow_insert_would_auto_run(query: str) -> bool:
     """Return True when a workflow INSERT results in an enabled non-manual workflow."""
     parsed = _parse_insert_for_injection(query)
@@ -1710,6 +1794,30 @@ async def _run_sql_write(
                         f"Allowed columns: {', '.join(sorted(allowed_cols))}"
                     )
                 }
+
+    if table == "org_members":
+        can_manage_other_members = await _can_user_manage_other_org_members(organization_id, user_id)
+        if not can_manage_other_members:
+            scoped_query, scope_error = _scope_org_member_write_to_user(
+                query=query,
+                operation=operation or "",
+                user_id=user_id,
+            )
+            if scope_error:
+                logger.warning(
+                    "[Tools._run_sql_write] Blocked non-admin org_members write org=%s user=%s error=%s",
+                    organization_id,
+                    user_id,
+                    scope_error,
+                )
+                return {"error": scope_error}
+            if scoped_query and scoped_query != query:
+                logger.info(
+                    "[Tools._run_sql_write] Scoped non-admin org_members write to caller row org=%s user=%s",
+                    organization_id,
+                    user_id,
+                )
+                query = scoped_query
 
     # Prevent autonomous workflow fan-out: a workflow run cannot create other
     # workflows that are automatically runnable (enabled + non-manual trigger).

--- a/backend/tests/test_tools_sql_write_org_members_permissions.py
+++ b/backend/tests/test_tools_sql_write_org_members_permissions.py
@@ -1,0 +1,46 @@
+from agents import tools
+
+
+def test_scope_org_members_update_to_current_user() -> None:
+    query = "UPDATE org_members SET title = 'CEO' WHERE id = 'membership-1'"
+
+    scoped_query, error = tools._scope_org_member_write_to_user(
+        query=query,
+        operation="UPDATE",
+        user_id="00000000-0000-0000-0000-000000000123",
+    )
+
+    assert error is None
+    assert scoped_query is not None
+    assert "AND user_id = '00000000-0000-0000-0000-000000000123'" in scoped_query
+
+
+def test_scope_org_members_insert_rejects_other_user_id() -> None:
+    query = (
+        "INSERT INTO org_members (organization_id, user_id, role) VALUES "
+        "('org-1', '00000000-0000-0000-0000-000000000999', 'member')"
+    )
+
+    scoped_query, error = tools._scope_org_member_write_to_user(
+        query=query,
+        operation="INSERT",
+        user_id="00000000-0000-0000-0000-000000000123",
+    )
+
+    assert scoped_query is None
+    assert error == "Non-admin users can only write their own org_members row."
+
+
+def test_scope_org_members_insert_injects_user_id_when_missing() -> None:
+    query = "INSERT INTO org_members (organization_id, role) VALUES ('org-1', 'member')"
+
+    scoped_query, error = tools._scope_org_member_write_to_user(
+        query=query,
+        operation="INSERT",
+        user_id="00000000-0000-0000-0000-000000000123",
+    )
+
+    assert error is None
+    assert scoped_query is not None
+    assert "(organization_id, role, user_id)" in scoped_query
+    assert "'00000000-0000-0000-0000-000000000123'" in scoped_query


### PR DESCRIPTION
### Motivation
- Prevent non-admin users from using the SQL write tooling to modify other members' org-scoped fields (e.g. job `title`) and limit writes to the caller's own membership row. 
- Provide explicit guardrails and clear error/logging when a non-admin attempts to change other members via `run_sql_write`.

### Description
- Add `_scope_org_member_write_to_user(...)` to validate/transform `org_members` `UPDATE`/`DELETE`/`INSERT` statements so non-admins can only affect their own membership row. 
- Add `_sql_literal_matches_user_id(...)` to safely validate quoted UUID literals (supports `::uuid` cast) and `_can_user_manage_other_org_members(...)` to detect org-admin/global-admin privileges. 
- Enforce the new scoping inside `_run_sql_write(...)` for `table == "org_members"`, rejecting or scoping queries for non-admin callers and logging actions and rejections. 
- Add unit tests `backend/tests/test_tools_sql_write_org_members_permissions.py` to cover update scoping, insert rejection when specifying a different `user_id`, and insert auto-injection of the caller `user_id`.

### Testing
- Ran Python byte-compile for the modified module and the new test file with `python -m py_compile backend/agents/tools.py backend/tests/test_tools_sql_write_org_members_permissions.py`, which succeeded. 
- Executed `pytest -q backend/tests/test_tools_sql_write_users_blocked.py backend/tests/test_tools_sql_write_org_members_permissions.py`, which failed during test collection due to an existing circular import involving `agents.tools` and `agents.orchestrator`, preventing full test execution in this environment. 
- Logs and explicit error responses are emitted by the new guards when a non-admin write is blocked or transformed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de42cb8ee08321920b8c351e6de66d)