### PR TITLE
Restrict org_members writes to self unless admin

### DIFF
--- a/backend/db/migrations/versions/133_org_members_self_edit.py
+++ b/backend/db/migrations/versions/133_org_members_self_edit.py
@@ -1,0 +1,104 @@
+"""Restrict org_members writes so non-admins can only edit themselves.
+
+Revision ID: 133_org_members_self_edit
+Revises: 132_wf_llm_model
+Create Date: 2026-04-14
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "133_org_members_self_edit"
+down_revision: Union[str, Sequence[str], None] = "132_wf_llm_model"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_ORG_MATCH: str = """
+organization_id::text = COALESCE(
+    NULLIF(current_setting('app.current_org_id', true), ''),
+    '00000000-0000-0000-0000-000000000000'
+)
+""".strip()
+
+_USER_MATCH: str = """
+user_id::text = COALESCE(
+    NULLIF(current_setting('app.current_user_id', true), ''),
+    '00000000-0000-0000-0000-000000000000'
+)
+""".strip()
+
+_ADMIN_IN_ORG: str = """
+EXISTS (
+    SELECT 1
+    FROM org_members admin_membership
+    WHERE admin_membership.organization_id = org_members.organization_id
+      AND admin_membership.user_id::text = COALESCE(
+          NULLIF(current_setting('app.current_user_id', true), ''),
+          '00000000-0000-0000-0000-000000000000'
+      )
+      AND admin_membership.role = 'admin'
+      AND admin_membership.status IN ('active', 'onboarding')
+)
+""".strip()
+
+_CAN_EDIT_ROW: str = f"({_USER_MATCH}) OR ({_ADMIN_IN_ORG})"
+
+
+def upgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS org_isolation ON org_members")
+    op.execute("DROP POLICY IF EXISTS org_members_select ON org_members")
+    op.execute("DROP POLICY IF EXISTS org_members_insert ON org_members")
+    op.execute("DROP POLICY IF EXISTS org_members_update ON org_members")
+    op.execute("DROP POLICY IF EXISTS org_members_delete ON org_members")
+
+    op.execute(
+        f"""
+        CREATE POLICY org_members_select ON org_members
+        FOR SELECT
+        USING ({_ORG_MATCH})
+        """
+    )
+
+    op.execute(
+        f"""
+        CREATE POLICY org_members_insert ON org_members
+        FOR INSERT
+        WITH CHECK ({_ORG_MATCH})
+        """
+    )
+
+    op.execute(
+        f"""
+        CREATE POLICY org_members_update ON org_members
+        FOR UPDATE
+        USING ({_ORG_MATCH} AND ({_CAN_EDIT_ROW}))
+        WITH CHECK ({_ORG_MATCH} AND ({_CAN_EDIT_ROW}))
+        """
+    )
+
+    op.execute(
+        f"""
+        CREATE POLICY org_members_delete ON org_members
+        FOR DELETE
+        USING ({_ORG_MATCH} AND ({_CAN_EDIT_ROW}))
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS org_members_select ON org_members")
+    op.execute("DROP POLICY IF EXISTS org_members_insert ON org_members")
+    op.execute("DROP POLICY IF EXISTS org_members_update ON org_members")
+    op.execute("DROP POLICY IF EXISTS org_members_delete ON org_members")
+
+    op.execute(
+        f"""
+        CREATE POLICY org_isolation ON org_members
+        FOR ALL
+        USING ({_ORG_MATCH})
+        WITH CHECK ({_ORG_MATCH})
+        """
+    )

--- a/backend/tests/test_org_members_self_edit_migration.py
+++ b/backend/tests/test_org_members_self_edit_migration.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib
+from unittest.mock import patch
+
+
+class TestOrgMembersSelfEditMigration:
+    def _load_migration(self):
+        return importlib.import_module("db.migrations.versions.133_org_members_self_edit")
+
+    def test_revision_metadata(self) -> None:
+        mig = self._load_migration()
+        assert mig.revision == "133_org_members_self_edit"
+        assert mig.down_revision == "132_wf_llm_model"
+        assert len(mig.revision) <= 32
+        assert len(mig.down_revision) <= 32
+
+    def test_upgrade_creates_self_or_admin_write_policies(self) -> None:
+        mig = self._load_migration()
+        executed_sql: list[str] = []
+
+        with patch.object(mig.op, "execute", side_effect=lambda sql: executed_sql.append(str(sql))):
+            mig.upgrade()
+
+        combined_sql = "\n".join(executed_sql)
+
+        assert "DROP POLICY IF EXISTS org_isolation ON org_members" in combined_sql
+        assert "CREATE POLICY org_members_select ON org_members" in combined_sql
+        assert "CREATE POLICY org_members_insert ON org_members" in combined_sql
+        assert "CREATE POLICY org_members_update ON org_members" in combined_sql
+        assert "CREATE POLICY org_members_delete ON org_members" in combined_sql
+
+        # Non-admin users should only be able to update/delete their own row.
+        assert "user_id::text = COALESCE" in combined_sql
+        # Org admins can edit any row in the same org.
+        assert "admin_membership.role = 'admin'" in combined_sql
+        assert "admin_membership.status IN ('active', 'onboarding')" in combined_sql
+
+    def test_downgrade_restores_org_isolation_policy(self) -> None:
+        mig = self._load_migration()
+        executed_sql: list[str] = []
+
+        with patch.object(mig.op, "execute", side_effect=lambda sql: executed_sql.append(str(sql))):
+            mig.downgrade()
+
+        combined_sql = "\n".join(executed_sql)
+
+        assert "DROP POLICY IF EXISTS org_members_select ON org_members" in combined_sql
+        assert "DROP POLICY IF EXISTS org_members_insert ON org_members" in combined_sql
+        assert "DROP POLICY IF EXISTS org_members_update ON org_members" in combined_sql
+        assert "DROP POLICY IF EXISTS org_members_delete ON org_members" in combined_sql
+        assert "CREATE POLICY org_isolation ON org_members" in combined_sql
+        assert "FOR ALL" in combined_sql
+        assert "WITH CHECK" in combined_sql


### PR DESCRIPTION
### Motivation
- Enforce that non-admin users can only modify their own `org_members` row while allowing org admins to edit any membership in their org to meet the access control requirement.

### Description
- Add Alembic migration `133_org_members_self_edit` that replaces the single `org_isolation` policy on `org_members` with operation-specific policies (`org_members_select`, `org_members_insert`, `org_members_update`, `org_members_delete`).
- Define `_ORG_MATCH`, `_USER_MATCH`, and `_ADMIN_IN_ORG` SQL expressions and require `UPDATE`/`DELETE` to satisfy org match AND either row ownership (`user_id` == current user) or current user being an active/onboarding admin in the org.
- Preserve org-scoped `SELECT` and `INSERT` behavior and include a downgrade that restores the previous `org_isolation FOR ALL` policy with `WITH CHECK`.
- Ensure the Alembic `revision` and `down_revision` values conform to the migration naming/length constraints.

### Testing
- Ran a preflight check script via `importlib.machinery.SourceFileLoader` to assert `len(revision) <= 32` and `len(down_revision) <= 32`, which passed.
- Compiled the migration with `python -m py_compile backend/db/migrations/versions/133_org_members_self_edit.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de4638441483218b0b93d17f8632ae)