### PR TITLE
Pass `user_id` to DB session in `run_sql_write` to satisfy RLS

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -1776,7 +1776,7 @@ async def _run_sql_write(
     # Non-CRM Tables: Direct execution
     # ==========================================================================
     try:
-        async with get_session(organization_id=organization_id) as session:
+        async with get_session(organization_id=organization_id, user_id=user_id) as session:
             
             # For INSERT, inject required columns
             final_query = query_to_use

--- a/backend/tests/test_workflow_sql_write_guards.py
+++ b/backend/tests/test_workflow_sql_write_guards.py
@@ -51,3 +51,43 @@ def test_workflow_cannot_update_child_workflow_to_run_automatically() -> None:
 
     assert "error" in result
     assert "cannot enable or configure schedule/event triggers" in result["error"]
+
+
+def test_sql_write_passes_user_id_to_session(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeResult:
+        rowcount = 1
+
+    class _FakeSession:
+        async def execute(self, _query: object) -> _FakeResult:
+            return _FakeResult()
+
+        async def commit(self) -> None:
+            return None
+
+    class _FakeSessionCtx:
+        async def __aenter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    def _fake_get_session(*, organization_id: str, user_id: str | None = None) -> _FakeSessionCtx:
+        captured["organization_id"] = organization_id
+        captured["user_id"] = user_id
+        return _FakeSessionCtx()
+
+    monkeypatch.setattr("agents.tools.get_session", _fake_get_session)
+
+    result = asyncio.run(
+        _run_sql_write(
+            params={"query": "UPDATE org_members SET title = 'CTO' WHERE id = '8ab46e6b-93a7-424a-898e-ff8bac468756'"},
+            organization_id=ORG_ID,
+            user_id=USER_ID,
+            context=None,
+        )
+    )
+
+    assert result.get("success") is True
+    assert captured == {"organization_id": ORG_ID, "user_id": USER_ID}


### PR DESCRIPTION
### Motivation
- Writes using `run_sql_write` against RLS-protected tables (e.g. `org_members`) failed because the DB session was opened without the acting `user_id`, so `app.current_user_id` was not set for row-level security checks.

### Description
- Updated `_run_sql_write` to open the non-CRM write DB session with both `organization_id` and `user_id` by calling `get_session(organization_id=organization_id, user_id=user_id)`.
- Added a regression test `test_sql_write_passes_user_id_to_session` that monkeypatches `get_session` and verifies the `user_id` is forwarded when executing a sample `UPDATE org_members ...` query.

### Testing
- Ran `pytest -q backend/tests/test_workflow_sql_write_guards.py`, and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de505163e48321adc0791fd70fc181)