### PR TITLE
Fix Slack and external link previews for public apps/artifacts

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -6,19 +6,24 @@ Uses admin session with explicit visibility filter (RLS bypass).
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, Response
 from pydantic import BaseModel
 from sqlalchemy import select
 
+from config import settings
 from models.app import App
 from models.artifact import Artifact
 from models.database import get_admin_session, get_session
 from services.app_query_runner import AppQueryResponse as QueryResponse, run_named_app_query
+from services.public_previews import build_preview_html, decode_data_url_image, render_card_png
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.get("/apps/{app_id}")
@@ -139,3 +144,129 @@ async def get_public_artifact(artifact_id: str) -> PublicArtifactResponse:
         user_id=str(artifact.user_id) if artifact.user_id else None,
         visibility="public",
     )
+
+
+def _frontend_origin() -> str:
+    return settings.FRONTEND_URL.rstrip("/")
+
+
+@router.get("/share/apps/{app_id}", response_class=HTMLResponse)
+async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLResponse:
+    """HTML metadata endpoint used by Slack + external scrapers for public app links."""
+    try:
+        app_uuid = UUID(app_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid app ID")
+
+    async with get_admin_session() as session:
+        result = await session.execute(
+            select(App).where(App.id == app_uuid, App.visibility == "public")
+        )
+        app: App | None = result.scalar_one_or_none()
+    if app is None:
+        raise HTTPException(status_code=404, detail="App not found")
+
+    logger.info("[public_preview] rendering app preview app_id=%s", app_id)
+    canonical_url = f"{_frontend_origin()}/public/apps/{app_id}"
+    image_url = f"{request.base_url}api/public/share/apps/{app_id}/snapshot.png"
+    title = app.title or "Basebase App"
+    description = app.description or "Interactive app shared from Basebase."
+    html = build_preview_html(
+        page_title=title,
+        description=description,
+        canonical_url=canonical_url,
+        image_url=image_url,
+        redirect_url=canonical_url,
+    )
+    return HTMLResponse(content=html, headers={"Cache-Control": "public, max-age=300"})
+
+
+@router.get("/share/apps/{app_id}/snapshot.png")
+async def get_public_app_share_snapshot(app_id: str) -> Response:
+    """Snapshot image used by link preview scrapers for shared app links."""
+    try:
+        app_uuid = UUID(app_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid app ID")
+
+    async with get_admin_session() as session:
+        result = await session.execute(
+            select(App).where(App.id == app_uuid, App.visibility == "public")
+        )
+        app: App | None = result.scalar_one_or_none()
+    if app is None:
+        raise HTTPException(status_code=404, detail="App not found")
+
+    screenshot_data_url: str | None = (app.widget_config or {}).get("screenshot")
+    decoded = decode_data_url_image(screenshot_data_url)
+    if decoded is not None:
+        image_bytes, mime_type = decoded
+        logger.info("[public_preview] serving app screenshot app_id=%s mime=%s", app_id, mime_type)
+        return Response(content=image_bytes, media_type=mime_type, headers={"Cache-Control": "public, max-age=300"})
+
+    logger.info("[public_preview] app screenshot missing; serving generated card app_id=%s", app_id)
+    image_bytes = render_card_png(
+        heading="Basebase App",
+        title=app.title or "Untitled App",
+        description=app.description or "Interactive app shared from Basebase.",
+        footer=f"App ID: {app_id}",
+    )
+    return Response(content=image_bytes, media_type="image/png", headers={"Cache-Control": "public, max-age=300"})
+
+
+@router.get("/share/artifacts/{artifact_id}", response_class=HTMLResponse)
+async def get_public_artifact_share_preview(artifact_id: str, request: Request) -> HTMLResponse:
+    """HTML metadata endpoint used by Slack + external scrapers for public artifact links."""
+    try:
+        artifact_uuid = UUID(artifact_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid artifact ID")
+
+    async with get_admin_session() as session:
+        result = await session.execute(
+            select(Artifact).where(Artifact.id == artifact_uuid, Artifact.visibility == "public")
+        )
+        artifact: Artifact | None = result.scalar_one_or_none()
+    if artifact is None:
+        raise HTTPException(status_code=404, detail="Artifact not found")
+
+    logger.info("[public_preview] rendering artifact preview artifact_id=%s", artifact_id)
+    canonical_url = f"{_frontend_origin()}/public/artifacts/{artifact_id}"
+    image_url = f"{request.base_url}api/public/share/artifacts/{artifact_id}/snapshot.png"
+    title = artifact.title or "Basebase Artifact"
+    description = artifact.description or (artifact.content or "Shared artifact from Basebase.")
+    html = build_preview_html(
+        page_title=title,
+        description=description[:240],
+        canonical_url=canonical_url,
+        image_url=image_url,
+        redirect_url=canonical_url,
+    )
+    return HTMLResponse(content=html, headers={"Cache-Control": "public, max-age=300"})
+
+
+@router.get("/share/artifacts/{artifact_id}/snapshot.png")
+async def get_public_artifact_share_snapshot(artifact_id: str) -> Response:
+    """Snapshot image used by link preview scrapers for shared artifact links."""
+    try:
+        artifact_uuid = UUID(artifact_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid artifact ID")
+
+    async with get_admin_session() as session:
+        result = await session.execute(
+            select(Artifact).where(Artifact.id == artifact_uuid, Artifact.visibility == "public")
+        )
+        artifact: Artifact | None = result.scalar_one_or_none()
+    if artifact is None:
+        raise HTTPException(status_code=404, detail="Artifact not found")
+
+    summary = (artifact.description or artifact.content or "Shared artifact from Basebase.").replace("\n", " ")
+    image_bytes = render_card_png(
+        heading="Basebase Artifact",
+        title=artifact.title or "Untitled Artifact",
+        description=summary,
+        footer=f"Type: {artifact.content_type or artifact.type or 'document'}",
+    )
+    logger.info("[public_preview] serving generated artifact snapshot artifact_id=%s", artifact_id)
+    return Response(content=image_bytes, media_type="image/png", headers={"Cache-Control": "public, max-age=300"})

--- a/backend/services/public_previews.py
+++ b/backend/services/public_previews.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import base64
+import binascii
+from html import escape
+from io import BytesIO
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+def decode_data_url_image(data_url: str | None) -> tuple[bytes, str] | None:
+    if not data_url or not data_url.startswith("data:image/"):
+        return None
+    marker = ";base64,"
+    if marker not in data_url:
+        return None
+    mime_type = data_url[5:data_url.index(marker)]
+    encoded = data_url[data_url.index(marker) + len(marker):]
+    try:
+        return base64.b64decode(encoded, validate=True), mime_type
+    except (ValueError, binascii.Error):
+        return None
+
+
+def render_card_png(
+    *,
+    heading: str,
+    title: str,
+    description: str,
+    footer: str,
+    width: int = 1200,
+    height: int = 630,
+) -> bytes:
+    image = Image.new("RGB", (width, height), color=(16, 18, 25))
+    draw = ImageDraw.Draw(image)
+    title_font = ImageFont.load_default()
+    subtitle_font = ImageFont.load_default()
+    body_font = ImageFont.load_default()
+
+    draw.rectangle((0, 0, width, 8), fill=(99, 102, 241))
+    draw.text((56, 48), heading, fill=(165, 180, 252), font=subtitle_font)
+    draw.text((56, 100), title[:120], fill=(255, 255, 255), font=title_font)
+    draw.text((56, 190), description[:260], fill=(209, 213, 219), font=body_font)
+    draw.text((56, height - 72), footer[:140], fill=(156, 163, 175), font=subtitle_font)
+
+    output = BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()
+
+
+def build_preview_html(
+    *,
+    page_title: str,
+    description: str,
+    canonical_url: str,
+    image_url: str,
+    redirect_url: str,
+) -> str:
+    safe_title = escape(page_title)
+    safe_desc = escape(description)
+    safe_canonical = escape(canonical_url)
+    safe_image = escape(image_url)
+    safe_redirect = escape(redirect_url)
+    return f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{safe_title}</title>
+    <meta name="description" content="{safe_desc}" />
+    <link rel="canonical" href="{safe_canonical}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Basebase" />
+    <meta property="og:title" content="{safe_title}" />
+    <meta property="og:description" content="{safe_desc}" />
+    <meta property="og:url" content="{safe_canonical}" />
+    <meta property="og:image" content="{safe_image}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="{safe_title}" />
+    <meta name="twitter:description" content="{safe_desc}" />
+    <meta name="twitter:image" content="{safe_image}" />
+    <meta http-equiv="refresh" content="0;url={safe_redirect}" />
+  </head>
+  <body>
+    <script>window.location.replace("{safe_redirect}");</script>
+  </body>
+</html>"""

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import base64
+
+from services.public_previews import build_preview_html, decode_data_url_image, render_card_png
+
+
+def test_decode_data_url_image_valid_png() -> None:
+    payload = base64.b64encode(b"hello").decode("ascii")
+    decoded = decode_data_url_image(f"data:image/png;base64,{payload}")
+    assert decoded is not None
+    content, mime = decoded
+    assert content == b"hello"
+    assert mime == "image/png"
+
+
+def test_build_preview_html_includes_og_and_twitter_tags() -> None:
+    html = build_preview_html(
+        page_title="Example",
+        description="Description",
+        canonical_url="https://example.com/public/apps/abc",
+        image_url="https://example.com/api/public/share/apps/abc/snapshot.png",
+        redirect_url="https://example.com/public/apps/abc",
+    )
+    assert 'property="og:title" content="Example"' in html
+    assert 'name="twitter:image" content="https://example.com/api/public/share/apps/abc/snapshot.png"' in html
+    assert 'http-equiv="refresh"' in html
+
+
+def test_render_card_png_returns_png_bytes() -> None:
+    png = render_card_png(
+        heading="Basebase App",
+        title="Pipeline Dashboard",
+        description="Current app snapshot",
+        footer="App ID: abc",
+    )
+    assert png.startswith(b"\x89PNG")

--- a/frontend/src/components/ArtifactFullView.tsx
+++ b/frontend/src/components/ArtifactFullView.tsx
@@ -209,7 +209,7 @@ export function ArtifactFullView({
   const handleCopyLink = async (): Promise<void> => {
     const isPublic: boolean = visibility === "public";
     const url: string = isPublic
-      ? `${window.location.origin}/public/artifacts/${artifactId}`
+      ? `${window.location.origin}/api/public/share/artifacts/${artifactId}`
       : `${window.location.origin}${prefix}/artifacts/${artifactId}`;
     await navigator.clipboard.writeText(url);
     setLinkCopied(true);
@@ -223,7 +223,7 @@ export function ArtifactFullView({
       );
       return;
     }
-    const url: string = `${window.location.origin}/public/artifacts/${artifactId}`;
+    const url: string = `${window.location.origin}/api/public/share/artifacts/${artifactId}`;
     const snippet: string = `<iframe src="${url}" width="100%" height="600" frameborder="0"></iframe>`;
     await navigator.clipboard.writeText(snippet);
     setEmbedCopied(true);

--- a/frontend/src/components/apps/AppFullView.tsx
+++ b/frontend/src/components/apps/AppFullView.tsx
@@ -114,7 +114,7 @@ export function AppFullView({ appId }: AppFullViewProps): JSX.Element {
   const handleCopyLink = async (): Promise<void> => {
     const isPublic: boolean = app?.visibility === "public";
     const url: string = isPublic
-      ? `${window.location.origin}/public/apps/${appId}`
+      ? `${window.location.origin}/api/public/share/apps/${appId}`
       : `${window.location.origin}${prefix}/apps/${appId}`;
     await navigator.clipboard.writeText(url);
     setLinkCopied(true);


### PR DESCRIPTION
### Motivation
- External scrapers and Slack were showing a generic site-level preview when users shared public app or artifact links instead of a meaningful title and snapshot image.
- The goal is to expose link-preview metadata and a snapshot image so unfurls show the app/artifact title and a current visual preview.

### Description
- Added scraper-friendly share endpoints returning OG/Twitter metadata HTML that immediately redirect to the canonical public page: `GET /api/public/share/apps/{id}` and `GET /api/public/share/artifacts/{id}`.
- Added snapshot image endpoints that scrapers will use: `GET /api/public/share/apps/{id}/snapshot.png` (serves saved app screenshot when present or a generated PNG card fallback) and `GET /api/public/share/artifacts/{id}/snapshot.png` (generates a PNG card from title/description/content), and set `Cache-Control: public, max-age=300` on these responses.
- Introduced reusable preview helpers in `backend/services/public_previews.py` for HTML metadata generation, decoding `data:image/...;base64,` screenshots, and rendering PNG card snapshots, and wired them into `backend/api/routes/public.py`.
- Updated frontend copy/embed behavior to point public copy links at the new share URLs (`/api/public/share/apps/{id}` and `/api/public/share/artifacts/{id}`) so users share scraper-optimized links.
- Added focused unit tests for preview helpers (`backend/tests/test_public_previews.py`).

### Testing
- Ran backend unit tests with `cd backend && pytest -q tests/test_public_previews.py`, which completed successfully (`3 passed`).
- Ran frontend lint with `cd frontend && npm run -s lint`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb0fc08588321ae1c28c6fc4d43ea)