### PR TITLE
Set member RLS context during daily digest generation

### DIFF
--- a/backend/services/daily_digest.py
+++ b/backend/services/daily_digest.py
@@ -11,7 +11,7 @@ from typing import Any
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, or_, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from config import settings
@@ -680,6 +680,16 @@ async def generate_org_digests_for_session(
     errors: list[str] = []
     for m in members:
         try:
+            await session.execute(
+                text("SELECT set_config('app.current_user_id', :uid, false)"),
+                {"uid": str(m.user_id)},
+            )
+            logger.debug(
+                "daily_digest set app.current_user_id for member generation org=%s user_id=%s date=%s",
+                organization_id,
+                m.user_id,
+                digest_date,
+            )
             await generate_member_digest(session, organization_id, m.user_id, digest_date)
             generated += 1
         except Exception as exc:
@@ -688,6 +698,9 @@ async def generate_org_digests_for_session(
             logger.exception("daily_digest member failed %s", err_msg)
 
     try:
+        await session.execute(
+            text("SELECT set_config('app.current_user_id', '', false)")
+        )
         await generate_team_summary(session, organization_id, digest_date)
     except Exception as exc:
         errors.append(f"team_summary: {exc}")


### PR DESCRIPTION
### Motivation
- Daily digest generation failed with row-level security errors because member-level `INSERT`/`UPDATE` policies on `daily_digests` require `app.current_user_id` to match the target user, while the worker was running with only org-scoped session context.

### Description
- In `backend/services/daily_digest.py` added `text` import and set `app.current_user_id` via `SELECT set_config('app.current_user_id', :uid, false)` before generating each member digest in `generate_org_digests_for_session`.
- Added a debug log when setting per-member RLS context and reset `app.current_user_id` (`SELECT set_config('app.current_user_id', '', false)`) before generating the team summary to avoid leaking user context.
- Changes are localized to `generate_org_digests_for_session` to ensure per-member upserts meet RLS `WITH CHECK`/`USING` conditions for `daily_digests`.

### Testing
- Ran `python -m py_compile backend/services/daily_digest.py`, which succeeded.
- Ran full backend test suite with `cd backend && pytest -q`, which completed successfully: `401 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfba29ae6c832181c14e39d4cc5de1)