### PR TITLE
Adjust daily digest action buttons for mobile

### DIFF
--- a/frontend/src/components/DailyDigestGrid.tsx
+++ b/frontend/src/components/DailyDigestGrid.tsx
@@ -472,14 +472,24 @@ export function DailyDigestGrid({ digestDate, onDigestDateChange }: DailyDigestG
             type="button"
             disabled={generating}
             onClick={() => void handleGenerate()}
-            className="inline-flex items-center justify-center min-w-[8.5rem] md:min-w-[9rem] h-8 px-3 rounded-md border border-surface-600 text-xs text-surface-300 hover:text-surface-100 hover:bg-surface-800 disabled:opacity-50"
+            className="inline-flex items-center justify-center min-w-[4.25rem] md:min-w-[9rem] h-7 md:h-8 px-2 md:px-3 rounded-md border border-surface-600 text-[11px] md:text-xs text-surface-300 hover:text-surface-100 hover:bg-surface-800 disabled:opacity-50"
           >
-            {generating ? "Generating…" : `Generate for ${formatDayMonth(digestDate)}`}
+            {generating ? (
+              <>
+                <span className="md:hidden">Gen…</span>
+                <span className="hidden md:inline">Generating…</span>
+              </>
+            ) : (
+              <>
+                <span className="md:hidden">Generate</span>
+                <span className="hidden md:inline">{`Generate for ${formatDayMonth(digestDate)}`}</span>
+              </>
+            )}
           </button>
           <button
             type="button"
             onClick={() => void load()}
-            className="inline-flex items-center justify-center min-w-[8.5rem] md:min-w-[9rem] h-8 px-3 rounded-md border border-primary-500/40 text-xs text-primary-400 hover:text-primary-300 hover:bg-primary-500/10"
+            className="inline-flex items-center justify-center min-w-[4.25rem] md:min-w-[9rem] h-7 md:h-8 px-2 md:px-3 rounded-md border border-primary-500/40 text-[11px] md:text-xs text-primary-400 hover:text-primary-300 hover:bg-primary-500/10"
           >
             Refresh
           </button>


### PR DESCRIPTION
### Motivation
- Reduce the mobile footprint of the Daily Digest action buttons so the Generate and Refresh controls take about half the space on small screens while preserving desktop sizing.

### Description
- Changed `frontend/src/components/DailyDigestGrid.tsx` to shrink base breakpoint sizing (reduced `min-w`, `h`, `px`, and font size) and added responsive `md:` classes to preserve existing desktop/tablet styles; the Generate button now shows shortened labels on mobile and full contextual text on `md` and up.

### Testing
- Ran the frontend checks: `npm run -s typecheck` (ran but exited with errors) and a production build `cd frontend && npm run build` which completed successfully with non-blocking Vite chunk-size warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd504c5748321b4afc4ac22fa6017)