### PR TITLE
Fix app query runner JSON serialization for nested DB values

### DIFF
--- a/backend/services/app_query_runner.py
+++ b/backend/services/app_query_runner.py
@@ -42,6 +42,14 @@ def validate_sql_is_select(sql: str) -> None:
 
 def json_serial(obj: Any) -> Any:
     """JSON serializer for types not handled by default."""
+    if isinstance(obj, dict):
+        return {str(k): json_serial(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [json_serial(item) for item in obj]
+    if isinstance(obj, set):
+        return [json_serial(item) for item in sorted(obj, key=str)]
+    if isinstance(obj, (str, int, float, bool, type(None))):
+        return obj
     if isinstance(obj, datetime):
         if obj.tzinfo is not None:
             return obj.isoformat()


### PR DESCRIPTION
### Motivation
- App query execution was failing when rows contained JSON-like nested values (dict/list/set), raising `Object of type dict is not JSON serializable`, so responses need to be converted to JSON-compatible structures before returning.

### Description
- Update `json_serial` in `backend/services/app_query_runner.py` to recursively serialize `dict`, `list`/`tuple`, and `set`, add a fast-path for primitive JSON-safe scalars, and preserve existing conversions for `datetime`, `date`, `Decimal`, and `UUID`.

### Testing
- Ran `python -m compileall backend/services/app_query_runner.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd56f5e648321827f74eca1448940)