### PR TITLE
Forward orchestrator model metadata into connector query calls

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1659,6 +1659,7 @@ class ChatOrchestrator:
                     per_tool_ctx["message_id"] = str(self._current_message_id)
                 per_tool_ctx["tool_id"] = tool_use["id"]
                 per_tool_ctx["source"] = self.source
+                per_tool_ctx["model"] = model_name
 
                 tool_tasks.append(asyncio.create_task(
                     _run_single_tool(tool_use["name"], tool_use["input"], tool_use["id"], per_tool_ctx),

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -342,7 +342,7 @@ async def execute_tool(
         # Connector-driven generic tools
         "list_connected_connectors": lambda: _list_connected_connectors(organization_id),
         "get_connector_docs": lambda: _get_connector_docs(tool_input, organization_id),
-        "query_on_connector": lambda: _query_on_connector(tool_input, organization_id, user_id),
+        "query_on_connector": lambda: _query_on_connector(tool_input, organization_id, user_id, context),
         "write_on_connector": lambda: _write_on_connector(tool_input, organization_id, user_id, skip_approval, context),
         "run_on_connector": lambda: _run_on_connector(tool_input, organization_id, user_id, skip_approval, context),
     }
@@ -971,7 +971,10 @@ async def _attach_connector_docs(
 
 
 async def _query_on_connector(
-    params: dict[str, Any], organization_id: str, user_id: str | None
+    params: dict[str, Any],
+    organization_id: str,
+    user_id: str | None,
+    context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Dispatch a query to a QUERY-capable connector."""
     connector: str = (params.get("connector") or "").strip()
@@ -997,9 +1000,23 @@ async def _query_on_connector(
     assert instance is not None
 
     cross_user_warning = _build_cross_user_connector_warning(connector, instance, user_id)
+    query_info: dict[str, Any] = {}
+    context_model: str | None = (context or {}).get("model")
+    if context_model:
+        query_info["model"] = context_model
+        logger.info(
+            "[Tools] query_on_connector forwarding model context connector=%s model=%s",
+            connector,
+            context_model,
+        )
 
     try:
-        result = await instance.query(query)
+        # New connector interface accepts optional metadata in `info`; gracefully
+        # fallback for older connectors that only accept a request string.
+        try:
+            result = await instance.query(query, info=query_info or None)
+        except TypeError:
+            result = await instance.query(query)
         return _attach_cross_user_connector_warning(result, cross_user_warning)
     except Exception as exc:
         logger.error("[Tools] query_on_connector(%s) failed: %s", connector, exc, exc_info=True)

--- a/backend/connectors/_template.py
+++ b/backend/connectors/_template.py
@@ -137,7 +137,7 @@ class TemplateConnector(BaseConnector):
             {"entity": "contacts", "fields": ["id", "name", "email"]},
         ]
 
-    async def query(self, request: str) -> dict[str, Any]:
+    async def query(self, request: str, info: dict[str, Any] | None = None) -> dict[str, Any]:
         """Execute an on-demand query."""
         return {"results": [], "query": request}
 

--- a/backend/connectors/apollo.py
+++ b/backend/connectors/apollo.py
@@ -424,7 +424,7 @@ class ApolloConnector(BaseConnector):
     # QUERY capability
     # =========================================================================
 
-    async def query(self, request: str) -> dict[str, Any]:
+    async def query(self, request: str, info: dict[str, Any] | None = None) -> dict[str, Any]:
         """Dispatch enrichment queries: person or company."""
         import json as _json
 

--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -179,7 +179,7 @@ class AppsConnector(BaseConnector):
     async def fetch_deal(self, deal_id: str) -> dict[str, Any]:
         return {}
 
-    async def query(self, request: str) -> dict[str, Any]:
+    async def query(self, request: str, info: dict[str, Any] | None = None) -> dict[str, Any]:
         req: str = (request or "").strip()
         if not req.lower().startswith("read "):
             return {

--- a/backend/connectors/artifacts.py
+++ b/backend/connectors/artifacts.py
@@ -99,7 +99,7 @@ class ArtifactConnector(BaseConnector):
     async def fetch_deal(self, deal_id: str) -> dict[str, Any]:
         return {}
 
-    async def query(self, request: str) -> dict[str, Any]:
+    async def query(self, request: str, info: dict[str, Any] | None = None) -> dict[str, Any]:
         req: str = (request or "").strip()
         if not req.lower().startswith("read "):
             return {

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -715,7 +715,7 @@ class BaseConnector(ABC):
         """Return schema/entity metadata (QUERY capability)."""
         return []
 
-    async def query(self, request: str) -> dict[str, Any]:
+    async def query(self, request: str, info: dict[str, Any] | None = None) -> dict[str, Any]:
         """Execute an on-demand query (QUERY capability)."""
         raise NotImplementedError(f"{self.source_system} does not support query()")
 

--- a/backend/connectors/github.py
+++ b/backend/connectors/github.py
@@ -802,7 +802,7 @@ Use `run_sql_query` on `github_repositories`, `github_commits`, `github_pull_req
 
         return prefix, value.strip(), params
 
-    async def query(self, request: str) -> dict[str, Any]:
+    async def query(self, request: str, info: dict[str, Any] | None = None) -> dict[str, Any]:
         """Dispatch an on-demand read query (QUERY capability).
 
         Supported prefixes: file:, dir:, issue:, issues:, pr:, prs:, commit:.

--- a/backend/connectors/google_drive.py
+++ b/backend/connectors/google_drive.py
@@ -2078,7 +2078,7 @@ Call via `run_on_connector(connector='google_drive', action='edit_file', params=
         total: int = sum(counts.values())
         return {"files": total}
 
-    async def query(self, request: str) -> dict[str, Any]:
+    async def query(self, request: str, info: dict[str, Any] | None = None) -> dict[str, Any]:
         """Search files or read file content (QUERY capability).
 
         Prefix with 'search:' to search by file name; use 'search:spreadsheet' (or sheet/doc/slides) to list by type.

--- a/backend/connectors/granola.py
+++ b/backend/connectors/granola.py
@@ -357,7 +357,7 @@ class GranolaConnector(BaseConnector):
 
     # -- QUERY capability --------------------------------------------------------
 
-    async def query(self, request: str) -> dict[str, Any]:
+    async def query(self, request: str, info: dict[str, Any] | None = None) -> dict[str, Any]:
         """Execute an on-demand query against Granola meetings.
 
         Supports:

--- a/backend/connectors/ispot_tv.py
+++ b/backend/connectors/ispot_tv.py
@@ -334,7 +334,7 @@ class ISpotTvConnector(BaseConnector):
             },
         ]
 
-    async def query(self, request: str) -> dict[str, Any]:
+    async def query(self, request: str, info: dict[str, Any] | None = None) -> dict[str, Any]:
         """Execute an ad-hoc iSpot API query. Request is JSON with endpoint, filters, include, metrics, sort, page_size."""
         try:
             payload: dict[str, Any] = json.loads(request) if isinstance(request, str) else request

--- a/backend/connectors/mcp.py
+++ b/backend/connectors/mcp.py
@@ -280,7 +280,7 @@ class McpConnector(BaseConnector):
     # QUERY capability
     # ------------------------------------------------------------------
 
-    async def query(self, request: str) -> dict[str, Any]:
+    async def query(self, request: str, info: dict[str, Any] | None = None) -> dict[str, Any]:
         """List available tools or describe a specific tool."""
         endpoint_url, auth_header, cached_tools = await self._get_mcp_config()
 

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -1205,7 +1205,7 @@ Returns normalized messages for one channel since a cutoff (does not write to th
             # Silently ignore if reaction was already removed or doesn't exist
             pass
 
-    async def query(self, request: str) -> dict[str, Any]:
+    async def query(self, request: str, info: dict[str, Any] | None = None) -> dict[str, Any]:
         """Execute a read-only query against Slack."""
         stripped = request.strip()
         if stripped.lower().replace(" ", "_") in ("list_channels", "channels", "get_channels"):

--- a/backend/connectors/web_search.py
+++ b/backend/connectors/web_search.py
@@ -90,7 +90,7 @@ class WebSearchConnector(BaseConnector):
     async def fetch_deal(self, deal_id: str) -> dict[str, Any]:
         return {}
 
-    async def query(self, request: str) -> dict[str, Any]:
+    async def query(self, request: str, info: dict[str, Any] | None = None) -> dict[str, Any]:
         provider: str = "exa"
         query: str = request.strip()
         if query.lower().startswith("provider:perplexity "):


### PR DESCRIPTION
### Motivation
- Provide connector implementations with the orchestrator's active LLM model as metadata so connector logic can log, route, or adapt behavior based on which model produced the query.

### Description
- Add the active model name to per-tool runtime context with `per_tool_ctx["model"] = model_name` in the orchestrator so downstream tool handlers can access it.
- Pass the tool `context` into `query_on_connector` and propagate `context.model` as `info["model"]` when invoking connector `query` methods. 
- Make `query_on_connector` call `instance.query(query, info=...)` when possible and fall back to `instance.query(query)` for older connectors, and add a `logger.info` line when forwarding model context.
- Extend the connector interface to accept optional metadata by changing `BaseConnector.query` to `query(request, info=None)` and update built-in connector `query` signatures accordingly.

### Testing
- Compiled all modified modules with `python -m compileall` for the changed files and the compilation completed successfully. 
- No additional automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd601539883219d19ea9213e373d7)