### PR TITLE
Pass active orchestrator model through query info payload

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1620,6 +1620,10 @@ class ChatOrchestrator:
                 t_name: str, t_input: dict[str, Any], t_id: str, t_ctx: dict[str, Any],
             ) -> dict[str, Any]:
                 """Execute one tool with timeout; returns result dict (never raises)."""
+                if t_name == "query_on_connector":
+                    tool_info: dict[str, Any] = dict(t_input.get("info") or {})
+                    tool_info.setdefault("orchestrator_model", model_name)
+                    t_input = {**t_input, "info": tool_info}
                 logger.info(
                     "[Orchestrator] Tool call: %s | input=%s | org_id=%s | user_id=%s",
                     t_name, t_input, self.organization_id, self.user_id,

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -976,6 +976,7 @@ async def _query_on_connector(
     """Dispatch a query to a QUERY-capable connector."""
     connector: str = (params.get("connector") or "").strip()
     query: str = (params.get("query") or "").strip()
+    info: dict[str, Any] = dict(params.get("info") or {})
     if not connector:
         return {"error": "connector is required"}
     if not query:
@@ -987,7 +988,10 @@ async def _query_on_connector(
         provider=connector,
         operation="query",
     )
-    dp_result = await check_connector_call(dp_ctx, {"connector": connector, "query": query})
+    dp_result = await check_connector_call(
+        dp_ctx,
+        {"connector": connector, "query": query, "info": info} if info else {"connector": connector, "query": query},
+    )
     if not dp_result.allowed:
         return {"error": dp_result.deny_reason or "Connector query not allowed"}
 
@@ -999,7 +1003,15 @@ async def _query_on_connector(
     cross_user_warning = _build_cross_user_connector_warning(connector, instance, user_id)
 
     try:
+        if info:
+            logger.info(
+                "[Tools] query_on_connector(%s) info=%s",
+                connector,
+                info,
+            )
         result = await instance.query(query)
+        if info and isinstance(result, dict):
+            result.setdefault("info", info)
         return _attach_cross_user_connector_warning(result, cross_user_warning)
     except Exception as exc:
         logger.error("[Tools] query_on_connector(%s) failed: %s", connector, exc, exc_info=True)


### PR DESCRIPTION
### Motivation
- Provide explicit provenance for connector queries by attaching the orchestrator's active model to `query_on_connector` calls so connectors and access checks can observe which model initiated a query.
- Make connector access-control decisions and debugging easier by surface this metadata in the `info` payload and logs.

### Description
- In `backend/agents/orchestrator.py` inject an `info.orchestrator_model` field into tool input for calls where `t_name == "query_on_connector"`, populated from the selected `model_name` for the turn.
- In `backend/agents/tools.py` read an optional `info` object from `params`, include it in the `check_connector_call` payload so policy checks receive the info, and log `info` when present for debugging.
- Echo the `info` back into connector results when the connector returns a dictionary so downstream consumers can inspect query provenance.

### Testing
- Ran `python -m py_compile backend/agents/orchestrator.py backend/agents/tools.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd601539883219d19ea9213e373d7)