### PR TITLE
Reduce mobile width of Daily Digest action buttons

### DIFF
--- a/frontend/src/components/DailyDigestGrid.tsx
+++ b/frontend/src/components/DailyDigestGrid.tsx
@@ -472,14 +472,14 @@ export function DailyDigestGrid({ digestDate, onDigestDateChange }: DailyDigestG
             type="button"
             disabled={generating}
             onClick={() => void handleGenerate()}
-            className="inline-flex items-center justify-center min-w-[8.5rem] md:min-w-[9rem] h-8 px-3 rounded-md border border-surface-600 text-xs text-surface-300 hover:text-surface-100 hover:bg-surface-800 disabled:opacity-50"
+            className="inline-flex items-center justify-center w-[4.25rem] md:w-auto md:min-w-[9rem] h-8 px-2 md:px-3 rounded-md border border-surface-600 text-xs text-surface-300 hover:text-surface-100 hover:bg-surface-800 disabled:opacity-50"
           >
             {generating ? "Generating…" : `Generate for ${formatDayMonth(digestDate)}`}
           </button>
           <button
             type="button"
             onClick={() => void load()}
-            className="inline-flex items-center justify-center min-w-[8.5rem] md:min-w-[9rem] h-8 px-3 rounded-md border border-primary-500/40 text-xs text-primary-400 hover:text-primary-300 hover:bg-primary-500/10"
+            className="inline-flex items-center justify-center w-[4.25rem] md:w-auto md:min-w-[9rem] h-8 px-2 md:px-3 rounded-md border border-primary-500/40 text-xs text-primary-400 hover:text-primary-300 hover:bg-primary-500/10"
           >
             Refresh
           </button>


### PR DESCRIPTION
### Motivation
- On mobile the Daily Digest "Generate" and "Refresh" action buttons should be roughly half their current width while keeping the same height and preserving desktop sizing behavior.

### Description
- Updated `frontend/src/components/DailyDigestGrid.tsx` to replace the mobile `min-w-[8.5rem]` with `w-[4.25rem]`, added `md:w-auto md:min-w-[9rem]` to keep desktop sizing, and reduced horizontal padding on mobile via `px-2` (desktop remains `md:px-3`).

### Testing
- Ran the production build with `npm --prefix frontend run -s build` which completed successfully. 
- Ran typecheck with `npm --prefix frontend run -s typecheck`, which returned a non-zero exit (did not succeed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd62e64188321aa21e8007044ad06)