### PR TITLE
Count workflow `error` executions as failed query outcomes

### DIFF
--- a/backend/tests/test_workflow_query_outcome_metrics.py
+++ b/backend/tests/test_workflow_query_outcome_metrics.py
@@ -70,3 +70,27 @@ def test_record_workflow_query_outcome_ignores_skipped_status(monkeypatch) -> No
     )
 
     assert calls == []
+
+
+def test_record_workflow_query_outcome_records_error_status_as_failure(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_record_query_outcome(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "services.query_outcome_metrics.record_query_outcome",
+        _fake_record_query_outcome,
+    )
+
+    asyncio.run(
+        workflows._record_workflow_query_outcome(
+            result={"status": "error", "error": "Model is not available"},
+            workflow_id="wf-999",
+        )
+    )
+
+    assert captured["platform"] == "workflow"
+    assert captured["was_success"] is False
+    assert captured["failure_reason"] == "model is not available"
+    assert captured["conversation_id"] == "workflow:wf-999"

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -49,7 +49,7 @@ async def _record_workflow_query_outcome(
         return
 
     status = (result.get("status") or "").strip().lower()
-    if status not in {"completed", "failed"}:
+    if status not in {"completed", "failed", "error"}:
         return
 
     from services.query_outcome_metrics import normalize_failure_reason, record_query_outcome


### PR DESCRIPTION
### Motivation
- Workflow runs that terminate with `status="error"` (e.g., model unavailable) should count as failed query outcomes so rolling success/failure monitoring and incident thresholds reflect real failures.

### Description
- Treat `status == "error"` as a failure by including `"error"` in the accepted statuses in `_record_workflow_query_outcome` in `backend/workers/tasks/workflows.py`.
- Preserve existing failure-reason normalization and conversation ID fallback (`workflow:{workflow_id}`) when recording the outcome.
- Add `test_record_workflow_query_outcome_records_error_status_as_failure` to `backend/tests/test_workflow_query_outcome_metrics.py` to verify `was_success is False`, normalized failure reason, and conversation fallback.

### Testing
- Ran `pytest -q backend/tests/test_workflow_query_outcome_metrics.py backend/tests/test_query_outcome_metrics.py`, and all tests passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd6cda8788321b3bf2e46a991796f)