### PR TITLE
Fix circular import causing ChatOrchestrator import failures in workflows

### DIFF
--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -298,24 +298,12 @@ async def broadcast_conversation_message(
 # Chat WebSocket Handler
 # =============================================================================
 
-from agents.orchestrator import ChatOrchestrator
-from agents.tools import (
-    execute_crm_operation,
-    cancel_crm_operation,
-    update_tool_call_result,
-    execute_send_email_from,
-    execute_send_slack,
-    execute_save_memory,
-    execute_keep_notes,
-)
 from models.conversation import Conversation
 from models.database import get_session
 from models.user import User
 from models.chat_message import ChatMessage
 from models.workflow import WorkflowRun
 from sqlalchemy import and_, select
-from services.credits import can_use_credits
-from services.task_manager import task_manager
 
 
 def _generate_title(message: str) -> str:
@@ -491,6 +479,8 @@ async def _execute_tool_approval(
     from models.pending_operation import PendingOperation, CrmOperation
     from models.database import get_session
     from agents.tools import (
+        cancel_crm_operation,
+        execute_crm_operation,
         get_pending_operation,
         remove_pending_operation,
         execute_send_email_from,
@@ -608,6 +598,14 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
     Args:
         websocket: The WebSocket connection
     """
+    from agents.tools import (
+        cancel_crm_operation,
+        execute_crm_operation,
+        update_tool_call_result,
+    )
+    from services.credits import can_use_credits
+    from services.task_manager import task_manager
+
     # Verify JWT token BEFORE accepting the connection
     from api.auth_middleware import verify_websocket_token
     


### PR DESCRIPTION
### Motivation
- Tests and runtime paths were failing with "cannot import name 'ChatOrchestrator'" due to a circular import triggered during module import. 
- The cycle traced was `agents.orchestrator -> agents.tools -> connectors.fireflies -> api.websockets -> agents.orchestrator`, caused by eager imports in `backend/api/websockets.py`.

### Description
- Removed eager module-level imports of `agents.orchestrator`, `agents.tools` helpers, `services.credits`, and `services.task_manager` from `backend/api/websockets.py` so the module no longer drags in the orchestrator stack on import. 
- Added localized (lazy) imports inside `_execute_tool_approval` for CRM/tool execution helpers and inside `websocket_endpoint` for tool handlers, credits, and task manager so those names are only resolved when the functions run. 
- No business logic changes were made; this is an import-location refactor that preserves existing runtime behavior.

### Testing
- Ran `pytest -q tests/test_orchestrator_identity.py` and the suite passed (`2 passed`).
- Verified `from agents.orchestrator import ChatOrchestrator` via a small Python invocation and it imported successfully. 
- Verified importing `workers.tasks.workflows` no longer triggers the circular-import error by importing the module in a Python invocation without raising an exception.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd894b9b88321a32ae313aa513ccf)