### PR TITLE
Ensure workflow conversations are visible to both creator and trigger user

### DIFF
--- a/backend/api/routes/workflows.py
+++ b/backend/api/routes/workflows.py
@@ -56,6 +56,19 @@ def _sanitize_workflow_auto_approve_tools(tools: list[str] | None) -> list[str]:
     return sanitized
 
 
+def _workflow_conversation_participants(
+    workflow_creator_user_id: UUID | None,
+    trigger_user_uuid: UUID | None,
+) -> list[UUID]:
+    """Build workflow conversation participants for visibility controls."""
+    participants: list[UUID] = []
+    if workflow_creator_user_id:
+        participants.append(workflow_creator_user_id)
+    if trigger_user_uuid and trigger_user_uuid not in participants:
+        participants.append(trigger_user_uuid)
+    return participants
+
+
 # ============================================================================
 # Request/Response Models
 # ============================================================================
@@ -637,6 +650,10 @@ async def trigger_workflow(
         # For prompt-based workflows, create conversation upfront so we can return its ID
         conversation_id: str | None = None
         if workflow.prompt and workflow.prompt.strip():
+            participants = _workflow_conversation_participants(
+                workflow_creator_user_id=workflow.created_by_user_id,
+                trigger_user_uuid=trigger_user_uuid,
+            )
             conversation = Conversation(
                 user_id=trigger_user_uuid or workflow.created_by_user_id,
                 organization_id=workflow.organization_id,
@@ -644,9 +661,12 @@ async def trigger_workflow(
                 scope="private",
                 workflow_id=workflow.id,
                 title=f"Workflow: {workflow.name}",
+                participating_user_ids=participants,
             )
             logger.info(
-                "[Workflows API] Creating workflow conversation with private default scope",
+                "[Workflows API] Creating workflow conversation with private default scope "
+                "participants=%s",
+                [str(user_id) for user_id in participants],
                 extra={
                     "workflow_id": str(workflow.id),
                     "conversation_scope": "private",

--- a/backend/tests/test_workflow_conversation_participants.py
+++ b/backend/tests/test_workflow_conversation_participants.py
@@ -1,0 +1,53 @@
+from uuid import UUID
+
+from api.routes.workflows import _workflow_conversation_participants as api_participants
+from workers.tasks.workflows import _workflow_conversation_participants as task_participants
+
+
+def test_api_workflow_conversation_participants_includes_creator_and_trigger_user() -> None:
+    creator = UUID("00000000-0000-0000-0000-000000000001")
+    trigger_user = UUID("00000000-0000-0000-0000-000000000002")
+
+    participants = api_participants(
+        workflow_creator_user_id=creator,
+        trigger_user_uuid=trigger_user,
+    )
+
+    assert participants == [creator, trigger_user]
+
+
+def test_api_workflow_conversation_participants_deduplicates_when_same_user() -> None:
+    creator = UUID("00000000-0000-0000-0000-000000000001")
+
+    participants = api_participants(
+        workflow_creator_user_id=creator,
+        trigger_user_uuid=creator,
+    )
+
+    assert participants == [creator]
+
+
+def test_task_workflow_conversation_participants_merges_existing_and_trigger_user() -> None:
+    creator = UUID("00000000-0000-0000-0000-000000000001")
+    existing = [UUID("00000000-0000-0000-0000-000000000003")]
+    trigger_user_id = "00000000-0000-0000-0000-000000000002"
+
+    participants = task_participants(
+        workflow_creator_user_id=creator,
+        triggered_by_user_id=trigger_user_id,
+        existing_participants=existing,
+    )
+
+    assert participants == [existing[0], creator, UUID(trigger_user_id)]
+
+
+def test_task_workflow_conversation_participants_ignores_invalid_trigger_user() -> None:
+    creator = UUID("00000000-0000-0000-0000-000000000001")
+
+    participants = task_participants(
+        workflow_creator_user_id=creator,
+        triggered_by_user_id="not-a-uuid",
+        existing_participants=None,
+    )
+
+    assert participants == [creator]

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -39,6 +39,31 @@ WORKFLOW_NESTING_GUARDRAIL = (
 )
 
 
+def _workflow_conversation_participants(
+    workflow_creator_user_id: UUID | None,
+    triggered_by_user_id: str | None,
+    existing_participants: list[UUID] | None = None,
+) -> list[UUID]:
+    """Return merged participant IDs for workflow conversations."""
+    participants: list[UUID] = list(existing_participants or [])
+
+    if workflow_creator_user_id and workflow_creator_user_id not in participants:
+        participants.append(workflow_creator_user_id)
+
+    if triggered_by_user_id:
+        try:
+            trigger_user_uuid = UUID(triggered_by_user_id)
+            if trigger_user_uuid not in participants:
+                participants.append(trigger_user_uuid)
+        except ValueError:
+            logger.warning(
+                "[Workflow] Invalid triggered_by_user_id for participants merge: %s",
+                triggered_by_user_id,
+            )
+
+    return participants
+
+
 async def _record_workflow_query_outcome(
     *,
     result: dict[str, Any] | None,
@@ -946,6 +971,10 @@ async def _execute_workflow_via_agent(
                 workflow.id,
                 triggered_by_user_id,
             )
+    workflow_participants = _workflow_conversation_participants(
+        workflow_creator_user_id=workflow.created_by_user_id,
+        triggered_by_user_id=triggered_by_user_id,
+    )
 
     # Use existing conversation or create a new one
     if existing_conversation_id:
@@ -964,15 +993,32 @@ async def _execute_workflow_via_agent(
                 workflow_id=workflow.id,
                 title=f"Workflow: {workflow.name}",
                 parent_conversation_id=parent_conversation_id,
+                participating_user_ids=workflow_participants,
             )
             logger.info(
                 "[Workflow] Creating fallback workflow conversation with private scope "
-                "workflow_id=%s parent_conversation_id=%s",
+                "workflow_id=%s parent_conversation_id=%s participants=%s",
                 workflow.id,
                 parent_conversation_id,
+                [str(user_id) for user_id in workflow_participants],
             )
             session.add(conversation)
             await session.flush()
+        else:
+            merged_participants = _workflow_conversation_participants(
+                workflow_creator_user_id=workflow.created_by_user_id,
+                triggered_by_user_id=triggered_by_user_id,
+                existing_participants=conversation.participating_user_ids,
+            )
+            if merged_participants != (conversation.participating_user_ids or []):
+                conversation.participating_user_ids = merged_participants
+                logger.info(
+                    "[Workflow] Updated existing workflow conversation participants "
+                    "workflow_id=%s conversation_id=%s participants=%s",
+                    workflow.id,
+                    conversation.id,
+                    [str(user_id) for user_id in merged_participants],
+                )
     else:
         # Create a new workflow conversation
         conversation = Conversation(
@@ -983,12 +1029,14 @@ async def _execute_workflow_via_agent(
             workflow_id=workflow.id,
             title=f"Workflow: {workflow.name}",
             parent_conversation_id=parent_conversation_id,
+            participating_user_ids=workflow_participants,
         )
         logger.info(
             "[Workflow] Creating workflow conversation with private scope "
-            "workflow_id=%s parent_conversation_id=%s",
+            "workflow_id=%s parent_conversation_id=%s participants=%s",
             workflow.id,
             parent_conversation_id,
+            [str(user_id) for user_id in workflow_participants],
         )
         session.add(conversation)
         await session.flush()


### PR DESCRIPTION
### Motivation
- Workflow runs created a private `Conversation` but could omit the workflow creator or the user who triggered the run from `participating_user_ids`, making the conversation invisible to one of the intended participants.
- When reusing a pre-created conversation the existing participant list was not merged with the triggerer/creator, so visibility could be lost.

### Description
- Added `_workflow_conversation_participants` helpers in `backend/api/routes/workflows.py` and `backend/workers/tasks/workflows.py` to build/merge participant lists including the workflow creator and trigger user, with deduplication and invalid-UUID handling.
- Updated the API pre-creation path to set `participating_user_ids` when creating a private prompt-based workflow conversation and logged the final participant set.
- Updated worker-side `_execute_workflow_via_agent` to use the merge helper for new conversations, fallback creation, and when reusing an existing conversation to preserve and update participants.
- Added unit tests in `backend/tests/test_workflow_conversation_participants.py` covering include/dedup/merge/invalid-trigger scenarios.

### Testing
- Ran `pytest -q backend/tests/test_workflow_conversation_participants.py`, which passed with `4 passed`.
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd912b80083219ac5898450fa2d6c)