### PR TITLE
Expose active orchestrator model in chat streaming UI

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1083,6 +1083,12 @@ class ChatOrchestrator:
             is_workflow_run,
             workflow_model_override,
         )
+        yield _json_dumps({
+            "type": "model_selected",
+            "model": selected_model,
+            "provider": self._llm_config.provider,
+            "is_workflow": is_workflow_run,
+        })
 
         # Keep track of content blocks for saving (preserves interleaving order)
         content_blocks: list[dict[str, Any]] = []

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -328,6 +328,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
   const markConversationMessageComplete = useAppStore((state) => state.markConversationMessageComplete);
   const advanceConversationChunkIndex = useAppStore((state) => state.advanceConversationChunkIndex);
   const setConversationThinking = useAppStore((state) => state.setConversationThinking);
+  const setConversationActiveModel = useAppStore((state) => state.setConversationActiveModel);
   const updateConversationToolMessage = useAppStore((state) => state.updateConversationToolMessage);
   const addConversationArtifactBlock = useAppStore((state) => state.addConversationArtifactBlock);
   const addConversationAppBlock = useAppStore((state) => state.addConversationAppBlock);
@@ -770,7 +771,12 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
           } else if (typeof chunkData === 'object' && chunkData !== null) {
             const data = chunkData as Record<string, unknown>;
 
-            if (data.type === 'thinking_start') {
+            if (data.type === 'model_selected') {
+              const selectedModel = typeof data.model === 'string' && data.model.trim().length > 0
+                ? data.model.trim()
+                : null;
+              setConversationActiveModel(conversation_id, selectedModel);
+            } else if (data.type === 'thinking_start') {
               const state = useAppStore.getState();
               const convState = state.conversations[conversation_id];
               const thinkingBlock = { type: 'thinking' as const, text: '', isStreaming: true };
@@ -1287,7 +1293,12 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
                 }
               } else if (typeof chunkData === 'object' && chunkData !== null) {
                 const data = chunkData as Record<string, unknown>;
-                if (data.type === 'thinking_start') {
+                if (data.type === 'model_selected') {
+                  const selectedModel = typeof data.model === 'string' && data.model.trim().length > 0
+                    ? data.model.trim()
+                    : null;
+                  setConversationActiveModel(conversationId, selectedModel);
+                } else if (data.type === 'thinking_start') {
                   const state = useAppStore.getState();
                   const convState = state.conversations[conversationId];
                   const thinkingBlock = { type: 'thinking' as const, text: '', isStreaming: true };
@@ -1636,7 +1647,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
     }
   }, [
     shouldBroadcastWebSocket,
-    setActiveTasks, setConversationActiveTask, setConversationThinking,
+    setActiveTasks, setConversationActiveTask, setConversationThinking, setConversationActiveModel,
     addConversation, addConversationMessage, appendToConversationStreaming,
     startConversationStreaming, markConversationMessageComplete, updateConversationToolMessage,
     addConversationArtifactBlock, addConversationAppBlock, setCurrentChatId,

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -381,7 +381,11 @@ export function Chat({
   const conversationThinking = conversationState?.isThinking ?? false;
   
   const orgInfo = useOrganization();
-  const activeModelName: string | null = orgInfo?.llmPrimaryModel ?? null;
+  const configuredPrimaryModel: string | null = orgInfo?.llmPrimaryModel ?? null;
+  const activeModelName: string | null = conversationState?.activeModelName ?? configuredPrimaryModel;
+  const activeModelLabel: string | null = conversationState?.activeModelName
+    ? `Running: ${conversationState.activeModelName}`
+    : (configuredPrimaryModel ? `Default: ${configuredPrimaryModel}` : null);
 
   // Get actions from Zustand (stable references)
   const addConversationMessage = useAppStore((s) => s.addConversationMessage);
@@ -2679,9 +2683,9 @@ export function Chat({
               </button>
             );
 
-            const modelLabel: JSX.Element | null = activeModelName ? (
-              <span className="text-[11px] text-surface-500 truncate max-w-[160px]" title={activeModelName}>
-                {activeModelName}
+            const modelLabel: JSX.Element | null = activeModelLabel ? (
+              <span className="text-[11px] text-surface-500 truncate max-w-[200px]" title={activeModelName ?? undefined}>
+                {activeModelLabel}
               </span>
             ) : null;
 

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -66,6 +66,7 @@ const defaultConversationState: ConversationState = {
   messages: [],
   title: "New Chat",
   isThinking: false,
+  activeModelName: null,
   streamingMessageId: null,
   activeTaskId: null,
   lastChunkIndex: -1,
@@ -169,6 +170,10 @@ export interface ChatState {
   setConversationThinking: (
     conversationId: string,
     thinking: boolean,
+  ) => void;
+  setConversationActiveModel: (
+    conversationId: string,
+    modelName: string | null,
   ) => void;
   setConversationActiveTask: (
     conversationId: string,
@@ -1057,6 +1062,19 @@ export const useChatStore = create<ChatState>()(
       });
     },
 
+    setConversationActiveModel: (conversationId, modelName) => {
+      const { conversations } = get();
+      const current = conversations[conversationId] ?? {
+        ...defaultConversationState,
+      };
+      set({
+        conversations: {
+          ...conversations,
+          [conversationId]: { ...current, activeModelName: modelName },
+        },
+      });
+    },
+
     setConversationActiveTask: (conversationId, taskId) => {
       const { conversations, activeTasksByConversation } = get();
       const current = conversations[conversationId] ?? {
@@ -1076,7 +1094,7 @@ export const useChatStore = create<ChatState>()(
           [conversationId]: {
             ...current,
             activeTaskId: taskId,
-            ...(taskId ? { lastChunkIndex: -1, pendingChunks: [] } : {}),
+            ...(taskId ? { lastChunkIndex: -1, pendingChunks: [] } : { activeModelName: null }),
           },
         },
         activeTasksByConversation: updatedActiveTasks,

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -275,6 +275,7 @@ export interface ConversationState {
   messages: ChatMessage[];
   title: string;
   isThinking: boolean;
+  activeModelName: string | null;
   streamingMessageId: string | null;
   activeTaskId: string | null;
   lastChunkIndex: number;


### PR DESCRIPTION
### Motivation
- Make the LLM provider/model resolved for a running turn visible to the prompt/response layer so the UI can show which model is actively running for a conversation.

### Description
- Emit a new streaming chunk `model_selected` from the orchestrator immediately after resolving per-org provider/model so clients can learn the selected model early in the turn (`backend/agents/orchestrator.py`).
- Add an ephemeral `activeModelName` field to `ConversationState` and store actions to set it, and ensure it is cleared when a task finishes (`frontend/src/store/types.ts`, `frontend/src/store/chatStore.ts`).
- Consume `model_selected` in live `task_chunk` handling and in `catchup` flows and write the value into the conversation state (`frontend/src/components/AppLayout.tsx`).
- Surface the active model in the chat composer as `Running: <model>` during an active turn and fall back to `Default: <primary model>` otherwise (`frontend/src/components/Chat.tsx`).

### Testing
- Ran the frontend production build with `npm --prefix frontend run build`, which completed successfully. 
- Ran the backend unit test `pytest -q backend/tests/test_orchestrator_context_window.py`, which failed during collection due to an existing circular import between `agents.orchestrator` and `api.websockets` (this circular import was present in the test environment and not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfd8e33d8c832199ee3398a469f7ed)