### PR TITLE
Prevent Daily Digest toolbar overflow on mobile and widen action buttons

### DIFF
--- a/frontend/src/components/DailyDigestGrid.tsx
+++ b/frontend/src/components/DailyDigestGrid.tsx
@@ -430,7 +430,7 @@ export function DailyDigestGrid({ digestDate, onDigestDateChange }: DailyDigestG
           </button>
         </div>
 
-        <div className="flex items-center gap-2 w-full md:w-auto overflow-x-auto pr-1">
+        <div className="flex items-center flex-wrap md:flex-nowrap gap-2 w-full md:w-auto pr-1">
           {/* Search */}
           <div className="relative">
             <svg className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-surface-500 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -468,21 +468,23 @@ export function DailyDigestGrid({ digestDate, onDigestDateChange }: DailyDigestG
           </div>
 
           {/* Generate / Refresh */}
-          <button
-            type="button"
-            disabled={generating}
-            onClick={() => void handleGenerate()}
-            className="inline-flex items-center justify-center w-[4.25rem] md:w-auto md:min-w-[9rem] h-8 px-2 md:px-3 rounded-md border border-surface-600 text-xs text-surface-300 hover:text-surface-100 hover:bg-surface-800 disabled:opacity-50"
-          >
-            {generating ? "Generating…" : `Generate for ${formatDayMonth(digestDate)}`}
-          </button>
-          <button
-            type="button"
-            onClick={() => void load()}
-            className="inline-flex items-center justify-center w-[4.25rem] md:w-auto md:min-w-[9rem] h-8 px-2 md:px-3 rounded-md border border-primary-500/40 text-xs text-primary-400 hover:text-primary-300 hover:bg-primary-500/10"
-          >
-            Refresh
-          </button>
+          <div className="flex items-center gap-2 w-full md:w-auto">
+            <button
+              type="button"
+              disabled={generating}
+              onClick={() => void handleGenerate()}
+              className="inline-flex items-center justify-center flex-1 md:flex-none min-w-0 md:w-auto md:min-w-[9rem] h-8 px-3 rounded-md border border-surface-600 text-xs text-surface-300 hover:text-surface-100 hover:bg-surface-800 disabled:opacity-50"
+            >
+              {generating ? "Generating…" : `Generate for ${formatDayMonth(digestDate)}`}
+            </button>
+            <button
+              type="button"
+              onClick={() => void load()}
+              className="inline-flex items-center justify-center flex-1 md:flex-none min-w-0 md:w-auto md:min-w-[9rem] h-8 px-3 rounded-md border border-primary-500/40 text-xs text-primary-400 hover:text-primary-300 hover:bg-primary-500/10"
+            >
+              Refresh
+            </button>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- Keep the Daily Digest toolbar controls on one visible line on desktop while preventing horizontal overflow on small screens and make the Generate/Refresh buttons easier to tap on mobile.

### Description
- Update `frontend/src/components/DailyDigestGrid.tsx` to allow the toolbar to wrap on small screens and group the Generate/Refresh controls into a full-width mobile action row where both buttons use `flex-1` with `min-w-0` and preserve the desktop `md:min-w-[9rem]` sizing.

### Testing
- Ran `npm --prefix /workspace/basebase/frontend run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfdb4c70b08321a1bc0e20b6ce7bed)