### PR TITLE
Avoid circular import by late-importing ChatOrchestrator in TaskManager

### DIFF
--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -13,17 +13,19 @@ import json
 import logging
 from datetime import datetime, timedelta
 from contextlib import asynccontextmanager
-from typing import Any, Callable, Coroutine
+from typing import TYPE_CHECKING, Any, Callable, Coroutine
 from uuid import UUID, uuid4
 
 from fastapi import WebSocket
 from sqlalchemy import and_, or_, select, update
 
-from agents.orchestrator import ChatOrchestrator
 from models.agent_task import AgentTask
 from models.chat_message import ChatMessage
 from models.conversation import Conversation
 from models.database import get_admin_session, get_session
+
+if TYPE_CHECKING:
+    from agents.orchestrator import ChatOrchestrator
 
 logger = logging.getLogger(__name__)
 
@@ -248,6 +250,9 @@ class TaskManager:
         failure_reason: str | None = None
         try:
             async with self._conversation_execution_lock(conversation_id):
+                # Late import to avoid module import cycles during app startup.
+                from agents.orchestrator import ChatOrchestrator
+
                 orchestrator = ChatOrchestrator(
                     user_id=user_id,
                     organization_id=organization_id,


### PR DESCRIPTION
### Motivation
- Prevent the runtime circular import that can leave `agents.orchestrator` partially initialized and cause "cannot import name 'ChatOrchestrator'" errors when importing `services.task_manager` at module load.

### Description
- Replaced the module-level `from agents.orchestrator import ChatOrchestrator` with a `TYPE_CHECKING`-only import and a late import inside `_run_task` in `backend/services/task_manager.py` so the runtime import happens only when the task executes.

### Testing
- Verified runtime import ordering with a smoke script: `import services.task_manager` followed by `from agents.orchestrator import ChatOrchestrator`, which succeeded. 
- Ran targeted tests `pytest -q tests/test_orchestrator_identity.py tests/test_websocket_fanout.py`, resulting in `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfddb86db48321a135eaba64cda4bf)