### PR TITLE
Fix circular import between task manager and orchestrator

### DIFF
--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -13,17 +13,19 @@ import json
 import logging
 from datetime import datetime, timedelta
 from contextlib import asynccontextmanager
-from typing import Any, Callable, Coroutine
+from typing import TYPE_CHECKING, Any, Callable, Coroutine
 from uuid import UUID, uuid4
 
 from fastapi import WebSocket
 from sqlalchemy import and_, or_, select, update
 
-from agents.orchestrator import ChatOrchestrator
 from models.agent_task import AgentTask
 from models.chat_message import ChatMessage
 from models.conversation import Conversation
 from models.database import get_admin_session, get_session
+
+if TYPE_CHECKING:
+    from agents.orchestrator import ChatOrchestrator
 
 logger = logging.getLogger(__name__)
 
@@ -248,6 +250,10 @@ class TaskManager:
         failure_reason: str | None = None
         try:
             async with self._conversation_execution_lock(conversation_id):
+                # Import lazily to avoid circular imports during app startup
+                # (agents.orchestrator imports modules that may import task_manager).
+                from agents.orchestrator import ChatOrchestrator
+
                 orchestrator = ChatOrchestrator(
                     user_id=user_id,
                     organization_id=organization_id,


### PR DESCRIPTION
### Motivation
- Prevent a circular import error when importing `agents.orchestrator` that arises because `services.task_manager` previously imported `ChatOrchestrator` at module import time.

### Description
- Remove the runtime top-level `from agents.orchestrator import ChatOrchestrator` and add a `TYPE_CHECKING`-only import for type hints, and perform a lazy `from agents.orchestrator import ChatOrchestrator` inside `TaskManager._run_task` just before instantiation.

### Testing
- Verified both modules import cleanly by running the quick import check script `cd backend && python - <<'PY'\nimport importlib\nm1=importlib.import_module('services.task_manager')\nprint('task_manager import ok', hasattr(m1,'TaskManager'))\nm2=importlib.import_module('agents.orchestrator')\nprint('orchestrator import ok', hasattr(m2,'ChatOrchestrator'))\nPY` which printed successful import signs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfddb86db48321a135eaba64cda4bf)