### PR TITLE
Add global admin "Kill all jobs" emergency control

### DIFF
--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -178,6 +178,16 @@ class AdminCancelJobResponse(BaseModel):
     message: str
 
 
+class AdminKillAllJobsResponse(BaseModel):
+    """Response model for emergency kill-all jobs operation."""
+
+    status: str
+    message: str
+    revoked_task_count: int
+    queue_purged_count: int
+    workflow_pause_until: str
+
+
 def _ensure_org_path_matches_auth(organization_id: str, auth: AuthContext) -> None:
     """Require active org context and that path org matches JWT org (unless global admin)."""
     if auth.is_global_admin:
@@ -662,6 +672,91 @@ async def cancel_admin_running_job(
         job_id=job_id,
         job_type=request.job_type,
         message="Celery task revoke requested",
+    )
+
+
+@router.post("/admin/jobs/kill-all", response_model=AdminKillAllJobsResponse)
+async def kill_all_admin_jobs(
+    auth: AuthContext = Depends(require_global_admin),
+) -> AdminKillAllJobsResponse:
+    """Terminate all active worker tasks, purge queued work, and pause workflows briefly."""
+    from workers.celery_app import celery_app
+    from services.workflow_pause import pause_workflow_execution_for_seconds
+
+    revoked_ids: set[str] = set()
+    queue_purged_count = 0
+    pause_seconds = 60
+
+    try:
+        inspector = celery_app.control.inspect(timeout=2.0)
+        active_by_worker = inspector.active() or {}
+        reserved_by_worker = inspector.reserved() or {}
+        scheduled_by_worker = inspector.scheduled() or {}
+    except Exception as exc:
+        logger.exception("Admin %s failed to inspect celery jobs for kill-all: %s", auth.user_id, exc)
+        raise HTTPException(status_code=503, detail="Failed to inspect worker queues") from exc
+
+    def _revoke_task(task_id: str) -> None:
+        normalized_task_id = str(task_id).strip()
+        if not normalized_task_id or normalized_task_id in revoked_ids:
+            return
+        celery_app.control.revoke(normalized_task_id, terminate=True, signal="SIGKILL")
+        revoked_ids.add(normalized_task_id)
+
+    for worker_name, tasks in active_by_worker.items():
+        for task in tasks:
+            task_id = str(task.get("id") or "")
+            _revoke_task(task_id)
+        logger.warning(
+            "Admin %s kill-all revoked %d active task(s) on worker=%s",
+            auth.user_id,
+            len(tasks),
+            worker_name,
+        )
+
+    for worker_name, tasks in reserved_by_worker.items():
+        for task in tasks:
+            task_id = str(task.get("id") or "")
+            _revoke_task(task_id)
+        logger.warning(
+            "Admin %s kill-all revoked %d reserved task(s) on worker=%s",
+            auth.user_id,
+            len(tasks),
+            worker_name,
+        )
+
+    for worker_name, tasks in scheduled_by_worker.items():
+        for task in tasks:
+            request = task.get("request") if isinstance(task, dict) else None
+            task_id = str((request or {}).get("id") or task.get("id") or "") if isinstance(task, dict) else ""
+            _revoke_task(task_id)
+        logger.warning(
+            "Admin %s kill-all revoked %d scheduled task(s) on worker=%s",
+            auth.user_id,
+            len(tasks),
+            worker_name,
+        )
+
+    try:
+        queue_purged_count = int(celery_app.control.purge() or 0)
+    except Exception as exc:
+        logger.exception("Admin %s failed to purge celery queues during kill-all: %s", auth.user_id, exc)
+        raise HTTPException(status_code=503, detail="Failed to purge queued tasks") from exc
+
+    workflow_pause_until = await pause_workflow_execution_for_seconds(seconds=pause_seconds)
+    logger.warning(
+        "Admin %s executed kill-all jobs operation revoked=%d purged=%d workflow_pause_until=%s",
+        auth.user_id,
+        len(revoked_ids),
+        queue_purged_count,
+        workflow_pause_until.isoformat(),
+    )
+    return AdminKillAllJobsResponse(
+        status="ok",
+        message="All active work was terminated, queued tasks purged, and workflow execution paused for 60 seconds",
+        revoked_task_count=len(revoked_ids),
+        queue_purged_count=queue_purged_count,
+        workflow_pause_until=workflow_pause_until.isoformat(),
     )
 
 

--- a/backend/api/routes/workflows.py
+++ b/backend/api/routes/workflows.py
@@ -18,6 +18,7 @@ from models.database import get_session
 from models.workflow import Workflow, WorkflowRun
 from api.auth_middleware import AuthContext, require_organization
 from services.llm_provider import is_model_allowed
+from services.workflow_pause import get_workflow_execution_pause_until
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -679,6 +680,19 @@ async def trigger_workflow(
 
     # Queue execution via Celery
     from workers.tasks.workflows import execute_workflow
+    pause_until = await get_workflow_execution_pause_until()
+    if pause_until is not None:
+        logger.warning(
+            "[Workflows API] Manual trigger blocked by workflow execution pause workflow_id=%s organization_id=%s pause_until=%s",
+            workflow_id,
+            organization_id,
+            pause_until.isoformat(),
+        )
+        raise HTTPException(
+            status_code=503,
+            detail=f"Workflow execution temporarily paused until {pause_until.isoformat()}",
+        )
+
     logger.info(
         "[Workflows API] Queueing manual workflow run",
         extra={

--- a/backend/services/workflow_pause.py
+++ b/backend/services/workflow_pause.py
@@ -1,0 +1,72 @@
+"""Workflow execution pause controls for emergency admin operations."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+
+import redis.asyncio as aioredis
+
+from config import get_redis_connection_kwargs, settings
+
+logger = logging.getLogger(__name__)
+
+WORKFLOW_EXECUTION_PAUSE_KEY = "admin:workflow_execution_pause_until"
+
+
+async def pause_workflow_execution_for_seconds(*, seconds: int) -> datetime:
+    """Pause new workflow execution attempts for a fixed duration in seconds."""
+    now_utc = datetime.now(timezone.utc)
+    pause_until = now_utc.timestamp() + max(seconds, 0)
+    ttl_seconds = max(seconds, 1)
+    redis_client = aioredis.from_url(
+        settings.REDIS_URL,
+        **get_redis_connection_kwargs(decode_responses=True),
+    )
+    try:
+        async with redis_client:
+            await redis_client.set(
+                WORKFLOW_EXECUTION_PAUSE_KEY,
+                str(pause_until),
+                ex=ttl_seconds,
+            )
+    except Exception:
+        logger.exception("Failed to set workflow execution pause flag")
+        raise
+    return datetime.fromtimestamp(pause_until, tz=timezone.utc)
+
+
+async def get_workflow_execution_pause_until() -> datetime | None:
+    """Return the pause-until timestamp when workflow execution is paused."""
+    redis_client = aioredis.from_url(
+        settings.REDIS_URL,
+        **get_redis_connection_kwargs(decode_responses=True),
+    )
+    try:
+        async with redis_client:
+            raw_value = await redis_client.get(WORKFLOW_EXECUTION_PAUSE_KEY)
+    except Exception:
+        logger.exception("Failed to read workflow execution pause flag")
+        return None
+
+    if raw_value is None:
+        return None
+
+    try:
+        pause_until_epoch = float(raw_value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Workflow execution pause flag had non-numeric value=%r",
+            raw_value,
+        )
+        return None
+    pause_until = datetime.fromtimestamp(pause_until_epoch, tz=timezone.utc)
+    if pause_until <= datetime.now(timezone.utc):
+        return None
+    return pause_until
+
+
+async def is_workflow_execution_paused() -> bool:
+    """Whether new workflow execution attempts should be blocked."""
+    return await get_workflow_execution_pause_until() is not None
+

--- a/backend/tests/test_workflow_pause.py
+++ b/backend/tests/test_workflow_pause.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import services.workflow_pause as workflow_pause
+
+
+class _FakeRedisClient:
+    def __init__(self, stored_value: str | None = None) -> None:
+        self.stored_value = stored_value
+        self.set_calls: list[tuple[str, str, int]] = []
+
+    async def __aenter__(self) -> "_FakeRedisClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def set(self, key: str, value: str, ex: int) -> None:
+        self.set_calls.append((key, value, ex))
+        self.stored_value = value
+
+    async def get(self, key: str) -> str | None:
+        return self.stored_value
+
+
+@pytest.mark.asyncio
+async def test_pause_workflow_execution_for_seconds_sets_pause_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_client = _FakeRedisClient()
+    monkeypatch.setattr(workflow_pause.aioredis, "from_url", lambda *args, **kwargs: fake_client)
+
+    pause_until = await workflow_pause.pause_workflow_execution_for_seconds(seconds=60)
+
+    assert fake_client.set_calls
+    key, value, ttl = fake_client.set_calls[0]
+    assert key == workflow_pause.WORKFLOW_EXECUTION_PAUSE_KEY
+    assert ttl == 60
+    assert float(value) > datetime.now(timezone.utc).timestamp()
+    assert pause_until > datetime.now(timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_get_workflow_execution_pause_until_returns_none_for_expired(monkeypatch: pytest.MonkeyPatch) -> None:
+    expired = (datetime.now(timezone.utc) - timedelta(seconds=5)).timestamp()
+    fake_client = _FakeRedisClient(stored_value=str(expired))
+    monkeypatch.setattr(workflow_pause.aioredis, "from_url", lambda *args, **kwargs: fake_client)
+
+    pause_until = await workflow_pause.get_workflow_execution_pause_until()
+
+    assert pause_until is None
+
+
+@pytest.mark.asyncio
+async def test_is_workflow_execution_paused_true_when_pause_in_future(monkeypatch: pytest.MonkeyPatch) -> None:
+    future = (datetime.now(timezone.utc) + timedelta(seconds=30)).timestamp()
+    fake_client = _FakeRedisClient(stored_value=str(future))
+    monkeypatch.setattr(workflow_pause.aioredis, "from_url", lambda *args, **kwargs: fake_client)
+
+    assert await workflow_pause.is_workflow_execution_paused() is True

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -27,6 +27,7 @@ from uuid import UUID
 from workers.celery_app import celery_app
 from services.automated_agent_footer import ensure_automated_agent_footer
 from services.anthropic_health import report_anthropic_call_failure, report_anthropic_call_success
+from services.workflow_pause import get_workflow_execution_pause_until
 
 logger = logging.getLogger(__name__)
 
@@ -621,6 +622,18 @@ async def _check_scheduled_workflows() -> dict[str, Any]:
     from croniter import croniter
     
     now = datetime.utcnow()
+    pause_until = await get_workflow_execution_pause_until()
+    if pause_until is not None:
+        logger.warning(
+            "[Workflow Scheduler] Skipping scheduled workflow checks due to admin pause until %s",
+            pause_until.isoformat(),
+        )
+        return {
+            "checked_at": now.isoformat(),
+            "workflows_triggered": [],
+            "paused_until": pause_until.isoformat(),
+        }
+
     triggered: list[str] = []
     
     # Admin session: iterates across ALL organizations' workflows
@@ -682,6 +695,18 @@ async def _process_pending_events() -> dict[str, Any]:
     from models.workflow import Workflow
     from workers.events import get_pending_events
     
+    pause_until = await get_workflow_execution_pause_until()
+    if pause_until is not None:
+        logger.warning(
+            "[Workflow Events] Skipping pending event processing due to admin pause until %s",
+            pause_until.isoformat(),
+        )
+        return {
+            "events_processed": 0,
+            "workflows_triggered": [],
+            "paused_until": pause_until.isoformat(),
+        }
+
     events = await get_pending_events(limit=100)
     if not events:
         return {"events_processed": 0, "workflows_triggered": []}
@@ -755,7 +780,20 @@ async def _execute_workflow(
     from models.workflow import Workflow, WorkflowRun
     
     started_at = datetime.utcnow()
-    
+    pause_until = await get_workflow_execution_pause_until()
+    if pause_until is not None:
+        logger.warning(
+            "[Workflow] Aborting execution due to admin pause workflow_id=%s organization_id=%s pause_until=%s",
+            workflow_id,
+            organization_id,
+            pause_until.isoformat(),
+        )
+        return {
+            "status": "skipped",
+            "reason": "workflow_execution_paused",
+            "paused_until": pause_until.isoformat(),
+        }
+
     async with get_session(organization_id=organization_id) as session:
         # Load workflow
         result = await session.execute(

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -520,6 +520,7 @@ export function AdminPanel(): JSX.Element {
   const [jobsLoading, setJobsLoading] = useState<boolean>(true);
   const [jobsError, setJobsError] = useState<string | null>(null);
   const [cancellingJobId, setCancellingJobId] = useState<string | null>(null);
+  const [killingAllJobs, setKillingAllJobs] = useState<boolean>(false);
 
   // Dashboard tab state
   const [creditUsage, setCreditUsage] = useState<CreditUsageResponse | null>(null);
@@ -761,6 +762,44 @@ export function AdminPanel(): JSX.Element {
       alert('Failed to cancel job: ' + (err instanceof Error ? err.message : 'Unknown error'));
     } finally {
       setCancellingJobId(null);
+    }
+  };
+
+  const handleKillAllJobs = async (): Promise<void> => {
+    if (!user || killingAllJobs) return;
+
+    const shouldProceed = window.confirm(
+      'Are you sure? This will disrupt all current work. It will terminate running jobs, clear queued work, and pause workflow execution for 1 minute.'
+    );
+    if (!shouldProceed) return;
+
+    setKillingAllJobs(true);
+    try {
+      const authHeaders = await getAuthenticatedRequestHeaders();
+      const response = await fetch(`${API_BASE}/sync/admin/jobs/kill-all`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
+      });
+
+      if (!response.ok) {
+        const data = await response.json() as { detail?: string };
+        throw new Error(data.detail ?? 'Failed to kill all jobs');
+      }
+
+      const result = await response.json() as {
+        revoked_task_count: number;
+        queue_purged_count: number;
+        workflow_pause_until: string;
+      };
+      alert(
+        `Kill-all completed. Revoked ${result.revoked_task_count} active/reserved tasks, purged ${result.queue_purged_count} queued tasks, workflows paused until ${new Date(result.workflow_pause_until).toLocaleTimeString()}.`
+      );
+      await fetchRunningJobs();
+    } catch (err) {
+      console.error('Failed to kill all jobs:', err);
+      alert('Failed to kill all jobs: ' + (err instanceof Error ? err.message : 'Unknown error'));
+    } finally {
+      setKillingAllJobs(false);
     }
   };
 
@@ -2569,12 +2608,21 @@ export function AdminPanel(): JSX.Element {
           <div className="space-y-4">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <p className="text-sm text-surface-400">Manage currently running chat, workflow, and connector sync jobs.</p>
-              <button
-                onClick={() => void fetchRunningJobs()}
-                className="rounded-lg border border-surface-700 bg-surface-800 px-3 py-1.5 text-sm text-surface-200 hover:bg-surface-700 sm:self-auto self-start"
-              >
-                Refresh
-              </button>
+              <div className="flex items-center gap-2 sm:self-auto self-start">
+                <button
+                  onClick={() => void handleKillAllJobs()}
+                  disabled={killingAllJobs}
+                  className="rounded-lg border border-red-500/40 bg-red-500/15 px-3 py-1.5 text-sm text-red-200 hover:bg-red-500/25 disabled:opacity-50"
+                >
+                  {killingAllJobs ? 'Killing all jobs...' : 'Kill all jobs'}
+                </button>
+                <button
+                  onClick={() => void fetchRunningJobs()}
+                  className="rounded-lg border border-surface-700 bg-surface-800 px-3 py-1.5 text-sm text-surface-200 hover:bg-surface-700"
+                >
+                  Refresh
+                </button>
+              </div>
             </div>
 
             {jobsError && (


### PR DESCRIPTION
### Motivation
- Provide a global-admin emergency control to immediately terminate in-flight work, clear queued tasks, and temporarily pause starting new workflow executions to allow safe operational remediation.
- Require explicit confirmation and global-admin scope for this disruptive action and surface an operational summary back to the operator.

### Description
- Add a new admin endpoint `POST /api/sync/admin/jobs/kill-all` that inspects workers, revokes active/reserved/scheduled Celery tasks, purges queued tasks, logs the operation, and returns a summary payload including revoked/purged counts and pause-until timestamp (`backend/api/routes/sync.py`).
- Introduce a reusable pause service `services/workflow_pause.py` that stores a pause-until timestamp in Redis under `admin:workflow_execution_pause_until` and exposes helpers `pause_workflow_execution_for_seconds` and `get_workflow_execution_pause_until`.
- Enforce the pause across workflow entry points by blocking manual API triggers (`backend/api/routes/workflows.py`), skipping scheduled and event dispatchers, and short-circuiting worker-side execution as a safety net (`backend/workers/tasks/workflows.py`).
- Add a "Kill all jobs" button to the Global Admin "Currently running jobs" UI with a confirmation dialog and client call to the new endpoint, and add unit tests for the pause service (`frontend/src/components/AdminPanel.tsx`, `backend/tests/test_workflow_pause.py`).

### Testing
- Ran unit tests: `pytest -q backend/tests/test_admin_jobs_task_parsing.py backend/tests/test_workflow_pause.py` and all tests passed (`12 passed`).
- Verified the new pause helper using a fake Redis client in `backend/tests/test_workflow_pause.py` which asserts set/get/expiration semantics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe1d84a5c83219609aa6250b03369)