### PR TITLE
Add unauthenticated /basebase share preview routes with rich OG metadata

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -157,6 +157,7 @@ async def global_exception_handler(request: Request, exc: Exception) -> JSONResp
 # Routes
 app.include_router(apps.router, prefix="/api/apps", tags=["apps"])
 app.include_router(public.router, prefix="/api/public", tags=["public"])
+app.include_router(public.share_router, tags=["public"])
 app.include_router(connectors.router, prefix="/api/connectors", tags=["connectors"])
 app.include_router(artifacts.router, prefix="/api/artifacts", tags=["artifacts"])
 app.include_router(auth.router, prefix="/api/auth", tags=["auth"])

--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -18,11 +18,14 @@ from sqlalchemy import select
 from config import settings
 from models.app import App
 from models.artifact import Artifact
+from models.conversation import Conversation
 from models.database import get_admin_session, get_session
+from models.user import User
 from services.app_query_runner import AppQueryResponse as QueryResponse, run_named_app_query
 from services.public_previews import build_preview_html, decode_data_url_image, render_card_png
 
 router = APIRouter()
+share_router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
@@ -150,7 +153,39 @@ def _frontend_origin() -> str:
     return settings.FRONTEND_URL.rstrip("/")
 
 
+def _owner_label(user: User | None) -> str:
+    """Return a compact owner label suitable for public descriptions."""
+    if user is None:
+        return "Unknown owner"
+    if user.name:
+        return user.name
+    if user.email:
+        return user.email
+    return "Unknown owner"
+
+
+def _public_preview_description(
+    *,
+    conversation: Conversation | None,
+    app: App | None = None,
+    artifact: Artifact | None = None,
+    owner: User | None,
+) -> str:
+    """Build a concise public description for social preview unfurls."""
+    owner_label = _owner_label(owner)
+    if conversation and conversation.title:
+        return f"{conversation.title} — {owner_label}"
+    if app and app.title:
+        return f"{app.title} — {owner_label}"
+    if artifact and artifact.title:
+        return f"{artifact.title} — {owner_label}"
+    if artifact:
+        return f"Document — {owner_label}"
+    return f"Application — {owner_label}"
+
+
 @router.get("/share/apps/{app_id}", response_class=HTMLResponse)
+@share_router.get("/basebase/apps/{app_id}", response_class=HTMLResponse)
 async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLResponse:
     """HTML metadata endpoint used by Slack + external scrapers for public app links."""
     try:
@@ -163,20 +198,35 @@ async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLRes
             select(App).where(App.id == app_uuid, App.visibility == "public")
         )
         app: App | None = result.scalar_one_or_none()
+        conversation: Conversation | None = None
+        owner: User | None = None
+        if app is not None and app.conversation_id:
+            conversation = await session.scalar(
+                select(Conversation).where(Conversation.id == app.conversation_id)
+            )
+        if app is not None:
+            owner = await session.scalar(select(User).where(User.id == app.user_id))
     if app is None:
         raise HTTPException(status_code=404, detail="App not found")
 
     logger.info("[public_preview] rendering app preview app_id=%s", app_id)
-    canonical_url = f"{_frontend_origin()}/public/apps/{app_id}"
+    canonical_url = f"{_frontend_origin()}/basebase/apps/{app_id}"
+    redirect_url = f"{_frontend_origin()}/public/apps/{app_id}"
     image_url = f"{request.base_url}api/public/share/apps/{app_id}/snapshot.png"
-    title = app.title or "Basebase App"
-    description = app.description or "Interactive app shared from Basebase."
+    title = "base base"
+    description = _public_preview_description(conversation=conversation, app=app, owner=owner)
+    logger.info(
+        "[public_preview] app metadata app_id=%s title=%s description=%s",
+        app_id,
+        title,
+        description,
+    )
     html = build_preview_html(
         page_title=title,
         description=description,
         canonical_url=canonical_url,
         image_url=image_url,
-        redirect_url=canonical_url,
+        redirect_url=redirect_url,
     )
     return HTMLResponse(content=html, headers={"Cache-Control": "public, max-age=300"})
 
@@ -215,6 +265,8 @@ async def get_public_app_share_snapshot(app_id: str) -> Response:
 
 
 @router.get("/share/artifacts/{artifact_id}", response_class=HTMLResponse)
+@share_router.get("/basebase/documents/{artifact_id}", response_class=HTMLResponse)
+@share_router.get("/basebase/artifacts/{artifact_id}", response_class=HTMLResponse)
 async def get_public_artifact_share_preview(artifact_id: str, request: Request) -> HTMLResponse:
     """HTML metadata endpoint used by Slack + external scrapers for public artifact links."""
     try:
@@ -227,20 +279,35 @@ async def get_public_artifact_share_preview(artifact_id: str, request: Request) 
             select(Artifact).where(Artifact.id == artifact_uuid, Artifact.visibility == "public")
         )
         artifact: Artifact | None = result.scalar_one_or_none()
+        conversation: Conversation | None = None
+        owner: User | None = None
+        if artifact is not None and artifact.conversation_id:
+            conversation = await session.scalar(
+                select(Conversation).where(Conversation.id == artifact.conversation_id)
+            )
+        if artifact is not None and artifact.user_id:
+            owner = await session.scalar(select(User).where(User.id == artifact.user_id))
     if artifact is None:
         raise HTTPException(status_code=404, detail="Artifact not found")
 
     logger.info("[public_preview] rendering artifact preview artifact_id=%s", artifact_id)
-    canonical_url = f"{_frontend_origin()}/public/artifacts/{artifact_id}"
+    canonical_url = f"{_frontend_origin()}/basebase/documents/{artifact_id}"
+    redirect_url = f"{_frontend_origin()}/public/artifacts/{artifact_id}"
     image_url = f"{request.base_url}api/public/share/artifacts/{artifact_id}/snapshot.png"
-    title = artifact.title or "Basebase Artifact"
-    description = artifact.description or (artifact.content or "Shared artifact from Basebase.")
+    title = "base base"
+    description = _public_preview_description(conversation=conversation, artifact=artifact, owner=owner)
+    logger.info(
+        "[public_preview] artifact metadata artifact_id=%s title=%s description=%s",
+        artifact_id,
+        title,
+        description,
+    )
     html = build_preview_html(
         page_title=title,
         description=description[:240],
         canonical_url=canonical_url,
         image_url=image_url,
-        redirect_url=canonical_url,
+        redirect_url=redirect_url,
     )
     return HTMLResponse(content=html, headers={"Cache-Control": "public, max-age=300"})
 

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import base64
+from types import SimpleNamespace
 
+from api.routes.public import _public_preview_description
 from services.public_previews import build_preview_html, decode_data_url_image, render_card_png
 
 
@@ -35,3 +37,21 @@ def test_render_card_png_returns_png_bytes() -> None:
         footer="App ID: abc",
     )
     assert png.startswith(b"\x89PNG")
+
+
+def test_public_preview_description_prefers_conversation_title_with_owner() -> None:
+    description = _public_preview_description(
+        conversation=SimpleNamespace(title="Q2 forecast"),
+        app=SimpleNamespace(title="Pipeline app"),
+        owner=SimpleNamespace(name="Alex", email="alex@example.com"),
+    )
+    assert description == "Q2 forecast — Alex"
+
+
+def test_public_preview_description_falls_back_to_document_and_owner_email() -> None:
+    description = _public_preview_description(
+        conversation=None,
+        artifact=SimpleNamespace(title=None),
+        owner=SimpleNamespace(name=None, email="owner@example.com"),
+    )
+    assert description == "Document — owner@example.com"

--- a/frontend/src/components/ArtifactFullView.tsx
+++ b/frontend/src/components/ArtifactFullView.tsx
@@ -209,7 +209,7 @@ export function ArtifactFullView({
   const handleCopyLink = async (): Promise<void> => {
     const isPublic: boolean = visibility === "public";
     const url: string = isPublic
-      ? `${window.location.origin}/api/public/share/artifacts/${artifactId}`
+      ? `${window.location.origin}/basebase/documents/${artifactId}`
       : `${window.location.origin}${prefix}/artifacts/${artifactId}`;
     await navigator.clipboard.writeText(url);
     setLinkCopied(true);
@@ -223,7 +223,7 @@ export function ArtifactFullView({
       );
       return;
     }
-    const url: string = `${window.location.origin}/api/public/share/artifacts/${artifactId}`;
+    const url: string = `${window.location.origin}/basebase/documents/${artifactId}`;
     const snippet: string = `<iframe src="${url}" width="100%" height="600" frameborder="0"></iframe>`;
     await navigator.clipboard.writeText(snippet);
     setEmbedCopied(true);

--- a/frontend/src/components/apps/AppFullView.tsx
+++ b/frontend/src/components/apps/AppFullView.tsx
@@ -114,7 +114,7 @@ export function AppFullView({ appId }: AppFullViewProps): JSX.Element {
   const handleCopyLink = async (): Promise<void> => {
     const isPublic: boolean = app?.visibility === "public";
     const url: string = isPublic
-      ? `${window.location.origin}/api/public/share/apps/${appId}`
+      ? `${window.location.origin}/basebase/apps/${appId}`
       : `${window.location.origin}${prefix}/apps/${appId}`;
     await navigator.clipboard.writeText(url);
     setLinkCopied(true);


### PR DESCRIPTION
### Motivation
- Make shared links like `https://app.basebase.com/basebase/apps/<id>` and document links scrapable by external scrapers (Slack, Twitter, etc.) without requiring auth. 
- Provide stable, well-formed Open Graph / Twitter metadata with a clear title, description and preview image so previews are informative. 
- Prefer human-friendly descriptions derived from conversation title, app/document title and owner information for better social unfurls.

### Description
- Added a new `share_router` and unauthenticated scraper-friendly endpoints `GET /basebase/apps/{app_id}`, `GET /basebase/documents/{artifact_id}` and `GET /basebase/artifacts/{artifact_id}` in `backend/api/routes/public.py`. 
- Introduced helper functions ` _owner_label` and `_public_preview_description` to compute compact preview descriptions prioritizing conversation title, then app/artifact title, then owner info. 
- Set social preview page title to the fixed `base base`, compute `canonical_url` for the `/basebase/...` path and add a `redirect_url` that points to the existing public viewer at `/public/...`. 
- Kept existing snapshot image behavior (use stored app `widget_config` screenshot when present; fallback to generated card PNG) and added logging for metadata rendering. 
- Wired the new `share_router` into the application by registering it in `backend/api/main.py` and updated frontend copy/embed link generation in `frontend/src/components/apps/AppFullView.tsx` and `frontend/src/components/ArtifactFullView.tsx` to use the new `/basebase/...` share URLs. 
- Added unit tests for the preview-description fallback logic in `backend/tests/test_public_previews.py` and reused existing preview HTML / PNG helpers.

### Testing
- Ran `pytest -q backend/tests/test_public_previews.py` and observed `5 passed` indicating the preview helpers and new description fallbacks behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe6c7abf48321908a3c6e8e471f8b)