### PR TITLE
Improve social unfurl metadata titles for shared app/artifact links

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -184,6 +184,17 @@ def _public_preview_description(
     return f"Application — {owner_label}"
 
 
+def _public_preview_title(*, app: App | None = None, artifact: Artifact | None = None) -> str:
+    """Return a concise social preview title with product branding."""
+    if app and app.title:
+        return f"{app.title} · Basebase"
+    if artifact and artifact.title:
+        return f"{artifact.title} · Basebase"
+    if artifact:
+        return "Basebase Document"
+    return "Basebase App"
+
+
 @router.get("/share/apps/{app_id}", response_class=HTMLResponse)
 @share_router.get("/basebase/apps/{app_id}", response_class=HTMLResponse)
 async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLResponse:
@@ -213,7 +224,7 @@ async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLRes
     canonical_url = f"{_frontend_origin()}/basebase/apps/{app_id}"
     redirect_url = f"{_frontend_origin()}/public/apps/{app_id}"
     image_url = f"{request.base_url}api/public/share/apps/{app_id}/snapshot.png"
-    title = "base base"
+    title = _public_preview_title(app=app)
     description = _public_preview_description(conversation=conversation, app=app, owner=owner)
     logger.info(
         "[public_preview] app metadata app_id=%s title=%s description=%s",
@@ -294,7 +305,7 @@ async def get_public_artifact_share_preview(artifact_id: str, request: Request) 
     canonical_url = f"{_frontend_origin()}/basebase/documents/{artifact_id}"
     redirect_url = f"{_frontend_origin()}/public/artifacts/{artifact_id}"
     image_url = f"{request.base_url}api/public/share/artifacts/{artifact_id}/snapshot.png"
-    title = "base base"
+    title = _public_preview_title(artifact=artifact)
     description = _public_preview_description(conversation=conversation, artifact=artifact, owner=owner)
     logger.info(
         "[public_preview] artifact metadata artifact_id=%s title=%s description=%s",

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 from types import SimpleNamespace
 
-from api.routes.public import _public_preview_description
+from api.routes.public import _public_preview_description, _public_preview_title
 from services.public_previews import build_preview_html, decode_data_url_image, render_card_png
 
 
@@ -55,3 +55,13 @@ def test_public_preview_description_falls_back_to_document_and_owner_email() -> 
         owner=SimpleNamespace(name=None, email="owner@example.com"),
     )
     assert description == "Document — owner@example.com"
+
+
+def test_public_preview_title_uses_app_name_with_branding() -> None:
+    title = _public_preview_title(app=SimpleNamespace(title="Quarterly Pipeline"))
+    assert title == "Quarterly Pipeline · Basebase"
+
+
+def test_public_preview_title_falls_back_for_untitled_artifact() -> None:
+    title = _public_preview_title(artifact=SimpleNamespace(title=None))
+    assert title == "Basebase Document"


### PR DESCRIPTION
### Motivation
- Public/shared links were unfurling with a generic title instead of showing the app or document name, making previews less informative. 
- Richer, branded titles improve recognizability in Discord and other link-previewing apps. 
- Keep preview metadata consistent between app and artifact share endpoints.

### Description
- Added a helper ` _public_preview_title` in `backend/api/routes/public.py` to centralize title generation and include `· Basebase` branding when appropriate. 
- Replaced the hardcoded `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe8b88cc88321a71250dac8f433a2)