### PR TITLE
Use resource-specific titles for public share previews

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -184,6 +184,19 @@ def _public_preview_description(
     return f"Application — {owner_label}"
 
 
+def _public_preview_title(*, app: App | None = None, artifact: Artifact | None = None) -> str:
+    """Build a specific page title so social previews never look generic."""
+    if app and app.title:
+        return f"{app.title} · Basebase"
+    if artifact and artifact.title:
+        return f"{artifact.title} · Basebase"
+    if app:
+        return "Shared App · Basebase"
+    if artifact:
+        return "Shared Document · Basebase"
+    return "Basebase"
+
+
 @router.get("/share/apps/{app_id}", response_class=HTMLResponse)
 @share_router.get("/basebase/apps/{app_id}", response_class=HTMLResponse)
 async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLResponse:
@@ -213,7 +226,7 @@ async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLRes
     canonical_url = f"{_frontend_origin()}/basebase/apps/{app_id}"
     redirect_url = f"{_frontend_origin()}/public/apps/{app_id}"
     image_url = f"{request.base_url}api/public/share/apps/{app_id}/snapshot.png"
-    title = "base base"
+    title = _public_preview_title(app=app)
     description = _public_preview_description(conversation=conversation, app=app, owner=owner)
     logger.info(
         "[public_preview] app metadata app_id=%s title=%s description=%s",
@@ -294,7 +307,7 @@ async def get_public_artifact_share_preview(artifact_id: str, request: Request) 
     canonical_url = f"{_frontend_origin()}/basebase/documents/{artifact_id}"
     redirect_url = f"{_frontend_origin()}/public/artifacts/{artifact_id}"
     image_url = f"{request.base_url}api/public/share/artifacts/{artifact_id}/snapshot.png"
-    title = "base base"
+    title = _public_preview_title(artifact=artifact)
     description = _public_preview_description(conversation=conversation, artifact=artifact, owner=owner)
     logger.info(
         "[public_preview] artifact metadata artifact_id=%s title=%s description=%s",

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 from types import SimpleNamespace
 
-from api.routes.public import _public_preview_description
+from api.routes.public import _public_preview_description, _public_preview_title
 from services.public_previews import build_preview_html, decode_data_url_image, render_card_png
 
 
@@ -55,3 +55,13 @@ def test_public_preview_description_falls_back_to_document_and_owner_email() -> 
         owner=SimpleNamespace(name=None, email="owner@example.com"),
     )
     assert description == "Document — owner@example.com"
+
+
+def test_public_preview_title_uses_app_title_when_present() -> None:
+    title = _public_preview_title(app=SimpleNamespace(title="Revenue Tracker"))
+    assert title == "Revenue Tracker · Basebase"
+
+
+def test_public_preview_title_falls_back_when_artifact_title_missing() -> None:
+    title = _public_preview_title(artifact=SimpleNamespace(title=None))
+    assert title == "Shared Document · Basebase"


### PR DESCRIPTION
### Motivation
- Social unfurls (Discord, Slack, etc.) were showing a generic title because the public share HTML used a hardcoded title instead of the app/document name. 
- Link previews rely on `og:title`/`twitter:title`, so making the title resource-specific improves visibility and context for shared links.

### Description
- Added a `_public_preview_title` helper that generates a branded page title from an `App` or `Artifact` (e.g. `"{App Title} · Basebase"`) in `backend/api/routes/public.py`.
- Replaced the previous hardcoded title with calls to `_public_preview_title` in the app and artifact share-preview handlers (`/share/apps/{app_id}` and `/share/artifacts/{artifact_id}`).
- Added unit tests for the new title behavior in `backend/tests/test_public_previews.py` covering app titles and artifact fallback titles.

### Testing
- Ran `pytest -q backend/tests/test_public_previews.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe8b88cc88321a71250dac8f433a2)