### PR TITLE
Resolve workflow organization_id before RLS session to prevent conversation insert failures

### DIFF
--- a/backend/tests/test_workflow_org_resolution.py
+++ b/backend/tests/test_workflow_org_resolution.py
@@ -1,0 +1,50 @@
+import asyncio
+from contextlib import asynccontextmanager
+from uuid import UUID
+
+from workers.tasks import workflows
+
+
+class _FakeResult:
+    def __init__(self, value: UUID | None) -> None:
+        self._value = value
+
+    def scalar_one_or_none(self) -> UUID | None:
+        return self._value
+
+
+class _FakeAdminSession:
+    def __init__(self, value: UUID | None) -> None:
+        self._value = value
+
+    async def execute(self, _query: object) -> _FakeResult:
+        return _FakeResult(self._value)
+
+
+def test_resolve_workflow_org_id_returns_passed_value_without_lookup() -> None:
+    async def _run() -> str | None:
+        return await workflows._resolve_workflow_organization_id(
+            workflow_id="00000000-0000-0000-0000-000000000010",
+            organization_id="00000000-0000-0000-0000-000000000099",
+        )
+
+    assert asyncio.run(_run()) == "00000000-0000-0000-0000-000000000099"
+
+
+def test_resolve_workflow_org_id_looks_up_when_missing(monkeypatch) -> None:
+    org_id = UUID("00000000-0000-0000-0000-0000000000aa")
+
+    @asynccontextmanager
+    async def _fake_get_admin_session():
+        yield _FakeAdminSession(org_id)
+
+    monkeypatch.setattr("models.database.get_admin_session", _fake_get_admin_session)
+
+    async def _run() -> str | None:
+        return await workflows._resolve_workflow_organization_id(
+            workflow_id="00000000-0000-0000-0000-000000000010",
+            organization_id=None,
+        )
+
+    assert asyncio.run(_run()) == str(org_id)
+

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -753,6 +753,50 @@ async def _process_pending_events() -> dict[str, Any]:
     }
 
 
+async def _resolve_workflow_organization_id(
+    *,
+    workflow_id: str,
+    organization_id: str | None,
+) -> str | None:
+    """Return an organization ID for workflow execution, deriving it when omitted."""
+    if organization_id:
+        return organization_id
+
+    from sqlalchemy import select
+    from models.database import get_admin_session
+    from models.workflow import Workflow
+
+    try:
+        workflow_uuid = UUID(workflow_id)
+    except ValueError:
+        logger.warning(
+            "[Workflow] Unable to resolve organization for invalid workflow_id=%s",
+            workflow_id,
+        )
+        return None
+
+    async with get_admin_session() as session:
+        result = await session.execute(
+            select(Workflow.organization_id).where(Workflow.id == workflow_uuid)
+        )
+        resolved_org_id = result.scalar_one_or_none()
+
+    if resolved_org_id is None:
+        logger.warning(
+            "[Workflow] Unable to resolve organization_id because workflow was not found workflow_id=%s",
+            workflow_id,
+        )
+        return None
+
+    resolved_org_str = str(resolved_org_id)
+    logger.info(
+        "[Workflow] Resolved missing organization_id from workflow row workflow_id=%s organization_id=%s",
+        workflow_id,
+        resolved_org_str,
+    )
+    return resolved_org_str
+
+
 async def _execute_workflow(
     workflow_id: str,
     triggered_by: str,
@@ -794,7 +838,24 @@ async def _execute_workflow(
             "paused_until": pause_until.isoformat(),
         }
 
-    async with get_session(organization_id=organization_id) as session:
+    resolved_organization_id = await _resolve_workflow_organization_id(
+        workflow_id=workflow_id,
+        organization_id=organization_id,
+    )
+
+    if not resolved_organization_id:
+        result_payload = {
+            "status": "failed",
+            "workflow_id": workflow_id,
+            "error": "Unable to resolve organization_id for workflow execution",
+        }
+        await _record_workflow_query_outcome(
+            result=result_payload,
+            workflow_id=workflow_id,
+        )
+        return result_payload
+
+    async with get_session(organization_id=resolved_organization_id) as session:
         # Load workflow
         result = await session.execute(
             select(Workflow).where(Workflow.id == UUID(workflow_id))


### PR DESCRIPTION
### Motivation
- Workflow runs sometimes invoked without an `organization_id`, causing `get_session()` to set empty RLS context and producing `InsufficientPrivilegeError` when inserting `conversations` under RLS.
- Ensure every workflow execution that needs to create a conversation has a valid tenant context so row-level security policies allow inserts.

### Description
- Added helper `async def _resolve_workflow_organization_id(*, workflow_id, organization_id)` which returns the provided org id or looks it up from the `workflows` row via an admin session (`get_admin_session`).
- Updated `_execute_workflow(...)` to call the resolver before opening an RLS-scoped session (`get_session(...)`) and to return a clear failure payload and record the outcome if resolution fails.
- Added informative logging on success/failure paths so operators can trace missing org resolutions.
- Added unit tests in `backend/tests/test_workflow_org_resolution.py` to cover both passthrough and admin-lookup behaviors.

### Testing
- Ran `pytest -q backend/tests/test_workflow_org_resolution.py backend/tests/test_workflow_permissions.py` and all tests passed.
- Test output: `9 passed` (includes the newly added org-resolution tests and the existing workflow permission tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfec2b43a483218154e44abb1e174f)