### PR TITLE
Count workflow fast-fail privilege/RLS errors as failures

### DIFF
--- a/backend/tests/test_workflow_query_outcome_metrics.py
+++ b/backend/tests/test_workflow_query_outcome_metrics.py
@@ -72,6 +72,30 @@ def test_record_workflow_query_outcome_ignores_skipped_status(monkeypatch) -> No
     assert calls == []
 
 
+def test_record_workflow_query_outcome_records_skipped_privilege_fast_fail(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def _fake_record_query_outcome(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "services.query_outcome_metrics.record_query_outcome",
+        _fake_record_query_outcome,
+    )
+
+    asyncio.run(
+        workflows._record_workflow_query_outcome(
+            result={"status": "skipped", "reason": "RLS permission denied on workflow_runs"},
+            workflow_id="wf-fast-fail",
+        )
+    )
+
+    assert captured["platform"] == "workflow"
+    assert captured["was_success"] is False
+    assert captured["failure_reason"] == "rls permission denied on workflow_runs"
+    assert captured["conversation_id"] == "workflow:wf-fast-fail"
+
+
 def test_record_workflow_query_outcome_records_error_status_as_failure(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -75,12 +75,13 @@ async def _record_workflow_query_outcome(
         return
 
     status = (result.get("status") or "").strip().lower()
-    if status not in {"completed", "failed", "error"}:
+    is_fast_fail = _is_workflow_fast_fail_result(result=result)
+    if status not in {"completed", "failed", "error"} and not is_fast_fail:
         return
 
     from services.query_outcome_metrics import normalize_failure_reason, record_query_outcome
 
-    was_success = status == "completed"
+    was_success = status == "completed" and not is_fast_fail
     failure_reason = (
         str(result.get("error") or result.get("reason") or "workflow_failed")
         if not was_success
@@ -107,6 +108,36 @@ async def _record_workflow_query_outcome(
             conversation_id,
             failure_reason,
         )
+
+
+def _is_workflow_fast_fail_result(*, result: dict[str, Any]) -> bool:
+    """Detect workflow turn fast-fail results that should count as failures."""
+    status = str(result.get("status") or "").strip().lower()
+    if status not in {"skipped", "rejected", "fast_failed", "fast-failed"}:
+        return False
+
+    reason_text = " ".join(
+        str(value).strip().lower()
+        for value in (
+            result.get("reason"),
+            result.get("error"),
+            result.get("message"),
+            result.get("detail"),
+        )
+        if value
+    )
+    if not reason_text:
+        return False
+
+    fast_fail_markers = (
+        "insufficient privilege",
+        "insufficient privileges",
+        "permission denied",
+        "not authorized",
+        "row-level security",
+        "rls",
+    )
+    return any(marker in reason_text for marker in fast_fail_markers)
 
 
 def _extract_allowed_slack_channels(workflow: Any) -> list[str]:


### PR DESCRIPTION
### Motivation
- Monitoring should treat workflow turns that fast-fail due to authorization/RLS (insufficient privileges, permission denied, etc.) as failures instead of silently ignoring them.
- Current logic ignored non-error `skipped`/`rejected` outcomes which hides operational problems when a turn fails early due to access issues.

### Description
- Update `_record_workflow_query_outcome` to detect fast-fail outcomes and count them as failures by setting `was_success=False` when appropriate.
- Add a helper `def _is_workflow_fast_fail_result(*, result: dict[str, Any]) -> bool` that inspects `status` plus `reason/error/message/detail` text for markers like `insufficient privileges`, `permission denied`, `not authorized`, `row-level security`, and `rls`.
- Add a unit test `test_record_workflow_query_outcome_records_skipped_privilege_fast_fail` to assert skipped/RLS privilege fast-fails are recorded as failures while preserving existing behavior for benign `skipped` states.

### Testing
- Ran `pytest -q backend/tests/test_workflow_query_outcome_metrics.py` and all tests passed (`5 passed`).
- New and existing unit tests verify completed/failed/error statuses, ignored skipped states, and the new privilege/RLS fast-fail detection behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfede370108321a22e01aed5379310)