### PR TITLE
Fix workflow conversation creation failing under conversations RLS

### DIFF
--- a/backend/tests/test_workflow_execution_user_context.py
+++ b/backend/tests/test_workflow_execution_user_context.py
@@ -1,0 +1,54 @@
+import asyncio
+from contextlib import asynccontextmanager
+from uuid import UUID
+
+from workers.tasks import workflows
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _FakeAdminSession:
+    def __init__(self, creator_user_id):
+        self.creator_user_id = creator_user_id
+
+    async def execute(self, _query):
+        return _ScalarResult(self.creator_user_id)
+
+
+
+def test_resolve_execution_user_uses_trigger_user_when_valid() -> None:
+    trigger_user_id = "00000000-0000-0000-0000-000000000123"
+
+    resolved = asyncio.run(
+        workflows._resolve_workflow_execution_user_id(
+            workflow_id="00000000-0000-0000-0000-000000000999",
+            triggered_by_user_id=trigger_user_id,
+        )
+    )
+
+    assert resolved == trigger_user_id
+
+
+def test_resolve_execution_user_falls_back_to_workflow_creator(monkeypatch) -> None:
+    creator_user_id = UUID("00000000-0000-0000-0000-000000000456")
+
+    @asynccontextmanager
+    async def _fake_admin_session():
+        yield _FakeAdminSession(creator_user_id)
+
+    monkeypatch.setattr("models.database.get_admin_session", _fake_admin_session)
+
+    resolved = asyncio.run(
+        workflows._resolve_workflow_execution_user_id(
+            workflow_id="00000000-0000-0000-0000-000000000999",
+            triggered_by_user_id=None,
+        )
+    )
+
+    assert resolved == str(creator_user_id)

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -828,6 +828,57 @@ async def _resolve_workflow_organization_id(
     return resolved_org_str
 
 
+async def _resolve_workflow_execution_user_id(
+    *,
+    workflow_id: str,
+    triggered_by_user_id: str | None,
+) -> str | None:
+    """Return a user ID to seed RLS context for workflow execution writes."""
+    if triggered_by_user_id:
+        try:
+            return str(UUID(triggered_by_user_id))
+        except ValueError:
+            logger.warning(
+                "[Workflow] Invalid triggered_by_user_id for RLS context workflow_id=%s user_id=%s",
+                workflow_id,
+                triggered_by_user_id,
+            )
+
+    from sqlalchemy import select
+    from models.database import get_admin_session
+    from models.workflow import Workflow
+
+    try:
+        workflow_uuid = UUID(workflow_id)
+    except ValueError:
+        logger.warning(
+            "[Workflow] Unable to resolve execution user for invalid workflow_id=%s",
+            workflow_id,
+        )
+        return None
+
+    async with get_admin_session() as session:
+        result = await session.execute(
+            select(Workflow.created_by_user_id).where(Workflow.id == workflow_uuid)
+        )
+        creator_user_id = result.scalar_one_or_none()
+
+    if creator_user_id is None:
+        logger.warning(
+            "[Workflow] No created_by_user_id found for workflow execution context workflow_id=%s",
+            workflow_id,
+        )
+        return None
+
+    execution_user_id = str(creator_user_id)
+    logger.info(
+        "[Workflow] Resolved execution user from workflow owner workflow_id=%s user_id=%s",
+        workflow_id,
+        execution_user_id,
+    )
+    return execution_user_id
+
+
 async def _execute_workflow(
     workflow_id: str,
     triggered_by: str,
@@ -886,7 +937,21 @@ async def _execute_workflow(
         )
         return result_payload
 
-    async with get_session(organization_id=resolved_organization_id) as session:
+    execution_user_id = await _resolve_workflow_execution_user_id(
+        workflow_id=workflow_id,
+        triggered_by_user_id=triggered_by_user_id,
+    )
+    logger.info(
+        "[Workflow] Opening RLS session for execution workflow_id=%s organization_id=%s user_id=%s",
+        workflow_id,
+        resolved_organization_id,
+        execution_user_id,
+    )
+
+    async with get_session(
+        organization_id=resolved_organization_id,
+        user_id=execution_user_id,
+    ) as session:
         # Load workflow
         result = await session.execute(
             select(Workflow).where(Workflow.id == UUID(workflow_id))


### PR DESCRIPTION
### Motivation
- Conversation inserts during workflow execution were failing RLS `WITH CHECK` because sessions were opened with an organization context but no `app.current_user_id`, causing `InsufficientPrivilegeError: new row violates row-level security policy for table "conversations"`.
- The change ensures workflow runs always seed a user-scoped RLS context so `conversations` visibility predicates that reference the current user are satisfied.

### Description
- Added `_resolve_workflow_execution_user_id` to choose an execution user ID, preferring a valid `triggered_by_user_id` and falling back to `Workflow.created_by_user_id` via `get_admin_session` when needed.
- Pass the resolved user into `get_session(..., user_id=...)` when opening the tenant-scoped session used for workflow execution to populate `app.current_user_id` for RLS.
- Added explicit logging around execution-user resolution and RLS session bootstrap to aid debugging of privilege/RLS issues.
- Added unit tests in `backend/tests/test_workflow_execution_user_context.py` covering both valid trigger-user and creator-fallback resolution paths.

### Testing
- Ran `pytest -q backend/tests/test_workflow_execution_user_context.py backend/tests/test_workflow_conversation_participants.py` and both suites passed.
- Ran `pytest -q backend/tests/test_workflow_trigger_defaults.py` and the test passed.
- All added/modified tests succeeded (total `6 passed` for the combined execution context tests and `1 passed` for trigger defaults).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff2c6df088321a6623dedb91a8ffa)