### PR TITLE
Keep Slack conversation creator as app owner

### DIFF
--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -319,6 +319,31 @@ class AppsConnector(BaseConnector):
         message_id: str | None = data.get("message_id")
         conversation_id: str | None = data.get("conversation_id")
         user_uuid: UUID | None = None
+        conversation_uuid: UUID | None = None
+        if conversation_id:
+            try:
+                conversation_uuid = UUID(conversation_id)
+            except (ValueError, TypeError, AttributeError):
+                logger.warning(
+                    "[AppsConnector] Could not parse conversation_id as UUID for owner resolution: conversation_id=%s",
+                    conversation_id,
+                )
+            else:
+                async with get_session(organization_id=self.organization_id) as session:
+                    row = await session.execute(
+                        select(Conversation.user_id).where(
+                            Conversation.id == conversation_uuid,
+                        )
+                    )
+                    conversation_user_id: UUID | None = row.scalar_one_or_none()
+                    if conversation_user_id is not None:
+                        user_uuid = conversation_user_id
+                        logger.info(
+                            "[AppsConnector] Resolved app owner from conversation owner: conversation_id=%s user_id=%s",
+                            conversation_id,
+                            conversation_user_id,
+                        )
+
         if message_id:
             try:
                 message_uuid = UUID(message_id)
@@ -335,7 +360,7 @@ class AppsConnector(BaseConnector):
                         )
                     )
                     message_user_id: UUID | None = row.scalar_one_or_none()
-                    if message_user_id is not None:
+                    if message_user_id is not None and user_uuid is None:
                         user_uuid = message_user_id
                         logger.info(
                             "[AppsConnector] Resolved app owner from initiating message: message_id=%s user_id=%s",
@@ -349,22 +374,6 @@ class AppsConnector(BaseConnector):
                 "[AppsConnector] Falling back to connector user context for app owner: user_id=%s",
                 user_uuid,
             )
-
-        if not user_uuid and conversation_id:
-            async with get_session(organization_id=self.organization_id) as session:
-                row = await session.execute(
-                    select(Conversation.user_id).where(
-                        Conversation.id == UUID(conversation_id),
-                    )
-                )
-                conv_user_id: UUID | None = row.scalar_one_or_none()
-                if conv_user_id is not None:
-                    user_uuid = conv_user_id
-                    logger.info(
-                        "[AppsConnector] Falling back to conversation owner for app owner: conversation_id=%s user_id=%s",
-                        conversation_id,
-                        conv_user_id,
-                    )
 
         if not user_uuid:
             return {
@@ -392,7 +401,7 @@ class AppsConnector(BaseConnector):
                 queries=queries,
                 frontend_code=frontend_code,
                 frontend_code_compiled=compiled_code,
-                conversation_id=UUID(conversation_id) if conversation_id else None,
+                conversation_id=conversation_uuid,
                 message_id=msg_id_str,
             )
             session.add(app)

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -600,8 +600,13 @@ class WorkspaceMessenger(BaseMessenger):
                     changed = True
 
                 if revtops_user_id and conversation.user_id != UUID(revtops_user_id):
-                    conversation.user_id = UUID(revtops_user_id)
-                    changed = True
+                    logger.info(
+                        "[%s] Preserving original conversation owner for %s: existing_user_id=%s incoming_user_id=%s",
+                        source,
+                        conversation.id,
+                        conversation.user_id,
+                        revtops_user_id,
+                    )
 
                 if conversation.scope != target_scope:
                     conversation.scope = target_scope


### PR DESCRIPTION
### Motivation
- Preserve the original conversation owner so apps created from Slack/workspace conversations inherit the true creator instead of the latest participant. 
- Avoid surprising ownership changes when users reply in an existing Slack thread. 
- Improve diagnostics for owner resolution when `conversation_id` or message IDs are malformed.

### Description
- Stop overwriting `Conversation.user_id` in `backend/messengers/_workspace.py` and log when an incoming participant differs from the stored owner. 
- In `backend/connectors/apps.py` prioritize resolving the app `user_id` from the `Conversation.user_id` (via `conversation_id`) before falling back to the initiating message author or connector user context. 
- Add robust UUID parsing and warnings for `conversation_id` and reuse a parsed `conversation_uuid` when persisting the new `App` row. 
- Only assign owner from the message author if no owner was found from the conversation, and add informational logs for each resolution path.

### Testing
- Ran `python -m pytest backend/tests/test_workspace_conversation_scope.py backend/tests/test_workspace_slow_reply_window.py` and the suite completed successfully. 
- Test result: `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff52a0aa083218c3bbe5d7259b98c)