### PR TITLE
Fix social unfurl metadata for shared app links

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -153,6 +153,19 @@ def _frontend_origin() -> str:
     return settings.FRONTEND_URL.rstrip("/")
 
 
+def _public_origin(request: Request) -> str:
+    """Best-effort absolute origin for public preview assets behind proxies."""
+    configured = (settings.BACKEND_PUBLIC_URL or "").strip().rstrip("/")
+    if configured:
+        return configured
+
+    forwarded_proto = (request.headers.get("x-forwarded-proto") or "").split(",")[0].strip()
+    forwarded_host = (request.headers.get("x-forwarded-host") or "").split(",")[0].strip()
+    scheme = forwarded_proto or request.url.scheme or "https"
+    host = forwarded_host or request.headers.get("host") or request.url.netloc
+    return f"{scheme}://{host}".rstrip("/")
+
+
 def _owner_label(user: User | None) -> str:
     """Return a compact owner label suitable for public descriptions."""
     if user is None:
@@ -225,7 +238,7 @@ async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLRes
     logger.info("[public_preview] rendering app preview app_id=%s", app_id)
     canonical_url = f"{_frontend_origin()}/basebase/apps/{app_id}"
     redirect_url = f"{_frontend_origin()}/public/apps/{app_id}"
-    image_url = f"{request.base_url}api/public/share/apps/{app_id}/snapshot.png"
+    image_url = f"{_public_origin(request)}/api/public/share/apps/{app_id}/snapshot.png"
     title = _public_preview_title(app=app)
     description = _public_preview_description(conversation=conversation, app=app, owner=owner)
     logger.info(
@@ -306,7 +319,7 @@ async def get_public_artifact_share_preview(artifact_id: str, request: Request) 
     logger.info("[public_preview] rendering artifact preview artifact_id=%s", artifact_id)
     canonical_url = f"{_frontend_origin()}/basebase/documents/{artifact_id}"
     redirect_url = f"{_frontend_origin()}/public/artifacts/{artifact_id}"
-    image_url = f"{request.base_url}api/public/share/artifacts/{artifact_id}/snapshot.png"
+    image_url = f"{_public_origin(request)}/api/public/share/artifacts/{artifact_id}/snapshot.png"
     title = _public_preview_title(artifact=artifact)
     description = _public_preview_description(conversation=conversation, artifact=artifact, owner=owner)
     logger.info(

--- a/backend/services/public_previews.py
+++ b/backend/services/public_previews.py
@@ -75,6 +75,8 @@ def build_preview_html(
     <meta property="og:description" content="{safe_desc}" />
     <meta property="og:url" content="{safe_canonical}" />
     <meta property="og:image" content="{safe_image}" />
+    <meta property="og:image:secure_url" content="{safe_image}" />
+    <meta property="og:image:alt" content="{safe_title}" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="{safe_title}" />
     <meta name="twitter:description" content="{safe_desc}" />

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 from types import SimpleNamespace
 
-from api.routes.public import _public_preview_description, _public_preview_title
+from api.routes.public import _public_origin, _public_preview_description, _public_preview_title
 from services.public_previews import build_preview_html, decode_data_url_image, render_card_png
 
 
@@ -26,6 +26,7 @@ def test_build_preview_html_includes_og_and_twitter_tags() -> None:
     )
     assert 'property="og:title" content="Example"' in html
     assert 'name="twitter:image" content="https://example.com/api/public/share/apps/abc/snapshot.png"' in html
+    assert 'property="og:image:secure_url" content="https://example.com/api/public/share/apps/abc/snapshot.png"' in html
     assert 'http-equiv="refresh"' in html
 
 
@@ -65,3 +66,11 @@ def test_public_preview_title_uses_app_title_when_present() -> None:
 def test_public_preview_title_falls_back_when_artifact_title_missing() -> None:
     title = _public_preview_title(artifact=SimpleNamespace(title=None))
     assert title == "Shared Document · Basebase"
+
+
+def test_public_origin_prefers_forwarded_proxy_headers() -> None:
+    request = SimpleNamespace(
+        headers={"x-forwarded-proto": "https", "x-forwarded-host": "app.basebase.com"},
+        url=SimpleNamespace(scheme="http", netloc="internal:8000"),
+    )
+    assert _public_origin(request) == "https://app.basebase.com"

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -17,6 +17,16 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # Social unfurl support: route share links to backend-rendered Open Graph pages.
+    # Discord/Facebook crawlers don't run JS, so this bypasses the SPA shell.
+    location ~ ^/basebase/apps/([0-9a-fA-F-]{36})$ {
+        return 302 https://api.basebase.com/basebase/apps/$1;
+    }
+
+    location ~ ^/basebase/(documents|artifacts)/([0-9a-fA-F-]{36})$ {
+        return 302 https://api.basebase.com/basebase/$1/$2;
+    }
+
     # Cache static assets
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;


### PR DESCRIPTION
### Motivation
- Social crawlers (Discord/Facebook) were getting the SPA `index.html` and/or internal backend origins for shared app/document links, preventing correct title/image previews. 
- OG image URLs could be generated with an internal origin when running behind proxies, which breaks external scrapers that need a public URL. 
- Some social scrapers expect `og:image:secure_url` and `og:image:alt` for reliable preview rendering. 

### Description
- Add a proxy-aware origin helper ` _public_origin(request: Request)` in `backend/api/routes/public.py` that prefers `BACKEND_PUBLIC_URL` and `x-forwarded-*` headers when building preview asset URLs. 
- Use ` _public_origin` to construct `image_url` for app and artifact preview pages in `backend/api/routes/public.py`. 
- Add `og:image:secure_url` and `og:image:alt` meta tags to the generated preview HTML in `backend/services/public_previews.py`. 
- Configure the frontend `nginx.conf` to redirect `/basebase/apps/:id` and `/basebase/documents|artifacts/:id` to the backend preview endpoints so crawlers receive server-rendered OG HTML instead of the SPA shell. 
- Extend `backend/tests/test_public_previews.py` to validate the `og:image:secure_url` tag and forwarded-header origin resolution. 

### Testing
- Ran `pytest -q backend/tests/test_public_previews.py` and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dff6765cd88321acaadc93d9a083dc)