### PR TITLE
Proxy backend OG pages for /basebase share links to improve unfurls

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -19,12 +19,21 @@ server {
 
     # Social unfurl support: route share links to backend-rendered Open Graph pages.
     # Discord/Facebook crawlers don't run JS, so this bypasses the SPA shell.
-    location ~ ^/basebase/apps/([0-9a-fA-F-]{36})$ {
-        return 302 https://api.basebase.com/basebase/apps/$1;
+    location ~ ^/basebase/apps/([0-9a-fA-F-]{36})/?$ {
+        # Serve metadata directly from backend to avoid crawler redirect quirks.
+        proxy_pass https://api.basebase.com/basebase/apps/$1;
+        proxy_set_header Host api.basebase.com;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_server_name on;
     }
 
-    location ~ ^/basebase/(documents|artifacts)/([0-9a-fA-F-]{36})$ {
-        return 302 https://api.basebase.com/basebase/$1/$2;
+    location ~ ^/basebase/(documents|artifacts)/([0-9a-fA-F-]{36})/?$ {
+        proxy_pass https://api.basebase.com/basebase/$1/$2;
+        proxy_set_header Host api.basebase.com;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_server_name on;
     }
 
     # Cache static assets


### PR DESCRIPTION
### Motivation
- Slack and other link scrapers can mishandle cross-domain `302` redirects for shared app/document links, resulting in generic previews instead of the backend-generated Open Graph metadata.

### Description
- Updated `frontend/nginx.conf` so `/basebase/apps/:id` and `/basebase/documents|artifacts/:id` are proxied to the backend unfurl endpoints instead of returning `302` redirects.
- Expanded route matching to accept an optional trailing slash (`/?$`) to handle crawler URL variants.
- Forwarded upstream context with `Host`/`X-Forwarded-Host`/`X-Forwarded-Proto` headers and enabled `proxy_ssl_server_name` for SNI on the HTTPS upstream.

### Testing
- Attempted `nginx -t -c frontend/nginx.conf` but could not run syntax validation in this environment because `nginx` is not installed (`nginx: command not found`).
- Verified the updated file contents with `nl -ba frontend/nginx.conf` and committed the change with `git` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dffd6034c48321a5a37859dcb0daae)