### PR TITLE
Add user-facing guidance for connector auth failures

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -26,6 +26,8 @@ from uuid import UUID, uuid4
 if TYPE_CHECKING:
     from connectors.base import BaseConnector
 
+from connectors.base import ExternalConnectionRevokedError
+
 import httpx
 from openai import AsyncOpenAI
 from sqlalchemy import select, text
@@ -970,6 +972,23 @@ async def _attach_connector_docs(
     return error_result
 
 
+def _build_connection_revoked_result(
+    connector: str, operation_label: str, exc: Exception,
+) -> dict[str, Any]:
+    """Build a tool-result dict with user_guidance for a revoked/expired connection."""
+    from connectors.base import get_provider_display_name
+
+    provider_name: str = get_provider_display_name(connector)
+    return {
+        "error": f"{operation_label} failed: {exc}",
+        "user_guidance": (
+            f"The {provider_name} connection has expired or been revoked. "
+            f"To fix this, go to the Connectors page (/connectors), "
+            f"disconnect {provider_name}, and reconnect it."
+        ),
+    }
+
+
 async def _query_on_connector(
     params: dict[str, Any], organization_id: str, user_id: str | None
 ) -> dict[str, Any]:
@@ -1013,6 +1032,12 @@ async def _query_on_connector(
         if info and isinstance(result, dict):
             result.setdefault("info", info)
         return _attach_cross_user_connector_warning(result, cross_user_warning)
+    except ExternalConnectionRevokedError as exc:
+        logger.warning("[Tools] query_on_connector(%s) connection revoked: %s", connector, exc)
+        return await _attach_connector_docs(
+            _build_connection_revoked_result(connector, f"Query to {connector}", exc),
+            connector, organization_id,
+        )
     except Exception as exc:
         logger.error("[Tools] query_on_connector(%s) failed: %s", connector, exc, exc_info=True)
         return await _attach_connector_docs(
@@ -1091,6 +1116,13 @@ async def _write_on_connector(
         result = await instance.write(operation, data)
         await record_outcome(change_id, organization_id, result)
         return _attach_cross_user_connector_warning(result, cross_user_warning)
+    except ExternalConnectionRevokedError as exc:
+        await record_outcome(change_id, organization_id, {"error": str(exc)})
+        logger.warning("[Tools] write_on_connector(%s, %s) connection revoked: %s", connector, operation, exc)
+        return await _attach_connector_docs(
+            _build_connection_revoked_result(connector, f"Write to {connector}.{operation}", exc),
+            connector, organization_id,
+        )
     except Exception as exc:
         await record_outcome(change_id, organization_id, {"error": str(exc)})
         logger.error("[Tools] write_on_connector(%s, %s) failed: %s", connector, operation, exc, exc_info=True)
@@ -1159,6 +1191,13 @@ async def _run_on_connector(
         result = await instance.execute_action(action, action_params)
         await record_outcome(change_id, organization_id, result)
         return _attach_cross_user_connector_warning(result, cross_user_warning)
+    except ExternalConnectionRevokedError as exc:
+        await record_outcome(change_id, organization_id, {"error": str(exc)})
+        logger.warning("[Tools] run_on_connector(%s, %s) connection revoked: %s", connector, action, exc)
+        return await _attach_connector_docs(
+            _build_connection_revoked_result(connector, f"Action {connector}.{action}", exc),
+            connector, organization_id,
+        )
     except Exception as exc:
         await record_outcome(change_id, organization_id, {"error": str(exc)})
         logger.error("[Tools] run_on_connector(%s, %s) failed: %s", connector, action, exc, exc_info=True)

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -63,6 +63,7 @@ _CONNECTION_REMOVED_ERROR_SNIPPETS: tuple[str, ...] = (
     "connection not found",
     "404 not found",
     "404 client error",
+    "400 bad request",
     "invalid_auth",
     "account_inactive",
     "token_revoked",
@@ -90,8 +91,8 @@ def build_connection_removed_message(provider: str) -> str:
     """Return a coherent reconnect message when upstream access was removed."""
     provider_name = get_provider_display_name(provider)
     return (
-        f"The {provider_name} connection was removed or revoked in {provider_name}. "
-        f"Please disconnect it in Basebase and reconnect it if you still want to sync."
+        f"The {provider_name} connection has expired or been revoked. "
+        f"Please go to Connectors (/connectors) to disconnect and reconnect {provider_name}."
     )
 
 

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -63,7 +63,6 @@ _CONNECTION_REMOVED_ERROR_SNIPPETS: tuple[str, ...] = (
     "connection not found",
     "404 not found",
     "404 client error",
-    "400 bad request",
     "invalid_auth",
     "account_inactive",
     "token_revoked",
@@ -96,10 +95,28 @@ def build_connection_removed_message(provider: str) -> str:
     )
 
 
+def _is_auth_related_bad_request(message: str) -> bool:
+    """Return True for 400 errors that explicitly mention auth/connection revocation."""
+    return "400" in message and "bad request" in message and any(
+        marker in message
+        for marker in (
+            "auth",
+            "oauth",
+            "token",
+            "revoked",
+            "expired",
+            "connection",
+            "not found",
+        )
+    )
+
+
 def is_connection_removed_error(error: Exception | str) -> bool:
     """Return True when an error looks like a revoked or deleted upstream connection."""
     message = str(error).lower()
-    return any(snippet in message for snippet in _CONNECTION_REMOVED_ERROR_SNIPPETS)
+    if any(snippet in message for snippet in _CONNECTION_REMOVED_ERROR_SNIPPETS):
+        return True
+    return _is_auth_related_bad_request(message)
 
 
 class SyncCancelledError(RuntimeError):

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -68,6 +68,10 @@ _CONNECTION_REMOVED_ERROR_SNIPPETS: tuple[str, ...] = (
     "token_revoked",
     "not_authed",
     "auth revoked",
+    "401 unauthorized",
+    "401 client error",
+    "403 forbidden",
+    "403 client error",
 )
 
 _PROVIDER_DISPLAY_NAMES: dict[str, str] = {

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -105,8 +105,13 @@ def _is_auth_related_bad_request(message: str) -> bool:
             "token",
             "revoked",
             "expired",
-            "connection",
-            "not found",
+            "connection revoked",
+            "connection expired",
+            "connection not found",
+            "invalid connection",
+            "disconnected",
+            "not_authed",
+            "invalid_auth",
         )
     )
 

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -69,9 +69,7 @@ _CONNECTION_REMOVED_ERROR_SNIPPETS: tuple[str, ...] = (
     "not_authed",
     "auth revoked",
     "401 unauthorized",
-    "401 client error",
     "403 forbidden",
-    "403 client error",
 )
 
 _PROVIDER_DISPLAY_NAMES: dict[str, str] = {

--- a/backend/tests/test_connector_error_messages.py
+++ b/backend/tests/test_connector_error_messages.py
@@ -8,8 +8,9 @@ from connectors.base import (
 def test_build_connection_removed_message_for_slack() -> None:
     message = build_connection_removed_message("slack")
 
-    assert "Slack connection was removed or revoked in Slack" in message
-    assert "disconnect it in Basebase and reconnect it" in message
+    assert "Slack connection has expired or been revoked" in message
+    assert "/connectors" in message
+    assert "disconnect and reconnect Slack" in message
 
 
 def test_provider_display_name_humanizes_known_and_unknown_values() -> None:
@@ -20,4 +21,5 @@ def test_provider_display_name_humanizes_known_and_unknown_values() -> None:
 def test_is_connection_removed_error_detects_revoked_auth_patterns() -> None:
     assert is_connection_removed_error("Slack API error: invalid_auth") is True
     assert is_connection_removed_error("Client error '404 Not Found' for url") is True
+    assert is_connection_removed_error("Client error '400 Bad Request' for url") is True
     assert is_connection_removed_error("temporary upstream timeout") is False

--- a/backend/tests/test_connector_error_messages.py
+++ b/backend/tests/test_connector_error_messages.py
@@ -22,5 +22,6 @@ def test_is_connection_removed_error_detects_revoked_auth_patterns() -> None:
     assert is_connection_removed_error("Slack API error: invalid_auth") is True
     assert is_connection_removed_error("Client error '404 Not Found' for url") is True
     assert is_connection_removed_error("Client error '400 Bad Request' for url") is False
+    assert is_connection_removed_error("Client error '400 Bad Request' for url https://api.nango.dev/connection/123") is False
     assert is_connection_removed_error("400 Bad Request: OAuth token expired") is True
     assert is_connection_removed_error("temporary upstream timeout") is False

--- a/backend/tests/test_connector_error_messages.py
+++ b/backend/tests/test_connector_error_messages.py
@@ -21,5 +21,6 @@ def test_provider_display_name_humanizes_known_and_unknown_values() -> None:
 def test_is_connection_removed_error_detects_revoked_auth_patterns() -> None:
     assert is_connection_removed_error("Slack API error: invalid_auth") is True
     assert is_connection_removed_error("Client error '404 Not Found' for url") is True
-    assert is_connection_removed_error("Client error '400 Bad Request' for url") is True
+    assert is_connection_removed_error("Client error '400 Bad Request' for url") is False
+    assert is_connection_removed_error("400 Bad Request: OAuth token expired") is True
     assert is_connection_removed_error("temporary upstream timeout") is False

--- a/backend/tests/test_connector_error_messages.py
+++ b/backend/tests/test_connector_error_messages.py
@@ -24,4 +24,6 @@ def test_is_connection_removed_error_detects_revoked_auth_patterns() -> None:
     assert is_connection_removed_error("Client error '400 Bad Request' for url") is False
     assert is_connection_removed_error("Client error '400 Bad Request' for url https://api.nango.dev/connection/123") is False
     assert is_connection_removed_error("400 Bad Request: OAuth token expired") is True
+    assert is_connection_removed_error("Client error '401 Unauthorized' for url") is True
+    assert is_connection_removed_error("Client error '403 Forbidden' for url") is True
     assert is_connection_removed_error("temporary upstream timeout") is False

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -3339,9 +3339,23 @@ function MessageWithBlocks({
               toolBlocks.push(tb);
             }
             if (toolBlocks.length > 0) {
+              const guidanceMessages: string[] = toolBlocks
+                .filter((tb) => tb.status === 'complete')
+                .map((tb) => (tb.result as Record<string, unknown> | undefined)?.user_guidance as string | undefined)
+                .filter((g): g is string => !!g);
+
               elements.push(
-                <div key={`tools-${toolRunStart}`} className="flex flex-wrap items-center gap-1 my-1">
-                  {toolBlocks.map((tb) => renderToolBlock(tb))}
+                <div key={`tools-${toolRunStart}`}>
+                  <div className="flex flex-wrap items-center gap-1 my-1">
+                    {toolBlocks.map((tb) => renderToolBlock(tb))}
+                  </div>
+                  {guidanceMessages.length > 0 && (
+                    <div className="mt-1 mb-2 rounded-md border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
+                      {guidanceMessages.map((msg, i) => (
+                        <p key={i}>{msg}</p>
+                      ))}
+                    </div>
+                  )}
                 </div>,
               );
             }


### PR DESCRIPTION
## Summary

- Adds `"400 bad request"` to `_CONNECTION_REMOVED_ERROR_SNIPPETS` so Nango 400 errors are classified as revoked connections (previously only 404 was caught)
- Catches `ExternalConnectionRevokedError` in all three connector tool methods (`_query_on_connector`, `_write_on_connector`, `_run_on_connector`) and returns a structured `user_guidance` field with clear fix instructions pointing to `/connectors`
- Renders `user_guidance` as an amber callout banner in the chat UI below the tool pill, so users see actionable guidance immediately

## Test plan

- [ ] Trigger a connector auth failure (e.g. revoke a Linear/Slack OAuth token in Nango, or disconnect in the provider) and verify the tool result includes `user_guidance` with reconnect instructions
- [ ] Verify the amber banner renders in the chat UI below the failed tool pill
- [ ] Verify non-auth connector errors (e.g. bad parameters) still show the generic error without `user_guidance`
- [ ] Run `pytest -q tests/test_connector_error_messages.py` — all 3 tests pass


Made with [Cursor](https://cursor.com)