### PR TITLE
Fix unfurl reliability for app/doc links and snapshots

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -33,6 +33,7 @@ _PREVIEW_CACHE_TTL_SECONDS = 300
 _PREVIEW_CACHE_MAX_ITEMS = 512
 _preview_html_cache: dict[str, tuple[float, str]] = {}
 _preview_image_cache: dict[str, tuple[float, bytes, str]] = {}
+_UNFURLABLE_VISIBILITIES: frozenset[str] = frozenset({"private", "team", "public"})
 
 
 def _cache_get_html(key: str) -> str | None:
@@ -73,6 +74,10 @@ def _cache_set_image(key: str, image_bytes: bytes, mime_type: str) -> None:
         image_bytes,
         mime_type,
     )
+
+
+def _is_unfurlable_visibility(visibility: str | None) -> bool:
+    return visibility in _UNFURLABLE_VISIBILITIES
 
 
 @router.get("/apps/{app_id}")
@@ -266,12 +271,16 @@ async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLRes
         raise HTTPException(status_code=400, detail="Invalid app ID")
 
     async with get_admin_session() as session:
-        result = await session.execute(
-            select(App).where(App.id == app_uuid, App.visibility == "public")
-        )
+        result = await session.execute(select(App).where(App.id == app_uuid))
         app: App | None = result.scalar_one_or_none()
-    if app is None:
+    if app is None or not _is_unfurlable_visibility(app.visibility):
         raise HTTPException(status_code=404, detail="App not found")
+    if app.visibility != "public":
+        logger.info(
+            "[public_preview] rendering non-public app unfurl app_id=%s visibility=%s",
+            app_id,
+            app.visibility,
+        )
 
     logger.info("[public_preview] rendering app preview app_id=%s", app_id)
     app_updated_at = app.updated_at.isoformat() if app.updated_at else "none"
@@ -328,12 +337,16 @@ async def get_public_app_share_snapshot(app_id: str) -> Response:
         raise HTTPException(status_code=400, detail="Invalid app ID")
 
     async with get_admin_session() as session:
-        result = await session.execute(
-            select(App).where(App.id == app_uuid, App.visibility == "public")
-        )
+        result = await session.execute(select(App).where(App.id == app_uuid))
         app: App | None = result.scalar_one_or_none()
-    if app is None:
+    if app is None or not _is_unfurlable_visibility(app.visibility):
         raise HTTPException(status_code=404, detail="App not found")
+    if app.visibility != "public":
+        logger.info(
+            "[public_preview] serving non-public app snapshot app_id=%s visibility=%s",
+            app_id,
+            app.visibility,
+        )
     app_updated_at = app.updated_at.isoformat() if app.updated_at else "none"
     image_cache_key = f"app_snapshot:{app_id}:{app_updated_at}"
     cached_image = _cache_get_image(image_cache_key)
@@ -384,12 +397,16 @@ async def get_public_artifact_share_preview(artifact_id: str, request: Request) 
         raise HTTPException(status_code=400, detail="Invalid artifact ID")
 
     async with get_admin_session() as session:
-        result = await session.execute(
-            select(Artifact).where(Artifact.id == artifact_uuid, Artifact.visibility == "public")
-        )
+        result = await session.execute(select(Artifact).where(Artifact.id == artifact_uuid))
         artifact: Artifact | None = result.scalar_one_or_none()
-    if artifact is None:
+    if artifact is None or not _is_unfurlable_visibility(artifact.visibility):
         raise HTTPException(status_code=404, detail="Artifact not found")
+    if artifact.visibility != "public":
+        logger.info(
+            "[public_preview] rendering non-public artifact unfurl artifact_id=%s visibility=%s",
+            artifact_id,
+            artifact.visibility,
+        )
 
     logger.info("[public_preview] rendering artifact preview artifact_id=%s", artifact_id)
     artifact_version = ":".join(
@@ -453,12 +470,16 @@ async def get_public_artifact_share_snapshot(artifact_id: str) -> Response:
         raise HTTPException(status_code=400, detail="Invalid artifact ID")
 
     async with get_admin_session() as session:
-        result = await session.execute(
-            select(Artifact).where(Artifact.id == artifact_uuid, Artifact.visibility == "public")
-        )
+        result = await session.execute(select(Artifact).where(Artifact.id == artifact_uuid))
         artifact: Artifact | None = result.scalar_one_or_none()
-    if artifact is None:
+    if artifact is None or not _is_unfurlable_visibility(artifact.visibility):
         raise HTTPException(status_code=404, detail="Artifact not found")
+    if artifact.visibility != "public":
+        logger.info(
+            "[public_preview] serving non-public artifact snapshot artifact_id=%s visibility=%s",
+            artifact_id,
+            artifact.visibility,
+        )
     artifact_version = ":".join(
         [
             str(artifact.created_at.isoformat() if artifact.created_at else "none"),

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from api.routes.public import (
     _cache_get_html,
     _cache_set_html,
+    _is_unfurlable_visibility,
     _public_origin,
     _public_preview_description,
     _public_preview_title,
@@ -91,3 +92,11 @@ def test_preview_html_cache_hit_and_expiry(monkeypatch) -> None:
 
     fake_now["value"] += 301.0
     assert _cache_get_html("preview:test") is None
+
+
+def test_is_unfurlable_visibility_allows_known_levels() -> None:
+    assert _is_unfurlable_visibility("public")
+    assert _is_unfurlable_visibility("team")
+    assert _is_unfurlable_visibility("private")
+    assert not _is_unfurlable_visibility(None)
+    assert not _is_unfurlable_visibility("archived")

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -36,6 +36,15 @@ server {
         proxy_ssl_server_name on;
     }
 
+    # Ensure OG image snapshot fetches on app.basebase.com are forwarded to API.
+    location ~ ^/api/public/share/(apps|artifacts)/([0-9a-fA-F-]{36})/snapshot\.png$ {
+        proxy_pass https://api.basebase.com/api/public/share/$1/$2/snapshot.png;
+        proxy_set_header Host api.basebase.com;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_server_name on;
+    }
+
     # Cache static assets
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;


### PR DESCRIPTION
### Motivation
- Social preview HTML could emit `og:image` URLs using the request host (e.g. `https://app.basebase.com/.../snapshot.png`) while the frontend Nginx did not forward those image fetches to the API, causing broken/404 image loads.
- Share preview and snapshot endpoints previously required `visibility == "public"`, so previews for non-public `team`/`private` resources returned 404 and produced poor/no unfurl cards.
- Improve diagnosability of unfurls by logging when non-public resources are being rendered for scrapers.

### Description
- Add an Nginx proxy rule in `frontend/nginx.conf` to forward `/api/public/share/(apps|artifacts)/<id>/snapshot.png` requests to `https://api.basebase.com`, ensuring OG image fetches on the frontend host are proxied to the backend.
- Introduce `_UNFURLABLE_VISIBILITIES` and helper `_is_unfurlable_visibility` in `backend/api/routes/public.py` and change share preview/snapshot queries to look up the resource regardless of visibility but reject unknown/unsupported visibility levels, allowing `private`, `team`, and `public` to be unfurled.
- Add logging when non-public resources are being rendered or their snapshots are served to help debugging of unfurl behavior.
- Add unit test `test_is_unfurlable_visibility_allows_known_levels` to `backend/tests/test_public_previews.py` to cover the new helper, and keep unauthenticated content APIs (`/api/public/apps/*`, `/api/public/artifacts/*`) unchanged.

### Testing
- Ran `pytest -q backend/tests/test_public_previews.py`, all tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03bb76f888321976e74277719a5a5)