### PR TITLE
Fix app/doc unfurl proxy routing to public share endpoints

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -20,8 +20,8 @@ server {
     # Social unfurl support: route share links to backend-rendered Open Graph pages.
     # Discord/Facebook crawlers don't run JS, so this bypasses the SPA shell.
     location ~ ^/basebase/apps/([0-9a-fA-F-]{36})/?$ {
-        # Serve metadata directly from backend to avoid crawler redirect quirks.
-        proxy_pass https://api.basebase.com/basebase/apps/$1;
+        # Route through versioned public preview endpoint; some API gateways only expose /api/*.
+        proxy_pass https://api.basebase.com/api/public/share/apps/$1;
         proxy_set_header Host api.basebase.com;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -29,7 +29,7 @@ server {
     }
 
     location ~ ^/basebase/(documents|artifacts)/([0-9a-fA-F-]{36})/?$ {
-        proxy_pass https://api.basebase.com/basebase/$1/$2;
+        proxy_pass https://api.basebase.com/api/public/share/$1/$2;
         proxy_set_header Host api.basebase.com;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
### Motivation
- Crawlers fetching unfurl metadata for shared app/document links can hit the SPA shell or non-exposed upstream paths when the frontend proxies to non-`/api` backend routes, producing generic previews instead of the app-specific Open Graph/Twitter metadata and image.

### Description
- Updated `frontend/nginx.conf` to proxy `/basebase/apps/{id}` to `https://api.basebase.com/api/public/share/apps/{id}` so metadata is fetched from the backend public preview endpoint.
- Updated `frontend/nginx.conf` to proxy `/basebase/documents/{id}` and `/basebase/artifacts/{id}` to `https://api.basebase.com/api/public/share/{...}` for consistent artifact/app unfurl behavior.
- Left existing snapshot image proxying (`/api/public/share/.../snapshot.png`) unchanged.

### Testing
- No automated test suite was executed for this change; validation was done by inspecting code and routes with repository searches using `rg` which confirmed backend preview endpoints exist in `backend/api/routes/public.py` and by reviewing the `git diff` for `frontend/nginx.conf` to verify the intended edits, and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03f930b948321b6fde75dc6d7439c)