### PR TITLE
Fix Discord unfurl metadata redirect behavior

### DIFF
--- a/backend/services/public_previews.py
+++ b/backend/services/public_previews.py
@@ -81,9 +81,18 @@ def build_preview_html(
     <meta name="twitter:title" content="{safe_title}" />
     <meta name="twitter:description" content="{safe_desc}" />
     <meta name="twitter:image" content="{safe_image}" />
-    <meta http-equiv="refresh" content="0;url={safe_redirect}" />
   </head>
   <body>
-    <script>window.location.replace("{safe_redirect}");</script>
+    <script>
+      // Keep metadata discoverable for unfurl bots that may follow/meta-refresh redirects.
+      // Real browsers still navigate to the interactive public page immediately.
+      window.location.replace("{safe_redirect}");
+    </script>
+    <noscript>
+      <p>
+        Continue to the shared page:
+        <a href="{safe_redirect}">{safe_redirect}</a>
+      </p>
+    </noscript>
   </body>
 </html>"""

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -34,7 +34,8 @@ def test_build_preview_html_includes_og_and_twitter_tags() -> None:
     assert 'property="og:title" content="Example"' in html
     assert 'name="twitter:image" content="https://example.com/api/public/share/apps/abc/snapshot.png"' in html
     assert 'property="og:image:secure_url" content="https://example.com/api/public/share/apps/abc/snapshot.png"' in html
-    assert 'http-equiv="refresh"' in html
+    assert 'window.location.replace("https://example.com/public/apps/abc")' in html
+    assert '<noscript>' in html
 
 
 def test_render_card_png_returns_png_bytes() -> None:


### PR DESCRIPTION
### Motivation
- Social crawlers (Discord/Facebook) were not reliably extracting OG/Twitter metadata because the preview page used an HTML `meta refresh` which causes some bots to follow the redirect before reading tags, so previews were blank.

### Description
- Replace the `meta http-equiv="refresh"` redirect with a client-side JS redirect `window.location.replace(...)` and add a `<noscript>` fallback link so metadata remains discoverable while browsers still navigate to the interactive page; changed `backend/services/public_previews.py` and updated the corresponding test in `backend/tests/test_public_previews.py`.

### Testing
- Ran `pytest backend/tests/test_public_previews.py`; all tests passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04a8b54ec83219d7df02bd5810886)