### PR TITLE
Fix nginx share proxy DNS resolver error

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -23,7 +23,8 @@ server {
     # minimal/container Nginx builds while still constraining to UUID-like chars.
     location ~ ^/basebase/apps/([0-9a-fA-F-]+)/?$ {
         # Route through versioned public preview endpoint; some API gateways only expose /api/*.
-        proxy_pass https://api.basebase.com/api/public/share/apps/$1;
+        rewrite ^/basebase/apps/([0-9a-fA-F-]+)/?$ /api/public/share/apps/$1 break;
+        proxy_pass https://api.basebase.com;
         proxy_set_header Host api.basebase.com;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -31,7 +32,8 @@ server {
     }
 
     location ~ ^/basebase/(documents|artifacts)/([0-9a-fA-F-]+)/?$ {
-        proxy_pass https://api.basebase.com/api/public/share/$1/$2;
+        rewrite ^/basebase/(documents|artifacts)/([0-9a-fA-F-]+)/?$ /api/public/share/$1/$2 break;
+        proxy_pass https://api.basebase.com;
         proxy_set_header Host api.basebase.com;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -40,7 +42,8 @@ server {
 
     # Ensure OG image snapshot fetches on app.basebase.com are forwarded to API.
     location ~ ^/api/public/share/(apps|artifacts)/([0-9a-fA-F-]+)/snapshot\.png$ {
-        proxy_pass https://api.basebase.com/api/public/share/$1/$2/snapshot.png;
+        rewrite ^/api/public/share/(apps|artifacts)/([0-9a-fA-F-]+)/snapshot\.png$ /api/public/share/$1/$2/snapshot.png break;
+        proxy_pass https://api.basebase.com;
         proxy_set_header Host api.basebase.com;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
### Motivation
- Prevent Nginx from requiring a runtime DNS `resolver` by removing captured variables from `proxy_pass` in the share/unfurl routes, which was causing `no resolver defined to resolve api.basebase.com`.

### Description
- Updated `frontend/nginx.conf` share/unfurl `location` blocks to use `rewrite ... break` followed by `proxy_pass https://api.basebase.com;` for `/basebase/apps/{id}`, `/basebase/(documents|artifacts)/ {id}`, and the OG snapshot route, keeping behavior identical while eliminating variable-based upstream URLs.

### Testing
- Attempted `nginx -t -c /workspace/basebase/frontend/nginx.conf` to validate the configuration but the `nginx` binary is not available in this environment so config validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e050468da883219f14bfe54e7525d5)