### PR TITLE
Prefer app description in public preview and use canonical /basebase/apps redirect

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -237,6 +237,9 @@ def _public_preview_description(
 ) -> str:
     """Build a concise public description for social preview unfurls."""
     owner_label = _owner_label(owner)
+    app_description = (getattr(app, "description", None) or "").strip() if app else ""
+    if app_description:
+        return f"{app_description} — {owner_label}"
     if conversation and conversation.title:
         return f"{conversation.title} — {owner_label}"
     if app and app.title:
@@ -304,7 +307,7 @@ async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLRes
         owner = await session.scalar(select(User).where(User.id == app.user_id))
 
     canonical_url = f"{_frontend_origin()}/basebase/apps/{app_id}"
-    redirect_url = f"{_frontend_origin()}/public/apps/{app_id}"
+    redirect_url = canonical_url
     image_url = f"{_public_origin(request)}/api/public/share/apps/{app_id}/snapshot.png"
     title = _public_preview_title(app=app)
     description = _public_preview_description(conversation=conversation, app=app, owner=owner)

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -57,6 +57,18 @@ def test_public_preview_description_prefers_conversation_title_with_owner() -> N
     assert description == "Q2 forecast — Alex"
 
 
+def test_public_preview_description_prefers_app_description_with_owner() -> None:
+    description = _public_preview_description(
+        conversation=SimpleNamespace(title="Q2 forecast"),
+        app=SimpleNamespace(
+            title="Pipeline app",
+            description="Shows the current largest celestial body visible in the sky...",
+        ),
+        owner=SimpleNamespace(name="Alex", email="alex@example.com"),
+    )
+    assert description == "Shows the current largest celestial body visible in the sky... — Alex"
+
+
 def test_public_preview_description_falls_back_to_document_and_owner_email() -> None:
     description = _public_preview_description(
         conversation=None,
@@ -64,6 +76,17 @@ def test_public_preview_description_falls_back_to_document_and_owner_email() -> 
         owner=SimpleNamespace(name=None, email="owner@example.com"),
     )
     assert description == "Document — owner@example.com"
+
+
+def test_build_preview_html_uses_basebase_apps_redirect_url() -> None:
+    html = build_preview_html(
+        page_title="Example",
+        description="Description",
+        canonical_url="https://app.basebase.com/basebase/apps/abc",
+        image_url="https://app.basebase.com/api/public/share/apps/abc/snapshot.png",
+        redirect_url="https://app.basebase.com/basebase/apps/abc",
+    )
+    assert 'window.location.replace("https://app.basebase.com/basebase/apps/abc")' in html
 
 
 def test_public_preview_title_uses_app_title_when_present() -> None:


### PR DESCRIPTION
### Motivation
- Ensure social/link previews show the app's own description text (e.g. "Shows the current largest celestial body visible in the sky...") followed by the owner, rather than falling back to conversation/app titles when a description is present.
- Ensure clicking the shared app preview directs users to the canonical `/basebase/apps/:id` URL instead of `/public/apps/:id` so links resolve to the intended front-end route.

### Description
- Updated `_public_preview_description` in `backend/api/routes/public.py` to prefer the app's `description` (trimmed) when present, using a safe `getattr` fallback for non-model test fixtures, and append the owner label.
- Changed the share preview `redirect_url` in `get_public_app_share_preview` to use the previously computed `canonical_url` (`/basebase/apps/:id`) instead of `/public/apps/:id`.
- Added tests in `backend/tests/test_public_previews.py`: `test_public_preview_description_prefers_app_description_with_owner` and `test_build_preview_html_uses_basebase_apps_redirect_url` to cover the new behavior.

### Testing
- Ran `pytest -q backend/tests/test_public_previews.py` and all tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e059ca94448321ab1c3f035a6e805a)