### PR TITLE
Warm preview metadata/snapshot cache before returning new app/artifact links

### DIFF
--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -27,6 +27,7 @@ from models.app import App
 from models.chat_message import ChatMessage
 from models.conversation import Conversation
 from models.database import get_session
+from services.public_preview_warmup import warm_public_preview_cache
 
 logger = logging.getLogger(__name__)
 
@@ -413,6 +414,7 @@ class AppsConnector(BaseConnector):
             title,
             list(queries.keys()),
         )
+        await warm_public_preview_cache("app", app_id_str)
 
         app_url: str = f"{settings.FRONTEND_URL.rstrip('/')}/apps/{app_id_str}"
         return {

--- a/backend/connectors/artifacts.py
+++ b/backend/connectors/artifacts.py
@@ -27,6 +27,7 @@ from connectors.registry import (
 )
 from models.artifact import Artifact
 from models.database import get_session
+from services.public_preview_warmup import warm_public_preview_cache
 
 logger = logging.getLogger(__name__)
 
@@ -248,6 +249,7 @@ class ArtifactConnector(BaseConnector):
             content_type,
             title,
         )
+        await warm_public_preview_cache("artifact", artifact_id_str)
         view_url: str = f"{settings.FRONTEND_URL.rstrip('/')}/artifacts/{artifact_id_str}"
         return {
             "status": "success",

--- a/backend/services/public_preview_warmup.py
+++ b/backend/services/public_preview_warmup.py
@@ -1,0 +1,80 @@
+"""Utilities for warming public preview metadata/image caches after creation."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Literal
+
+import httpx
+
+from config import settings
+
+logger = logging.getLogger(__name__)
+
+PreviewEntity = Literal["app", "artifact"]
+
+
+def _build_preview_urls(entity: PreviewEntity, entity_id: str) -> list[str]:
+    """Return candidate URLs that trigger metadata + snapshot cache generation."""
+    base = settings.FRONTEND_URL.rstrip("/")
+    if entity == "app":
+        return [
+            f"{base}/basebase/apps/{entity_id}",
+            f"{base}/api/public/share/apps/{entity_id}",
+            f"{base}/api/public/share/apps/{entity_id}/snapshot.png",
+        ]
+    return [
+        f"{base}/basebase/documents/{entity_id}",
+        f"{base}/api/public/share/artifacts/{entity_id}",
+        f"{base}/api/public/share/artifacts/{entity_id}/snapshot.png",
+    ]
+
+
+async def _fetch_for_warmup(client: httpx.AsyncClient, url: str) -> tuple[str, int | None]:
+    try:
+        response = await client.get(url)
+        return url, response.status_code
+    except Exception:
+        logger.exception("[public_preview_warmup] request failed url=%s", url)
+        return url, None
+
+
+async def warm_public_preview_cache(entity: PreviewEntity, entity_id: str) -> None:
+    """
+    Best-effort warmup for social preview endpoints before returning share/view links.
+
+    This intentionally never raises so create flows remain reliable if warmup endpoints
+    are temporarily unavailable.
+    """
+    urls = _build_preview_urls(entity, entity_id)
+    logger.info(
+        "[public_preview_warmup] start entity=%s entity_id=%s candidate_urls=%s",
+        entity,
+        entity_id,
+        urls,
+    )
+    timeout = httpx.Timeout(5.0, connect=2.0)
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+        results = await asyncio.gather(*[_fetch_for_warmup(client, url) for url in urls])
+
+    for url, status in results:
+        if status is None:
+            logger.warning("[public_preview_warmup] no-response entity=%s entity_id=%s url=%s", entity, entity_id, url)
+            continue
+        if status >= 400:
+            logger.warning(
+                "[public_preview_warmup] non-success status entity=%s entity_id=%s status=%s url=%s",
+                entity,
+                entity_id,
+                status,
+                url,
+            )
+            continue
+        logger.info(
+            "[public_preview_warmup] warmed entity=%s entity_id=%s status=%s url=%s",
+            entity,
+            entity_id,
+            status,
+            url,
+        )


### PR DESCRIPTION
### Motivation
- External scrapers (Slack, social unfurl bots) can miss metadata or snapshot generation for freshly-created apps/documents, resulting in poor link previews.
- Ensure previews are ready before handing back share/view links so downstream unfurlers consistently see the cached metadata/image.

### Description
- Added a new best-effort warmup service `backend/services/public_preview_warmup.py` that requests the metadata and snapshot endpoints for a given entity (`app` or `artifact`) and logs results without raising.
- The warmup targets a small set of URLs that trigger preview generation (page metadata endpoints and `/snapshot.png`) and uses short timeouts and follow-redirects for robustness.
- Wired app creation to call `warm_public_preview_cache("app", app_id)` before returning the created app URL in `backend/connectors/apps.py`.
- Wired artifact creation to call `warm_public_preview_cache("artifact", artifact_id)` before returning the created artifact view URL in `backend/connectors/artifacts.py`.

### Testing
- Ran unit tests targeting previews with `pytest -q backend/tests/test_public_previews.py` and all tests passed (`10 passed`).
- Verified the new module and changed files compile with `python -m compileall backend/connectors/apps.py backend/connectors/artifacts.py backend/services/public_preview_warmup.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e05b357d948321beea4c238be8bf6e)