### PR TITLE
Avoid redirect loop for public app share previews

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -264,6 +264,20 @@ def _public_preview_title(*, app: App | None = None, artifact: Artifact | None =
     return "Basebase"
 
 
+def _app_share_redirect_url(*, app_id: str, visibility: str | None) -> str:
+    """
+    Resolve the browser redirect target for /basebase/apps/:id share previews.
+
+    Public apps should land on the unauthenticated public app page to avoid
+    redirect loops through the share endpoint. Non-public apps should stay on
+    the canonical in-app route, where auth/access handling is enforced.
+    """
+    frontend_origin = _frontend_origin()
+    if visibility == "public":
+        return f"{frontend_origin}/public/apps/{app_id}"
+    return f"{frontend_origin}/basebase/apps/{app_id}"
+
+
 @router.get("/share/apps/{app_id}", response_class=HTMLResponse)
 @share_router.get("/basebase/apps/{app_id}", response_class=HTMLResponse)
 async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLResponse:
@@ -307,7 +321,7 @@ async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLRes
         owner = await session.scalar(select(User).where(User.id == app.user_id))
 
     canonical_url = f"{_frontend_origin()}/basebase/apps/{app_id}"
-    redirect_url = canonical_url
+    redirect_url = _app_share_redirect_url(app_id=app_id, visibility=app.visibility)
     image_url = f"{_public_origin(request)}/api/public/share/apps/{app_id}/snapshot.png"
     title = _public_preview_title(app=app)
     description = _public_preview_description(conversation=conversation, app=app, owner=owner)

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -4,6 +4,7 @@ import base64
 from types import SimpleNamespace
 
 from api.routes.public import (
+    _app_share_redirect_url,
     _cache_get_html,
     _cache_set_html,
     _is_unfurlable_visibility,
@@ -11,6 +12,7 @@ from api.routes.public import (
     _public_preview_description,
     _public_preview_title,
 )
+from config import settings
 from services.public_previews import build_preview_html, decode_data_url_image, render_card_png
 
 
@@ -78,15 +80,31 @@ def test_public_preview_description_falls_back_to_document_and_owner_email() -> 
     assert description == "Document — owner@example.com"
 
 
-def test_build_preview_html_uses_basebase_apps_redirect_url() -> None:
+def test_build_preview_html_uses_configured_redirect_url() -> None:
     html = build_preview_html(
         page_title="Example",
         description="Description",
         canonical_url="https://app.basebase.com/basebase/apps/abc",
         image_url="https://app.basebase.com/api/public/share/apps/abc/snapshot.png",
-        redirect_url="https://app.basebase.com/basebase/apps/abc",
+        redirect_url="https://app.basebase.com/public/apps/abc",
     )
-    assert 'window.location.replace("https://app.basebase.com/basebase/apps/abc")' in html
+    assert 'window.location.replace("https://app.basebase.com/public/apps/abc")' in html
+
+
+def test_app_share_redirect_url_uses_public_path_for_public_apps() -> None:
+    frontend_origin = settings.FRONTEND_URL.rstrip("/")
+    assert (
+        _app_share_redirect_url(app_id="abc", visibility="public")
+        == f"{frontend_origin}/public/apps/abc"
+    )
+
+
+def test_app_share_redirect_url_keeps_basebase_path_for_non_public_apps() -> None:
+    frontend_origin = settings.FRONTEND_URL.rstrip("/")
+    assert (
+        _app_share_redirect_url(app_id="abc", visibility="private")
+        == f"{frontend_origin}/basebase/apps/abc"
+    )
 
 
 def test_public_preview_title_uses_app_title_when_present() -> None:


### PR DESCRIPTION
### Motivation
- Public app share preview links were redirecting to the canonical `/basebase/apps/:id` path which could loop when the share rewrite pointed back to the share endpoint, causing endless redirects for public apps.

### Description
- Add `_app_share_redirect_url(*, app_id, visibility)` to choose the browser redirect target based on an app's visibility, using `_frontend_origin()` as the base.
- Route public app share previews to `/public/apps/:id` while keeping non-public apps on `/basebase/apps/:id` to preserve in-app auth and access behavior.
- Update the `/share/apps/{app_id}` preview handler to use the new helper for the runtime `redirect_url`.
- Update `backend/tests/test_public_previews.py` to assert the configured redirect behavior and add tests for `_app_share_redirect_url`.

### Testing
- Ran `pytest -q backend/tests/test_public_previews.py` and all tests passed (`14 passed`).
- Unit tests added/updated: `test_app_share_redirect_url_uses_public_path_for_public_apps` and `test_app_share_redirect_url_keeps_basebase_path_for_non_public_apps`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e05fa49e188321a06ff23e2551e207)