### PR TITLE
Fix app ownership attribution for Slack-initiated app creation

### DIFF
--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -321,29 +321,20 @@ class AppsConnector(BaseConnector):
         conversation_id: str | None = data.get("conversation_id")
         user_uuid: UUID | None = None
         conversation_uuid: UUID | None = None
-        if conversation_id:
+
+        if self.user_id:
             try:
-                conversation_uuid = UUID(conversation_id)
+                user_uuid = UUID(self.user_id)
             except (ValueError, TypeError, AttributeError):
                 logger.warning(
-                    "[AppsConnector] Could not parse conversation_id as UUID for owner resolution: conversation_id=%s",
-                    conversation_id,
+                    "[AppsConnector] Could not parse connector user_id as UUID for owner resolution: user_id=%s",
+                    self.user_id,
                 )
             else:
-                async with get_session(organization_id=self.organization_id) as session:
-                    row = await session.execute(
-                        select(Conversation.user_id).where(
-                            Conversation.id == conversation_uuid,
-                        )
-                    )
-                    conversation_user_id: UUID | None = row.scalar_one_or_none()
-                    if conversation_user_id is not None:
-                        user_uuid = conversation_user_id
-                        logger.info(
-                            "[AppsConnector] Resolved app owner from conversation owner: conversation_id=%s user_id=%s",
-                            conversation_id,
-                            conversation_user_id,
-                        )
+                logger.info(
+                    "[AppsConnector] Resolved app owner from connector user context: user_id=%s",
+                    user_uuid,
+                )
 
         if message_id:
             try:
@@ -369,12 +360,29 @@ class AppsConnector(BaseConnector):
                             message_user_id,
                         )
 
-        if not user_uuid and self.user_id:
-            user_uuid = UUID(self.user_id)
-            logger.info(
-                "[AppsConnector] Falling back to connector user context for app owner: user_id=%s",
-                user_uuid,
-            )
+        if conversation_id:
+            try:
+                conversation_uuid = UUID(conversation_id)
+            except (ValueError, TypeError, AttributeError):
+                logger.warning(
+                    "[AppsConnector] Could not parse conversation_id as UUID for owner resolution fallback: conversation_id=%s",
+                    conversation_id,
+                )
+            else:
+                async with get_session(organization_id=self.organization_id) as session:
+                    row = await session.execute(
+                        select(Conversation.user_id).where(
+                            Conversation.id == conversation_uuid,
+                        )
+                    )
+                    conversation_user_id: UUID | None = row.scalar_one_or_none()
+                    if conversation_user_id is not None and user_uuid is None:
+                        user_uuid = conversation_user_id
+                        logger.info(
+                            "[AppsConnector] Resolved app owner from conversation owner fallback: conversation_id=%s user_id=%s",
+                            conversation_id,
+                            conversation_user_id,
+                        )
 
         if not user_uuid:
             return {

--- a/backend/tests/test_apps_connector_owner_resolution.py
+++ b/backend/tests/test_apps_connector_owner_resolution.py
@@ -1,0 +1,77 @@
+import asyncio
+from contextlib import asynccontextmanager
+from uuid import UUID
+
+from connectors.apps import AppsConnector
+
+
+class _FakeExecuteResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _FakeSession:
+    def __init__(self, *, message_user_id: UUID | None, conversation_user_id: UUID | None):
+        self.message_user_id = message_user_id
+        self.conversation_user_id = conversation_user_id
+        self.added = []
+        self.execute_calls = 0
+        self.committed = False
+
+    async def execute(self, _query, _params=None):
+        self.execute_calls += 1
+        if self.execute_calls == 1:
+            return _FakeExecuteResult(self.message_user_id)
+        return _FakeExecuteResult(self.conversation_user_id)
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.committed = True
+
+
+def test_create_prefers_turn_user_over_conversation_owner(monkeypatch):
+    org_id = "00000000-0000-0000-0000-000000000010"
+    turn_user_id = "00000000-0000-0000-0000-000000000011"
+    message_user_id = UUID("00000000-0000-0000-0000-000000000012")
+    conversation_user_id = UUID("00000000-0000-0000-0000-000000000013")
+    fake_session = _FakeSession(
+        message_user_id=message_user_id,
+        conversation_user_id=conversation_user_id,
+    )
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        yield fake_session
+
+    async def _fake_warm(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("connectors.apps.get_session", _fake_get_session)
+    monkeypatch.setattr("connectors.apps.warm_public_preview_cache", _fake_warm)
+    monkeypatch.setattr("utils.transpile_jsx.transpile_jsx", lambda _code: (None,))
+
+    connector = AppsConnector(organization_id=org_id, user_id=turn_user_id)
+
+    result = asyncio.run(
+        connector._create(
+            {
+                "title": "Slack-owned app",
+                "queries": {
+                    "q": {"sql": "SELECT 1 AS n", "params": {}},
+                },
+                "frontend_code": "export default function App(){ return <div/>; }",
+                "message_id": "00000000-0000-0000-0000-000000000014",
+                "conversation_id": "00000000-0000-0000-0000-000000000015",
+            }
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_session.committed is True
+    assert len(fake_session.added) == 1
+    assert fake_session.added[0].user_id == UUID(turn_user_id)


### PR DESCRIPTION
### Motivation
- Ensure apps created from a Slack-initiated turn are attributed to the Slack actor mapped to a Basebase user (the current turn user) rather than the conversation/thread owner.
- Avoid misattribution when a thread is reused or when conversation ownership differs from the user who actually initiated the current turn.

### Description
- Reordered owner resolution in `AppsConnector._create` to prefer the current turn user (`self.user_id`) first, then fall back to the initiating `message_id` user, and lastly to the conversation owner when needed (file: `backend/connectors/apps.py`).
- Added stricter UUID parsing handling and clearer logging messages for each resolution step to aid debugging when parsing or lookups fail.
- Preserved the existing message- and conversation-level lookups as fallbacks and only set owner from those when the turn user is unavailable.
- Added a regression test `backend/tests/test_apps_connector_owner_resolution.py` that verifies app creation uses the turn user over the conversation owner.

### Testing
- Ran the new unit test with `pytest -q tests/test_apps_connector_owner_resolution.py`, which passed: `1 passed`.
- No other automated test suites were modified or executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0603d97188321b4e59ab051081372)