### PR TITLE
Fix legacy /basebase app link routing to avoid public redirect

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -408,11 +408,24 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
     isSyncingFromUrlRef.current = true;
     try {
       useUIStore.setState({ orgAccessError: null });
-      const path = window.location.pathname;
+      const rawPath = window.location.pathname;
+      const basebasePrefix = "/basebase";
+      const path =
+        rawPath === basebasePrefix
+          ? "/"
+          : rawPath.startsWith(`${basebasePrefix}/`)
+            ? rawPath.slice(basebasePrefix.length)
+            : rawPath;
+      if (rawPath !== path) {
+        console.info("[routing] normalized legacy /basebase path", {
+          rawPath,
+          normalizedPath: path,
+        });
+      }
 
       const orgPrefixMatch = path.match(/^\/([a-z0-9-]+)(?:\/(.*))?$/);
     const orgHandleFromPath: string | null =
-      orgPrefixMatch && orgPrefixMatch[1] && !/^(auth|admin|embed|chat|apps|documents|artifact|artifacts|connectors|data|workflows|memory|changes)$/i.test(orgPrefixMatch[1])
+      orgPrefixMatch && orgPrefixMatch[1] && !/^(auth|admin|embed|chat|apps|documents|artifact|artifacts|connectors|data|workflows|memory|changes|basebase)$/i.test(orgPrefixMatch[1])
         ? orgPrefixMatch[1]
         : null;
 


### PR DESCRIPTION
### Motivation
- Legacy links under `/basebase/...` (for example `/basebase/apps/<id>`) were being misinterpreted as org-prefixed routes (`/:handle/...`) and could trigger org-access fallback and redirect to public pages. 
- Normalize these legacy paths so they resolve to the intended internal routes instead of invoking org resolution logic.

### Description
- Normalize incoming `window.location.pathname` by stripping a `/basebase` prefix before the app’s URL sync logic in `frontend/src/components/AppLayout.tsx` (`syncStateFromUrl`).
- Treat `basebase` as a reserved top-level segment by adding it to the org-handle exclusion regex so it is not interpreted as an organization handle.
- Add an informational `console.info` log when a legacy `/basebase` path is normalized to aid routing diagnostics.

### Testing
- Ran linting with `npm run lint` in `frontend/` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e062aae4ac832199afa6494025f8b4)