### PR TITLE
Resolve Apps connector owner via Slack identity mappings

### DIFF
--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -27,6 +27,7 @@ from models.app import App
 from models.chat_message import ChatMessage
 from models.conversation import Conversation
 from models.database import get_session
+from models.external_identity_mapping import ExternalIdentityMapping
 from services.public_preview_warmup import warm_public_preview_cache
 
 logger = logging.getLogger(__name__)
@@ -297,6 +298,74 @@ class AppsConnector(BaseConnector):
             "frontend_code_with_lines": self._add_line_numbers(app.frontend_code),
         }
 
+    async def _resolve_user_from_external_actor(
+        self,
+        *,
+        source: str | None,
+        external_user_id: str | None,
+    ) -> UUID | None:
+        """Resolve an internal user from an external actor identifier."""
+        normalized_source: str = (source or "").strip().lower()
+        normalized_external_user: str = (external_user_id or "").strip()
+        if not normalized_source or not normalized_external_user:
+            logger.debug(
+                "[AppsConnector] External actor resolution skipped due to missing source/external_user_id: source=%s external_user_id=%s",
+                source,
+                external_user_id,
+            )
+            return None
+
+        if normalized_source != "slack":
+            logger.debug(
+                "[AppsConnector] External actor resolution skipped for unsupported source: source=%s external_user_id=%s",
+                normalized_source,
+                normalized_external_user,
+            )
+            return None
+
+        org_uuid: UUID = UUID(self.organization_id)
+        async with get_session(organization_id=self.organization_id) as session:
+            slack_row = await session.execute(
+                select(ExternalIdentityMapping.user_id).where(
+                    ExternalIdentityMapping.organization_id == org_uuid,
+                    ExternalIdentityMapping.external_userid == normalized_external_user,
+                    ExternalIdentityMapping.source == "slack",
+                    ExternalIdentityMapping.user_id.is_not(None),
+                )
+            )
+            slack_user_id: UUID | None = slack_row.scalar_one_or_none()
+            if slack_user_id is not None:
+                logger.debug(
+                    "[AppsConnector] Resolved app owner from Slack identity mapping: external_user_id=%s user_id=%s",
+                    normalized_external_user,
+                    slack_user_id,
+                )
+                return slack_user_id
+
+            legacy_row = await session.execute(
+                select(ExternalIdentityMapping.user_id).where(
+                    ExternalIdentityMapping.organization_id == org_uuid,
+                    ExternalIdentityMapping.external_userid == normalized_external_user,
+                    ExternalIdentityMapping.source == "revtops_unknown",
+                    ExternalIdentityMapping.user_id.is_not(None),
+                )
+            )
+            legacy_user_id: UUID | None = legacy_row.scalar_one_or_none()
+            if legacy_user_id is not None:
+                logger.debug(
+                    "[AppsConnector] Resolved app owner from legacy revtops_unknown identity mapping: external_user_id=%s user_id=%s",
+                    normalized_external_user,
+                    legacy_user_id,
+                )
+                return legacy_user_id
+
+        logger.debug(
+            "[AppsConnector] Could not resolve app owner from external actor: source=%s external_user_id=%s",
+            normalized_source,
+            normalized_external_user,
+        )
+        return None
+
     async def _create(self, data: dict[str, Any]) -> dict[str, Any]:
         """Create a new app."""
         title: str = str(data.get("title", "Untitled App"))
@@ -371,11 +440,24 @@ class AppsConnector(BaseConnector):
             else:
                 async with get_session(organization_id=self.organization_id) as session:
                     row = await session.execute(
-                        select(Conversation.user_id).where(
+                        select(
+                            Conversation.user_id,
+                            Conversation.source,
+                            Conversation.source_user_id,
+                        ).where(
                             Conversation.id == conversation_uuid,
                         )
                     )
-                    conversation_user_id: UUID | None = row.scalar_one_or_none()
+                    conversation_record: tuple[UUID | None, str | None, str | None] | None = row.one_or_none()
+                    conversation_user_id: UUID | None = None
+                    conversation_source: str | None = None
+                    conversation_source_user_id: str | None = None
+                    if conversation_record is not None:
+                        (
+                            conversation_user_id,
+                            conversation_source,
+                            conversation_source_user_id,
+                        ) = conversation_record
                     if conversation_user_id is not None and user_uuid is None:
                         user_uuid = conversation_user_id
                         logger.info(
@@ -383,6 +465,20 @@ class AppsConnector(BaseConnector):
                             conversation_id,
                             conversation_user_id,
                         )
+                    elif user_uuid is None:
+                        external_actor_user_id: UUID | None = await self._resolve_user_from_external_actor(
+                            source=conversation_source,
+                            external_user_id=conversation_source_user_id,
+                        )
+                        if external_actor_user_id is not None:
+                            user_uuid = external_actor_user_id
+                            logger.info(
+                                "[AppsConnector] Resolved app owner from external actor mapping: conversation_id=%s source=%s external_user_id=%s user_id=%s",
+                                conversation_id,
+                                conversation_source,
+                                conversation_source_user_id,
+                                external_actor_user_id,
+                            )
 
         if not user_uuid:
             return {

--- a/backend/tests/test_apps_connector_owner_resolution.py
+++ b/backend/tests/test_apps_connector_owner_resolution.py
@@ -12,20 +12,49 @@ class _FakeExecuteResult:
     def scalar_one_or_none(self):
         return self._value
 
+    def one_or_none(self):
+        return self._value
+
 
 class _FakeSession:
-    def __init__(self, *, message_user_id: UUID | None, conversation_user_id: UUID | None):
+    def __init__(
+        self,
+        *,
+        message_user_id: UUID | None,
+        conversation_user_id: UUID | None,
+        conversation_source: str | None = None,
+        conversation_source_user_id: str | None = None,
+        slack_mapping_user_id: UUID | None = None,
+        legacy_mapping_user_id: UUID | None = None,
+    ):
         self.message_user_id = message_user_id
         self.conversation_user_id = conversation_user_id
+        self.conversation_source = conversation_source
+        self.conversation_source_user_id = conversation_source_user_id
+        self.slack_mapping_user_id = slack_mapping_user_id
+        self.legacy_mapping_user_id = legacy_mapping_user_id
+        self.mapping_query_calls = 0
         self.added = []
-        self.execute_calls = 0
         self.committed = False
 
-    async def execute(self, _query, _params=None):
-        self.execute_calls += 1
-        if self.execute_calls == 1:
+    async def execute(self, query, _params=None):
+        q = str(query)
+        if "chat_messages" in q:
             return _FakeExecuteResult(self.message_user_id)
-        return _FakeExecuteResult(self.conversation_user_id)
+        if "conversations" in q:
+            return _FakeExecuteResult(
+                (
+                    self.conversation_user_id,
+                    self.conversation_source,
+                    self.conversation_source_user_id,
+                )
+            )
+        if "user_mappings_for_identity" in q:
+            self.mapping_query_calls += 1
+            if self.mapping_query_calls == 1:
+                return _FakeExecuteResult(self.slack_mapping_user_id)
+            return _FakeExecuteResult(self.legacy_mapping_user_id)
+        raise AssertionError(f"Unexpected query: {q}")
 
     def add(self, obj):
         self.added.append(obj)
@@ -51,9 +80,13 @@ def test_create_prefers_turn_user_over_conversation_owner(monkeypatch):
     async def _fake_warm(*_args, **_kwargs):
         return None
 
+    async def _fake_test_execute_queries(*_args, **_kwargs):
+        return []
+
     monkeypatch.setattr("connectors.apps.get_session", _fake_get_session)
     monkeypatch.setattr("connectors.apps.warm_public_preview_cache", _fake_warm)
     monkeypatch.setattr("utils.transpile_jsx.transpile_jsx", lambda _code: (None,))
+    monkeypatch.setattr("connectors.apps.AppsConnector._test_execute_queries", _fake_test_execute_queries)
 
     connector = AppsConnector(organization_id=org_id, user_id=turn_user_id)
 
@@ -75,3 +108,51 @@ def test_create_prefers_turn_user_over_conversation_owner(monkeypatch):
     assert fake_session.committed is True
     assert len(fake_session.added) == 1
     assert fake_session.added[0].user_id == UUID(turn_user_id)
+
+
+def test_create_resolves_owner_from_slack_identity_mapping_when_conversation_user_missing(monkeypatch):
+    org_id = "00000000-0000-0000-0000-000000000010"
+    resolved_user_id = UUID("00000000-0000-0000-0000-000000000099")
+    fake_session = _FakeSession(
+        message_user_id=None,
+        conversation_user_id=None,
+        conversation_source="slack",
+        conversation_source_user_id="U123SLACK",
+        slack_mapping_user_id=resolved_user_id,
+    )
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        yield fake_session
+
+    async def _fake_warm(*_args, **_kwargs):
+        return None
+
+    async def _fake_test_execute_queries(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr("connectors.apps.get_session", _fake_get_session)
+    monkeypatch.setattr("connectors.apps.warm_public_preview_cache", _fake_warm)
+    monkeypatch.setattr("utils.transpile_jsx.transpile_jsx", lambda _code: (None,))
+    monkeypatch.setattr("connectors.apps.AppsConnector._test_execute_queries", _fake_test_execute_queries)
+
+    connector = AppsConnector(organization_id=org_id, user_id=None)
+
+    result = asyncio.run(
+        connector._create(
+            {
+                "title": "Slack-owned app",
+                "queries": {
+                    "q": {"sql": "SELECT 1 AS n", "params": {}},
+                },
+                "frontend_code": "export default function App(){ return <div/>; }",
+                "message_id": "00000000-0000-0000-0000-000000000014",
+                "conversation_id": "00000000-0000-0000-0000-000000000015",
+            }
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_session.committed is True
+    assert len(fake_session.added) == 1
+    assert fake_session.added[0].user_id == resolved_user_id


### PR DESCRIPTION
### Motivation
- Allow apps created from Slack-initiated turns to have their owner set to the Slack user who invoked the bot when `conversation.user_id` is null.

### Description
- Added `AppsConnector._resolve_user_from_external_actor(...)` to look up internal users from external actor identifiers via the `user_mappings_for_identity` table, preferring `source='slack'` and falling back to legacy `source='revtops_unknown'` rows. 
- Updated `_create(...)` owner-resolution flow to load `Conversation.source` and `Conversation.source_user_id` and call the new helper when `conversation.user_id` is missing. 
- Imported the `ExternalIdentityMapping` model and added debug/info logs for each owner-resolution path. 
- Extended `backend/tests/test_apps_connector_owner_resolution.py` with a richer fake session that simulates conversation rows and mapping lookups and added a test that validates Slack identity mapping fallback.

### Testing
- Ran `pytest -q backend/tests/test_apps_connector_owner_resolution.py` and the suite passed (`2 passed`).
- Unit tests exercise both the existing precedence (connector `user_id` → message `user_id` → conversation `user_id`) and the new external-actor mapping fallback path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e069dfcbe08321bde8f60220e5b2e8)