### PR TITLE
AppFullView: fall back to public app endpoint for /apps/:id

### DIFF
--- a/frontend/src/components/apps/AppFullView.tsx
+++ b/frontend/src/components/apps/AppFullView.tsx
@@ -23,7 +23,7 @@ interface AppDetail {
   query_names: string[];
   conversation_id: string | null;
   created_at: string | null;
-  user_id: string;
+  user_id: string | null;
   widget_config?: Record<string, unknown> | null;
   visibility: string;
 }
@@ -54,15 +54,30 @@ export function AppFullView({ appId }: AppFullViewProps): JSX.Element {
 
   const fetchApp = useCallback(async (): Promise<void> => {
     setLoading(true);
+    setError(null);
+
     const resp = await apiRequest<AppDetail>(`/apps/${appId}`);
-    if (resp.error || !resp.data) {
-      setError(resp.error ?? "Failed to load app");
-    } else {
+    if (resp.data) {
       setApp({
         ...resp.data,
         visibility: resp.data.visibility ?? "team",
       });
+      setLoading(false);
+      return;
     }
+
+    const publicResp = await apiRequest<AppDetail>(`/public/apps/${appId}`);
+    if (publicResp.data) {
+      setApp({
+        ...publicResp.data,
+        user_id: publicResp.data.user_id ?? null,
+        visibility: "public",
+      });
+      setLoading(false);
+      return;
+    }
+
+    setError(resp.error ?? publicResp.error ?? "Failed to load app");
     setLoading(false);
   }, [appId]);
 


### PR DESCRIPTION
### Motivation
- Allow the in-browser `/apps/:id` route to render public apps without forcing a redirect by tolerating unauthenticated payloads and fetching the public endpoint as a fallback.

### Description
- Make `AppDetail.user_id` nullable and update `AppFullView` to first call `apiRequest('/apps/:id')` and then fall back to `apiRequest('/public/apps/:id')` if the authenticated request fails, marking the result `visibility: "public"` when using the public endpoint.

### Testing
- Ran the frontend build with `npm --prefix /workspace/basebase/frontend run build`, which completed successfully (Vite produced non-fatal bundle/chunk warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e06a8ca9d8832195a04126031dc43c)