### PR TITLE
Adjust mobile daily summary toolbar alignment

### DIFF
--- a/frontend/src/components/DailyDigestGrid.tsx
+++ b/frontend/src/components/DailyDigestGrid.tsx
@@ -407,32 +407,32 @@ export function DailyDigestGrid({ digestDate, onDigestDateChange }: DailyDigestG
   return (
     <div className="flex flex-col gap-4">
       {/* Toolbar: date nav + search + layout toggle + actions */}
-      <div className="flex flex-col md:flex-row md:flex-wrap md:items-center md:justify-between gap-3">
-        <div className="flex items-center justify-center md:justify-start gap-2 w-full md:w-auto">
-          <button
-            type="button"
-            onClick={handlePrev}
-            className="px-2 py-1 rounded-md border border-surface-600 text-surface-300 hover:bg-surface-800 text-sm"
-            aria-label="Previous day"
-          >
-            ←
-          </button>
-          <span className="text-surface-200 text-sm font-medium min-w-[8rem] text-center">
-            {formatDisplayDate(digestDate)}
-          </span>
-          <button
-            type="button"
-            onClick={handleNext}
-            className="px-2 py-1 rounded-md border border-surface-600 text-surface-300 hover:bg-surface-800 text-sm"
-            aria-label="Next day"
-          >
-            →
-          </button>
-        </div>
+      <div className="flex flex-col gap-2.5 md:gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-1.5 sm:gap-2 w-full pr-1 flex-nowrap overflow-x-auto">
+          <div className="flex items-center justify-start gap-1.5 sm:gap-2 shrink-0">
+            <button
+              type="button"
+              onClick={handlePrev}
+              className="px-2 py-1 rounded-md border border-surface-600 text-surface-300 hover:bg-surface-800 text-sm"
+              aria-label="Previous day"
+            >
+              ←
+            </button>
+            <span className="text-surface-200 text-sm font-medium min-w-[6.5rem] sm:min-w-[8rem] text-center">
+              {formatDisplayDate(digestDate)}
+            </span>
+            <button
+              type="button"
+              onClick={handleNext}
+              className="px-2 py-1 rounded-md border border-surface-600 text-surface-300 hover:bg-surface-800 text-sm"
+              aria-label="Next day"
+            >
+              →
+            </button>
+          </div>
 
-        <div className="flex items-center flex-wrap md:flex-nowrap gap-2 w-full md:w-auto pr-1">
           {/* Search */}
-          <div className="relative">
+          <div className="relative shrink-0">
             <svg className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-surface-500 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
             </svg>
@@ -441,12 +441,12 @@ export function DailyDigestGrid({ digestDate, onDigestDateChange }: DailyDigestG
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="Search members…"
-              className="w-32 sm:w-40 pl-7 pr-2 py-1 rounded-md border border-surface-600 bg-surface-800 text-surface-200 text-xs placeholder:text-surface-500 focus:outline-none focus:border-primary-500"
+              className="w-28 sm:w-40 pl-7 pr-2 py-1 rounded-md border border-surface-600 bg-surface-800 text-surface-200 text-xs placeholder:text-surface-500 focus:outline-none focus:border-primary-500"
             />
           </div>
 
           {/* Layout toggle */}
-          <div className="flex items-center rounded-md border border-surface-600 overflow-hidden">
+          <div className="flex items-center rounded-md border border-surface-600 overflow-hidden shrink-0">
             <button
               type="button"
               onClick={() => setLayout("cards")}
@@ -466,25 +466,25 @@ export function DailyDigestGrid({ digestDate, onDigestDateChange }: DailyDigestG
               <ListIcon active={layout === "list"} />
             </button>
           </div>
+        </div>
 
-          {/* Generate / Refresh */}
-          <div className="flex items-center gap-2 w-full md:w-auto">
-            <button
-              type="button"
-              disabled={generating}
-              onClick={() => void handleGenerate()}
-              className="inline-flex items-center justify-center flex-1 md:flex-none min-w-0 md:w-auto md:min-w-[9rem] h-8 px-3 rounded-md border border-surface-600 text-xs text-surface-300 hover:text-surface-100 hover:bg-surface-800 disabled:opacity-50"
-            >
-              {generating ? "Generating…" : `Generate for ${formatDayMonth(digestDate)}`}
-            </button>
-            <button
-              type="button"
-              onClick={() => void load()}
-              className="inline-flex items-center justify-center flex-1 md:flex-none min-w-0 md:w-auto md:min-w-[9rem] h-8 px-3 rounded-md border border-primary-500/40 text-xs text-primary-400 hover:text-primary-300 hover:bg-primary-500/10"
-            >
-              Refresh
-            </button>
-          </div>
+        {/* Generate / Refresh */}
+        <div className="flex items-center gap-2 w-full md:w-auto">
+          <button
+            type="button"
+            disabled={generating}
+            onClick={() => void handleGenerate()}
+            className="inline-flex items-center justify-center flex-1 md:flex-none min-w-0 md:w-auto md:min-w-[9rem] h-8 px-3 rounded-md border border-surface-600 text-xs text-surface-300 hover:text-surface-100 hover:bg-surface-800 disabled:opacity-50"
+          >
+            {generating ? "Generating…" : `Generate for ${formatDayMonth(digestDate)}`}
+          </button>
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="inline-flex items-center justify-center flex-1 md:flex-none min-w-0 md:w-auto md:min-w-[9rem] h-8 px-3 rounded-md border border-primary-500/40 text-xs text-primary-400 hover:text-primary-300 hover:bg-primary-500/10"
+          >
+            Refresh
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- Make the Daily Summary toolbar more usable on mobile by placing the date picker at the start of the same row as the search box and layout toggle so all primary controls appear together.
- Reduce horizontal footprint of the date label and search input so the controls fit comfortably on small screens.
- Preserve desktop/MD layout and keep generate/refresh actions logically separated from the control group.

### Description
- Reworked the toolbar markup in `frontend/src/components/DailyDigestGrid.tsx` to combine date navigation, search input, and layout toggle into a single horizontally scrollable row on small screens while keeping a two-group layout on larger screens.
- Reduced date label minimum width to `min-w-[6.5rem] sm:min-w-[8rem]` and narrowed the search input to `w-28 sm:w-40` to shrink the mobile footprint.
- Added `shrink-0` and `overflow-x-auto` to relevant wrappers so controls keep intended sizing and the row can scroll if needed.
- Kept the generate/refresh buttons in a separate container to preserve desktop alignment and accessibility.

### Testing
- Ran `cd frontend && npx eslint src/components/DailyDigestGrid.tsx` and it completed successfully.
- Ran `npm --prefix frontend run lint -- frontend/src/components/DailyDigestGrid.tsx` which failed because that lint invocation pattern did not match files, unrelated to the changed file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e06c000d6483219e23f686702746c6)