### PR TITLE
Support app link previews and redirects across slug paths

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -266,7 +266,13 @@ def _public_preview_title(*, app: App | None = None, artifact: Artifact | None =
 
 @router.get("/share/apps/{app_id}", response_class=HTMLResponse)
 @share_router.get("/basebase/apps/{app_id}", response_class=HTMLResponse)
-async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLResponse:
+@share_router.get("/{org_slug}/apps/{app_id}", response_class=HTMLResponse)
+@share_router.get("/apps/{org_slug}/{app_id}", response_class=HTMLResponse)
+async def get_public_app_share_preview(
+    app_id: str,
+    request: Request,
+    org_slug: str | None = None,
+) -> HTMLResponse:
     """HTML metadata endpoint used by Slack + external scrapers for public app links."""
     try:
         app_uuid = UUID(app_id)
@@ -285,7 +291,7 @@ async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLRes
             app.visibility,
         )
 
-    logger.info("[public_preview] rendering app preview app_id=%s", app_id)
+    logger.info("[public_preview] rendering app preview app_id=%s org_slug=%s", app_id, org_slug)
     app_updated_at = app.updated_at.isoformat() if app.updated_at else "none"
     html_cache_key = f"app_preview:{app_id}:{app_updated_at}"
     cached_html = _cache_get_html(html_cache_key)
@@ -306,8 +312,9 @@ async def get_public_app_share_preview(app_id: str, request: Request) -> HTMLRes
             )
         owner = await session.scalar(select(User).where(User.id == app.user_id))
 
-    canonical_url = f"{_frontend_origin()}/basebase/apps/{app_id}"
-    redirect_url = canonical_url
+    canonical_path = request.url.path if request.url.path else f"/basebase/apps/{app_id}"
+    canonical_url = f"{_frontend_origin()}{canonical_path}"
+    redirect_url = f"{_frontend_origin()}/public/apps/{app_id}"
     image_url = f"{_public_origin(request)}/api/public/share/apps/{app_id}/snapshot.png"
     title = _public_preview_title(app=app)
     description = _public_preview_description(conversation=conversation, app=app, owner=owner)

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -78,15 +78,15 @@ def test_public_preview_description_falls_back_to_document_and_owner_email() -> 
     assert description == "Document — owner@example.com"
 
 
-def test_build_preview_html_uses_basebase_apps_redirect_url() -> None:
+def test_build_preview_html_uses_public_apps_redirect_url() -> None:
     html = build_preview_html(
         page_title="Example",
         description="Description",
         canonical_url="https://app.basebase.com/basebase/apps/abc",
         image_url="https://app.basebase.com/api/public/share/apps/abc/snapshot.png",
-        redirect_url="https://app.basebase.com/basebase/apps/abc",
+        redirect_url="https://app.basebase.com/public/apps/abc",
     )
-    assert 'window.location.replace("https://app.basebase.com/basebase/apps/abc")' in html
+    assert 'window.location.replace("https://app.basebase.com/public/apps/abc")' in html
 
 
 def test_public_preview_title_uses_app_title_when_present() -> None:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -31,6 +31,22 @@ server {
         proxy_ssl_server_name on;
     }
 
+    # Support app link previews for arbitrary org slug/middle path segment.
+    # Example: /acme/apps/<uuid>, /FOO/apps/<uuid>
+    location ~ ^/[A-Za-z0-9-]+/apps/([0-9a-fA-F-]+)/?$ {
+        rewrite ^/[A-Za-z0-9-]+/apps/([0-9a-fA-F-]+)/?$ /api/public/share/apps/$1 break;
+        proxy_pass https://api.basebase.com;
+        proxy_set_header Host api.basebase.com;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_server_name on;
+    }
+
+    # Normalize legacy /apps/<slug>/<uuid> deep links to canonical /apps/<uuid>.
+    location ~ ^/apps/[A-Za-z0-9-]+/([0-9a-fA-F-]+)/?$ {
+        return 302 /apps/$1;
+    }
+
     location ~ ^/basebase/(documents|artifacts)/([0-9a-fA-F-]+)/?$ {
         rewrite ^/basebase/(documents|artifacts)/([0-9a-fA-F-]+)/?$ /api/public/share/$1/$2 break;
         proxy_pass https://api.basebase.com;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -350,6 +350,15 @@ function App(): JSX.Element {
 
   // Handle OAuth callback route
   const path = window.location.pathname;
+
+  // Normalize legacy app route shape once: /apps/<slug>/<appId> -> /apps/<appId>.
+  const legacyAppsSlugMatch = path.match(/^\/apps\/[A-Za-z0-9-]+\/([a-f0-9-]+)$/i);
+  if (legacyAppsSlugMatch && legacyAppsSlugMatch[1]) {
+    const normalized = `/apps/${legacyAppsSlugMatch[1]}${window.location.search}${window.location.hash}`;
+    window.location.replace(normalized);
+    return null;
+  }
+
   if (path === '/auth/callback') {
     return <OAuthCallback />;
   }


### PR DESCRIPTION
### Motivation
- Unfurl/link previews should work for app URLs that include an arbitrary slug segment (e.g. `/acme/apps/<uuid>`, `/FOO/apps/<uuid>`) and legacy deep links, and the preview should redirect viewers to the canonical public app page at `/public/apps/<app_id>`.

### Description
- Updated `backend/api/routes/public.py` to accept additional share routes `/{org_slug}/apps/{app_id}` and `/apps/{org_slug}/{app_id}`, added an optional `org_slug` parameter, and logged `org_slug` in preview rendering. 
- Adjusted preview metadata to build `canonical_url` from the incoming `request.url.path` and to set `redirect_url` to `f"{_frontend_origin()}/public/apps/{app_id}"`.
- Extended `frontend/nginx.conf` to proxy `/<slug>/apps/<uuid>` requests to the public preview endpoint and added a one-time 302 normalization from `/apps/<slug>/<uuid>` to `/apps/<uuid>`.
- Added a client-side normalization in `frontend/src/App.tsx` to rewrite legacy `/apps/<slug>/<appId>` URLs to `/apps/<appId>` when Nginx rewrites are not applied. 
- Updated `backend/tests/test_public_previews.py` to expect the new `/public/apps/...` redirect target.

### Testing
- Ran `pytest -q backend/tests/test_public_previews.py` and all tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e075ac174c832197c0774ed8a17f0e)