### PR TITLE
Fix TypeScript build error in App redirect branch

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -356,7 +356,7 @@ function App(): JSX.Element {
   if (legacyAppsSlugMatch && legacyAppsSlugMatch[1]) {
     const normalized = `/apps/${legacyAppsSlugMatch[1]}${window.location.search}${window.location.hash}`;
     window.location.replace(normalized);
-    return null;
+    return <></>;
   }
 
   if (path === '/auth/callback') {


### PR DESCRIPTION
### Motivation
- Resolve the build-breaking TypeScript error caused by returning `null` from `App(): JSX.Element` in the legacy route normalization branch.

### Description
- Replace `return null;` with an empty React fragment `return <></>;` in `frontend/src/App.tsx` so the `App` component always returns a valid JSX element while keeping the `window.location.replace(...)` redirect behavior unchanged.

### Testing
- Ran `npm run build` in `frontend/` and the TypeScript/Vite build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e076e4f33483218663a534eda1408a)