### PR TITLE
Redirect org-scoped app URLs to canonical /apps/:id (fix fallback)

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -442,20 +442,20 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       ): Promise<void> => {
         const appMatchFail = subPath.match(/^apps\/([a-f0-9-]+)$/i);
         const artifactMatchFail = subPath.match(/^artifacts?\/([a-f0-9-]+)$/i);
-        if (appMatchFail?.[1] || artifactMatchFail?.[1]) {
-          const appIdFail: string | undefined = appMatchFail?.[1];
-          const artifactIdFail: string | undefined = artifactMatchFail?.[1];
-          const endpoint: string = appIdFail
-            ? `/public/apps/${appIdFail}`
-            : `/public/artifacts/${artifactIdFail!}`;
+        if (appMatchFail?.[1]) {
+          const appIdFail: string = appMatchFail[1];
+          window.location.replace(`/apps/${appIdFail}`);
+          return;
+        }
+
+        if (artifactMatchFail?.[1]) {
+          const artifactIdFail: string = artifactMatchFail[1];
+          const endpoint: string = `/public/artifacts/${artifactIdFail}`;
           const { data: publicData } = await apiRequest<Record<string, unknown>>(endpoint, {
             method: "GET",
           });
           if (publicData) {
-            const fePath: string = appIdFail
-              ? `/public/apps/${appIdFail}`
-              : `/public/artifacts/${artifactIdFail!}`;
-            window.location.replace(fePath);
+            window.location.replace(`/public/artifacts/${artifactIdFail}`);
             return;
           }
         }


### PR DESCRIPTION
### Motivation
- Fix incorrect fallback for org-scoped app links (`/:org/apps/:id`) which was redirecting users to `/public/apps/:id` instead of the canonical `/apps/:id` when org resolution/switch failed.

### Description
- Update `handleOrgAccessDenied` in `frontend/src/components/AppLayout.tsx` to detect `apps/:id` and immediately redirect to `/apps/:id` via `window.location.replace`.
- Keep artifact behavior intact by checking `GET /public/artifacts/:id` and redirecting to `/public/artifacts/:id` when the artifact is publicly available, otherwise surface the org access error UI.

### Testing
- Ran `npm run build` in `frontend/` and the build completed successfully (Vite emitted non-blocking warnings for chunk size/dynamic-imports but no errors).
- No automated unit tests were added or changed for this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e078df3aec8321a44e21644f374e26)