### PR TITLE
Prefer current turn user as app owner for AppsConnector app creation

### DIFF
--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -412,7 +412,14 @@ class AppsConnector(BaseConnector):
                     self.user_id,
                 )
 
-        if message_id:
+        if connector_user_uuid is not None:
+            user_uuid = connector_user_uuid
+            logger.info(
+                "[AppsConnector] Using current turn user context for app owner: user_id=%s",
+                connector_user_uuid,
+            )
+
+        if message_id and user_uuid is None:
             try:
                 message_uuid = UUID(message_id)
             except (ValueError, TypeError, AttributeError):
@@ -436,7 +443,7 @@ class AppsConnector(BaseConnector):
                             message_user_id,
                         )
 
-        if conversation_id:
+        if conversation_id and user_uuid is None:
             try:
                 conversation_uuid = UUID(conversation_id)
             except (ValueError, TypeError, AttributeError):
@@ -486,13 +493,6 @@ class AppsConnector(BaseConnector):
                                 conversation_source_user_id,
                                 external_actor_user_id,
                             )
-
-        if user_uuid is None and connector_user_uuid is not None:
-            user_uuid = connector_user_uuid
-            logger.info(
-                "[AppsConnector] Falling back to connector user context for app owner: user_id=%s",
-                connector_user_uuid,
-            )
 
         if not user_uuid:
             return {


### PR DESCRIPTION
### Motivation
- Ensure apps created from chat are owned by the user taking the current turn by preferring the connector `user_id` over message/conversation metadata when resolving the app owner.

### Description
- In `backend/connectors/apps.py` inside `AppsConnector._create`, set `user_uuid` from the current turn `self.user_id` (parsed as `connector_user_uuid`) before falling back to message or conversation owner resolution and add a log message to reflect this precedence.

### Testing
- Ran `python -m py_compile backend/connectors/apps.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e07c11f39c8321a2ab681ad2f2c386)