### PR TITLE
Remove app share-link unfurl nginx routes

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -17,31 +17,6 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Social unfurl support: route share links to backend-rendered Open Graph pages.
-    # Discord/Facebook crawlers don't run JS, so this bypasses the SPA shell.
-    # Keep ID matching permissive here to avoid regex quantifier parsing issues in
-    # minimal/container Nginx builds while still constraining to UUID-like chars.
-    location ~ ^/basebase/apps/([0-9a-fA-F-]+)/?$ {
-        # Route through versioned public preview endpoint; some API gateways only expose /api/*.
-        rewrite ^/basebase/apps/([0-9a-fA-F-]+)/?$ /api/public/share/apps/$1 break;
-        proxy_pass https://api.basebase.com;
-        proxy_set_header Host api.basebase.com;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_ssl_server_name on;
-    }
-
-    # Support app link previews for arbitrary org slug/middle path segment.
-    # Example: /acme/apps/<uuid>, /FOO/apps/<uuid>
-    location ~ ^/[A-Za-z0-9-]+/apps/([0-9a-fA-F-]+)/?$ {
-        rewrite ^/[A-Za-z0-9-]+/apps/([0-9a-fA-F-]+)/?$ /api/public/share/apps/$1 break;
-        proxy_pass https://api.basebase.com;
-        proxy_set_header Host api.basebase.com;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_ssl_server_name on;
-    }
-
     # Normalize legacy /apps/<slug>/<uuid> deep links to canonical /apps/<uuid>.
     location ~ ^/apps/[A-Za-z0-9-]+/([0-9a-fA-F-]+)/?$ {
         return 302 /apps/$1;


### PR DESCRIPTION
### Motivation
- Remove frontend Nginx proxy rules that routed social unfurl/app share links to the API to simplify the config and stop special-casing `/basebase/apps/<id>` and `/<org>/apps/<id>` deep links.

### Description
- Deleted the two `location` blocks in `frontend/nginx.conf` that rewrote and proxied `/basebase/apps/([0-9a-fA-F-]+)` and `/[A-Za-z0-9-]+/apps/([0-9a-fA-F-]+)` to `/api/public/share/apps/$1` on `https://api.basebase.com`, leaving all other routing and proxy behavior unchanged.

### Testing
- Searched the repository and reviewed the resulting `frontend/nginx.conf` diff to confirm only the targeted location blocks were removed and that SPA routing, document/artifact share proxying, OG snapshot proxying, static asset caching, and security headers remain intact; verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e07d430d8c83219a5f19f53215ec1e)