### PR TITLE
Add app unfurl support for /apps/{app_id} links

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -265,6 +265,7 @@ def _public_preview_title(*, app: App | None = None, artifact: Artifact | None =
 
 
 @router.get("/share/apps/{app_id}", response_class=HTMLResponse)
+@share_router.get("/apps/{app_id}", response_class=HTMLResponse)
 @share_router.get("/basebase/apps/{app_id}", response_class=HTMLResponse)
 @share_router.get("/{org_slug}/apps/{app_id}", response_class=HTMLResponse)
 @share_router.get("/apps/{org_slug}/{app_id}", response_class=HTMLResponse)

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -89,6 +89,18 @@ def test_build_preview_html_uses_public_apps_redirect_url() -> None:
     assert 'window.location.replace("https://app.basebase.com/public/apps/abc")' in html
 
 
+def test_build_preview_html_supports_direct_apps_path_links() -> None:
+    html = build_preview_html(
+        page_title="Example",
+        description="Description",
+        canonical_url="https://app.basebase.com/apps/abc",
+        image_url="https://app.basebase.com/api/public/share/apps/abc/snapshot.png",
+        redirect_url="https://app.basebase.com/public/apps/abc",
+    )
+    assert 'property="og:url" content="https://app.basebase.com/apps/abc"' in html
+    assert 'window.location.replace("https://app.basebase.com/public/apps/abc")' in html
+
+
 def test_public_preview_title_uses_app_title_when_present() -> None:
     title = _public_preview_title(app=SimpleNamespace(title="Revenue Tracker"))
     assert title == "Revenue Tracker · Basebase"


### PR DESCRIPTION
### Motivation
- Support unfurl/link previews for direct app URLs like `https://app.basebase.com/apps/{app_id}` so external scrapers and chat platforms receive OG/Twitter metadata even when the org slug is omitted.

### Description
- Register a new share route `@share_router.get("/apps/{app_id}")` on the existing `get_public_app_share_preview` handler in `backend/api/routes/public.py` and add a test in `backend/tests/test_public_previews.py` asserting `og:url` and redirect behavior for the direct `/apps/{app_id}` canonical path.

### Testing
- Ran `pytest -q backend/tests/test_public_previews.py` and the suite passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e07e39afc08321904a49691b73d924)