### PR TITLE
Support OG unfurl for /apps/<uuid> links (nginx + backend share route)

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -265,6 +265,7 @@ def _public_preview_title(*, app: App | None = None, artifact: Artifact | None =
 
 
 @router.get("/share/apps/{app_id}", response_class=HTMLResponse)
+@share_router.get("/apps/{app_id}", response_class=HTMLResponse)
 @share_router.get("/basebase/apps/{app_id}", response_class=HTMLResponse)
 @share_router.get("/{org_slug}/apps/{app_id}", response_class=HTMLResponse)
 @share_router.get("/apps/{org_slug}/{app_id}", response_class=HTMLResponse)

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -10,6 +10,7 @@ from api.routes.public import (
     _public_origin,
     _public_preview_description,
     _public_preview_title,
+    share_router,
 )
 from services.public_previews import build_preview_html, decode_data_url_image, render_card_png
 
@@ -124,3 +125,8 @@ def test_is_unfurlable_visibility_allows_known_levels() -> None:
     assert _is_unfurlable_visibility("private")
     assert not _is_unfurlable_visibility(None)
     assert not _is_unfurlable_visibility("archived")
+
+
+def test_share_router_supports_apps_uuid_path_for_unfurl_links() -> None:
+    route_paths = {route.path for route in share_router.routes}
+    assert "/apps/{app_id}" in route_paths

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -23,9 +23,10 @@ server {
     }
 
     # Route app deep links to API-based OG preview metadata for link unfurl bots only.
+    # Includes common social crawlers and Google/Gmail fetchers (GoogleImageProxy).
     location ~ ^/(?:basebase/apps|apps|[A-Za-z0-9-]+/apps)/([0-9a-fA-F-]+)/?$ {
         set $preview_bot 0;
-        if ($http_user_agent ~* "(Slackbot|Discordbot|Twitterbot|facebookexternalhit|LinkedInBot|WhatsApp|TelegramBot|bot|crawler|spider)") {
+        if ($http_user_agent ~* "(Slackbot|Discordbot|Twitterbot|facebookexternalhit|LinkedInBot|WhatsApp|TelegramBot|GoogleImageProxy|APIs-Google|Googlebot|bot|crawler|spider)") {
             set $preview_bot 1;
         }
         if ($preview_bot = 1) {

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -22,6 +22,23 @@ server {
         return 302 /apps/$1;
     }
 
+    # Route app deep links to API-based OG preview metadata for link unfurl bots only.
+    location ~ ^/(?:basebase/apps|apps|[A-Za-z0-9-]+/apps)/([0-9a-fA-F-]+)/?$ {
+        set $preview_bot 0;
+        if ($http_user_agent ~* "(Slackbot|Discordbot|Twitterbot|facebookexternalhit|LinkedInBot|WhatsApp|TelegramBot|bot|crawler|spider)") {
+            set $preview_bot 1;
+        }
+        if ($preview_bot = 1) {
+            proxy_pass https://api.basebase.com$request_uri;
+            proxy_set_header Host api.basebase.com;
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_ssl_server_name on;
+            break;
+        }
+        try_files $uri $uri/ /index.html;
+    }
+
     location ~ ^/basebase/(documents|artifacts)/([0-9a-fA-F-]+)/?$ {
         rewrite ^/basebase/(documents|artifacts)/([0-9a-fA-F-]+)/?$ /api/public/share/$1/$2 break;
         proxy_pass https://api.basebase.com;


### PR DESCRIPTION
### Motivation
- Ensure link previews (Open Graph metadata and snapshot images) work for app links in the shapes `https://app.basebase.com/apps/<id>`, `https://app.basebase.com/basebase/apps/<id>`, and `https://app.basebase.com/<org_slug>/apps/<id>` so external crawlers/unfurlers show rich previews even when pages are normally behind auth.

### Description
- Add a share route handler for the unscoped path `@share_router.get("/apps/{app_id}")` so the backend can serve OG preview HTML for app links without an org slug (`backend/api/routes/public.py`).
- Update `frontend/nginx.conf` with a location block matching `/basebase/apps`, `/apps`, and `/<slug>/apps` deep links that inspects common crawler user agents and proxies those requests to the API (`https://api.basebase.com$request_uri`) to return OG metadata while still serving the SPA for normal users.
- Add a regression test that imports `share_router` and asserts the route `"/apps/{app_id}"` is registered to protect against accidental removal (`backend/tests/test_public_previews.py`).

### Testing
- Ran `pytest -q backend/tests/test_public_previews.py` and all tests passed (`13 passed`).
- Attempted `nginx -t -c /workspace/basebase/frontend/nginx.conf` but the `nginx` binary is not present in the container so the config syntax check could not be executed there.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e07e39afc08321904a49691b73d924)