### PR TITLE
Fix invalid proxy directives inside bot preview location

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -25,19 +25,18 @@ server {
     # Route app deep links to API-based OG preview metadata for link unfurl bots only.
     # Includes common social crawlers and Google/Gmail fetchers (GoogleImageProxy).
     location ~ ^/(?:basebase/apps|apps|[A-Za-z0-9-]+/apps)/([0-9a-fA-F-]+)/?$ {
-        set $preview_bot 0;
         if ($http_user_agent ~* "(Slackbot|Discordbot|Twitterbot|facebookexternalhit|LinkedInBot|WhatsApp|TelegramBot|GoogleImageProxy|APIs-Google|Googlebot|bot|crawler|spider)") {
-            set $preview_bot 1;
-        }
-        if ($preview_bot = 1) {
-            proxy_pass https://api.basebase.com$request_uri;
-            proxy_set_header Host api.basebase.com;
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_ssl_server_name on;
-            break;
+            return 418;
         }
         try_files $uri $uri/ /index.html;
+    }
+    error_page 418 = @og_preview_proxy;
+    location @og_preview_proxy {
+        proxy_pass https://api.basebase.com$request_uri;
+        proxy_set_header Host api.basebase.com;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_ssl_server_name on;
     }
 
     location ~ ^/basebase/(documents|artifacts)/([0-9a-fA-F-]+)/?$ {


### PR DESCRIPTION
### Motivation
- Nginx rejected `proxy_set_header` directives when they were placed inside an `if` block, causing startup failure with the error `"proxy_set_header" directive is not allowed here`.
- Ensure bot user agents requesting OG preview metadata are still proxied to the API while keeping SPA routing for regular users.

### Description
- Update `frontend/nginx.conf` to remove `proxy_set_header` directives from the `if` block and replace the bot UA branch with `return 418`.
- Add `error_page 418 = @og_preview_proxy` and a named location `@og_preview_proxy` that performs the `proxy_pass` and sets `proxy_set_header` directives safely.
- Preserve existing SPA behavior by keeping `try_files $uri $uri/ /index.html` for non-bot requests.

### Testing
- Ran `nginx -t -c $(pwd)/frontend/nginx.conf` to validate the configuration, but the test could not run because the `nginx` binary is not installed in this environment (failed).
- Ran `docker --version` to check for containerized validation tooling, but `docker` is not installed in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e080b7cb7c83219cd8ddba340816de)