### PR TITLE
Prioritize conversation owner when creating apps

### DIFF
--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -420,38 +420,7 @@ class AppsConnector(BaseConnector):
                     self.user_id,
                 )
 
-        if connector_user_uuid is not None:
-            user_uuid = connector_user_uuid
-            logger.info(
-                "[AppsConnector] Using current turn user context for app owner: user_id=%s",
-                connector_user_uuid,
-            )
-
-        if message_id and user_uuid is None:
-            try:
-                message_uuid = UUID(message_id)
-            except (ValueError, TypeError, AttributeError):
-                logger.warning(
-                    "[AppsConnector] Could not parse message_id as UUID for owner resolution fallback: message_id=%s",
-                    message_id,
-                )
-            else:
-                async with get_session(organization_id=self.organization_id) as session:
-                    row = await session.execute(
-                        select(ChatMessage.user_id).where(
-                            ChatMessage.id == message_uuid,
-                        )
-                    )
-                    message_user_id: UUID | None = row.scalar_one_or_none()
-                    if message_user_id is not None and user_uuid is None:
-                        user_uuid = message_user_id
-                        logger.info(
-                            "[AppsConnector] Resolved app owner from initiating message: message_id=%s user_id=%s",
-                            message_id,
-                            message_user_id,
-                        )
-
-        if conversation_id and user_uuid is None:
+        if conversation_id:
             try:
                 conversation_uuid = UUID(conversation_id)
             except (ValueError, TypeError, AttributeError):
@@ -480,14 +449,20 @@ class AppsConnector(BaseConnector):
                             conversation_source,
                             conversation_source_user_id,
                         ) = conversation_record
-                    if conversation_user_id is not None and user_uuid is None:
+                    if conversation_user_id is not None:
                         user_uuid = conversation_user_id
                         logger.info(
-                            "[AppsConnector] Resolved app owner from conversation owner fallback: conversation_id=%s user_id=%s",
+                            "[AppsConnector] Resolved app owner from conversation owner: conversation_id=%s user_id=%s",
                             conversation_id,
                             conversation_user_id,
                         )
-                    elif user_uuid is None:
+                        if connector_user_uuid is not None and connector_user_uuid != conversation_user_id:
+                            logger.info(
+                                "[AppsConnector] Conversation owner overrides connector user for app owner: conversation_owner_id=%s connector_user_id=%s",
+                                conversation_user_id,
+                                connector_user_uuid,
+                            )
+                    else:
                         external_actor_user_id: UUID | None = await self._resolve_user_from_external_actor(
                             source=conversation_source,
                             external_user_id=conversation_source_user_id,
@@ -501,6 +476,37 @@ class AppsConnector(BaseConnector):
                                 conversation_source_user_id,
                                 external_actor_user_id,
                             )
+
+        if message_id and user_uuid is None:
+            try:
+                message_uuid = UUID(message_id)
+            except (ValueError, TypeError, AttributeError):
+                logger.warning(
+                    "[AppsConnector] Could not parse message_id as UUID for owner resolution fallback: message_id=%s",
+                    message_id,
+                )
+            else:
+                async with get_session(organization_id=self.organization_id) as session:
+                    row = await session.execute(
+                        select(ChatMessage.user_id).where(
+                            ChatMessage.id == message_uuid,
+                        )
+                    )
+                    message_user_id: UUID | None = row.scalar_one_or_none()
+                    if message_user_id is not None and user_uuid is None:
+                        user_uuid = message_user_id
+                        logger.info(
+                            "[AppsConnector] Resolved app owner from initiating message: message_id=%s user_id=%s",
+                            message_id,
+                            message_user_id,
+                        )
+
+        if connector_user_uuid is not None and user_uuid is None:
+            user_uuid = connector_user_uuid
+            logger.info(
+                "[AppsConnector] Using current turn user context for app owner fallback: user_id=%s",
+                connector_user_uuid,
+            )
 
         if not user_uuid:
             logger.warning(

--- a/backend/tests/test_apps_connector_owner_resolution.py
+++ b/backend/tests/test_apps_connector_owner_resolution.py
@@ -86,7 +86,7 @@ class _FakeSession:
         self.committed = True
 
 
-def test_create_prefers_message_user_over_turn_user_and_conversation_owner(monkeypatch):
+def test_create_prefers_conversation_owner_over_turn_user_and_message_user(monkeypatch):
     org_id = "00000000-0000-0000-0000-000000000010"
     turn_user_id = "00000000-0000-0000-0000-000000000011"
     message_user_id = UUID("00000000-0000-0000-0000-000000000012")
@@ -134,7 +134,7 @@ def test_create_prefers_message_user_over_turn_user_and_conversation_owner(monke
     assert result["status"] == "success"
     assert fake_session.committed is True
     assert len(fake_session.added) == 1
-    assert fake_session.added[0].user_id == message_user_id
+    assert fake_session.added[0].user_id == conversation_user_id
 
 
 def test_create_resolves_owner_from_slack_identity_mapping_when_conversation_user_missing(monkeypatch):


### PR DESCRIPTION
### Motivation
- Ensure app creations use the identity of the conversation owner when possible so apps created from a conversation are attributed to that conversation's owner rather than the connector user.
- This aligns ownership semantics with conversation-origin and external-actor mappings for more accurate attribution.
- Improve observability when connector and conversation owners differ to aid debugging.

### Description
- Reordered owner-resolution in `AppsConnector._create` (`backend/connectors/apps.py`) to check the `conversation` owner and conversation external-actor mapping before falling back to the initiating `message` user and lastly the connector `user_id`.
- Added an info log when a conversation owner is found that overrides a non-matching connector user (`[AppsConnector] Conversation owner overrides connector user for app owner: ...`).
- Updated the unit test `backend/tests/test_apps_connector_owner_resolution.py` to assert that the conversation owner is preferred over turn/message user contexts.

### Testing
- Ran `pytest -q backend/tests/test_apps_connector_owner_resolution.py` and all tests passed (`2 passed`).
- The modified owner-resolution logic is covered by the updated tests verifying conversation-owner precedence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e086da8e6c83218a982354a8e80a07)