### PR TITLE
Apps connector: support explicit app owner override

### DIFF
--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -401,17 +401,38 @@ class AppsConnector(BaseConnector):
         conversation_id: str | None = data.get("conversation_id")
         user_uuid: UUID | None = None
         conversation_uuid: UUID | None = None
+        owner_override_raw: Any = data.get(" app created by")
+        owner_override_id: str | None = None
+        if owner_override_raw is not None:
+            owner_override_id = str(owner_override_raw).strip()
+            if not owner_override_id:
+                owner_override_id = None
 
         logger.info(
-            "[AppsConnector] Creating app with ownership context: org_id=%s message_id=%s conversation_id=%s connector_user_id=%s",
+            "[AppsConnector] Creating app with ownership context: org_id=%s message_id=%s conversation_id=%s connector_user_id=%s owner_override_present=%s",
             self.organization_id,
             message_id,
             conversation_id,
             self.user_id,
+            bool(owner_override_id),
         )
 
+        if owner_override_id:
+            try:
+                user_uuid = UUID(owner_override_id)
+                logger.info(
+                    "[AppsConnector] Using explicit app owner override from request payload: user_id=%s",
+                    user_uuid,
+                )
+            except (ValueError, TypeError, AttributeError):
+                logger.warning(
+                    "[AppsConnector] Invalid app owner override provided; expected UUID: override_value=%s",
+                    owner_override_raw,
+                )
+                return {"error": "Invalid ' app created by' value: must be a valid UUID string"}
+
         connector_user_uuid: UUID | None = None
-        if self.user_id:
+        if self.user_id and user_uuid is None:
             try:
                 connector_user_uuid = UUID(self.user_id)
             except (ValueError, TypeError, AttributeError):
@@ -420,7 +441,7 @@ class AppsConnector(BaseConnector):
                     self.user_id,
                 )
 
-        if conversation_id:
+        if conversation_id and user_uuid is None:
             try:
                 conversation_uuid = UUID(conversation_id)
             except (ValueError, TypeError, AttributeError):

--- a/backend/tests/test_apps_connector_owner_resolution.py
+++ b/backend/tests/test_apps_connector_owner_resolution.py
@@ -187,3 +187,92 @@ def test_create_resolves_owner_from_slack_identity_mapping_when_conversation_use
     assert fake_session.committed is True
     assert len(fake_session.added) == 1
     assert fake_session.added[0].user_id == resolved_user_id
+
+
+def test_create_uses_explicit_owner_override_before_other_context(monkeypatch):
+    org_id = "00000000-0000-0000-0000-000000000010"
+    override_user_id = "00000000-0000-0000-0000-000000000021"
+    turn_user_id = "00000000-0000-0000-0000-000000000011"
+    message_user_id = UUID("00000000-0000-0000-0000-000000000012")
+    conversation_user_id = UUID("00000000-0000-0000-0000-000000000013")
+    fake_session = _FakeSession(
+        message_user_id=message_user_id,
+        conversation_user_id=conversation_user_id,
+    )
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        yield fake_session
+
+    async def _fake_warm(*_args, **_kwargs):
+        return None
+
+    async def _fake_test_execute_queries(*_args, **_kwargs):
+        return []
+
+    async def _fake_alternate(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr("connectors.apps.get_session", _fake_get_session)
+    monkeypatch.setattr("connectors.apps.warm_public_preview_cache", _fake_warm)
+    monkeypatch.setattr("connectors.apps.get_alternate_slack_user_ids_for_identity", _fake_alternate)
+    monkeypatch.setattr("utils.transpile_jsx.transpile_jsx", lambda _code: (None,))
+    monkeypatch.setattr("connectors.apps.AppsConnector._test_execute_queries", _fake_test_execute_queries)
+
+    connector = AppsConnector(organization_id=org_id, user_id=turn_user_id)
+
+    result = asyncio.run(
+        connector._create(
+            {
+                "title": "Override-owned app",
+                "queries": {
+                    "q": {"sql": "SELECT 1 AS n", "params": {}},
+                },
+                "frontend_code": "export default function App(){ return <div/>; }",
+                " app created by": override_user_id,
+                "message_id": "00000000-0000-0000-0000-000000000014",
+                "conversation_id": "00000000-0000-0000-0000-000000000015",
+            }
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_session.committed is True
+    assert len(fake_session.added) == 1
+    assert fake_session.added[0].user_id == UUID(override_user_id)
+
+
+def test_create_rejects_invalid_explicit_owner_override(monkeypatch):
+    org_id = "00000000-0000-0000-0000-000000000010"
+    fake_session = _FakeSession(
+        message_user_id=None,
+        conversation_user_id=None,
+    )
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        yield fake_session
+
+    async def _fake_test_execute_queries(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr("connectors.apps.get_session", _fake_get_session)
+    monkeypatch.setattr("connectors.apps.AppsConnector._test_execute_queries", _fake_test_execute_queries)
+
+    connector = AppsConnector(organization_id=org_id, user_id=None)
+
+    result = asyncio.run(
+        connector._create(
+            {
+                "title": "Invalid override app",
+                "queries": {
+                    "q": {"sql": "SELECT 1 AS n", "params": {}},
+                },
+                "frontend_code": "export default function App(){ return <div/>; }",
+                " app created by": "not-a-uuid",
+            }
+        )
+    )
+
+    assert "error" in result
+    assert "app created by" in result["error"]


### PR DESCRIPTION
### Motivation
- Allow callers to explicitly set the app owner when creating an app by providing an override payload field, so automated or external flows can assign ownership deterministically.
- The explicit override should take precedence over existing owner resolution paths (conversation owner, Slack mapping, message user, connector turn user) to avoid ambiguity.

### Description
- Added support in `AppsConnector._create` to read an optional payload field named `" app created by"` and treat it as a UUID owner override if present and valid.
- The override is validated and, when valid, assigned to the new app as the owner before any other resolution logic; an invalid value returns an error explaining the expected UUID format.
- Added logging for `owner_override_present` and for when the explicit override is used or rejected.
- Updated tests in `backend/tests/test_apps_connector_owner_resolution.py` to cover successful override precedence and invalid-override rejection (two new tests), and adjusted mocks as needed.

### Testing
- Ran `pytest -q backend/tests/test_apps_connector_owner_resolution.py` and all tests passed (`4 passed`), covering the new override behavior and existing owner-resolution cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e088d19fd48321bf46c77e0924b658)