### PR TITLE
Daily Summary: display Generate button date as mm/dd

### DIFF
--- a/frontend/src/components/DailyDigestGrid.tsx
+++ b/frontend/src/components/DailyDigestGrid.tsx
@@ -47,7 +47,7 @@ function formatDisplayDate(isoDate: string): string {
 function formatDayMonth(isoDate: string): string {
   const [, mm, dd] = isoDate.split("-");
   if (!mm || !dd) return isoDate;
-  return `${dd}/${mm}`;
+  return `${mm}/${dd}`;
 }
 
 function getNarrative(summary: DigestSummaryJson | null): string {


### PR DESCRIPTION
### Motivation
- Ensure the Daily Summary "Generate" button shows dates in `mm/dd` (US) order instead of `dd/mm` to match the expected display format.

### Description
- Update `formatDayMonth` in `frontend/src/components/DailyDigestGrid.tsx` to return `${mm}/${dd}` instead of `${dd}/${mm}`; no backend or database changes were made.

### Testing
- Ran frontend linter via `npm --prefix frontend run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08a53248483218eb963f63b83b8ae)