### PR TITLE
Artifact OG preview: use first 80 chars of document content

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -236,6 +236,11 @@ def _public_preview_description(
     owner: User | None,
 ) -> str:
     """Build a concise public description for social preview unfurls."""
+    if artifact:
+        artifact_document_text = " ".join((artifact.content or "").split())
+        if artifact_document_text:
+            return artifact_document_text[:80]
+
     owner_label = _owner_label(owner)
     app_description = (getattr(app, "description", None) or "").strip() if app else ""
     if app_description:

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -73,10 +73,23 @@ def test_public_preview_description_prefers_app_description_with_owner() -> None
 def test_public_preview_description_falls_back_to_document_and_owner_email() -> None:
     description = _public_preview_description(
         conversation=None,
-        artifact=SimpleNamespace(title=None),
+        artifact=SimpleNamespace(title=None, content=None),
         owner=SimpleNamespace(name=None, email="owner@example.com"),
     )
     assert description == "Document — owner@example.com"
+
+
+def test_public_preview_description_uses_first_80_chars_of_artifact_content() -> None:
+    content = (
+        "This is a shared artifact document body with enough characters to verify truncation occurs "
+        "at exactly eighty characters."
+    )
+    description = _public_preview_description(
+        conversation=None,
+        artifact=SimpleNamespace(title="Doc", content=content),
+        owner=SimpleNamespace(name="Alex", email="alex@example.com"),
+    )
+    assert description == content[:80]
 
 
 def test_build_preview_html_uses_public_apps_redirect_url() -> None:


### PR DESCRIPTION
### Motivation
- Open Graph/Twitter unfurls for shared artifacts should surface the document body instead of generic fallbacks when content exists.  
- The preview description should be concise and deterministic, using the first 80 characters of the artifact content.

### Description
- Added a fast-path in `_public_preview_description` to normalize whitespace from `artifact.content` and return its first 80 characters when present in `backend/api/routes/public.py`.
- The previous fallback chain (app description, conversation title, artifact title, owner label) is preserved for artifacts without content.  
- Updated `backend/tests/test_public_previews.py` to explicitly include `content=None` for the existing document-fallback test and added a test asserting the new 80-character truncation behavior.

### Testing
- Ran `pytest -q backend/tests/test_public_previews.py` and observed all tests passed.  
- Test run result: `14 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08b2e52c48321a59a7dbef293b80f)