### PR TITLE
Support OG unfurls for slugged artifact deep links

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -398,9 +398,16 @@ async def get_public_app_share_snapshot(app_id: str) -> Response:
 
 
 @router.get("/share/artifacts/{artifact_id}", response_class=HTMLResponse)
+@share_router.get("/artifacts/{artifact_id}", response_class=HTMLResponse)
 @share_router.get("/basebase/documents/{artifact_id}", response_class=HTMLResponse)
 @share_router.get("/basebase/artifacts/{artifact_id}", response_class=HTMLResponse)
-async def get_public_artifact_share_preview(artifact_id: str, request: Request) -> HTMLResponse:
+@share_router.get("/{org_slug}/artifacts/{artifact_id}", response_class=HTMLResponse)
+@share_router.get("/artifacts/{org_slug}/{artifact_id}", response_class=HTMLResponse)
+async def get_public_artifact_share_preview(
+    artifact_id: str,
+    request: Request,
+    org_slug: str | None = None,
+) -> HTMLResponse:
     """HTML metadata endpoint used by Slack + external scrapers for public artifact links."""
     try:
         artifact_uuid = UUID(artifact_id)
@@ -419,7 +426,11 @@ async def get_public_artifact_share_preview(artifact_id: str, request: Request) 
             artifact.visibility,
         )
 
-    logger.info("[public_preview] rendering artifact preview artifact_id=%s", artifact_id)
+    logger.info(
+        "[public_preview] rendering artifact preview artifact_id=%s org_slug=%s",
+        artifact_id,
+        org_slug,
+    )
     artifact_version = ":".join(
         [
             str(artifact.created_at.isoformat() if artifact.created_at else "none"),
@@ -447,7 +458,8 @@ async def get_public_artifact_share_preview(artifact_id: str, request: Request) 
         if artifact.user_id:
             owner = await session.scalar(select(User).where(User.id == artifact.user_id))
 
-    canonical_url = f"{_frontend_origin()}/basebase/documents/{artifact_id}"
+    canonical_path = request.url.path if request.url.path else f"/basebase/artifacts/{artifact_id}"
+    canonical_url = f"{_frontend_origin()}{canonical_path}"
     redirect_url = f"{_frontend_origin()}/public/artifacts/{artifact_id}"
     image_url = f"{_public_origin(request)}/api/public/share/artifacts/{artifact_id}/snapshot.png"
     title = _public_preview_title(artifact=artifact)

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -130,3 +130,10 @@ def test_is_unfurlable_visibility_allows_known_levels() -> None:
 def test_share_router_supports_apps_uuid_path_for_unfurl_links() -> None:
     route_paths = {route.path for route in share_router.routes}
     assert "/apps/{app_id}" in route_paths
+
+
+def test_share_router_supports_artifact_paths_for_unfurl_links() -> None:
+    route_paths = {route.path for route in share_router.routes}
+    assert "/artifacts/{artifact_id}" in route_paths
+    assert "/{org_slug}/artifacts/{artifact_id}" in route_paths
+    assert "/artifacts/{org_slug}/{artifact_id}" in route_paths

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -22,9 +22,15 @@ server {
         return 302 /apps/$1;
     }
 
-    # Route app deep links to API-based OG preview metadata for link unfurl bots only.
+
+    # Normalize legacy /artifacts/<slug>/<uuid> deep links to canonical /artifacts/<uuid>.
+    location ~ ^/artifacts/[A-Za-z0-9-]+/([0-9a-fA-F-]+)/?$ {
+        return 302 /artifacts/$1;
+    }
+
+    # Route app + artifact deep links to API-based OG preview metadata for link unfurl bots only.
     # Includes common social crawlers and Google/Gmail fetchers (GoogleImageProxy).
-    location ~ ^/(?:basebase/apps|apps|[A-Za-z0-9-]+/apps)/([0-9a-fA-F-]+)/?$ {
+    location ~ ^/(?:basebase/apps|apps|[A-Za-z0-9-]+/apps|basebase/artifacts|artifacts|[A-Za-z0-9-]+/artifacts)/([0-9a-fA-F-]+)/?$ {
         if ($http_user_agent ~* "(Slackbot|Discordbot|Twitterbot|facebookexternalhit|LinkedInBot|WhatsApp|TelegramBot|GoogleImageProxy|APIs-Google|Googlebot|bot|crawler|spider)") {
             return 418;
         }


### PR DESCRIPTION
### Motivation
- Enable link preview (OG) unfurls for artifact URLs that may include an org slug or legacy slug segment so social crawlers and chat apps get rich metadata even when the full frontend page is behind auth or uses a different path shape.

### Description
- Add artifact share-preview routes on `share_router` to support `/artifacts/{artifact_id}`, `/{org_slug}/artifacts/{artifact_id}`, and `/artifacts/{org_slug}/{artifact_id}` alongside existing `/basebase/...` paths.
- Preserve incoming request path when building artifact canonical URLs and log the `org_slug` to match app preview behavior.
- Extend `frontend/nginx.conf` deep-link handling to include artifact routes and add legacy slug normalization from `/artifacts/<slug>/<uuid>` → `/artifacts/<uuid>`, and include artifacts in the bot-only OG proxy routing.
- Add test assertions in `backend/tests/test_public_previews.py` to verify the artifact share routes are registered on `share_router`.

### Testing
- Ran `pytest -q backend/tests/test_public_previews.py` which passed (`14 passed`).
- Attempted `nginx -t -c $(pwd)/frontend/nginx.conf` but the `nginx` binary is not available in this environment so config validation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e08ca168a483218dfc81094f49a574)