### PR TITLE
Pass conversation owner into apps.create override owner context

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -1053,6 +1053,18 @@ async def _write_on_connector(
             data["conversation_id"] = ctx_apps["conversation_id"]
         if ctx_apps.get("message_id"):
             data["message_id"] = str(ctx_apps["message_id"]) if ctx_apps["message_id"] else None
+        if operation == "create" and not data.get(" app created by"):
+            conversation_owner_id = await _resolve_conversation_owner_user_id(
+                organization_id=organization_id,
+                conversation_id=ctx_apps.get("conversation_id"),
+            )
+            if conversation_owner_id:
+                data[" app created by"] = conversation_owner_id
+                logger.info(
+                    "[Tools] write_on_connector(apps.create): passing conversation owner as app override owner: conversation_id=%s owner_user_id=%s",
+                    ctx_apps.get("conversation_id"),
+                    conversation_owner_id,
+                )
     if connector == "linear":
         ctx_linear: dict[str, Any] = context or {}
         if ctx_linear.get("conversation_id"):
@@ -1098,6 +1110,37 @@ async def _write_on_connector(
             {"error": f"Write to {connector}.{operation} failed: {exc}"},
             connector, organization_id,
         )
+
+
+async def _resolve_conversation_owner_user_id(
+    organization_id: str,
+    conversation_id: Any,
+) -> str | None:
+    """Resolve conversation.user_id as a string UUID for connector ownership context."""
+    if not conversation_id:
+        return None
+
+    conversation_id_str: str = str(conversation_id).strip()
+    if not conversation_id_str:
+        return None
+
+    try:
+        conversation_uuid: UUID = UUID(conversation_id_str)
+    except (ValueError, TypeError, AttributeError):
+        logger.warning(
+            "[Tools] Could not parse conversation_id as UUID for owner lookup: conversation_id=%s",
+            conversation_id,
+        )
+        return None
+
+    async with get_session(organization_id=organization_id) as session:
+        row = await session.execute(
+            select(Conversation.user_id).where(Conversation.id == conversation_uuid)
+        )
+        owner_user_id: UUID | None = row.scalar_one_or_none()
+        if owner_user_id is None:
+            return None
+        return str(owner_user_id)
 
 
 async def _run_on_connector(

--- a/backend/tests/test_tools_write_to_system_of_record.py
+++ b/backend/tests/test_tools_write_to_system_of_record.py
@@ -59,3 +59,56 @@ def test_write_on_connector_routes_to_dispatcher(monkeypatch) -> None:
     assert called["user_id"] == "00000000-0000-0000-0000-000000000002"
     assert called["skip_approval"] is True
     assert called["context"] == {"conversation_id": "00000000-0000-0000-0000-000000000003"}
+
+
+def test_write_on_connector_apps_create_passes_conversation_owner_as_override(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeConnector:
+        async def write(self, operation: str, data: dict[str, object]) -> dict[str, object]:
+            captured["operation"] = operation
+            captured["data"] = data
+            return {"status": "success"}
+
+    async def _fake_check_connector_call(*_args, **_kwargs):
+        class _Allowed:
+            allowed = True
+            deny_reason = None
+        return _Allowed()
+
+    async def _fake_get_connector_instance(*_args, **_kwargs):
+        return _FakeConnector(), None
+
+    async def _fake_record_intent(*_args, **_kwargs):
+        return "change-1"
+
+    async def _fake_record_outcome(*_args, **_kwargs):
+        return None
+
+    async def _fake_resolve_conversation_owner_user_id(*_args, **_kwargs):
+        return "00000000-0000-0000-0000-000000000099"
+
+    monkeypatch.setattr(tools, "check_connector_call", _fake_check_connector_call)
+    monkeypatch.setattr(tools, "_get_connector_instance", _fake_get_connector_instance)
+    monkeypatch.setattr(tools, "_resolve_conversation_owner_user_id", _fake_resolve_conversation_owner_user_id)
+    monkeypatch.setattr("services.action_ledger.record_intent", _fake_record_intent)
+    monkeypatch.setattr("services.action_ledger.record_outcome", _fake_record_outcome)
+
+    result = asyncio.run(
+        tools._write_on_connector(
+            params={
+                "connector": "apps",
+                "operation": "create",
+                "data": {"title": "Demo", "queries": {"q": {"sql": "SELECT 1", "params": {}}}, "frontend_code": "x"},
+            },
+            organization_id="00000000-0000-0000-0000-000000000001",
+            user_id="00000000-0000-0000-0000-000000000002",
+            skip_approval=True,
+            context={"conversation_id": "00000000-0000-0000-0000-000000000003"},
+        )
+    )
+
+    assert result["status"] == "success"
+    assert captured["operation"] == "create"
+    assert isinstance(captured["data"], dict)
+    assert captured["data"][" app created by"] == "00000000-0000-0000-0000-000000000099"  # type: ignore[index]


### PR DESCRIPTION
### Motivation

- Ensure apps created by agents/tools running in a conversation inherit the conversation owner as the app owner when no explicit override is provided.
- Preserve existing explicit owner override behavior so manual overrides still take precedence.
- Reduce failed app-creation flows that lack a direct user context by using the conversation owner as a sensible default.

### Description

- In `backend/agents/tools.py` injected logic into `_write_on_connector` so for the `apps` connector and `create` operation the `" app created by"` field is auto-populated from the conversation owner when the field is absent. 
- Added `_resolve_conversation_owner_user_id(...)` helper that validates the `conversation_id` as a UUID, looks up `Conversation.user_id` via `get_session`, and returns the owner as a string UUID with logging on parse failures. 
- Kept explicit `" app created by"` overrides intact and only auto-inject when that key is not provided in the incoming `data`. 
- Added a regression test `test_write_on_connector_apps_create_passes_conversation_owner_as_override` in `backend/tests/test_tools_write_to_system_of_record.py` to verify the injected override is passed to the connector instance.

### Testing

- Ran `pytest -q backend/tests/test_tools_write_to_system_of_record.py backend/tests/test_apps_connector_owner_resolution.py` and all tests passed. 
- Test run summary: `6 passed` (completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0939dd1188321bd3fde03dd7c187a)