### PR TITLE
Avoid repeating artifact titles in social preview descriptions

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -238,6 +238,9 @@ def _public_preview_description(
     """Build a concise public description for social preview unfurls."""
     if artifact:
         artifact_document_text = " ".join((artifact.content or "").split())
+        artifact_title = (artifact.title or "").strip()
+        if artifact_title and artifact_document_text.startswith(artifact_title):
+            artifact_document_text = artifact_document_text[len(artifact_title):].lstrip(" \n\r\t-–—:|")
         if artifact_document_text:
             return artifact_document_text[:80]
 
@@ -249,8 +252,6 @@ def _public_preview_description(
         return f"{conversation.title} — {owner_label}"
     if app and app.title:
         return f"{app.title} — {owner_label}"
-    if artifact and artifact.title:
-        return f"{artifact.title} — {owner_label}"
     if artifact:
         return f"Document — {owner_label}"
     return f"Application — {owner_label}"

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -92,6 +92,25 @@ def test_public_preview_description_uses_first_80_chars_of_artifact_content() ->
     assert description == content[:80]
 
 
+def test_public_preview_description_strips_repeated_artifact_title_prefix() -> None:
+    content = "Weekly KPI Report — A concise summary of this week's performance and key changes."
+    description = _public_preview_description(
+        conversation=None,
+        artifact=SimpleNamespace(title="Weekly KPI Report", content=content),
+        owner=SimpleNamespace(name="Alex", email="alex@example.com"),
+    )
+    assert description == "A concise summary of this week's performance and key changes."
+
+
+def test_public_preview_description_does_not_fallback_to_artifact_title() -> None:
+    description = _public_preview_description(
+        conversation=None,
+        artifact=SimpleNamespace(title="Weekly KPI Report", content=None),
+        owner=SimpleNamespace(name="Alex", email="alex@example.com"),
+    )
+    assert description == "Document — Alex"
+
+
 def test_build_preview_html_uses_public_apps_redirect_url() -> None:
     html = build_preview_html(
         page_title="Example",


### PR DESCRIPTION
### Motivation
- Social preview descriptions for artifacts could repeat the artifact title when the artifact content began with the same title, causing redundant/unfriendly OG/Twitter unfurls.
- Fallback behavior previously reused the artifact title as the description when no other content existed, which produced noisy previews.

### Description
- Update `_public_preview_description` to detect when `artifact.content` begins with the `artifact.title` and strip that leading title prefix before truncating the content for the OG/twitter description, trimming leading separators with `lstrip(" \n\r\t-–—:|")`.
- Remove the fallback that returned `f"{artifact.title} — {owner_label}"`, so artifacts with no content now fall back to the generic `Document — {owner}` description instead of echoing the title.
- Add two regression tests in `backend/tests/test_public_previews.py`: `test_public_preview_description_strips_repeated_artifact_title_prefix` and `test_public_preview_description_does_not_fallback_to_artifact_title`.
- Files changed: `backend/api/routes/public.py`, `backend/tests/test_public_previews.py`.

### Testing
- Ran unit tests for the public preview suite with `pytest -q backend/tests/test_public_previews.py`, and all tests passed (`17 passed`).
- Existing preview HTML/rendering tests (`build_preview_html`, `render_card_png`) continue to pass as part of the same test file.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f56055cc832192f99327c24acd97)