### PR TITLE
Support artifact deep-link OG previews with optional org slug

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -403,9 +403,16 @@ async def get_public_app_share_snapshot(app_id: str) -> Response:
 
 
 @router.get("/share/artifacts/{artifact_id}", response_class=HTMLResponse)
+@share_router.get("/artifacts/{artifact_id}", response_class=HTMLResponse)
 @share_router.get("/basebase/documents/{artifact_id}", response_class=HTMLResponse)
 @share_router.get("/basebase/artifacts/{artifact_id}", response_class=HTMLResponse)
-async def get_public_artifact_share_preview(artifact_id: str, request: Request) -> HTMLResponse:
+@share_router.get("/{org_slug}/artifacts/{artifact_id}", response_class=HTMLResponse)
+@share_router.get("/artifacts/{org_slug}/{artifact_id}", response_class=HTMLResponse)
+async def get_public_artifact_share_preview(
+    artifact_id: str,
+    request: Request,
+    org_slug: str | None = None,
+) -> HTMLResponse:
     """HTML metadata endpoint used by Slack + external scrapers for public artifact links."""
     try:
         artifact_uuid = UUID(artifact_id)
@@ -424,7 +431,7 @@ async def get_public_artifact_share_preview(artifact_id: str, request: Request) 
             artifact.visibility,
         )
 
-    logger.info("[public_preview] rendering artifact preview artifact_id=%s", artifact_id)
+    logger.info("[public_preview] rendering artifact preview artifact_id=%s org_slug=%s", artifact_id, org_slug)
     artifact_version = ":".join(
         [
             str(artifact.created_at.isoformat() if artifact.created_at else "none"),

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -143,3 +143,10 @@ def test_is_unfurlable_visibility_allows_known_levels() -> None:
 def test_share_router_supports_apps_uuid_path_for_unfurl_links() -> None:
     route_paths = {route.path for route in share_router.routes}
     assert "/apps/{app_id}" in route_paths
+
+
+def test_share_router_supports_artifact_unfurl_paths_with_and_without_org_slug() -> None:
+    route_paths = {route.path for route in share_router.routes}
+    assert "/artifacts/{artifact_id}" in route_paths
+    assert "/{org_slug}/artifacts/{artifact_id}" in route_paths
+    assert "/artifacts/{org_slug}/{artifact_id}" in route_paths

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -22,9 +22,9 @@ server {
         return 302 /apps/$1;
     }
 
-    # Route app deep links to API-based OG preview metadata for link unfurl bots only.
+    # Route app/artifact deep links to API-based OG preview metadata for link unfurl bots only.
     # Includes common social crawlers and Google/Gmail fetchers (GoogleImageProxy).
-    location ~ ^/(?:basebase/apps|apps|[A-Za-z0-9-]+/apps)/([0-9a-fA-F-]+)/?$ {
+    location ~ ^/(?:basebase/(?:apps|artifacts|documents)|apps|artifacts|[A-Za-z0-9-]+/(?:apps|artifacts))/([0-9a-fA-F-]+)/?$ {
         if ($http_user_agent ~* "(Slackbot|Discordbot|Twitterbot|facebookexternalhit|LinkedInBot|WhatsApp|TelegramBot|GoogleImageProxy|APIs-Google|Googlebot|bot|crawler|spider)") {
             return 418;
         }
@@ -39,14 +39,6 @@ server {
         proxy_ssl_server_name on;
     }
 
-    location ~ ^/basebase/(documents|artifacts)/([0-9a-fA-F-]+)/?$ {
-        rewrite ^/basebase/(documents|artifacts)/([0-9a-fA-F-]+)/?$ /api/public/share/$1/$2 break;
-        proxy_pass https://api.basebase.com;
-        proxy_set_header Host api.basebase.com;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_ssl_server_name on;
-    }
 
     # Ensure OG image snapshot fetches on app.basebase.com are forwarded to API.
     location ~ ^/api/public/share/(apps|artifacts)/([0-9a-fA-F-]+)/snapshot\.png$ {


### PR DESCRIPTION
### Motivation
- Enable rich link previews (OG/tweet cards) for artifact links in all URL shapes the frontend emits, including with or without an org slug, following the same behavior we already have for apps.
- Ensure social crawlers and unfurl bots receive metadata and snapshot images even when artifact pages are normally behind auth, while preserving the normal in-app SPA rendering for human users.

### Description
- Added `share_router` routes in `backend/api/routes/public.py` to support artifact unfurl paths: `/artifacts/{artifact_id}`, `/{org_slug}/artifacts/{artifact_id}`, and `/artifacts/{org_slug}/{artifact_id}`, and accepted an optional `org_slug` parameter on the handler.
- Logged `org_slug` context in artifact preview rendering for improved debugging of slug-based unfurl traffic.
- Updated `frontend/nginx.conf` to include `artifacts` and `documents` in the bot-only OG proxy location regex so crawlers get proxied to API preview endpoints while normal requests still fall through to the SPA; removed the unconditional `/basebase/(documents|artifacts)/...` proxy block so in-app artifact pages continue to render for authenticated users.
- Added a regression test in `backend/tests/test_public_previews.py` asserting the artifact unfurl route patterns are registered on `share_router`.

### Testing
- Ran unit tests in `backend/tests/test_public_previews.py` with `pytest -q`, and all tests passed: `15 passed`.
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f743f5cc8321bdce1f8c82956215)