### PR TITLE
Add artifact unfurl routing and preview support for root/org-prefixed links

### DIFF
--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -403,9 +403,16 @@ async def get_public_app_share_snapshot(app_id: str) -> Response:
 
 
 @router.get("/share/artifacts/{artifact_id}", response_class=HTMLResponse)
+@share_router.get("/artifacts/{artifact_id}", response_class=HTMLResponse)
 @share_router.get("/basebase/documents/{artifact_id}", response_class=HTMLResponse)
 @share_router.get("/basebase/artifacts/{artifact_id}", response_class=HTMLResponse)
-async def get_public_artifact_share_preview(artifact_id: str, request: Request) -> HTMLResponse:
+@share_router.get("/{org_slug}/artifacts/{artifact_id}", response_class=HTMLResponse)
+@share_router.get("/artifacts/{org_slug}/{artifact_id}", response_class=HTMLResponse)
+async def get_public_artifact_share_preview(
+    artifact_id: str,
+    request: Request,
+    org_slug: str | None = None,
+) -> HTMLResponse:
     """HTML metadata endpoint used by Slack + external scrapers for public artifact links."""
     try:
         artifact_uuid = UUID(artifact_id)
@@ -424,7 +431,11 @@ async def get_public_artifact_share_preview(artifact_id: str, request: Request) 
             artifact.visibility,
         )
 
-    logger.info("[public_preview] rendering artifact preview artifact_id=%s", artifact_id)
+    logger.info(
+        "[public_preview] rendering artifact preview artifact_id=%s org_slug=%s",
+        artifact_id,
+        org_slug,
+    )
     artifact_version = ":".join(
         [
             str(artifact.created_at.isoformat() if artifact.created_at else "none"),
@@ -452,7 +463,8 @@ async def get_public_artifact_share_preview(artifact_id: str, request: Request) 
         if artifact.user_id:
             owner = await session.scalar(select(User).where(User.id == artifact.user_id))
 
-    canonical_url = f"{_frontend_origin()}/basebase/documents/{artifact_id}"
+    canonical_path = request.url.path if request.url.path else f"/basebase/artifacts/{artifact_id}"
+    canonical_url = f"{_frontend_origin()}{canonical_path}"
     redirect_url = f"{_frontend_origin()}/public/artifacts/{artifact_id}"
     image_url = f"{_public_origin(request)}/api/public/share/artifacts/{artifact_id}/snapshot.png"
     title = _public_preview_title(artifact=artifact)

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -143,3 +143,10 @@ def test_is_unfurlable_visibility_allows_known_levels() -> None:
 def test_share_router_supports_apps_uuid_path_for_unfurl_links() -> None:
     route_paths = {route.path for route in share_router.routes}
     assert "/apps/{app_id}" in route_paths
+
+
+def test_share_router_supports_artifact_uuid_paths_for_unfurl_links() -> None:
+    route_paths = {route.path for route in share_router.routes}
+    assert "/artifacts/{artifact_id}" in route_paths
+    assert "/basebase/artifacts/{artifact_id}" in route_paths
+    assert "/{org_slug}/artifacts/{artifact_id}" in route_paths

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -30,6 +30,12 @@ server {
         }
         try_files $uri $uri/ /index.html;
     }
+    location ~ ^/(?:basebase/artifacts|artifacts|[A-Za-z0-9-]+/artifacts)/([0-9a-fA-F-]+)/?$ {
+        if ($http_user_agent ~* "(Slackbot|Discordbot|Twitterbot|facebookexternalhit|LinkedInBot|WhatsApp|TelegramBot|GoogleImageProxy|APIs-Google|Googlebot|bot|crawler|spider)") {
+            return 418;
+        }
+        try_files $uri $uri/ /index.html;
+    }
     error_page 418 = @og_preview_proxy;
     location @og_preview_proxy {
         proxy_pass https://api.basebase.com$request_uri;


### PR DESCRIPTION
### Motivation
- Ensure artifact links like `https://app.basebase.com/artifacts/:id`, `https://app.basebase.com/basebase/artifacts/:id`, and `https://app.basebase.com/:org_slug/artifacts/:id` support the same unfurl/OG preview behavior as apps so social/chat bots receive metadata instead of the SPA.
- Preserve the incoming URL shape in OG metadata/canonical links so previews point to the same shared URL shape users posted.

### Description
- Added an NGINX bot-unfurl routing block for artifact deep links in `frontend/nginx.conf` to return `418` for known crawler user agents and route them to the OG preview proxy, mirroring the existing apps behavior.
- Extended artifact preview endpoint routing in `backend/api/routes/public.py` by registering artifact share routes on `share_router` for `"/artifacts/{artifact_id}"`, `"/{org_slug}/artifacts/{artifact_id}"`, and the existing `basebase` paths so unfurl bots can request metadata for all URL shapes.
- Updated artifact preview handling to log `org_slug` for easier diagnostics and to build the canonical OG URL from the incoming `request.url.path` so the `og:url` matches the incoming link shape.
- Added a regression test `test_share_router_supports_artifact_uuid_paths_for_unfurl_links` in `backend/tests/test_public_previews.py` to assert the new `share_router` artifact routes are registered.

### Testing
- Ran the targeted test suite with `pytest -q backend/tests/test_public_previews.py`, which completed successfully with `15 passed in 2.76s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f743f5cc8321bdce1f8c82956215)