### PR TITLE
Return org-scoped URIs for created apps and documents

### DIFF
--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -28,6 +28,7 @@ from models.chat_message import ChatMessage
 from models.conversation import Conversation
 from models.database import get_session
 from models.external_identity_mapping import ExternalIdentityMapping
+from models.organization import Organization
 from services.public_preview_warmup import warm_public_preview_cache
 from services.slack_identity import get_alternate_slack_user_ids_for_identity
 
@@ -576,7 +577,8 @@ class AppsConnector(BaseConnector):
         )
         await warm_public_preview_cache("app", app_id_str)
 
-        app_url: str = f"{settings.FRONTEND_URL.rstrip('/')}/apps/{app_id_str}"
+        app_uri_path: str = await self._build_app_uri_path(app_id_str)
+        app_url: str = f"{settings.FRONTEND_URL.rstrip('/')}{app_uri_path}"
         return {
             "status": "success",
             "app_id": app_id_str,
@@ -587,6 +589,7 @@ class AppsConnector(BaseConnector):
                 "frontendCode": frontend_code,
                 "frontendCodeCompiled": compiled_code,
             },
+            "uri": app_uri_path,
             "url": app_url,
             "message": f"Created interactive app: {title}. View it at {app_url}",
         }
@@ -650,7 +653,8 @@ class AppsConnector(BaseConnector):
 
             logger.info("[AppsConnector] Updated app: id=%s, title=%s", app_id_raw, app.title)
 
-        app_url: str = f"{settings.FRONTEND_URL.rstrip('/')}/apps/{app_id_raw}"
+        app_uri_path: str = await self._build_app_uri_path(app_id_raw)
+        app_url: str = f"{settings.FRONTEND_URL.rstrip('/')}{app_uri_path}"
         return {
             "status": "success",
             "app_id": app_id_raw,
@@ -661,9 +665,25 @@ class AppsConnector(BaseConnector):
                 "frontendCode": app.frontend_code,
                 "frontendCodeCompiled": app.frontend_code_compiled,
             },
+            "uri": app_uri_path,
             "url": app_url,
             "message": f"Updated app: {app.title}. View it at {app_url}",
         }
+
+    async def _build_app_uri_path(self, app_id: str) -> str:
+        org_handle: str | None = await self._get_org_handle()
+        if org_handle:
+            return f"/{org_handle}/apps/{app_id}"
+        return f"/apps/{app_id}"
+
+    async def _get_org_handle(self) -> str | None:
+        async with get_session(organization_id=self.organization_id) as session:
+            result = await session.execute(
+                select(Organization.handle).where(Organization.id == UUID(self.organization_id))
+            )
+            org_handle: str | None = result.scalar_one_or_none()
+        normalized: str = (org_handle or "").strip()
+        return normalized or None
 
     async def _test_query(self, data: dict[str, Any]) -> dict[str, Any]:
         """Run a query from an app and return sample data."""

--- a/backend/connectors/artifacts.py
+++ b/backend/connectors/artifacts.py
@@ -28,6 +28,7 @@ from connectors.registry import (
 )
 from models.artifact import Artifact
 from models.database import get_session
+from models.organization import Organization
 from services.public_preview_warmup import warm_public_preview_cache
 from services.slack_identity import get_alternate_slack_user_ids_for_identity
 
@@ -395,7 +396,8 @@ class ArtifactConnector(BaseConnector):
             title,
         )
         await warm_public_preview_cache("artifact", artifact_id_str)
-        view_url: str = f"{settings.FRONTEND_URL.rstrip('/')}/artifacts/{artifact_id_str}"
+        artifact_uri_path: str = await self._build_artifact_uri_path(artifact_id_str)
+        view_url: str = f"{settings.FRONTEND_URL.rstrip('/')}{artifact_uri_path}"
         return {
             "status": "success",
             "artifact_id": artifact_id_str,
@@ -405,8 +407,10 @@ class ArtifactConnector(BaseConnector):
                 "filename": filename,
                 "contentType": content_type,
                 "mimeType": mime_type,
+                "uri": artifact_uri_path,
                 "viewUrl": view_url,
             },
+            "uri": artifact_uri_path,
             "view_url": view_url,
             "message": f"Created {content_type} artifact: {title}",
         }
@@ -470,7 +474,8 @@ class ArtifactConnector(BaseConnector):
         final_filename: str = filename if filename is not None else prev_filename
         final_content_type: str = content_type if content_type is not None else prev_content_type
         artifact_id_str: str = str(artifact_uuid)
-        view_url: str = f"{settings.FRONTEND_URL.rstrip('/')}/artifacts/{artifact_id_str}"
+        artifact_uri_path: str = await self._build_artifact_uri_path(artifact_id_str)
+        view_url: str = f"{settings.FRONTEND_URL.rstrip('/')}{artifact_uri_path}"
 
         logger.info("[ArtifactConnector] Updated artifact: id=%s", artifact_id_str)
         return {
@@ -482,9 +487,26 @@ class ArtifactConnector(BaseConnector):
                 "filename": final_filename,
                 "contentType": final_content_type,
                 "mimeType": CONTENT_TYPE_TO_MIME.get(final_content_type, "application/octet-stream"),
+                "uri": artifact_uri_path,
                 "viewUrl": view_url,
                 "updated": True,
             },
+            "uri": artifact_uri_path,
             "view_url": view_url,
             "message": f"Updated artifact: {final_title}",
         }
+
+    async def _build_artifact_uri_path(self, artifact_id: str) -> str:
+        org_handle: str | None = await self._get_org_handle()
+        if org_handle:
+            return f"/{org_handle}/artifacts/{artifact_id}"
+        return f"/artifacts/{artifact_id}"
+
+    async def _get_org_handle(self) -> str | None:
+        async with get_session(organization_id=self.organization_id) as session:
+            result = await session.execute(
+                select(Organization.handle).where(Organization.id == UUID(self.organization_id))
+            )
+            org_handle: str | None = result.scalar_one_or_none()
+        normalized: str = (org_handle or "").strip()
+        return normalized or None

--- a/backend/tests/test_apps_connector_owner_resolution.py
+++ b/backend/tests/test_apps_connector_owner_resolution.py
@@ -25,6 +25,7 @@ class _FakeSession:
         *,
         message_user_id: UUID | None,
         conversation_user_id: UUID | None,
+        org_handle: str | None = None,
         conversation_source: str | None = None,
         conversation_source_user_id: str | None = None,
         slack_mapping_user_id: UUID | None = None,
@@ -32,6 +33,7 @@ class _FakeSession:
     ):
         self.message_user_id = message_user_id
         self.conversation_user_id = conversation_user_id
+        self.org_handle = org_handle
         self.conversation_source = conversation_source
         self.conversation_source_user_id = conversation_source_user_id
         self.slack_mapping_user_id = slack_mapping_user_id
@@ -77,6 +79,8 @@ class _FakeSession:
                     )
                 ]
             )
+        if "organizations.handle" in q:
+            return _FakeExecuteResult(self.org_handle)
         raise AssertionError(f"Unexpected query: {q}")
 
     def add(self, obj):
@@ -132,6 +136,7 @@ def test_create_prefers_conversation_owner_over_turn_user_and_message_user(monke
     )
 
     assert result["status"] == "success"
+    assert "/apps/" in result["uri"]
     assert fake_session.committed is True
     assert len(fake_session.added) == 1
     assert fake_session.added[0].user_id == conversation_user_id
@@ -184,6 +189,7 @@ def test_create_resolves_owner_from_slack_identity_mapping_when_conversation_use
     )
 
     assert result["status"] == "success"
+    assert "/apps/" in result["uri"]
     assert fake_session.committed is True
     assert len(fake_session.added) == 1
     assert fake_session.added[0].user_id == resolved_user_id
@@ -237,6 +243,7 @@ def test_create_uses_explicit_owner_override_before_other_context(monkeypatch):
     )
 
     assert result["status"] == "success"
+    assert "/apps/" in result["uri"]
     assert fake_session.committed is True
     assert len(fake_session.added) == 1
     assert fake_session.added[0].user_id == UUID(override_user_id)
@@ -276,3 +283,46 @@ def test_create_rejects_invalid_explicit_owner_override(monkeypatch):
 
     assert "error" in result
     assert "app created by" in result["error"]
+
+
+def test_create_returns_org_handle_scoped_uri_when_handle_present(monkeypatch):
+    org_id = "00000000-0000-0000-0000-000000000010"
+    fake_session = _FakeSession(
+        message_user_id=UUID("00000000-0000-0000-0000-000000000012"),
+        conversation_user_id=None,
+        org_handle="acme",
+    )
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        yield fake_session
+
+    async def _fake_warm(*_args, **_kwargs):
+        return None
+
+    async def _fake_test_execute_queries(*_args, **_kwargs):
+        return []
+
+    async def _fake_alternate(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr("connectors.apps.get_session", _fake_get_session)
+    monkeypatch.setattr("connectors.apps.warm_public_preview_cache", _fake_warm)
+    monkeypatch.setattr("connectors.apps.get_alternate_slack_user_ids_for_identity", _fake_alternate)
+    monkeypatch.setattr("utils.transpile_jsx.transpile_jsx", lambda _code: (None,))
+    monkeypatch.setattr("connectors.apps.AppsConnector._test_execute_queries", _fake_test_execute_queries)
+
+    connector = AppsConnector(organization_id=org_id, user_id=None)
+    result = asyncio.run(
+        connector._create(
+            {
+                "title": "Handle-scoped app",
+                "queries": {"q": {"sql": "SELECT 1 AS n", "params": {}}},
+                "frontend_code": "export default function App(){ return <div/>; }",
+                "message_id": "00000000-0000-0000-0000-000000000014",
+            }
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["uri"].startswith("/acme/apps/")

--- a/backend/tests/test_artifacts_connector_owner_resolution.py
+++ b/backend/tests/test_artifacts_connector_owner_resolution.py
@@ -25,6 +25,7 @@ class _FakeSession:
         *,
         message_user_id: UUID | None,
         conversation_user_id: UUID | None,
+        org_handle: str | None = None,
         conversation_source: str | None = None,
         conversation_source_user_id: str | None = None,
         slack_mapping_user_id: UUID | None = None,
@@ -32,6 +33,7 @@ class _FakeSession:
     ):
         self.message_user_id = message_user_id
         self.conversation_user_id = conversation_user_id
+        self.org_handle = org_handle
         self.conversation_source = conversation_source
         self.conversation_source_user_id = conversation_source_user_id
         self.slack_mapping_user_id = slack_mapping_user_id
@@ -65,6 +67,8 @@ class _FakeSession:
             return _FakeExecuteResult([
                 (self.conversation_source_user_id, "revtops_unknown", self.legacy_mapping_user_id)
             ])
+        if "organizations.handle" in q:
+            return _FakeExecuteResult(self.org_handle)
         raise AssertionError(f"Unexpected query: {q}")
 
     def add(self, obj):
@@ -115,6 +119,7 @@ def test_create_prefers_turn_user_over_conversation_owner(monkeypatch):
     )
 
     assert result["status"] == "success"
+    assert "/artifacts/" in result["uri"]
     assert fake_session.committed is True
     assert len(fake_session.added) == 1
     assert fake_session.added[0].user_id == message_user_id
@@ -162,6 +167,46 @@ def test_create_resolves_owner_from_slack_identity_mapping_when_conversation_use
     )
 
     assert result["status"] == "success"
+    assert "/artifacts/" in result["uri"]
     assert fake_session.committed is True
     assert len(fake_session.added) == 1
     assert fake_session.added[0].user_id == resolved_user_id
+
+
+def test_create_returns_org_handle_scoped_uri_when_handle_present(monkeypatch):
+    org_id = "00000000-0000-0000-0000-000000000010"
+    fake_session = _FakeSession(
+        message_user_id=UUID("00000000-0000-0000-0000-000000000012"),
+        conversation_user_id=None,
+        org_handle="acme",
+    )
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        yield fake_session
+
+    async def _fake_warm(*_args, **_kwargs):
+        return None
+
+    async def _fake_alternate(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr("connectors.artifacts.get_session", _fake_get_session)
+    monkeypatch.setattr("connectors.artifacts.warm_public_preview_cache", _fake_warm)
+    monkeypatch.setattr("connectors.artifacts.get_alternate_slack_user_ids_for_identity", _fake_alternate)
+
+    connector = ArtifactConnector(organization_id=org_id, user_id=None)
+    result = asyncio.run(
+        connector._create(
+            {
+                "title": "Handle-scoped artifact",
+                "filename": "artifact.md",
+                "content_type": "markdown",
+                "content": "hello",
+                "message_id": "00000000-0000-0000-0000-000000000014",
+            }
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["uri"].startswith("/acme/artifacts/")


### PR DESCRIPTION
### Motivation
- Created apps and artifacts should return a stable URI path that includes the organization's handle when available so links returned to users are shareable and org-scoped.

### Description
- Apps connector now returns a `uri` path and builds the `url` using an org-prefixed path (`/{org_handle}/apps/{app_id}`) when the organization `handle` exists, falling back to `/apps/{app_id}`; applied to both create and update responses (`backend/connectors/apps.py`).
- Artifacts connector now returns a `uri` path and builds the `view_url` using an org-prefixed path (`/{org_handle}/artifacts/{artifact_id}`) when the organization `handle` exists, falling back to `/artifacts/{artifact_id}`; applied to both create and update responses (`backend/connectors/artifacts.py`).
- Added helper methods to resolve the organization's `handle` via DB lookup and factored URI path construction into `_build_app_uri_path`/`_build_artifact_uri_path` and `_get_org_handle`.
- Updated owner-resolution tests to assert presence and correctness of the returned `uri`, and added explicit tests that verify org-handle-prefixed URIs for both apps and artifacts (`backend/tests/test_apps_connector_owner_resolution.py`, `backend/tests/test_artifacts_connector_owner_resolution.py`).

### Testing
- Ran `pytest -q tests/test_apps_connector_owner_resolution.py tests/test_artifacts_connector_owner_resolution.py` and received `8 passed` for the modified test suites.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e105558fa08321a5430ced9aceeab0)