### PR TITLE
Fix detached Artifact instance errors in artifacts connector query

### DIFF
--- a/backend/connectors/artifacts.py
+++ b/backend/connectors/artifacts.py
@@ -117,6 +117,7 @@ class ArtifactConnector(BaseConnector):
         except ValueError:
             return {"error": "Invalid artifact_id format (must be a valid UUID)"}
 
+        artifact_payload: dict[str, str] | None = None
         async with get_session(organization_id=self.organization_id) as session:
             result = await session.execute(
                 select(Artifact).where(
@@ -125,16 +126,21 @@ class ArtifactConnector(BaseConnector):
                 )
             )
             artifact: Artifact | None = result.scalar_one_or_none()
-        if not artifact:
-            return {"error": "Artifact not found or access denied"}
+            if artifact:
+                # Copy values while the row is still session-bound.
+                # get_session() performs a rollback in cleanup, which expires ORM
+                # attributes; reading after context exit can raise DetachedInstanceError.
+                artifact_payload = {
+                    "id": str(artifact.id),
+                    "title": artifact.title or "Untitled",
+                    "filename": artifact.filename or "artifact.txt",
+                    "content_type": artifact.content_type or "text",
+                    "content": artifact.content or "",
+                }
 
-        return {
-            "id": str(artifact.id),
-            "title": artifact.title or "Untitled",
-            "filename": artifact.filename or "artifact.txt",
-            "content_type": artifact.content_type or "text",
-            "content": artifact.content or "",
-        }
+        if not artifact_payload:
+            return {"error": "Artifact not found or access denied"}
+        return artifact_payload
 
     async def write(self, operation: str, data: dict[str, Any]) -> dict[str, Any]:
         if operation == "create":

--- a/backend/tests/test_artifacts_connector_query.py
+++ b/backend/tests/test_artifacts_connector_query.py
@@ -1,0 +1,71 @@
+import asyncio
+from contextlib import asynccontextmanager
+
+from connectors.artifacts import ArtifactConnector
+
+
+class _FakeExecuteResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _DetachingArtifact:
+    def __init__(self):
+        self.detached = False
+
+    def _value(self, value):
+        if self.detached:
+            raise RuntimeError("detached")
+        return value
+
+    @property
+    def id(self):
+        return self._value("22c70309-d097-4e8e-a50a-e4ad7efc789a")
+
+    @property
+    def title(self):
+        return self._value("Test Artifact")
+
+    @property
+    def filename(self):
+        return self._value("artifact.md")
+
+    @property
+    def content_type(self):
+        return self._value("markdown")
+
+    @property
+    def content(self):
+        return self._value("hello")
+
+
+class _FakeSession:
+    def __init__(self, artifact):
+        self.artifact = artifact
+
+    async def execute(self, _query):
+        return _FakeExecuteResult(self.artifact)
+
+
+def test_query_materializes_payload_before_session_cleanup(monkeypatch):
+    artifact = _DetachingArtifact()
+    fake_session = _FakeSession(artifact)
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        yield fake_session
+        artifact.detached = True
+
+    monkeypatch.setattr("connectors.artifacts.get_session", _fake_get_session)
+    connector = ArtifactConnector(
+        organization_id="00000000-0000-0000-0000-000000000010",
+        user_id="00000000-0000-0000-0000-000000000011",
+    )
+
+    result = asyncio.run(connector.query("read 22c70309-d097-4e8e-a50a-e4ad7efc789a"))
+
+    assert result["id"] == "22c70309-d097-4e8e-a50a-e4ad7efc789a"
+    assert result["content"] == "hello"


### PR DESCRIPTION
### Motivation
- Reading full artifact content could raise `DetachedInstanceError` because ORM attributes were accessed after the `get_session()` context cleaned up and detached the instance.

### Description
- Update `ArtifactConnector.query()` to materialize an `artifact_payload` dictionary while still inside the `get_session()` context so ORM attributes are read before session cleanup.
- Avoid any attribute access on the `Artifact` instance after the session context exits and return the pre-copied payload instead.
- Add a regression test `backend/tests/test_artifacts_connector_query.py` that simulates an artifact becoming detached after the session and verifies `query("read <id>")` returns the content.

### Testing
- Ran `pytest -q backend/tests/test_artifacts_connector_query.py backend/tests/test_artifacts_connector_owner_resolution.py` and all tests passed (`4 passed`).
- The new test verifies the fix prevents detached-instance errors when reading artifact content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e11315c3fc8321a8593d016c230167)