### PR TITLE
Redirect public app links to public URI

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -444,8 +444,14 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
         const artifactMatchFail = subPath.match(/^artifacts?\/([a-f0-9-]+)$/i);
         if (appMatchFail?.[1]) {
           const appIdFail: string = appMatchFail[1];
-          window.location.replace(`/apps/${appIdFail}`);
-          return;
+          const endpoint: string = `/public/apps/${appIdFail}`;
+          const { data: publicData } = await apiRequest<Record<string, unknown>>(endpoint, {
+            method: "GET",
+          });
+          if (publicData) {
+            window.location.replace(`/public/apps/${appIdFail}`);
+            return;
+          }
         }
 
         if (artifactMatchFail?.[1]) {


### PR DESCRIPTION
### Motivation
- Align app deep-link fallback with document behavior so org-scoped app URLs that the user cannot access first attempt a public fallback and land on the public interactive page when available.

### Description
- Update `handleOrgAccessDenied` in `frontend/src/components/AppLayout.tsx` to call the public lookup endpoint `/public/apps/:id` and redirect to `/public/apps/:id` when the app is publicly accessible, matching the existing artifact flow to `/public/artifacts/:id`.
- Preserve existing behavior for non-public resources by showing the org access error UI when the public lookup fails.
- No skill was used during this change.

### Testing
- Ran linter: `cd frontend && npm run lint -- src/components/AppLayout.tsx`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e115d9c6a08321b349ab2466269155)