### PR TITLE
Handle SPA-shell wrapped document/artifact payloads

### DIFF
--- a/frontend/src/components/ArtifactFullView.tsx
+++ b/frontend/src/components/ArtifactFullView.tsx
@@ -7,12 +7,13 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { apiRequest } from "../lib/api";
+import { API_BASE, apiRequest, getAuthenticatedRequestHeaders } from "../lib/api";
 import { downloadArtifactAsFile } from "../lib/artifactDownload";
 import { useAppStore, useUIStore } from "../store";
 import { ArtifactViewer } from "./ArtifactViewer";
 import type { VisibilityLevel } from "./VisibilitySelector";
 import { DetailViewHeader } from "./shared/DetailViewHeader";
+import { parsePossiblySpaWrappedJson } from "../lib/documentPayload";
 
 interface ArtifactApiResponse {
   id: string;
@@ -131,16 +132,31 @@ export function ArtifactFullView({
   const fetchArtifact = useCallback(async (): Promise<void> => {
     setLoading(true);
     setError(null);
-    const resp = await apiRequest<ArtifactApiResponse>(
-      `/artifacts/${artifactId}`,
-    );
-    if (resp.error || !resp.data) {
-      setError(resp.error ?? "Failed to load artifact");
+    try {
+      const authHeaders = await getAuthenticatedRequestHeaders();
+      const response = await fetch(`${API_BASE}/artifacts/${artifactId}`, {
+        headers: authHeaders,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const rawBody = await response.text();
+      const parsed = parsePossiblySpaWrappedJson(rawBody);
+      if (!parsed || typeof parsed !== "object") {
+        throw new Error("Artifact response was not valid JSON");
+      }
+      const artifactData = parsed as ArtifactApiResponse;
+      setArtifact(toFileArtifact(artifactData));
+      setVisibility((artifactData.visibility as VisibilityLevel) ?? "team");
+      setOwnerUserId(artifactData.user_id);
+      if (rawBody.toLowerCase().includes("<html")) {
+        console.info("[ArtifactFullView] Parsed artifact JSON from SPA shell fallback.");
+      }
+    } catch (fetchErr) {
+      const msg = fetchErr instanceof Error ? fetchErr.message : "Failed to load artifact";
+      console.error("[ArtifactFullView] Artifact fetch failed", fetchErr);
+      setError(msg);
       setArtifact(null);
-    } else {
-      setArtifact(toFileArtifact(resp.data));
-      setVisibility((resp.data.visibility as VisibilityLevel) ?? "team");
-      setOwnerUserId(resp.data.user_id);
     }
     setLoading(false);
   }, [artifactId]);

--- a/frontend/src/components/ArtifactViewer.tsx
+++ b/frontend/src/components/ArtifactViewer.tsx
@@ -16,9 +16,10 @@ import { useEffect, useRef, useState } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { apiRequest, API_BASE, getAuthenticatedRequestHeaders } from "../lib/api";
+import { API_BASE, getAuthenticatedRequestHeaders } from "../lib/api";
 import { downloadArtifactAsFile } from "../lib/artifactDownload";
 import { formatDateOnly } from "../lib/dates";
+import { extractDocumentTextFromBody, parsePossiblySpaWrappedJson } from "../lib/documentPayload";
 
 
 // New file-based artifact format
@@ -121,7 +122,11 @@ export function ArtifactViewer({
 
         if (disp === "text" || disp === "markdown") {
           const text = await response.text();
-          setContent(text);
+          const normalized = extractDocumentTextFromBody(text);
+          if (normalized !== text) {
+            console.info("[ArtifactViewer] Attachment response appeared SPA/JSON wrapped; normalized content.");
+          }
+          setContent(normalized);
         } else {
           const blob = await response.blob();
           const objectUrl = URL.createObjectURL(blob);
@@ -158,13 +163,29 @@ export function ArtifactViewer({
       setLoading(true);
       setError(null);
       try {
-        const { data, error: apiError } = await apiRequest<{ content: string }>(
-          `/artifacts/${artifact.id}`
-        );
-        if (apiError) {
-          throw new Error(apiError);
+        const authHeaders = await getAuthenticatedRequestHeaders();
+        const response = await fetch(`${API_BASE}/artifacts/${artifact.id}`, {
+          headers: authHeaders,
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
         }
-        setContent(data?.content ?? null);
+        const rawBody = await response.text();
+        const payload = parsePossiblySpaWrappedJson(rawBody);
+        if (payload && typeof payload === "object" && "content" in payload) {
+          const contentValue = (payload as { content?: unknown }).content;
+          if (typeof contentValue === "string") {
+            setContent(contentValue);
+            return;
+          }
+        }
+        const normalized = extractDocumentTextFromBody(rawBody);
+        if (normalized !== rawBody) {
+          console.info("[ArtifactViewer] Artifact response appeared SPA/JSON wrapped; normalized content.");
+        } else {
+          console.warn("[ArtifactViewer] Artifact response did not include JSON `content`; using raw body as fallback.");
+        }
+        setContent(normalized);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to load artifact");
       } finally {

--- a/frontend/src/components/public/PublicArtifactView.tsx
+++ b/frontend/src/components/public/PublicArtifactView.tsx
@@ -9,6 +9,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { API_BASE } from "../../lib/api";
 import { ArtifactViewer } from "../ArtifactViewer";
+import { parsePossiblySpaWrappedJson } from "../../lib/documentPayload";
 
 interface PublicArtifactApiResponse {
   id: string;
@@ -38,8 +39,12 @@ export function PublicArtifactView({ artifactId }: PublicArtifactViewProps): JSX
         setData(null);
         return;
       }
-      const json = (await res.json()) as PublicArtifactApiResponse;
-      setData(json);
+      const rawBody = await res.text();
+      const parsed = parsePossiblySpaWrappedJson(rawBody);
+      if (!parsed || typeof parsed !== "object") {
+        throw new Error("Invalid artifact payload");
+      }
+      setData(parsed as PublicArtifactApiResponse);
       setError(null);
     } catch {
       setError("Failed to load artifact");

--- a/frontend/src/lib/documentPayload.ts
+++ b/frontend/src/lib/documentPayload.ts
@@ -1,0 +1,83 @@
+/**
+ * Utilities for parsing document/artifact responses when API proxies
+ * accidentally return a SPA HTML shell instead of direct JSON/text.
+ */
+
+type JsonRecord = Record<string, unknown>;
+
+function tryParseJson(raw: string): unknown | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return null;
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function extractJsonFromHtmlCandidates(html: string): unknown | null {
+  if (typeof window === "undefined" || typeof DOMParser === "undefined") {
+    return null;
+  }
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const candidates: string[] = [];
+
+  const scriptNodes = Array.from(doc.querySelectorAll("script"));
+  for (const script of scriptNodes) {
+    const scriptType = (script.getAttribute("type") ?? "").toLowerCase();
+    if (script.src) continue;
+    if (scriptType === "" || scriptType === "application/json") {
+      candidates.push(script.textContent ?? "");
+    }
+  }
+
+  const preNodes = Array.from(doc.querySelectorAll("pre"));
+  for (const pre of preNodes) {
+    candidates.push(pre.textContent ?? "");
+  }
+
+  for (const candidate of candidates) {
+    const parsed = tryParseJson(candidate);
+    if (parsed !== null) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+export function parsePossiblySpaWrappedJson(rawBody: string): unknown | null {
+  const direct = tryParseJson(rawBody);
+  if (direct !== null) {
+    return direct;
+  }
+  const lower = rawBody.toLowerCase();
+  const looksLikeHtml = lower.includes("<html") || lower.includes("<!doctype html");
+  if (!looksLikeHtml) {
+    return null;
+  }
+  return extractJsonFromHtmlCandidates(rawBody);
+}
+
+function extractContentFromJsonPayload(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const obj = payload as JsonRecord;
+  if (typeof obj.content === "string") return obj.content;
+  if (obj.data && typeof obj.data === "object") {
+    const nested = obj.data as JsonRecord;
+    if (typeof nested.content === "string") return nested.content;
+  }
+  return null;
+}
+
+export function extractDocumentTextFromBody(rawBody: string): string {
+  const parsed = parsePossiblySpaWrappedJson(rawBody);
+  const extracted = extractContentFromJsonPayload(parsed);
+  if (extracted !== null) {
+    console.info("[documentPayload] Extracted artifact content from JSON/SPA wrapper payload.");
+    return extracted;
+  }
+  return rawBody;
+}
+


### PR DESCRIPTION
### Motivation
- API responses for documents/artifacts can sometimes be returned inside a SPA HTML shell (e.g. proxies returning index.html) which hides the JSON payload; the UI must recover the real JSON/text rather than assuming direct JSON or chart-only handling. 
- Apply robust parsing for all document/artifact fetch paths (attachments, authenticated artifacts, and public artifacts) so content is normalized for viewers across types.

### Description
- Add `frontend/src/lib/documentPayload.ts` with `parsePossiblySpaWrappedJson` and `extractDocumentTextFromBody` utilities that detect SPA HTML shells and extract JSON from inline `<script>` and `<pre>` nodes. 
- Update `ArtifactViewer` to normalize attachment text/markdown bodies and artifact fetch results using the new utilities, and to extract `content` when present; attachment handling now runs JSON extraction before treating text content. 
- Update `ArtifactFullView` to fetch raw response text with authentication headers and parse via the SPA-aware parser before mapping to the viewer model, with logging on SPA fallback. 
- Update `PublicArtifactView` to use the same SPA-shell-aware parsing for unauthenticated public artifact payloads for consistent behavior. 

### Testing
- Ran the frontend production build with `npm run build` (from `frontend/`) and the build completed successfully (warnings about chunk sizes were reported but build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1189889a48321839baf69b48f16eb)