### PR TITLE
Skip sentence breaks inside URIs

### DIFF
--- a/backend/messengers/_stream_breaks.py
+++ b/backend/messengers/_stream_breaks.py
@@ -8,6 +8,7 @@ StreamBreakStrategy = Literal["best", "quickest_safe"]
 _SENTENCE_BREAK_RE: re.Pattern[str] = re.compile(r"[.!?](?:\s|$)")
 _FENCE_RE: re.Pattern[str] = re.compile(r"^```", re.MULTILINE)
 _PIPE_TABLE_LINE_RE: re.Pattern[str] = re.compile(r"\|.+\||[^|\n]+(?:\|[^|\n]+){2,}")
+_URI_SCHEME_RE: re.Pattern[str] = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*://")
 _TITLE_ABBREVIATIONS: set[str] = {
     "mr",
     "mrs",
@@ -58,6 +59,19 @@ def _is_valid_sentence_break(text: str, punct_idx: int) -> bool:
         token_match: re.Match[str] | None = re.search(r"([A-Za-z]+)$", text[:punct_idx])
         if token_match and token_match.group(1).lower() in _TITLE_ABBREVIATIONS:
             return False
+    token_start: int = text.rfind(" ", 0, punct_idx) + 1
+    token_start = max(token_start, text.rfind("\n", 0, punct_idx) + 1)
+    token_end_space: int = text.find(" ", punct_idx)
+    token_end_newline: int = text.find("\n", punct_idx)
+    token_end_candidates: list[int] = [len(text)]
+    if token_end_space >= 0:
+        token_end_candidates.append(token_end_space)
+    if token_end_newline >= 0:
+        token_end_candidates.append(token_end_newline)
+    token_end: int = min(token_end_candidates)
+    token: str = text[token_start:token_end]
+    if _URI_SCHEME_RE.match(token):
+        return False
 
     line_start: int = text.rfind("\n", 0, punct_idx) + 1
     line_end: int = text.find("\n", punct_idx)

--- a/backend/tests/test_workspace_stream_breaks.py
+++ b/backend/tests/test_workspace_stream_breaks.py
@@ -50,6 +50,16 @@ def test_find_safe_stream_break_skips_vs_abbreviation() -> None:
     assert find_safe_break(text, strategy="quickest_safe") == len("This is a Lakers vs. Celtics preview. ")
 
 
+def test_find_safe_stream_break_skips_period_inside_uri() -> None:
+    text = "Link https://example.com/path.to/file and then continue"
+    assert find_safe_break(text, strategy="quickest_safe") == 0
+
+
+def test_find_safe_stream_break_skips_question_mark_inside_uri() -> None:
+    text = "Use https://example.com/search?q=test? value now"
+    assert find_safe_break(text, strategy="quickest_safe") == 0
+
+
 def test_find_safe_stream_break_defers_inside_pipe_table_with_pipes() -> None:
     text = "Here is the data:\n\n| Name | Email |\n| Alice | alice@co.com |"
     assert find_safe_break(text, strategy="quickest_safe") == 0


### PR DESCRIPTION
### Motivation
- The stream processor could split messages on punctuation that occurs inside URLs, producing broken/partial URIs in streamed output. 
- We need to treat punctuation that belongs to a URI token (e.g. `scheme://...`) as unsafe to break on so streamed segments remain valid.

### Description
- Added a URI scheme regex `_URI_SCHEME_RE` and token-boundary extraction in `_is_valid_sentence_break` to detect when the punctuation is part of a URI and return `False` for that break. 
- Preserved existing guards for abbreviations, markdown formatting, lists, and pipe tables in `backend/messengers/_stream_breaks.py`. 
- Added two regression tests `test_find_safe_stream_break_skips_period_inside_uri` and `test_find_safe_stream_break_skips_question_mark_inside_uri` in `backend/tests/test_workspace_stream_breaks.py` to cover `.` and `?` inside URIs.

### Testing
- Ran `pytest -q backend/tests/test_workspace_stream_breaks.py backend/tests/test_twilio_stream_breaks.py` and all tests passed. 
- Test run result: `16 passed` (completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e11dc6d3148321a6c4102f068f1af2)