### PR TITLE
ArtifactViewer: ignore unfurl URL placeholders and refetch full artifact content

### DIFF
--- a/frontend/src/components/ArtifactViewer.tsx
+++ b/frontend/src/components/ArtifactViewer.tsx
@@ -68,6 +68,16 @@ function attachmentDisplayType(mimeType: string): AttachmentDisplayType {
   return "text";
 }
 
+const BASEBASE_ARTIFACT_LINK_RE: RegExp =
+  /^(?:https?:\/\/[^/]+)?\/(?:basebase\/(?:documents|artifacts)|public\/artifacts)\/[a-f0-9-]+\/?$/i;
+
+function looksLikeBasebaseUnfurlUrl(content: string | undefined): boolean {
+  if (!content) return false;
+  const trimmed = content.trim();
+  if (!trimmed) return false;
+  return BASEBASE_ARTIFACT_LINK_RE.test(trimmed);
+}
+
 export function ArtifactViewer({
   artifact,
   attachmentId,
@@ -154,7 +164,7 @@ export function ArtifactViewer({
   useEffect(() => {
     if (isAttachmentMode || !artifact) return;
     if (!isFileArtifact(artifact)) return;
-    if (artifact.content) {
+    if (artifact.content && !looksLikeBasebaseUnfurlUrl(artifact.content)) {
       setContent(artifact.content);
       return;
     }
@@ -163,6 +173,9 @@ export function ArtifactViewer({
       setLoading(true);
       setError(null);
       try {
+        if (looksLikeBasebaseUnfurlUrl(artifact.content)) {
+          console.info("[ArtifactViewer] Artifact payload contained unfurl URL; refetching full artifact content by ID.");
+        }
         const authHeaders = await getAuthenticatedRequestHeaders();
         const response = await fetch(`${API_BASE}/artifacts/${artifact.id}`, {
           headers: authHeaders,


### PR DESCRIPTION
### Motivation
- The viewer could display an unfurl/share URL (e.g. `/basebase/documents/:id` or `/public/artifacts/:id`) when `artifact.content` contained a placeholder link instead of the actual document body, causing users to see the link rather than the document.

### Description
- Add a regex and helper `looksLikeBasebaseUnfurlUrl` to detect Basebase unfurl/share URL placeholders in `artifact.content` in `frontend/src/components/ArtifactViewer.tsx`.
- When a placeholder URL is detected, avoid rendering it and instead refetch the full artifact from the API (`GET /artifacts/:id`) and render the returned `content`.
- Emit an info log when the fallback path is taken to make the behavior easier to debug.

### Testing
- Ran `npm run lint` (frontend) and it completed successfully.
- Ran `npm run build` (frontend) and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e124bc579083218dee83de5486bb63)