### PR TITLE
Fix frontend artifact payload typing to unblock build

### DIFF
--- a/frontend/src/components/ArtifactFullView.tsx
+++ b/frontend/src/components/ArtifactFullView.tsx
@@ -31,6 +31,27 @@ interface ArtifactApiResponse {
   visibility?: string;
 }
 
+function isArtifactApiResponse(value: unknown): value is ArtifactApiResponse {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === "string" &&
+    ("type" in record) &&
+    ("title" in record) &&
+    ("description" in record) &&
+    ("content_type" in record) &&
+    ("mime_type" in record) &&
+    ("filename" in record) &&
+    ("content" in record) &&
+    ("conversation_id" in record) &&
+    ("message_id" in record) &&
+    ("created_at" in record) &&
+    ("user_id" in record)
+  );
+}
+
 // Map API snake_case to ArtifactViewer camelCase
 function toFileArtifact(api: ArtifactApiResponse): {
   id: string;
@@ -134,7 +155,10 @@ export function ArtifactFullView({
     setError(null);
     try {
       const parsed = await fetchArtifactByIdWithFallback(artifactId);
-      const artifactData = parsed as ArtifactApiResponse;
+      if (!isArtifactApiResponse(parsed)) {
+        throw new Error("Artifact response payload is missing expected fields");
+      }
+      const artifactData = parsed;
       setArtifact(toFileArtifact(artifactData));
       setVisibility((artifactData.visibility as VisibilityLevel) ?? "team");
       setOwnerUserId(artifactData.user_id);

--- a/frontend/src/lib/artifactFetch.ts
+++ b/frontend/src/lib/artifactFetch.ts
@@ -1,9 +1,9 @@
 import { API_BASE, DIRECT_API_BASE, getAuthenticatedRequestHeaders } from "./api";
 
-interface ArtifactLikePayload {
+type ArtifactLikePayload = Record<string, unknown> & {
   id?: unknown;
   content?: unknown;
-}
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;


### PR DESCRIPTION
### Motivation
- Fix TypeScript build failures caused by unsafe casting of parsed artifact JSON to a strict `ArtifactApiResponse`, and ensure malformed payloads fail fast with a clear error.

### Description
- Redefine `ArtifactLikePayload` as `Record<string, unknown> & { id?: unknown; content?: unknown; }` in `frontend/src/lib/artifactFetch.ts` so the fetch helper's return type is structurally compatible with `Record<string, unknown>`.
- Add a runtime type guard `isArtifactApiResponse` in `frontend/src/components/ArtifactFullView.tsx` and use it to validate the fetched payload before mapping it with `toFileArtifact`, removing the unsafe `as` cast that triggered `TS2352`.
- Keep existing behavior for valid payloads and surface a clear error when expected artifact fields are missing.
- No AGENTS.md skills were required for this change; it is a focused typing and runtime-guard update.

### Testing
- Ran `npm run build` in `frontend/` (runs `tsc && vite build`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1570355048321b43a7f2e32109847)