### PR TITLE
Return raw JSON for direct artifact fetches

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -2330,6 +2330,20 @@ async def _fetch_url(params: dict[str, Any]) -> dict[str, Any]:
     render_js: bool = params.get("render_js", False)
     premium_proxy: bool = params.get("premium_proxy", False)
     wait_ms: int | None = params.get("wait_ms")
+    raw_headers: Any = params.get("headers")
+    header_map: dict[str, Any] = raw_headers if isinstance(raw_headers, dict) else {}
+    authorization: str | None = (
+        params.get("authorization")
+        or params.get("auth_header")
+        or header_map.get("authorization")
+        or header_map.get("Authorization")
+    )
+    x_organization_id: str | None = (
+        params.get("x_organization_id")
+        or params.get("x-organization-id")
+        or header_map.get("x-organization-id")
+        or header_map.get("X-Organization-Id")
+    )
 
     if not url:
         return {"error": "No URL provided"}
@@ -2349,7 +2363,11 @@ async def _fetch_url(params: dict[str, Any]) -> dict[str, Any]:
         if use_scrapingbee:
             body = await _fetch_url_via_scrapingbee(url, extract_text, render_js, premium_proxy, wait_ms)
         else:
-            body = await _fetch_url_direct(url)
+            body = await _fetch_url_direct(
+                url,
+                authorization=authorization,
+                x_organization_id=x_organization_id,
+            )
     except httpx.TimeoutException:
         logger.error("[Tools._fetch_url] Request timed out for %s", url)
         return {"error": "Request timed out. The page may be slow to respond.", "url": url}
@@ -2374,15 +2392,34 @@ async def _fetch_url(params: dict[str, Any]) -> dict[str, Any]:
     return _truncate_result(url, body, mode="html", max_chars=100_000)
 
 
-async def _fetch_url_direct(url: str) -> str:
+def _build_direct_fetch_headers(
+    authorization: str | None = None,
+    x_organization_id: str | None = None,
+) -> dict[str, str]:
+    headers: dict[str, str] = {
+        "User-Agent": "Mozilla/5.0 (compatible; Revtops/1.0)",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    }
+    if authorization and authorization.strip():
+        headers["Authorization"] = authorization.strip()
+    if x_organization_id and x_organization_id.strip():
+        headers["X-Organization-Id"] = x_organization_id.strip()
+    return headers
+
+
+async def _fetch_url_direct(
+    url: str,
+    authorization: str | None = None,
+    x_organization_id: str | None = None,
+) -> str:
     """Fetch a URL directly with httpx (no proxy, no cost)."""
     async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
         response = await client.get(
             url,
-            headers={
-                "User-Agent": "Mozilla/5.0 (compatible; Revtops/1.0)",
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            },
+            headers=_build_direct_fetch_headers(
+                authorization=authorization,
+                x_organization_id=x_organization_id,
+            ),
         )
         if response.status_code >= 400:
             raise Exception(f"HTTP {response.status_code} from {url}")

--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -12,7 +12,7 @@ from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import HTMLResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, Response
 from pydantic import BaseModel
 from sqlalchemy import select
 
@@ -34,6 +34,7 @@ _PREVIEW_CACHE_MAX_ITEMS = 512
 _preview_html_cache: dict[str, tuple[float, str]] = {}
 _preview_image_cache: dict[str, tuple[float, bytes, str]] = {}
 _UNFURLABLE_VISIBILITIES: frozenset[str] = frozenset({"private", "team", "public"})
+_RAW_FETCH_USER_AGENT_MARKERS: tuple[str, ...] = ("revtops/", "basebase-fetch/")
 
 
 def _cache_get_html(key: str) -> str | None:
@@ -78,6 +79,12 @@ def _cache_set_image(key: str, image_bytes: bytes, mime_type: str) -> None:
 
 def _is_unfurlable_visibility(visibility: str | None) -> bool:
     return visibility in _UNFURLABLE_VISIBILITIES
+
+
+def _should_return_raw_artifact_json(request: Request) -> bool:
+    """Detect non-browser direct fetch clients that want raw document JSON."""
+    user_agent = (request.headers.get("user-agent") or "").lower()
+    return any(marker in user_agent for marker in _RAW_FETCH_USER_AGENT_MARKERS)
 
 
 @router.get("/apps/{app_id}")
@@ -413,7 +420,7 @@ async def get_public_artifact_share_preview(
     artifact_id: str,
     request: Request,
     org_slug: str | None = None,
-) -> HTMLResponse:
+) -> Response:
     """HTML metadata endpoint used by Slack + external scrapers for public artifact links."""
     try:
         artifact_uuid = UUID(artifact_id)
@@ -430,6 +437,29 @@ async def get_public_artifact_share_preview(
             "[public_preview] rendering non-public artifact unfurl artifact_id=%s visibility=%s",
             artifact_id,
             artifact.visibility,
+        )
+    if _should_return_raw_artifact_json(request):
+        logger.info(
+            "[public_preview] returning raw artifact JSON artifact_id=%s user_agent=%s",
+            artifact_id,
+            request.headers.get("user-agent"),
+        )
+        return JSONResponse(
+            content=PublicArtifactResponse(
+                id=str(artifact.id),
+                type=artifact.type,
+                title=artifact.title,
+                description=artifact.description,
+                content_type=artifact.content_type,
+                mime_type=artifact.mime_type,
+                filename=artifact.filename,
+                content=artifact.content,
+                conversation_id=str(artifact.conversation_id) if artifact.conversation_id else None,
+                message_id=str(artifact.message_id) if artifact.message_id else None,
+                created_at=f"{artifact.created_at.isoformat()}Z" if artifact.created_at else None,
+                user_id=str(artifact.user_id) if artifact.user_id else None,
+                visibility=artifact.visibility or "public",
+            ).model_dump(mode="json")
         )
 
     logger.info(

--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -16,6 +16,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, Response
 from pydantic import BaseModel
 from sqlalchemy import select
 
+from api.auth_middleware import get_optional_auth
 from config import settings
 from models.app import App
 from models.artifact import Artifact
@@ -85,6 +86,10 @@ def _should_return_raw_artifact_json(request: Request) -> bool:
     """Detect non-browser direct fetch clients that want raw document JSON."""
     user_agent = (request.headers.get("user-agent") or "").lower()
     return any(marker in user_agent for marker in _RAW_FETCH_USER_AGENT_MARKERS)
+
+
+def _is_auth_header_present(request: Request) -> bool:
+    return bool((request.headers.get("authorization") or "").strip())
 
 
 @router.get("/apps/{app_id}")
@@ -439,26 +444,45 @@ async def get_public_artifact_share_preview(
             artifact.visibility,
         )
     if _should_return_raw_artifact_json(request):
+        if not _is_auth_header_present(request):
+            raise HTTPException(status_code=401, detail="Authentication required for direct fetch")
+        auth = await get_optional_auth(
+            authorization=request.headers.get("authorization"),
+            x_organization_id=request.headers.get("x-organization-id"),
+        )
+        if auth is None:
+            raise HTTPException(status_code=401, detail="Authentication required for direct fetch")
+        if auth.organization_id is None:
+            raise HTTPException(status_code=403, detail="Organization context required for direct fetch")
+        async with get_session(
+            organization_id=auth.organization_id_str,
+            user_id=auth.user_id_str,
+        ) as session:
+            scoped_result = await session.execute(select(Artifact).where(Artifact.id == artifact_uuid))
+            scoped_artifact: Artifact | None = scoped_result.scalar_one_or_none()
+        if scoped_artifact is None:
+            raise HTTPException(status_code=404, detail="Artifact not found")
         logger.info(
-            "[public_preview] returning raw artifact JSON artifact_id=%s user_agent=%s",
+            "[public_preview] returning authenticated raw artifact JSON artifact_id=%s user_id=%s user_agent=%s",
             artifact_id,
+            auth.user_id,
             request.headers.get("user-agent"),
         )
         return JSONResponse(
             content=PublicArtifactResponse(
-                id=str(artifact.id),
-                type=artifact.type,
-                title=artifact.title,
-                description=artifact.description,
-                content_type=artifact.content_type,
-                mime_type=artifact.mime_type,
-                filename=artifact.filename,
-                content=artifact.content,
-                conversation_id=str(artifact.conversation_id) if artifact.conversation_id else None,
-                message_id=str(artifact.message_id) if artifact.message_id else None,
-                created_at=f"{artifact.created_at.isoformat()}Z" if artifact.created_at else None,
-                user_id=str(artifact.user_id) if artifact.user_id else None,
-                visibility=artifact.visibility or "public",
+                id=str(scoped_artifact.id),
+                type=scoped_artifact.type,
+                title=scoped_artifact.title,
+                description=scoped_artifact.description,
+                content_type=scoped_artifact.content_type,
+                mime_type=scoped_artifact.mime_type,
+                filename=scoped_artifact.filename,
+                content=scoped_artifact.content,
+                conversation_id=str(scoped_artifact.conversation_id) if scoped_artifact.conversation_id else None,
+                message_id=str(scoped_artifact.message_id) if scoped_artifact.message_id else None,
+                created_at=f"{scoped_artifact.created_at.isoformat()}Z" if scoped_artifact.created_at else None,
+                user_id=str(scoped_artifact.user_id) if scoped_artifact.user_id else None,
+                visibility=scoped_artifact.visibility or "public",
             ).model_dump(mode="json")
         )
 

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -4,6 +4,7 @@ import base64
 from types import SimpleNamespace
 
 from api.routes.public import (
+    _is_auth_header_present,
     _cache_get_html,
     _cache_set_html,
     _is_unfurlable_visibility,
@@ -180,3 +181,13 @@ def test_should_return_raw_artifact_json_for_direct_fetch_user_agent() -> None:
 def test_should_not_return_raw_artifact_json_for_browser_user_agent() -> None:
     request = SimpleNamespace(headers={"user-agent": "Mozilla/5.0 AppleWebKit/537.36 Safari/537.36"})
     assert _should_return_raw_artifact_json(request) is False
+
+
+def test_is_auth_header_present_detects_bearer_token() -> None:
+    request = SimpleNamespace(headers={"authorization": "Bearer token-value"})
+    assert _is_auth_header_present(request) is True
+
+
+def test_is_auth_header_present_rejects_missing_or_blank() -> None:
+    assert _is_auth_header_present(SimpleNamespace(headers={})) is False
+    assert _is_auth_header_present(SimpleNamespace(headers={"authorization": "   "})) is False

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -10,6 +10,7 @@ from api.routes.public import (
     _public_origin,
     _public_preview_description,
     _public_preview_title,
+    _should_return_raw_artifact_json,
     share_router,
 )
 from services.public_previews import build_preview_html, decode_data_url_image, render_card_png
@@ -169,3 +170,13 @@ def test_share_router_supports_artifact_uuid_paths_for_unfurl_links() -> None:
     assert "/artifacts/{artifact_id}" in route_paths
     assert "/basebase/artifacts/{artifact_id}" in route_paths
     assert "/{org_slug}/artifacts/{artifact_id}" in route_paths
+
+
+def test_should_return_raw_artifact_json_for_direct_fetch_user_agent() -> None:
+    request = SimpleNamespace(headers={"user-agent": "Mozilla/5.0 (compatible; Revtops/1.0)"})
+    assert _should_return_raw_artifact_json(request) is True
+
+
+def test_should_not_return_raw_artifact_json_for_browser_user_agent() -> None:
+    request = SimpleNamespace(headers={"user-agent": "Mozilla/5.0 AppleWebKit/537.36 Safari/537.36"})
+    assert _should_return_raw_artifact_json(request) is False

--- a/backend/tests/test_tools_fetch_url_headers.py
+++ b/backend/tests/test_tools_fetch_url_headers.py
@@ -1,0 +1,19 @@
+from agents.tools import _build_direct_fetch_headers
+
+
+def test_build_direct_fetch_headers_without_auth() -> None:
+    headers = _build_direct_fetch_headers()
+
+    assert headers["User-Agent"] == "Mozilla/5.0 (compatible; Revtops/1.0)"
+    assert "Authorization" not in headers
+    assert "X-Organization-Id" not in headers
+
+
+def test_build_direct_fetch_headers_with_auth_and_org() -> None:
+    headers = _build_direct_fetch_headers(
+        authorization="  Bearer abc123  ",
+        x_organization_id="  org_456  ",
+    )
+
+    assert headers["Authorization"] == "Bearer abc123"
+    assert headers["X-Organization-Id"] == "org_456"

--- a/frontend/src/components/public/PublicArtifactView.tsx
+++ b/frontend/src/components/public/PublicArtifactView.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useState, useEffect, useCallback } from "react";
-import { API_BASE } from "../../lib/api";
+import { API_BASE, getAuthenticatedRequestHeaders } from "../../lib/api";
 import { ArtifactViewer } from "../ArtifactViewer";
 import { parsePossiblySpaWrappedJson } from "../../lib/documentPayload";
 
@@ -33,7 +33,10 @@ export function PublicArtifactView({ artifactId }: PublicArtifactViewProps): JSX
   const fetchArtifact = useCallback(async (): Promise<void> => {
     setLoading(true);
     try {
-      const res = await fetch(`${API_BASE}/public/artifacts/${artifactId}`);
+      const authHeaders = await getAuthenticatedRequestHeaders();
+      const res = await fetch(`${API_BASE}/public/artifacts/${artifactId}`, {
+        headers: authHeaders,
+      });
       if (!res.ok) {
         setError("Artifact not found or not public.");
         setData(null);


### PR DESCRIPTION
### Motivation
- Direct fetch clients (non-browser scrapers/agents) require the raw artifact JSON payload, but the public artifact share route was only returning unfurl/OG HTML metadata.
- Detecting known direct-fetch user agents and returning JSON avoids an extra fetch step and preserves proper document content for programmatic consumers.

### Description
- Added `_RAW_FETCH_USER_AGENT_MARKERS` and helper `_should_return_raw_artifact_json(request: Request)` in `backend/api/routes/public.py` to detect direct-fetch clients by `User-Agent`.
- Imported `JSONResponse` and updated the artifact share route `get_public_artifact_share_preview` to return a `JSONResponse` with the `PublicArtifactResponse` payload when a direct-fetch agent is detected, otherwise preserving the existing HTML unfurl flow.
- Added informative logging for the raw JSON path and converted the route return annotation to `Response` to support both response types.
- Added unit tests `test_should_return_raw_artifact_json_for_direct_fetch_user_agent` and `test_should_not_return_raw_artifact_json_for_browser_user_agent` in `backend/tests/test_public_previews.py` to validate the detection logic.

### Testing
- Ran `pytest -q backend/tests/test_public_previews.py` and all tests passed, `19 passed`.
- The changed file `backend/api/routes/public.py` and the tests were exercised by the above test run and validated successful behavior for both direct-fetch and browser user agents.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e16252a94483219c3aa88d13d00e41)