### PR TITLE
Add content-group and campfire context plumbing with sync-time summaries

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -477,6 +477,7 @@ class ChatOrchestrator:
         source_user_email: str | None = None,
         workflow_context: dict[str, Any] | None = None,
         source: str = "web",
+        external_context_message: str | None = None,
     ) -> None:
         """
         Initialize the orchestrator.
@@ -511,6 +512,7 @@ class ChatOrchestrator:
         self.source_user_email = source_user_email
         self.workflow_context = workflow_context
         self.source: str = source
+        self.external_context_message = external_context_message
         self._llm_config: LLMConfig | None = None
         self._adapter: AnthropicAdapter | OpenAIAdapter | None = None
         # Track if we've saved the assistant message (for early save during tool execution)
@@ -1058,10 +1060,19 @@ class ChatOrchestrator:
             text_for_model, attachment_ids,
         )
 
-        # Add user message to context for Claude
-        messages: list[dict[str, Any]] = history + [
-            {"role": "user", "content": user_content}
-        ]
+        # Add context and user message to context for Claude.
+        messages: list[dict[str, Any]] = list(history)
+        if self.external_context_message:
+            messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        "Channel/campfire context block (summaries only; may be stale):\n"
+                        f"{self.external_context_message}"
+                    ),
+                }
+            )
+        messages.append({"role": "user", "content": user_content})
         cross_conversation_context_message: str | None = None
 
         # Resolve per-org LLM provider/model/key

--- a/backend/db/migrations/versions/134_content_groups.py
+++ b/backend/db/migrations/versions/134_content_groups.py
@@ -1,0 +1,80 @@
+"""Create content_groups and conversation linkage.
+
+Revision ID: 134_content_groups
+Revises: 133_org_members_self_edit
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "134_content_groups"
+down_revision: Union[str, Sequence[str], None] = "133_org_members_self_edit"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+assert len(revision) <= 32
+if isinstance(down_revision, str):
+    assert len(down_revision) <= 32
+
+
+def upgrade() -> None:
+    op.create_table(
+        "content_groups",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("platform", sa.String(length=30), nullable=False),
+        sa.Column("workspace_id", sa.String(length=100), nullable=False),
+        sa.Column("external_group_id", sa.String(length=255), nullable=False),
+        sa.Column("external_thread_id", sa.String(length=255), nullable=True),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint(
+            "organization_id",
+            "platform",
+            "workspace_id",
+            "external_group_id",
+            "external_thread_id",
+            name="uq_content_groups_key",
+        ),
+    )
+    op.create_index("ix_content_groups_org_platform_workspace", "content_groups", ["organization_id", "platform", "workspace_id"])
+    op.create_index("ix_content_groups_org_platform_group", "content_groups", ["organization_id", "platform", "external_group_id"])
+
+    op.add_column("conversations", sa.Column("content_group_id", postgresql.UUID(as_uuid=True), nullable=True))
+    op.create_foreign_key(
+        "fk_conversations_content_group_id",
+        "conversations",
+        "content_groups",
+        ["content_group_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index("ix_conversations_content_group", "conversations", ["content_group_id"])
+
+    op.execute("ALTER TABLE content_groups ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY content_groups_org_isolation ON content_groups
+        FOR ALL
+        USING (organization_id = current_setting('app.current_org_id')::uuid)
+        WITH CHECK (organization_id = current_setting('app.current_org_id')::uuid)
+        """
+    )
+    op.execute("GRANT ALL ON content_groups TO revtops_app")
+
+
+def downgrade() -> None:
+    op.drop_index("ix_conversations_content_group", table_name="conversations")
+    op.drop_constraint("fk_conversations_content_group_id", "conversations", type_="foreignkey")
+    op.drop_column("conversations", "content_group_id")
+
+    op.execute("DROP POLICY IF EXISTS content_groups_org_isolation ON content_groups")
+    op.drop_index("ix_content_groups_org_platform_group", table_name="content_groups")
+    op.drop_index("ix_content_groups_org_platform_workspace", table_name="content_groups")
+    op.drop_table("content_groups")

--- a/backend/db/migrations/versions/135_campfires.py
+++ b/backend/db/migrations/versions/135_campfires.py
@@ -1,0 +1,127 @@
+"""Create campfires and join tables.
+
+Revision ID: 135_campfires
+Revises: 134_content_groups
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "135_campfires"
+down_revision: Union[str, Sequence[str], None] = "134_content_groups"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+assert len(revision) <= 32
+if isinstance(down_revision, str):
+    assert len(down_revision) <= 32
+
+
+def upgrade() -> None:
+    op.create_table(
+        "campfires",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("is_archived", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("created_by_user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="SET NULL", onupdate="CASCADE"), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_campfires_org_archived", "campfires", ["organization_id", "is_archived"])
+
+    op.create_table(
+        "campfire_content_groups",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("campfire_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("campfires.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("content_group_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("content_groups.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("campfire_id", "content_group_id", name="uq_campfire_content_group"),
+    )
+
+    op.create_table(
+        "campfire_conversations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("campfire_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("campfires.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("conversation_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("conversations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("added_by_user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="SET NULL", onupdate="CASCADE"), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("campfire_id", "conversation_id", name="uq_campfire_conversation"),
+    )
+
+    op.execute("ALTER TABLE campfires ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE campfire_content_groups ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE campfire_conversations ENABLE ROW LEVEL SECURITY")
+
+    op.execute(
+        """
+        CREATE POLICY campfires_org_isolation ON campfires
+        FOR ALL
+        USING (organization_id = current_setting('app.current_org_id')::uuid)
+        WITH CHECK (organization_id = current_setting('app.current_org_id')::uuid)
+        """
+    )
+
+    op.execute(
+        """
+        CREATE POLICY campfire_content_groups_org_isolation ON campfire_content_groups
+        FOR ALL
+        USING (
+            EXISTS (
+                SELECT 1 FROM campfires
+                WHERE campfires.id = campfire_content_groups.campfire_id
+                  AND campfires.organization_id = current_setting('app.current_org_id')::uuid
+            )
+        )
+        WITH CHECK (
+            EXISTS (
+                SELECT 1 FROM campfires
+                WHERE campfires.id = campfire_content_groups.campfire_id
+                  AND campfires.organization_id = current_setting('app.current_org_id')::uuid
+            )
+        )
+        """
+    )
+
+    op.execute(
+        """
+        CREATE POLICY campfire_conversations_org_isolation ON campfire_conversations
+        FOR ALL
+        USING (
+            EXISTS (
+                SELECT 1 FROM campfires
+                WHERE campfires.id = campfire_conversations.campfire_id
+                  AND campfires.organization_id = current_setting('app.current_org_id')::uuid
+            )
+        )
+        WITH CHECK (
+            EXISTS (
+                SELECT 1 FROM campfires
+                WHERE campfires.id = campfire_conversations.campfire_id
+                  AND campfires.organization_id = current_setting('app.current_org_id')::uuid
+            )
+        )
+        """
+    )
+
+    op.execute("GRANT ALL ON campfires TO revtops_app")
+    op.execute("GRANT ALL ON campfire_content_groups TO revtops_app")
+    op.execute("GRANT ALL ON campfire_conversations TO revtops_app")
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS campfire_conversations_org_isolation ON campfire_conversations")
+    op.execute("DROP POLICY IF EXISTS campfire_content_groups_org_isolation ON campfire_content_groups")
+    op.execute("DROP POLICY IF EXISTS campfires_org_isolation ON campfires")
+
+    op.drop_table("campfire_conversations")
+    op.drop_table("campfire_content_groups")
+    op.drop_index("ix_campfires_org_archived", table_name="campfires")
+    op.drop_table("campfires")

--- a/backend/db/migrations/versions/136_group_summaries.py
+++ b/backend/db/migrations/versions/136_group_summaries.py
@@ -1,0 +1,71 @@
+"""Create content_group_summaries table.
+
+Revision ID: 136_group_summaries
+Revises: 135_campfires
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "136_group_summaries"
+down_revision: Union[str, Sequence[str], None] = "135_campfires"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+assert len(revision) <= 32
+if isinstance(down_revision, str):
+    assert len(down_revision) <= 32
+
+
+def upgrade() -> None:
+    op.create_table(
+        "content_group_summaries",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("content_group_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("content_groups.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("summary_text", sa.Text(), nullable=False),
+        sa.Column("summary_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("first_message_external_id", sa.String(length=255), nullable=True),
+        sa.Column("last_message_external_id", sa.String(length=255), nullable=True),
+        sa.Column("first_message_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_message_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("summarized_through_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("message_count", sa.Integer(), nullable=False),
+        sa.Column("model", sa.String(length=100), nullable=True),
+        sa.Column("prompt_version", sa.String(length=50), nullable=False, server_default=sa.text("'v1'")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+
+    op.create_index(
+        "ix_group_summaries_group_through_desc",
+        "content_group_summaries",
+        ["content_group_id", sa.text("summarized_through_at DESC")],
+    )
+    op.create_index(
+        "ix_group_summaries_org_group_range",
+        "content_group_summaries",
+        ["organization_id", "content_group_id", "first_message_at", "last_message_at"],
+    )
+
+    op.execute("ALTER TABLE content_group_summaries ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY content_group_summaries_org_isolation ON content_group_summaries
+        FOR ALL
+        USING (organization_id = current_setting('app.current_org_id')::uuid)
+        WITH CHECK (organization_id = current_setting('app.current_org_id')::uuid)
+        """
+    )
+    op.execute("GRANT ALL ON content_group_summaries TO revtops_app")
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS content_group_summaries_org_isolation ON content_group_summaries")
+    op.drop_index("ix_group_summaries_org_group_range", table_name="content_group_summaries")
+    op.drop_index("ix_group_summaries_group_through_desc", table_name="content_group_summaries")
+    op.drop_table("content_group_summaries")

--- a/backend/db/migrations/versions/137_content_groups_non_thread_unique.py
+++ b/backend/db/migrations/versions/137_content_groups_non_thread_unique.py
@@ -1,0 +1,53 @@
+"""Enforce non-thread content_group uniqueness.
+
+Revision ID: 137_group_non_thread_uq
+Revises: 136_group_summaries
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "137_group_non_thread_uq"
+down_revision: Union[str, Sequence[str], None] = "136_group_summaries"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+assert len(revision) <= 32
+if isinstance(down_revision, str):
+    assert len(down_revision) <= 32
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        WITH ranked AS (
+            SELECT
+                id,
+                ROW_NUMBER() OVER (
+                    PARTITION BY organization_id, platform, workspace_id, external_group_id
+                    ORDER BY updated_at DESC, created_at DESC, id DESC
+                ) AS rn
+            FROM content_groups
+            WHERE external_thread_id IS NULL
+        )
+        DELETE FROM content_groups cg
+        USING ranked r
+        WHERE cg.id = r.id
+          AND r.rn > 1
+        """
+    )
+
+    op.create_index(
+        "uq_content_groups_channel_non_thread",
+        "content_groups",
+        ["organization_id", "platform", "workspace_id", "external_group_id"],
+        unique=True,
+        postgresql_where=sa.text("external_thread_id IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_content_groups_channel_non_thread", table_name="content_groups")

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -955,6 +955,43 @@ class WorkspaceMessenger(BaseMessenger):
             conversation_id: str = await self.find_or_create_conversation(
                 organization_id, user, message,
             )
+            content_group_id: str | None = None
+            context_pack_text: str | None = None
+            try:
+                from services.content_groups import (
+                    associate_conversation_to_content_group,
+                    resolve_content_group_from_message,
+                )
+                from services.context_pack import build_incoming_message_context_pack
+
+                content_group = await resolve_content_group_from_message(
+                    message_ctx=message.messenger_context,
+                    organization_id=organization_id,
+                    platform=self.meta.slug,
+                )
+                if content_group is not None:
+                    content_group_id = str(content_group.id)
+                    await associate_conversation_to_content_group(
+                        organization_id=organization_id,
+                        conversation_id=conversation_id,
+                        content_group_id=content_group_id,
+                    )
+                    context_pack = await build_incoming_message_context_pack(
+                        organization_id=organization_id,
+                        content_group_id=content_group_id,
+                    )
+                    context_pack_text = (
+                        str(context_pack.get("context_text"))
+                        if context_pack and context_pack.get("context_text")
+                        else None
+                    )
+            except Exception:
+                logger.warning(
+                    "[%s] content_group_resolution_failed conversation_id=%s",
+                    self.meta.slug,
+                    conversation_id,
+                    exc_info=True,
+                )
 
             ctx: dict[str, Any] = message.messenger_context
             slack_user_email: str | None = ctx.get("user_email")
@@ -1007,6 +1044,7 @@ class WorkspaceMessenger(BaseMessenger):
                 source=self.meta.slug,
                 timezone=ctx.get("timezone"),
                 local_time=ctx.get("local_time"),
+                external_context_message=context_pack_text,
             )
 
             if self.meta.response_mode.value == "streaming":

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -34,6 +34,13 @@ from models.workstream_snapshot import WorkstreamSnapshot
 from models.notification import Notification
 from models.action_ledger import ActionLedgerEntry
 from models.daily_digest import DailyDigest
+from models.content_group import (
+    Campfire,
+    CampfireContentGroup,
+    CampfireConversation,
+    ContentGroup,
+    ContentGroupSummary,
+)
 
 __all__ = [
     "Base",
@@ -76,4 +83,9 @@ __all__ = [
     "Notification",
     "ActionLedgerEntry",
     "DailyDigest",
+    "ContentGroup",
+    "ContentGroupSummary",
+    "Campfire",
+    "CampfireContentGroup",
+    "CampfireConversation",
 ]

--- a/backend/models/content_group.py
+++ b/backend/models/content_group.py
@@ -27,6 +27,15 @@ class ContentGroup(Base):
         ),
         Index("ix_content_groups_org_platform_workspace", "organization_id", "platform", "workspace_id"),
         Index("ix_content_groups_org_platform_group", "organization_id", "platform", "external_group_id"),
+        Index(
+            "uq_content_groups_channel_non_thread",
+            "organization_id",
+            "platform",
+            "workspace_id",
+            "external_group_id",
+            unique=True,
+            postgresql_where=text("external_thread_id IS NULL"),
+        ),
         {"extend_existing": True},
     )
 

--- a/backend/models/content_group.py
+++ b/backend/models/content_group.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Optional
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint, func, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from models.database import Base
+
+if TYPE_CHECKING:
+    from models.conversation import Conversation
+
+
+class ContentGroup(Base):
+    __tablename__ = "content_groups"
+    __table_args__ = (
+        UniqueConstraint(
+            "organization_id",
+            "platform",
+            "workspace_id",
+            "external_group_id",
+            "external_thread_id",
+            name="uq_content_groups_key",
+        ),
+        Index("ix_content_groups_org_platform_workspace", "organization_id", "platform", "workspace_id"),
+        Index("ix_content_groups_org_platform_group", "organization_id", "platform", "external_group_id"),
+        {"extend_existing": True},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    platform: Mapped[str] = mapped_column(String(30), nullable=False)
+    workspace_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    external_group_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    external_thread_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=text("true")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+
+class ContentGroupSummary(Base):
+    __tablename__ = "content_group_summaries"
+    __table_args__ = (
+        Index(
+            "ix_group_summaries_group_through_desc",
+            "content_group_id",
+            text("summarized_through_at DESC"),
+        ),
+        Index(
+            "ix_group_summaries_org_group_range",
+            "organization_id",
+            "content_group_id",
+            "first_message_at",
+            "last_message_at",
+        ),
+        {"extend_existing": True},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    content_group_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("content_groups.id", ondelete="CASCADE"), nullable=False
+    )
+    summary_text: Mapped[str] = mapped_column(Text, nullable=False)
+    summary_json: Mapped[Optional[dict[str, Any]]] = mapped_column(JSONB, nullable=True)
+    first_message_external_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    last_message_external_id: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    first_message_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_message_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    summarized_through_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    message_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    model: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
+    prompt_version: Mapped[str] = mapped_column(
+        String(50), nullable=False, default="v1", server_default=text("'v1'")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+
+class Campfire(Base):
+    __tablename__ = "campfires"
+    __table_args__ = (
+        Index("ix_campfires_org_archived", "organization_id", "is_archived"),
+        {"extend_existing": True},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    is_archived: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+    created_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL", onupdate="CASCADE"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+
+class CampfireContentGroup(Base):
+    __tablename__ = "campfire_content_groups"
+    __table_args__ = (
+        UniqueConstraint("campfire_id", "content_group_id", name="uq_campfire_content_group"),
+        {"extend_existing": True},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    campfire_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("campfires.id", ondelete="CASCADE"), nullable=False
+    )
+    content_group_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("content_groups.id", ondelete="CASCADE"), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+
+class CampfireConversation(Base):
+    __tablename__ = "campfire_conversations"
+    __table_args__ = (
+        UniqueConstraint("campfire_id", "conversation_id", name="uq_campfire_conversation"),
+        {"extend_existing": True},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    campfire_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("campfires.id", ondelete="CASCADE"), nullable=False
+    )
+    conversation_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("conversations.id", ondelete="CASCADE"), nullable=False
+    )
+    added_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL", onupdate="CASCADE"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -40,6 +40,7 @@ class Conversation(Base):
     __tablename__ = "conversations"
     __table_args__ = (
         Index("ix_conversations_source_channel", "source", "source_channel_id"),
+        Index("ix_conversations_content_group", "content_group_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -63,6 +64,9 @@ class Conversation(Base):
     source_user_id: Mapped[Optional[str]] = mapped_column(
         String(100), nullable=True
     )  # External user ID (e.g., Slack user ID)
+    content_group_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("content_groups.id", ondelete="SET NULL"), nullable=True
+    )
     # All known RevTops users who have participated in this conversation.
     participating_user_ids: Mapped[list[uuid.UUID]] = mapped_column(
         ARRAY(UUID(as_uuid=True)), nullable=False, default=list

--- a/backend/services/campfires.py
+++ b/backend/services/campfires.py
@@ -10,6 +10,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from models.content_group import (
     Campfire,
     CampfireContentGroup,
+    ContentGroup,
     ContentGroupSummary,
 )
 from models.database import get_session
@@ -65,7 +66,29 @@ async def add_content_group_to_campfire(
     campfire_id: str,
     content_group_id: str,
 ) -> None:
+    org_uuid = UUID(organization_id)
     async with get_session(organization_id=organization_id) as session:
+        campfire_stmt = (
+            select(Campfire.id)
+            .where(Campfire.id == UUID(campfire_id))
+            .where(Campfire.organization_id == org_uuid)
+        )
+        content_group_stmt = (
+            select(ContentGroup.id)
+            .where(ContentGroup.id == UUID(content_group_id))
+            .where(ContentGroup.organization_id == org_uuid)
+        )
+        campfire_exists = (await session.execute(campfire_stmt)).scalar_one_or_none()
+        content_group_exists = (await session.execute(content_group_stmt)).scalar_one_or_none()
+        if campfire_exists is None or content_group_exists is None:
+            logger.warning(
+                "[campfire.add_content_group] org_mismatch_or_not_found org_id=%s campfire_id=%s content_group_id=%s",
+                organization_id,
+                campfire_id,
+                content_group_id,
+            )
+            return
+
         stmt = pg_insert(CampfireContentGroup).values(
             campfire_id=UUID(campfire_id),
             content_group_id=UUID(content_group_id),
@@ -125,12 +148,24 @@ async def list_campfire_context_summaries(
     *,
     summary_limit_per_group: int = 2,
 ) -> list[ContentGroupSummary]:
+    org_uuid = UUID(organization_id)
+    campfire_ids_subquery = (
+        select(CampfireContentGroup.campfire_id)
+        .join(Campfire, Campfire.id == CampfireContentGroup.campfire_id)
+        .where(Campfire.organization_id == org_uuid)
+        .where(Campfire.is_archived == False)  # noqa: E712
+        .where(CampfireContentGroup.content_group_id == UUID(content_group_id))
+    )
     stmt = (
         select(ContentGroupSummary)
+        .join(ContentGroup, ContentGroup.id == ContentGroupSummary.content_group_id)
         .join(CampfireContentGroup, CampfireContentGroup.content_group_id == ContentGroupSummary.content_group_id)
         .join(Campfire, Campfire.id == CampfireContentGroup.campfire_id)
-        .where(Campfire.organization_id == UUID(organization_id))
-        .where(CampfireContentGroup.content_group_id == UUID(content_group_id))
+        .where(Campfire.organization_id == org_uuid)
+        .where(ContentGroup.organization_id == org_uuid)
+        .where(ContentGroupSummary.organization_id == org_uuid)
+        .where(CampfireContentGroup.campfire_id.in_(campfire_ids_subquery))
+        .where(CampfireContentGroup.content_group_id != UUID(content_group_id))
         .where(Campfire.is_archived == False)  # noqa: E712
         .order_by(ContentGroupSummary.summarized_through_at.desc())
         .limit(summary_limit_per_group)

--- a/backend/services/campfires.py
+++ b/backend/services/campfires.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from models.content_group import (
+    Campfire,
+    CampfireContentGroup,
+    ContentGroupSummary,
+)
+from models.database import get_session
+
+logger = logging.getLogger(__name__)
+
+
+async def create_campfire(
+    organization_id: str,
+    name: str,
+    description: str | None = None,
+    created_by_user_id: str | None = None,
+) -> Campfire:
+    async with get_session(organization_id=organization_id, user_id=created_by_user_id) as session:
+        campfire = Campfire(
+            organization_id=UUID(organization_id),
+            name=name,
+            description=description,
+            created_by_user_id=UUID(created_by_user_id) if created_by_user_id else None,
+        )
+        session.add(campfire)
+        await session.commit()
+        await session.refresh(campfire)
+        return campfire
+
+
+async def update_campfire(
+    organization_id: str,
+    campfire_id: str,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    is_archived: bool | None = None,
+) -> Campfire | None:
+    async with get_session(organization_id=organization_id) as session:
+        campfire = await session.get(Campfire, UUID(campfire_id))
+        if campfire is None or str(campfire.organization_id) != organization_id:
+            return None
+        if name is not None:
+            campfire.name = name
+        if description is not None:
+            campfire.description = description
+        if is_archived is not None:
+            campfire.is_archived = is_archived
+        campfire.updated_at = datetime.now(UTC)
+        await session.commit()
+        await session.refresh(campfire)
+        return campfire
+
+
+async def add_content_group_to_campfire(
+    organization_id: str,
+    campfire_id: str,
+    content_group_id: str,
+) -> None:
+    async with get_session(organization_id=organization_id) as session:
+        stmt = pg_insert(CampfireContentGroup).values(
+            campfire_id=UUID(campfire_id),
+            content_group_id=UUID(content_group_id),
+        ).on_conflict_do_nothing(
+            constraint="uq_campfire_content_group"
+        )
+        await session.execute(stmt)
+        await session.commit()
+
+
+async def remove_content_group_from_campfire(
+    organization_id: str,
+    campfire_id: str,
+    content_group_id: str,
+) -> int:
+    async with get_session(organization_id=organization_id) as session:
+        stmt = (
+            CampfireContentGroup.__table__.delete()
+            .where(CampfireContentGroup.campfire_id == UUID(campfire_id))
+            .where(CampfireContentGroup.content_group_id == UUID(content_group_id))
+        )
+        result = await session.execute(stmt)
+        await session.commit()
+        return int(result.rowcount or 0)
+
+
+async def list_campfires_by_content_group(
+    organization_id: str,
+    content_group_id: str,
+) -> list[Campfire]:
+    stmt = (
+        select(Campfire)
+        .join(CampfireContentGroup, CampfireContentGroup.campfire_id == Campfire.id)
+        .where(Campfire.organization_id == UUID(organization_id))
+        .where(CampfireContentGroup.content_group_id == UUID(content_group_id))
+        .where(Campfire.is_archived == False)  # noqa: E712
+        .order_by(Campfire.updated_at.desc())
+    )
+    async with get_session(organization_id=organization_id) as session:
+        started = datetime.now(UTC)
+        rows = await session.execute(stmt)
+        campfires = list(rows.scalars().all())
+        elapsed_ms = int((datetime.now(UTC) - started).total_seconds() * 1000)
+        logger.info(
+            "[campfire.lookup] org_id=%s content_group_id=%s campfire_count=%d campfire_lookup_ms=%d",
+            organization_id,
+            content_group_id,
+            len(campfires),
+            elapsed_ms,
+        )
+        return campfires
+
+
+async def list_campfire_context_summaries(
+    organization_id: str,
+    content_group_id: str,
+    *,
+    summary_limit_per_group: int = 2,
+) -> list[ContentGroupSummary]:
+    stmt = (
+        select(ContentGroupSummary)
+        .join(CampfireContentGroup, CampfireContentGroup.content_group_id == ContentGroupSummary.content_group_id)
+        .join(Campfire, Campfire.id == CampfireContentGroup.campfire_id)
+        .where(Campfire.organization_id == UUID(organization_id))
+        .where(CampfireContentGroup.content_group_id == UUID(content_group_id))
+        .where(Campfire.is_archived == False)  # noqa: E712
+        .order_by(ContentGroupSummary.summarized_through_at.desc())
+        .limit(summary_limit_per_group)
+    )
+    async with get_session(organization_id=organization_id) as session:
+        rows = await session.execute(stmt)
+        return list(rows.scalars().all())

--- a/backend/services/content_group_summary.py
+++ b/backend/services/content_group_summary.py
@@ -47,7 +47,6 @@ def _select_messages_stmt(
         select(Activity)
         .where(Activity.organization_id == UUID(organization_id))
         .where(Activity.source_system == content_group.platform)
-        .where(Activity.custom_fields["workspace_id"].astext == content_group.workspace_id)
         .where(Activity.custom_fields["channel_id"].astext == content_group.external_group_id)
         .where(Activity.activity_date.is_not(None))
         .where(Activity.activity_date <= through)
@@ -164,6 +163,7 @@ async def generate_content_group_summary_for_sync(
 
         async def _write() -> dict[str, Any]:
             async with get_session(organization_id=organization_id) as session:
+                summarized_through_at = candidates[-1].activity_date or sync_through_at
                 row = ContentGroupSummary(
                     organization_id=UUID(organization_id),
                     content_group_id=UUID(content_group_id),
@@ -173,7 +173,7 @@ async def generate_content_group_summary_for_sync(
                     last_message_external_id=candidates[-1].source_id,
                     first_message_at=candidates[0].activity_date or sync_through_at,
                     last_message_at=candidates[-1].activity_date or sync_through_at,
-                    summarized_through_at=sync_through_at,
+                    summarized_through_at=summarized_through_at,
                     message_count=len(candidates),
                     model=llm_config.workflow_model or llm_config.primary_model,
                     prompt_version=PROMPT_VERSION,

--- a/backend/services/content_group_summary.py
+++ b/backend/services/content_group_summary.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import time
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import Select, select
+
+from models.activity import Activity
+from models.content_group import ContentGroup, ContentGroupSummary
+from models.database import get_session
+from services.llm_provider import get_adapter, resolve_llm_config
+
+logger = logging.getLogger(__name__)
+
+PROMPT_VERSION = "v1"
+_METRICS: dict[str, int] = {
+    "content_group_summary_generated_total": 0,
+    "content_group_summary_skipped_empty_total": 0,
+    "content_group_summary_failed_total": 0,
+}
+
+
+async def get_last_summary_watermark(content_group_id: str, organization_id: str) -> datetime | None:
+    stmt = (
+        select(ContentGroupSummary.summarized_through_at)
+        .where(ContentGroupSummary.content_group_id == UUID(content_group_id))
+        .order_by(ContentGroupSummary.summarized_through_at.desc())
+        .limit(1)
+    )
+    async with get_session(organization_id=organization_id) as session:
+        return (await session.execute(stmt)).scalar_one_or_none()
+
+
+def _select_messages_stmt(
+    organization_id: str,
+    content_group: ContentGroup,
+    since: datetime | None,
+    through: datetime,
+    limit: int,
+) -> Select[tuple[Activity]]:
+    stmt = (
+        select(Activity)
+        .where(Activity.organization_id == UUID(organization_id))
+        .where(Activity.source_system == content_group.platform)
+        .where(Activity.custom_fields["workspace_id"].astext == content_group.workspace_id)
+        .where(Activity.custom_fields["channel_id"].astext == content_group.external_group_id)
+        .where(Activity.activity_date.is_not(None))
+        .where(Activity.activity_date <= through)
+        .order_by(Activity.activity_date.asc())
+        .limit(limit)
+    )
+    if content_group.external_thread_id:
+        stmt = stmt.where(Activity.custom_fields["thread_ts"].astext == content_group.external_thread_id)
+    if since is not None:
+        stmt = stmt.where(Activity.activity_date > since)
+    return stmt
+
+
+async def select_unsummarized_messages(
+    organization_id: str,
+    content_group_id: str,
+    since: datetime | None,
+    through: datetime,
+    limit: int = 200,
+) -> list[Activity]:
+    async with get_session(organization_id=organization_id) as session:
+        group = await session.get(ContentGroup, UUID(content_group_id))
+        if group is None:
+            return []
+        rows = await session.execute(_select_messages_stmt(organization_id, group, since, through, limit))
+        activities = list(rows.scalars().all())
+        logger.info(
+            "[content_group.summary_candidates] org_id=%s content_group_id=%s candidate_count=%d since=%s through=%s",
+            organization_id,
+            content_group_id,
+            len(activities),
+            since.isoformat() if since else None,
+            through.isoformat(),
+        )
+        return activities
+
+
+def build_summary_prompt(transcript_chunk: str, metadata: dict[str, Any]) -> str:
+    return (
+        "Summarize this Slack/Teams channel window for AI context reuse. "
+        "Focus on decisions, blockers, owners, and concrete next steps. "
+        "Be concise, factual, and avoid speculation.\n\n"
+        f"Metadata: {metadata}\n\nTranscript:\n{transcript_chunk}"
+    )
+
+
+async def _with_retry(coro_factory: Any, *, attempts: int = 3) -> Any:
+    for attempt in range(1, attempts + 1):
+        try:
+            return await coro_factory()
+        except Exception as exc:
+            msg = str(exc).lower()
+            retriable = "deadlock" in msg or "serialization" in msg
+            if not retriable or attempt == attempts:
+                raise
+            sleep_s = (0.15 * (2 ** (attempt - 1))) + random.random() * 0.05
+            await asyncio.sleep(sleep_s)
+
+
+async def generate_content_group_summary_for_sync(
+    *,
+    organization_id: str,
+    content_group_id: str,
+    sync_through_at: datetime,
+) -> dict[str, Any]:
+    try:
+        watermark = await get_last_summary_watermark(content_group_id, organization_id)
+        candidates = await select_unsummarized_messages(
+            organization_id=organization_id,
+            content_group_id=content_group_id,
+            since=watermark,
+            through=sync_through_at,
+        )
+        if not candidates:
+            _METRICS["content_group_summary_skipped_empty_total"] += 1
+            return {"status": "skipped", "reason": "empty", "content_group_id": content_group_id}
+
+        transcript_lines = []
+        for row in candidates:
+            when = row.activity_date.isoformat() if row.activity_date else ""
+            who = (row.custom_fields or {}).get("user_id") or "unknown"
+            body = (row.description or row.subject or "").strip().replace("\n", " ")
+            transcript_lines.append(f"[{when}] {who}: {body}")
+        transcript = "\n".join(transcript_lines)
+
+        llm_config = await resolve_llm_config(organization_id)
+        adapter = get_adapter(llm_config)
+        prompt_meta = {
+            "content_group_id": content_group_id,
+            "message_count": len(candidates),
+            "first_message_id": candidates[0].source_id,
+            "last_message_id": candidates[-1].source_id,
+        }
+        prompt = build_summary_prompt(transcript, prompt_meta)
+
+        t0 = time.perf_counter()
+        response = await adapter.send_message(
+            system_prompt="You write compact channel summaries for downstream context injection.",
+            messages=[{"role": "user", "content": prompt}],
+            model=llm_config.workflow_model or llm_config.primary_model,
+            max_tokens=600,
+        )
+        elapsed_ms = int((time.perf_counter() - t0) * 1000)
+        summary_text = (response or "").strip()
+
+        logger.info(
+            "[content_group.summary_llm] org_id=%s content_group_id=%s model=%s prompt_version=%s llm_latency_ms=%d",
+            organization_id,
+            content_group_id,
+            llm_config.workflow_model or llm_config.primary_model,
+            PROMPT_VERSION,
+            elapsed_ms,
+        )
+
+        async def _write() -> dict[str, Any]:
+            async with get_session(organization_id=organization_id) as session:
+                row = ContentGroupSummary(
+                    organization_id=UUID(organization_id),
+                    content_group_id=UUID(content_group_id),
+                    summary_text=summary_text,
+                    summary_json=None,
+                    first_message_external_id=candidates[0].source_id,
+                    last_message_external_id=candidates[-1].source_id,
+                    first_message_at=candidates[0].activity_date or sync_through_at,
+                    last_message_at=candidates[-1].activity_date or sync_through_at,
+                    summarized_through_at=sync_through_at,
+                    message_count=len(candidates),
+                    model=llm_config.workflow_model or llm_config.primary_model,
+                    prompt_version=PROMPT_VERSION,
+                )
+                session.add(row)
+                await session.commit()
+                await session.refresh(row)
+                return {
+                    "status": "generated",
+                    "summary_id": str(row.id),
+                    "content_group_id": content_group_id,
+                    "message_count": row.message_count,
+                    "first_message_external_id": row.first_message_external_id,
+                    "last_message_external_id": row.last_message_external_id,
+                }
+
+        out = await _with_retry(_write)
+        _METRICS["content_group_summary_generated_total"] += 1
+        logger.info("[content_group.summary_write_success] %s", out)
+        return out
+    except Exception as exc:
+        _METRICS["content_group_summary_failed_total"] += 1
+        logger.exception(
+            "[content_group.summary_failed] org_id=%s content_group_id=%s error=%s",
+            organization_id,
+            content_group_id,
+            exc,
+        )
+        return {"status": "failed", "error": str(exc), "content_group_id": content_group_id}

--- a/backend/services/content_groups.py
+++ b/backend/services/content_groups.py
@@ -36,6 +36,48 @@ def _normalize_content_group_key(message_ctx: dict[str, Any], platform: str) -> 
     }
 
 
+def _build_content_group_upsert(
+    *,
+    organization_id: UUID,
+    platform: str,
+    workspace_id: str,
+    external_group_id: str,
+    external_thread_id: str | None,
+    name: str | None,
+):
+    insert_stmt = pg_insert(ContentGroup).values(
+        organization_id=organization_id,
+        platform=platform,
+        workspace_id=workspace_id,
+        external_group_id=external_group_id,
+        external_thread_id=external_thread_id,
+        name=name,
+        is_active=True,
+    )
+
+    update_values = {
+        "name": name,
+        "updated_at": datetime.now(UTC),
+        "is_active": True,
+    }
+    if external_thread_id is None:
+        return insert_stmt.on_conflict_do_update(
+            index_elements=[
+                "organization_id",
+                "platform",
+                "workspace_id",
+                "external_group_id",
+            ],
+            index_where=ContentGroup.external_thread_id.is_(None),
+            set_=update_values,
+        ).returning(ContentGroup.id)
+
+    return insert_stmt.on_conflict_do_update(
+        constraint="uq_content_groups_key",
+        set_=update_values,
+    ).returning(ContentGroup.id)
+
+
 async def resolve_content_group_from_message(
     message_ctx: dict[str, Any], organization_id: str, platform: str
 ) -> ContentGroup | None:
@@ -71,23 +113,14 @@ async def resolve_content_group_from_message(
                 group.updated_at = datetime.now(UTC)
 
         if group is None:
-            insert_stmt = pg_insert(ContentGroup).values(
+            upsert_stmt = _build_content_group_upsert(
                 organization_id=org_uuid,
                 platform=key["platform"],
                 workspace_id=key["workspace_id"],
                 external_group_id=key["external_group_id"],
                 external_thread_id=key["external_thread_id"],
                 name=key["name"],
-                is_active=True,
             )
-            upsert_stmt = insert_stmt.on_conflict_do_update(
-                constraint="uq_content_groups_key",
-                set_={
-                    "name": key["name"],
-                    "updated_at": datetime.now(UTC),
-                    "is_active": True,
-                },
-            ).returning(ContentGroup.id)
 
             group_id = (await session.execute(upsert_stmt)).scalar_one()
             group = await session.get(ContentGroup, group_id)

--- a/backend/services/content_groups.py
+++ b/backend/services/content_groups.py
@@ -51,26 +51,46 @@ async def resolve_content_group_from_message(
 
     org_uuid = UUID(organization_id)
     async with get_session(organization_id=organization_id) as session:
-        insert_stmt = pg_insert(ContentGroup).values(
-            organization_id=org_uuid,
-            platform=key["platform"],
-            workspace_id=key["workspace_id"],
-            external_group_id=key["external_group_id"],
-            external_thread_id=key["external_thread_id"],
-            name=key["name"],
-            is_active=True,
-        )
-        upsert_stmt = insert_stmt.on_conflict_do_update(
-            constraint="uq_content_groups_key",
-            set_={
-                "name": key["name"],
-                "updated_at": datetime.now(UTC),
-                "is_active": True,
-            },
-        ).returning(ContentGroup.id)
+        group = None
+        # Nullable external_thread_id means UNIQUE doesn't prevent duplicates for NULL.
+        # Resolve the non-threaded row first to keep channel-level groups stable.
+        if key["external_thread_id"] is None:
+            existing_stmt = (
+                select(ContentGroup)
+                .where(ContentGroup.organization_id == org_uuid)
+                .where(ContentGroup.platform == key["platform"])
+                .where(ContentGroup.workspace_id == key["workspace_id"])
+                .where(ContentGroup.external_group_id == key["external_group_id"])
+                .where(ContentGroup.external_thread_id.is_(None))
+                .limit(1)
+            )
+            group = (await session.execute(existing_stmt)).scalar_one_or_none()
+            if group is not None:
+                group.name = key["name"]
+                group.is_active = True
+                group.updated_at = datetime.now(UTC)
 
-        group_id = (await session.execute(upsert_stmt)).scalar_one()
-        group = await session.get(ContentGroup, group_id)
+        if group is None:
+            insert_stmt = pg_insert(ContentGroup).values(
+                organization_id=org_uuid,
+                platform=key["platform"],
+                workspace_id=key["workspace_id"],
+                external_group_id=key["external_group_id"],
+                external_thread_id=key["external_thread_id"],
+                name=key["name"],
+                is_active=True,
+            )
+            upsert_stmt = insert_stmt.on_conflict_do_update(
+                constraint="uq_content_groups_key",
+                set_={
+                    "name": key["name"],
+                    "updated_at": datetime.now(UTC),
+                    "is_active": True,
+                },
+            ).returning(ContentGroup.id)
+
+            group_id = (await session.execute(upsert_stmt)).scalar_one()
+            group = await session.get(ContentGroup, group_id)
         await session.commit()
 
     logger.info(

--- a/backend/services/content_groups.py
+++ b/backend/services/content_groups.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from models.content_group import ContentGroup, ContentGroupSummary
+from models.database import get_session
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_content_group_key(message_ctx: dict[str, Any], platform: str) -> dict[str, str | None] | None:
+    # Slack docs: channel_id is stable channel identifier; thread_ts is stable root
+    # timestamp for the reply chain. Teams inbound adapters expose workspace_id
+    # (tenant/team), channel_id/chat_id, and reply_to_id for thread reply chain IDs.
+    workspace_id = str(message_ctx.get("workspace_id") or "").strip()
+    external_group_id = str(message_ctx.get("channel_id") or message_ctx.get("chat_id") or "").strip()
+    if not workspace_id or not external_group_id:
+        return None
+
+    external_thread_id = (
+        str(message_ctx.get("thread_id") or message_ctx.get("thread_ts") or message_ctx.get("reply_to_id") or "").strip() or None
+    )
+    name = str(message_ctx.get("channel_name") or message_ctx.get("chat_name") or "").strip() or None
+    return {
+        "platform": platform,
+        "workspace_id": workspace_id,
+        "external_group_id": external_group_id,
+        "external_thread_id": external_thread_id,
+        "name": name,
+    }
+
+
+async def resolve_content_group_from_message(
+    message_ctx: dict[str, Any], organization_id: str, platform: str
+) -> ContentGroup | None:
+    key = _normalize_content_group_key(message_ctx, platform)
+    if key is None:
+        logger.warning(
+            "[content_group.resolve] missing_content_group_keys org_id=%s platform=%s ctx_keys=%s",
+            organization_id,
+            platform,
+            sorted(message_ctx.keys()),
+        )
+        return None
+
+    org_uuid = UUID(organization_id)
+    async with get_session(organization_id=organization_id) as session:
+        insert_stmt = pg_insert(ContentGroup).values(
+            organization_id=org_uuid,
+            platform=key["platform"],
+            workspace_id=key["workspace_id"],
+            external_group_id=key["external_group_id"],
+            external_thread_id=key["external_thread_id"],
+            name=key["name"],
+            is_active=True,
+        )
+        upsert_stmt = insert_stmt.on_conflict_do_update(
+            constraint="uq_content_groups_key",
+            set_={
+                "name": key["name"],
+                "updated_at": datetime.now(UTC),
+                "is_active": True,
+            },
+        ).returning(ContentGroup.id)
+
+        group_id = (await session.execute(upsert_stmt)).scalar_one()
+        group = await session.get(ContentGroup, group_id)
+        await session.commit()
+
+    logger.info(
+        "[content_group.resolve] org_id=%s platform=%s workspace_id=%s external_group_id=%s external_thread_id=%s content_group_id=%s",
+        organization_id,
+        platform,
+        key["workspace_id"],
+        key["external_group_id"],
+        key["external_thread_id"],
+        str(group.id) if group else None,
+    )
+    return group
+
+
+async def associate_conversation_to_content_group(
+    organization_id: str,
+    conversation_id: str,
+    content_group_id: str,
+) -> None:
+    from models.conversation import Conversation
+
+    async with get_session(organization_id=organization_id) as session:
+        conv = await session.get(Conversation, UUID(conversation_id))
+        if conv is None:
+            return
+        conv.content_group_id = UUID(content_group_id)
+        await session.commit()
+
+
+async def list_recent_summaries(
+    content_group_id: str,
+    limit: int = 4,
+    max_age_hours: int = 72,
+    organization_id: str | None = None,
+) -> list[ContentGroupSummary]:
+    cutoff = datetime.now(UTC) - timedelta(hours=max_age_hours)
+    stmt = (
+        select(ContentGroupSummary)
+        .where(ContentGroupSummary.content_group_id == UUID(content_group_id))
+        .where(ContentGroupSummary.summarized_through_at >= cutoff)
+        .order_by(ContentGroupSummary.summarized_through_at.desc())
+        .limit(limit)
+    )
+    async with get_session(organization_id=organization_id) as session:
+        rows = await session.execute(stmt)
+        return list(rows.scalars().all())

--- a/backend/services/context_pack.py
+++ b/backend/services/context_pack.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from services.campfires import list_campfire_context_summaries
+from services.content_groups import list_recent_summaries
+
+logger = logging.getLogger(__name__)
+
+
+async def build_incoming_message_context_pack(
+    *,
+    organization_id: str,
+    content_group_id: str | None,
+    summary_limit: int = 3,
+    campfire_limit: int = 2,
+    token_budget_chars: int = 3500,
+) -> dict[str, Any] | None:
+    if not content_group_id:
+        return None
+
+    source_summaries = await list_recent_summaries(
+        content_group_id=content_group_id,
+        limit=summary_limit,
+        max_age_hours=72,
+        organization_id=organization_id,
+    )
+    campfire_summaries = await list_campfire_context_summaries(
+        organization_id=organization_id,
+        content_group_id=content_group_id,
+        summary_limit_per_group=campfire_limit,
+    )
+
+    blocks: list[str] = []
+    pointers: list[dict[str, Any]] = []
+    for label, summaries in (
+        ("Recent context from source channel/chat", source_summaries),
+        ("Relevant campfire context", campfire_summaries),
+    ):
+        if not summaries:
+            continue
+        parts = [label + ":"]
+        for s in summaries:
+            parts.append(
+                f"- {s.summary_text}\n"
+                f"  range={s.first_message_at.isoformat()}..{s.last_message_at.isoformat()}"
+                f" ids={s.first_message_external_id}->{s.last_message_external_id}"
+                f" summarized_at={s.summarized_through_at.isoformat()}"
+            )
+            pointers.append({
+                "summary_id": str(s.id),
+                "content_group_id": str(s.content_group_id),
+                "summarized_through_at": s.summarized_through_at.isoformat(),
+            })
+        blocks.append("\n".join(parts))
+
+    if not blocks:
+        return None
+
+    raw_text = "\n\n".join(blocks)
+    trimmed_text = raw_text[:token_budget_chars]
+    selected_count = sum(1 for _ in pointers)
+    logger.info(
+        "[context_pack.build] org_id=%s content_group_id=%s incoming_context_pack_summaries_count=%d chars=%d",
+        organization_id,
+        content_group_id,
+        selected_count,
+        len(trimmed_text),
+    )
+
+    return {
+        "context_text": trimmed_text,
+        "summary_pointers": pointers,
+        "incoming_context_pack_summaries_count": selected_count,
+    }

--- a/backend/tests/test_content_group_context.py
+++ b/backend/tests/test_content_group_context.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from uuid import UUID
 
 import pytest
 
-from services.content_groups import _normalize_content_group_key
+from services.content_groups import _build_content_group_upsert, _normalize_content_group_key
 from services.context_pack import build_incoming_message_context_pack
 
 
@@ -38,6 +39,33 @@ def test_normalize_content_group_key_teams_reply_chain() -> None:
     assert out is not None
     assert out["external_group_id"] == "19:abc@thread.v2"
     assert out["external_thread_id"] == "17000"
+
+
+def test_content_group_upsert_non_thread_uses_partial_unique_index() -> None:
+    stmt = _build_content_group_upsert(
+        organization_id=UUID("00000000-0000-0000-0000-000000000000"),
+        platform="slack",
+        workspace_id="T123",
+        external_group_id="C123",
+        external_thread_id=None,
+        name="eng",
+    )
+    sql = str(stmt)
+    assert "ON CONFLICT (organization_id, platform, workspace_id, external_group_id)" in sql
+    assert "WHERE external_thread_id IS NULL" in sql
+
+
+def test_content_group_upsert_thread_uses_full_unique_constraint() -> None:
+    stmt = _build_content_group_upsert(
+        organization_id=UUID("00000000-0000-0000-0000-000000000000"),
+        platform="slack",
+        workspace_id="T123",
+        external_group_id="C123",
+        external_thread_id="1710000.01",
+        name="eng",
+    )
+    sql = str(stmt)
+    assert "ON CONFLICT ON CONSTRAINT uq_content_groups_key" in sql
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_content_group_context.py
+++ b/backend/tests/test_content_group_context.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from services.content_groups import _normalize_content_group_key
+from services.context_pack import build_incoming_message_context_pack
+
+
+def test_normalize_content_group_key_slack_thread() -> None:
+    out = _normalize_content_group_key(
+        {
+            "workspace_id": "T123",
+            "channel_id": "C111",
+            "thread_ts": "1710000.012",
+            "channel_name": "eng",
+        },
+        "slack",
+    )
+    assert out is not None
+    assert out["workspace_id"] == "T123"
+    assert out["external_group_id"] == "C111"
+    assert out["external_thread_id"] == "1710000.012"
+    assert out["name"] == "eng"
+
+
+def test_normalize_content_group_key_teams_reply_chain() -> None:
+    out = _normalize_content_group_key(
+        {
+            "workspace_id": "tenant-1",
+            "chat_id": "19:abc@thread.v2",
+            "reply_to_id": "17000",
+        },
+        "teams",
+    )
+    assert out is not None
+    assert out["external_group_id"] == "19:abc@thread.v2"
+    assert out["external_thread_id"] == "17000"
+
+
+@pytest.mark.asyncio
+async def test_context_pack_trims_to_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime.now(UTC)
+    summary = SimpleNamespace(
+        id="s1",
+        content_group_id="g1",
+        summary_text="x" * 5000,
+        first_message_at=now,
+        last_message_at=now,
+        first_message_external_id="m1",
+        last_message_external_id="m2",
+        summarized_through_at=now,
+    )
+
+    async def _source(**kwargs):  # type: ignore[no-untyped-def]
+        return [summary]
+
+    async def _camp(**kwargs):  # type: ignore[no-untyped-def]
+        return [summary]
+
+    monkeypatch.setattr("services.context_pack.list_recent_summaries", _source)
+    monkeypatch.setattr("services.context_pack.list_campfire_context_summaries", _camp)
+
+    pack = await build_incoming_message_context_pack(
+        organization_id="00000000-0000-0000-0000-000000000000",
+        content_group_id="11111111-1111-1111-1111-111111111111",
+        token_budget_chars=300,
+    )
+    assert pack is not None
+    assert len(pack["context_text"]) == 300

--- a/backend/workers/celery_app.py
+++ b/backend/workers/celery_app.py
@@ -79,6 +79,7 @@ celery_app = Celery(
         "workers.tasks.bulk_operations",
         "workers.tasks.monitoring",
         "workers.tasks.daily_digest",
+        "workers.tasks.content_group_summaries",
     ],
 )
 

--- a/backend/workers/tasks/content_group_summaries.py
+++ b/backend/workers/tasks/content_group_summaries.py
@@ -1,0 +1,73 @@
+"""Celery tasks for generating content-group summaries."""
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from workers.celery_app import celery_app
+from workers.run_async import run_async
+
+logger = logging.getLogger(__name__)
+
+
+async def _generate_for_org_provider_sync(
+    organization_id: str,
+    provider: str,
+    content_group_ids: list[str],
+    sync_through_iso: str,
+) -> dict[str, Any]:
+    from services.content_group_summary import generate_content_group_summary_for_sync
+
+    sync_through = datetime.fromisoformat(sync_through_iso)
+    if sync_through.tzinfo is None:
+        sync_through = sync_through.replace(tzinfo=UTC)
+
+    generated: int = 0
+    failed: int = 0
+    results: list[dict[str, Any]] = []
+    for content_group_id in content_group_ids:
+        result = await generate_content_group_summary_for_sync(
+            organization_id=organization_id,
+            content_group_id=content_group_id,
+            sync_through_at=sync_through,
+        )
+        results.append(result)
+        if result.get("status") == "generated":
+            generated += 1
+        elif result.get("status") == "failed":
+            failed += 1
+
+    return {
+        "status": "completed",
+        "organization_id": organization_id,
+        "provider": provider,
+        "content_group_count": len(content_group_ids),
+        "generated": generated,
+        "failed": failed,
+        "results": results,
+    }
+
+
+@celery_app.task(
+    bind=True,
+    name="workers.tasks.content_group_summaries.generate_for_org_provider_sync",
+    max_retries=2,
+    default_retry_delay=30,
+)
+def generate_for_org_provider_sync(
+    self: Any,
+    organization_id: str,
+    provider: str,
+    content_group_ids: list[str],
+    sync_through_iso: str | None = None,
+) -> dict[str, Any]:
+    logger.info(
+        "Task %s: generate_for_org_provider_sync org=%s provider=%s groups=%d",
+        self.request.id,
+        organization_id,
+        provider,
+        len(content_group_ids),
+    )
+    through = sync_through_iso or datetime.now(UTC).isoformat()
+    return run_async(_generate_for_org_provider_sync(organization_id, provider, content_group_ids, through))

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -296,9 +296,9 @@ async def _dispatch_content_group_summaries_for_sync_window(
             )
             .where(Activity.organization_id == org_uuid)
             .where(Activity.source_system == provider)
-            .where(Activity.activity_date.is_not(None))
-            .where(Activity.activity_date >= sync_started_at)
-            .where(Activity.activity_date <= sync_completed_at)
+            .where(Activity.synced_at.is_not(None))
+            .where(Activity.synced_at >= sync_started_at)
+            .where(Activity.synced_at <= sync_completed_at)
             .where(Activity.custom_fields.is_not(None))
             .where(Activity.custom_fields["workspace_id"].astext.is_not(None))
             .where(Activity.custom_fields["channel_id"].astext.is_not(None))
@@ -308,23 +308,45 @@ async def _dispatch_content_group_summaries_for_sync_window(
         for workspace_id, channel_id, thread_id, channel_name in rows:
             if not workspace_id or not channel_id:
                 continue
-            insert_stmt = pg_insert(ContentGroup).values(
-                organization_id=org_uuid,
-                platform=provider,
-                workspace_id=str(workspace_id),
-                external_group_id=str(channel_id),
-                external_thread_id=str(thread_id) if thread_id else None,
-                name=str(channel_name) if channel_name else None,
-            )
-            upsert_stmt = insert_stmt.on_conflict_do_update(
-                constraint="uq_content_groups_key",
-                set_={
-                    "name": str(channel_name) if channel_name else None,
-                    "is_active": True,
-                    "updated_at": datetime.utcnow(),
-                },
-            ).returning(ContentGroup.id)
-            cg_id = (await session.execute(upsert_stmt)).scalar_one()
+            thread_id_str = str(thread_id) if thread_id else None
+            name = str(channel_name) if channel_name else None
+            existing = None
+            if thread_id_str is None:
+                existing_stmt = (
+                    select(ContentGroup.id)
+                    .where(ContentGroup.organization_id == org_uuid)
+                    .where(ContentGroup.platform == provider)
+                    .where(ContentGroup.workspace_id == str(workspace_id))
+                    .where(ContentGroup.external_group_id == str(channel_id))
+                    .where(ContentGroup.external_thread_id.is_(None))
+                    .limit(1)
+                )
+                existing = (await session.execute(existing_stmt)).scalar_one_or_none()
+            if existing is not None:
+                await session.execute(
+                    ContentGroup.__table__.update()
+                    .where(ContentGroup.id == existing)
+                    .values(name=name, is_active=True, updated_at=datetime.utcnow())
+                )
+                cg_id = existing
+            else:
+                insert_stmt = pg_insert(ContentGroup).values(
+                    organization_id=org_uuid,
+                    platform=provider,
+                    workspace_id=str(workspace_id),
+                    external_group_id=str(channel_id),
+                    external_thread_id=thread_id_str,
+                    name=name,
+                )
+                upsert_stmt = insert_stmt.on_conflict_do_update(
+                    constraint="uq_content_groups_key",
+                    set_={
+                        "name": name,
+                        "is_active": True,
+                        "updated_at": datetime.utcnow(),
+                    },
+                ).returning(ContentGroup.id)
+                cg_id = (await session.execute(upsert_stmt)).scalar_one()
             content_group_ids.append(str(cg_id))
         await session.commit()
 

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -300,52 +300,77 @@ async def _dispatch_content_group_summaries_for_sync_window(
             .where(Activity.synced_at >= sync_started_at)
             .where(Activity.synced_at <= sync_completed_at)
             .where(Activity.custom_fields.is_not(None))
-            .where(Activity.custom_fields["workspace_id"].astext.is_not(None))
             .where(Activity.custom_fields["channel_id"].astext.is_not(None))
         )
         rows = (await session.execute(stmt)).all()
         content_group_ids: list[str] = []
         for workspace_id, channel_id, thread_id, channel_name in rows:
-            if not workspace_id or not channel_id:
+            if not channel_id:
                 continue
             thread_id_str = str(thread_id) if thread_id else None
             name = str(channel_name) if channel_name else None
-            existing = None
+            workspace_id_str = str(workspace_id) if workspace_id else None
+            existing: ContentGroup | None = None
             if thread_id_str is None:
                 existing_stmt = (
-                    select(ContentGroup.id)
+                    select(ContentGroup)
                     .where(ContentGroup.organization_id == org_uuid)
                     .where(ContentGroup.platform == provider)
-                    .where(ContentGroup.workspace_id == str(workspace_id))
                     .where(ContentGroup.external_group_id == str(channel_id))
                     .where(ContentGroup.external_thread_id.is_(None))
+                    .order_by(ContentGroup.updated_at.desc())
                     .limit(1)
                 )
                 existing = (await session.execute(existing_stmt)).scalar_one_or_none()
             if existing is not None:
                 await session.execute(
                     ContentGroup.__table__.update()
-                    .where(ContentGroup.id == existing)
+                    .where(ContentGroup.id == existing.id)
                     .values(name=name, is_active=True, updated_at=datetime.utcnow())
                 )
-                cg_id = existing
+                cg_id = existing.id
             else:
+                if workspace_id_str is None:
+                    logger.info(
+                        "Skipping content-group insert during sync summary dispatch: missing workspace_id org=%s provider=%s channel_id=%s thread_id=%s",
+                        organization_id,
+                        provider,
+                        str(channel_id),
+                        thread_id_str,
+                    )
+                    continue
                 insert_stmt = pg_insert(ContentGroup).values(
                     organization_id=org_uuid,
                     platform=provider,
-                    workspace_id=str(workspace_id),
+                    workspace_id=workspace_id_str,
                     external_group_id=str(channel_id),
                     external_thread_id=thread_id_str,
                     name=name,
                 )
-                upsert_stmt = insert_stmt.on_conflict_do_update(
-                    constraint="uq_content_groups_key",
-                    set_={
-                        "name": name,
-                        "is_active": True,
-                        "updated_at": datetime.utcnow(),
-                    },
-                ).returning(ContentGroup.id)
+                if thread_id_str is None:
+                    upsert_stmt = insert_stmt.on_conflict_do_update(
+                        index_elements=[
+                            "organization_id",
+                            "platform",
+                            "workspace_id",
+                            "external_group_id",
+                        ],
+                        index_where=ContentGroup.external_thread_id.is_(None),
+                        set_={
+                            "name": name,
+                            "is_active": True,
+                            "updated_at": datetime.utcnow(),
+                        },
+                    ).returning(ContentGroup.id)
+                else:
+                    upsert_stmt = insert_stmt.on_conflict_do_update(
+                        constraint="uq_content_groups_key",
+                        set_={
+                            "name": name,
+                            "is_active": True,
+                            "updated_at": datetime.utcnow(),
+                        },
+                    ).returning(ContentGroup.id)
                 cg_id = (await session.execute(upsert_stmt)).scalar_one()
             content_group_ids.append(str(cg_id))
         await session.commit()

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -157,9 +157,25 @@ async def _sync_integration(
 
         await _clear_last_errors_for_integration(organization_id, provider, user_id)
 
+        sync_started_at: datetime = datetime.utcnow()
         await connector.mark_sync_started()
         counts = await connector.sync_all()
         await connector.update_last_sync(counts)
+
+        try:
+            await _dispatch_content_group_summaries_for_sync_window(
+                organization_id=organization_id,
+                provider=provider,
+                sync_started_at=sync_started_at,
+                sync_completed_at=datetime.utcnow(),
+            )
+        except Exception as summary_dispatch_err:
+            logger.warning(
+                "Content-group summary dispatch failed org=%s provider=%s error=%s",
+                organization_id,
+                provider,
+                summary_dispatch_err,
+            )
 
         # Generate embeddings for newly synced activities
         try:
@@ -249,6 +265,91 @@ async def _sync_integration(
             "provider": provider,
             "error": error_msg,
         }
+
+
+async def _dispatch_content_group_summaries_for_sync_window(
+    *,
+    organization_id: str,
+    provider: str,
+    sync_started_at: datetime,
+    sync_completed_at: datetime,
+) -> None:
+    if provider not in {"slack", "teams"}:
+        return
+
+    from sqlalchemy import distinct, select
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from models.activity import Activity
+    from models.content_group import ContentGroup
+    from models.database import get_session
+    from workers.tasks.content_group_summaries import generate_for_org_provider_sync
+
+    org_uuid = UUID(organization_id)
+    async with get_session(organization_id=organization_id) as session:
+        stmt = (
+            select(
+                distinct(Activity.custom_fields["workspace_id"].astext),
+                Activity.custom_fields["channel_id"].astext,
+                Activity.custom_fields["thread_ts"].astext,
+                Activity.custom_fields["channel_name"].astext,
+            )
+            .where(Activity.organization_id == org_uuid)
+            .where(Activity.source_system == provider)
+            .where(Activity.activity_date.is_not(None))
+            .where(Activity.activity_date >= sync_started_at)
+            .where(Activity.activity_date <= sync_completed_at)
+            .where(Activity.custom_fields.is_not(None))
+            .where(Activity.custom_fields["workspace_id"].astext.is_not(None))
+            .where(Activity.custom_fields["channel_id"].astext.is_not(None))
+        )
+        rows = (await session.execute(stmt)).all()
+        content_group_ids: list[str] = []
+        for workspace_id, channel_id, thread_id, channel_name in rows:
+            if not workspace_id or not channel_id:
+                continue
+            insert_stmt = pg_insert(ContentGroup).values(
+                organization_id=org_uuid,
+                platform=provider,
+                workspace_id=str(workspace_id),
+                external_group_id=str(channel_id),
+                external_thread_id=str(thread_id) if thread_id else None,
+                name=str(channel_name) if channel_name else None,
+            )
+            upsert_stmt = insert_stmt.on_conflict_do_update(
+                constraint="uq_content_groups_key",
+                set_={
+                    "name": str(channel_name) if channel_name else None,
+                    "is_active": True,
+                    "updated_at": datetime.utcnow(),
+                },
+            ).returning(ContentGroup.id)
+            cg_id = (await session.execute(upsert_stmt)).scalar_one()
+            content_group_ids.append(str(cg_id))
+        await session.commit()
+
+    if not content_group_ids:
+        logger.info(
+            "No touched content groups for summary generation org=%s provider=%s window=%s..%s",
+            organization_id,
+            provider,
+            sync_started_at.isoformat(),
+            sync_completed_at.isoformat(),
+        )
+        return
+
+    logger.info(
+        "Dispatching content-group summary task org=%s provider=%s content_group_count=%d",
+        organization_id,
+        provider,
+        len(content_group_ids),
+    )
+    generate_for_org_provider_sync.delay(
+        organization_id,
+        provider,
+        content_group_ids,
+        sync_completed_at.replace(tzinfo=timezone.utc).isoformat(),
+    )
 
 
 async def _get_all_active_integrations() -> list[dict[str, str | None]]:


### PR DESCRIPTION
### Motivation
- Provide a stable, first-class abstraction for a source stream (Slack channel / Teams chat/thread) so we can summarize and surface channel context to LLMs (`ContentGroup`).
- Support grouping related channels into logical collections (`Campfire`) to surface cross-channel context in prompts without blocking inbound message handling.
- Generate LLM summaries at sync-time (best-effort, async) so inbound requests can include recent channel/campfire context without adding latency or long DB transactions.

### Description
- Added ORM models in `backend/models/content_group.py` for `ContentGroup`, `ContentGroupSummary`, `Campfire`, `CampfireContentGroup`, and `CampfireConversation` with the requested constraints and indexes.
- Created three Alembic-style migrations (`134_content_groups`, `135_campfires`, `136_group_summaries`) that include preflight assertions on `revision`/`down_revision` length and create RLS policies and indexes.
- Linked conversations to content groups via a nullable `conversations.content_group_id` column and index, and registered new models in `models/__init__.py`.
- Implemented service modules: `services/content_groups.py` (resolve/upsert content groups, associate conversation, list recent summaries), `services/content_group_summary.py` (watermarking, select unsummarized messages, LLM call, safe upsert with retry), `services/campfires.py` (campfire CRUD and lookups), and `services/context_pack.py` (build token-budgeted context pack with pointers).
- Integrated inbound flow: `backend/messengers/_workspace.py` resolves/upserts `ContentGroup`, associates it to the `Conversation`, builds a context pack, and safely passes its text into the orchestrator.
- Extended orchestrator (`backend/agents/orchestrator.py`) to accept `external_context_message` and inject a synthetic context message before the user message so summaries are available to the model while preserving history and token budgeting.
- Integrated sync-time dispatch: post-`connector.sync_all()` the sync path enumerates touched content groups, upserts them, and enqueues `workers.tasks.content_group_summaries.generate_for_org_provider_sync` (new Celery task module) for asynchronous summary generation; summary dispatch is best-effort and cannot fail the sync.
- Registered the new Celery task module in `backend/workers/celery_app.py` and added a lightweight task wrapper in `backend/workers/tasks/content_group_summaries.py`.
- Added unit tests `backend/tests/test_content_group_context.py` for key normalization and context-pack truncation behavior.

### Testing
- Ran static compile step with `python -m compileall models services workers/tests` which completed successfully (exit 0).
- Ran unit tests with `pytest -q tests/test_content_group_context.py tests/test_migration_safety.py` which passed (`4 passed`).
- Validated migration preflight by importing the new migration modules and asserting `len(revision) <= 32` and `len(down_revision) <= 32` for the new files, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19f4da97483219b5baa0368ad8bd4)