### PR TITLE
Fix /api/artifacts route being shadowed by share routes

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -157,7 +157,6 @@ async def global_exception_handler(request: Request, exc: Exception) -> JSONResp
 # Routes
 app.include_router(apps.router, prefix="/api/apps", tags=["apps"])
 app.include_router(public.router, prefix="/api/public", tags=["public"])
-app.include_router(public.share_router, tags=["public"])
 app.include_router(connectors.router, prefix="/api/connectors", tags=["connectors"])
 app.include_router(artifacts.router, prefix="/api/artifacts", tags=["artifacts"])
 app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
@@ -184,6 +183,9 @@ app.include_router(whatsapp_events.router, prefix="/api/whatsapp", tags=["whatsa
 app.include_router(teams_events.router, prefix="/api/teams", tags=["teams"])
 app.include_router(action_ledger.router, prefix="/api", tags=["action-ledger"])
 app.include_router(admin_dashboard.router, prefix="/api/admin-dashboard", tags=["admin-dashboard"])
+# Keep share router after /api routers so generic org-slug routes (e.g. /{org_slug}/artifacts/{id})
+# do not shadow concrete API endpoints like /api/artifacts/{id}.
+app.include_router(public.share_router, tags=["public"])
 
 # WebSocket - authenticated via JWT token in query parameter
 app.add_api_websocket_route("/ws/chat", websocket_endpoint)

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import base64
 from types import SimpleNamespace
+from uuid import uuid4
 
+from api.main import app
 from api.routes.public import (
     _cache_get_html,
     _cache_set_html,
@@ -12,6 +14,8 @@ from api.routes.public import (
     _public_preview_title,
     share_router,
 )
+from api.routes.artifacts import get_artifact
+from starlette.routing import Match
 from services.public_previews import build_preview_html, decode_data_url_image, render_card_png
 
 
@@ -169,3 +173,21 @@ def test_share_router_supports_artifact_uuid_paths_for_unfurl_links() -> None:
     assert "/artifacts/{artifact_id}" in route_paths
     assert "/basebase/artifacts/{artifact_id}" in route_paths
     assert "/{org_slug}/artifacts/{artifact_id}" in route_paths
+
+
+def test_api_artifact_route_is_resolved_before_slug_unfurl_route() -> None:
+    artifact_id = uuid4()
+    scope = {
+        "type": "http",
+        "path": f"/api/artifacts/{artifact_id}",
+        "method": "GET",
+    }
+
+    matched_endpoint = None
+    for route in app.router.routes:
+        match, child_scope = route.matches(scope)
+        if match == Match.FULL:
+            matched_endpoint = child_scope.get("endpoint")
+            break
+
+    assert matched_endpoint is get_artifact


### PR DESCRIPTION
### Motivation
- Public share routes with generic org-slug patterns (e.g. `/{org_slug}/artifacts/{artifact_id}`) could match before concrete API routes and cause direct artifact fetches like `/api/artifacts/{id}?direct_fetch_ts=...` to return unfurl/OG HTML instead of the artifact JSON payload.

### Description
- Moved registration of `public.share_router` to run after all `/api/*` routers in `backend/api/main.py` so concrete API endpoints (e.g. `/api/artifacts/{id}`) take precedence.
- Added a regression test `test_api_artifact_route_is_resolved_before_slug_unfurl_route` to `backend/tests/test_public_previews.py` that asserts a request to `/api/artifacts/{uuid}` resolves to the JSON artifact handler `get_artifact`.
- Added/imported `app`, `get_artifact`, `starlette.routing.Match`, and `uuid4` in the test file to perform route resolution checks.

### Testing
- Ran `pytest -q backend/tests/test_public_previews.py`, all tests passed (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1bd4aabd48321a3ec3ed2af1cc491)