### PR TITLE
Redirect unauthenticated share links to canonical public URIs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -351,6 +351,31 @@ function App(): JSX.Element {
   // Handle OAuth callback route
   const path = window.location.pathname;
 
+  const redirectToPublicUri = (targetPath: string): JSX.Element => {
+    const redirectPath = `${targetPath}${window.location.search}${window.location.hash}`;
+    console.info('[PublicRedirect] Unauthenticated access detected, redirecting to public URI', {
+      from: window.location.pathname,
+      to: targetPath,
+    });
+    window.location.replace(redirectPath);
+    return <></>;
+  };
+
+  // Normalize public share/link routes to canonical public URIs before auth gates.
+  const publicArtifactMatch = path.match(
+    /^\/(?:basebase\/(?:documents|artifacts)|[a-z0-9-]+\/artifacts?|artifacts?\/[a-z0-9-]+)\/([a-f0-9-]+)$/i,
+  );
+  if (publicArtifactMatch?.[1]) {
+    return redirectToPublicUri(`/public/artifacts/${publicArtifactMatch[1]}`);
+  }
+
+  const publicAppMatch = path.match(
+    /^\/(?:basebase\/apps|[a-z0-9-]+\/apps|apps\/[a-z0-9-]+)\/([a-f0-9-]+)$/i,
+  );
+  if (publicAppMatch?.[1]) {
+    return redirectToPublicUri(`/public/apps/${publicAppMatch[1]}`);
+  }
+
   // Normalize legacy app route shape once: /apps/<slug>/<appId> -> /apps/<appId>.
   const legacyAppsSlugMatch = path.match(/^\/apps\/[A-Za-z0-9-]+\/([a-f0-9-]+)$/i);
   if (legacyAppsSlugMatch && legacyAppsSlugMatch[1]) {


### PR DESCRIPTION
### Motivation
- Publicly shared app/document/artifact links were being routed into the authenticated app flow and prompting sign-in instead of landing on the standalone public pages.  
- The intent is to detect common share/link path shapes early and redirect to canonical `/public/...` URIs while preserving query and hash so public viewers see the public page without authentication prompts.

### Description
- Added a small helper `redirectToPublicUri` in `frontend/src/App.tsx` that preserves `window.location.search` and `window.location.hash` and logs redirect details.  
- Normalized several public share path variants (document/artifact shapes and app shapes) with regex checks and immediately redirect to `/public/artifacts/:id` or `/public/apps/:id` before any auth gating runs.  
- The new checks cover legacy and org-prefixed shapes such as `/basebase/documents/:id`, `/basebase/artifacts/:id`, `/:org/artifacts/:id`, `/basebase/apps/:id`, `/:org/apps/:id`, and similar variants.  
- Kept existing legacy normalization for `/apps/<slug>/<appId>` intact and placed the public redirects before that logic.

### Testing
- Built the frontend with `cd frontend && npm run -s build` and the build completed successfully; Vite emitted chunk-size/dynamic-import warnings but the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c04593008321899941bdfb9e05ac)