### PR TITLE
Add automated tests for artifact fetch via connector

### DIFF
--- a/backend/tests/test_artifacts_connector_query.py
+++ b/backend/tests/test_artifacts_connector_query.py
@@ -1,6 +1,8 @@
 import asyncio
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 
+from agents import tools
 from connectors.artifacts import ArtifactConnector
 
 
@@ -69,3 +71,43 @@ def test_query_materializes_payload_before_session_cleanup(monkeypatch):
 
     assert result["id"] == "22c70309-d097-4e8e-a50a-e4ad7efc789a"
     assert result["content"] == "hello"
+
+
+def test_query_on_connector_fetches_artifact_payload(monkeypatch):
+    requested_queries: list[str] = []
+
+    class _FakeArtifactsConnector:
+        async def query(self, request: str):
+            requested_queries.append(request)
+            return {
+                "id": "22c70309-d097-4e8e-a50a-e4ad7efc789a",
+                "title": "Fetched artifact",
+                "filename": "artifact.md",
+                "content_type": "markdown",
+                "content": "hello from connector",
+            }
+
+    async def _allow_connector_call(*_args, **_kwargs):
+        return SimpleNamespace(allowed=True, deny_reason=None)
+
+    async def _fake_get_connector_instance(*_args, **_kwargs):
+        return _FakeArtifactsConnector(), None
+
+    monkeypatch.setattr(tools, "check_connector_call", _allow_connector_call)
+    monkeypatch.setattr(tools, "_get_connector_instance", _fake_get_connector_instance)
+
+    result = asyncio.run(
+        tools._query_on_connector(
+            {
+                "connector": "artifacts",
+                "query": "read 22c70309-d097-4e8e-a50a-e4ad7efc789a",
+            },
+            organization_id="00000000-0000-0000-0000-000000000010",
+            user_id="00000000-0000-0000-0000-000000000011",
+        )
+    )
+
+    assert requested_queries == ["read 22c70309-d097-4e8e-a50a-e4ad7efc789a"]
+    assert result["id"] == "22c70309-d097-4e8e-a50a-e4ad7efc789a"
+    assert result["filename"] == "artifact.md"
+    assert result["content"] == "hello from connector"


### PR DESCRIPTION
### Motivation
- Prevent regressions similar to #997 by adding coverage for fetching artifact payloads through the generic connector dispatch path (`query_on_connector` / `tools._query_on_connector`).

### Description
- Added a regression test `test_query_on_connector_fetches_artifact_payload` in `backend/tests/test_artifacts_connector_query.py` that stubs `agents.tools.check_connector_call` and `agents.tools._get_connector_instance` and asserts the `artifacts` connector receives `read <artifact_id>` and returns the expected payload.
- Kept the existing `test_query_materializes_payload_before_session_cleanup` to continue guarding ORM lifecycle behaviour when reading artifact rows inside `connectors.artifacts.ArtifactConnector.query`.
- Imported `agents.tools` and `types.SimpleNamespace` in the test file to enable dispatch-path and access-control stubbing.

### Testing
- Ran `cd /workspace/basebase/backend && pytest -q tests/test_artifacts_connector_query.py`, which executed the two tests and reported `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c2249658832191cdd40a33b0b534)