### PR TITLE
Auth-first fallback to public URIs for shared apps/documents

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -435,29 +435,60 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       }
       const subPath: string = orgPrefixMatch?.[2] ?? "";
 
+      const tryRedirectToPublicResource = async (
+        resourceType: "apps" | "artifacts",
+        resourceId: string,
+      ): Promise<boolean> => {
+        const endpoint = `/public/${resourceType}/${resourceId}`;
+        console.info(
+          "[AppLayout] Checking public fallback for %s/%s via %s",
+          resourceType,
+          resourceId,
+          endpoint,
+        );
+        const { data: publicData } = await apiRequest<Record<string, unknown>>(endpoint, {
+          method: "GET",
+        });
+        if (!publicData) {
+          console.info(
+            "[AppLayout] Public fallback unavailable for %s/%s",
+            resourceType,
+            resourceId,
+          );
+          return false;
+        }
+        const publicUri = `/public/${resourceType}/${resourceId}`;
+        console.info(
+          "[AppLayout] Redirecting to public URI after auth/org access failure: %s",
+          publicUri,
+        );
+        window.location.replace(publicUri);
+        return true;
+      };
+
       // Helper: try public fallback then show org-access error.
       const handleOrgAccessDenied = async (
         handle: string,
         orgName: string,
       ): Promise<void> => {
         const appMatchFail = subPath.match(/^apps\/([a-f0-9-]+)$/i);
-        const artifactMatchFail = subPath.match(/^artifacts?\/([a-f0-9-]+)$/i);
+        const artifactMatchFail = subPath.match(/^(?:artifacts?|documents)\/([a-f0-9-]+)$/i);
         if (appMatchFail?.[1]) {
           const appIdFail: string = appMatchFail[1];
+          const redirected = await tryRedirectToPublicResource("apps", appIdFail);
+          if (redirected) return;
+          console.warn(
+            "[AppLayout] Auth/org access failed for app %s and public fallback was unavailable. Falling back to in-app route.",
+            appIdFail,
+          );
           window.location.replace(`/apps/${appIdFail}`);
           return;
         }
 
         if (artifactMatchFail?.[1]) {
           const artifactIdFail: string = artifactMatchFail[1];
-          const endpoint: string = `/public/artifacts/${artifactIdFail}`;
-          const { data: publicData } = await apiRequest<Record<string, unknown>>(endpoint, {
-            method: "GET",
-          });
-          if (publicData) {
-            window.location.replace(`/public/artifacts/${artifactIdFail}`);
-            return;
-          }
+          const redirected = await tryRedirectToPublicResource("artifacts", artifactIdFail);
+          if (redirected) return;
         }
         useUIStore.setState({
           orgAccessError: { handle, orgName },
@@ -495,7 +526,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
         setCurrentView("chat");
         return;
       }
-      const artifactMatch = subPath.match(/^artifacts?\/([a-f0-9-]+)$/i);
+      const artifactMatch = subPath.match(/^(?:artifacts?|documents)\/([a-f0-9-]+)$/i);
       if (artifactMatch && artifactMatch[1]) {
         openArtifact(artifactMatch[1]);
         return;
@@ -547,7 +578,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       setCurrentView("app-view");
       return;
     }
-    const artifactMatch = path.match(/^\/artifacts?\/([a-f0-9-]+)$/i);
+    const artifactMatch = path.match(/^\/(?:artifacts?|documents)\/([a-f0-9-]+)$/i);
     if (artifactMatch && artifactMatch[1]) {
       openArtifact(artifactMatch[1]);
       return;


### PR DESCRIPTION
### Motivation
- Ensure links to shared apps and documents attempt an authenticated load first and, if access is denied, fall back to the public URI so externally shared links still open when possible.
- Improve observability of routing/fallback attempts with logging to make debugging auth/org access failures easier.

### Description
- Added `tryRedirectToPublicResource` helper in `frontend/src/components/AppLayout.tsx` which checks `/public/apps/:id` and `/public/artifacts/:id` and redirects to the public URI when available. 
- Updated the org-prefixed and legacy route parsing to treat `/documents/:id` the same as artifact detail routes so document links are handled by the same public-fallback flow. 
- When org/auth access fails for `/apps/:id` or `/artifacts|documents/:id`, the code now first tries the public endpoint and only falls back to the existing in-app route or shows the org-access error if no public resource exists. 
- Added console logging around public-fallback checks and redirect decisions for easier debugging.

### Testing
- Ran lint: `npm --prefix frontend run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c42bb2248321b3015f81b0745079)