### PR TITLE
Add unauthenticated deep-link fallback to public app/artifact routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,10 @@ type Screen = 'auth' | 'blocked-email' | 'not-registered' | 'waitlist' | 'onboar
 // URL for public website (landing, blog, waitlist form)
 const WWW_URL = import.meta.env.VITE_WWW_URL ?? 'https://www.basebase.com';
 
+const UUID_PATH_SEGMENT = '([a-f0-9-]{36})';
+const APP_DEEP_LINK_REGEX = new RegExp(`^\\/(?:[a-z0-9-]+\\/)?apps\\/${UUID_PATH_SEGMENT}$`, 'i');
+const ARTIFACT_DEEP_LINK_REGEX = new RegExp(`^\\/(?:[a-z0-9-]+\\/)?(?:artifacts?|documents?)\\/${UUID_PATH_SEGMENT}$`, 'i');
+
 function App(): JSX.Element {
   const [screen, setScreen] = useState<Screen>('auth');
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -69,6 +73,39 @@ function App(): JSX.Element {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [screen, handleCreateNewOrg]);
 
+  const maybeRedirectToPublicDeepLink = useCallback(async (path: string): Promise<boolean> => {
+    const appMatch = path.match(APP_DEEP_LINK_REGEX);
+    if (appMatch?.[1]) {
+      const appId = appMatch[1];
+      try {
+        const response = await fetch(`${API_BASE}/public/apps/${appId}`);
+        if (response.ok) {
+          window.location.replace(`/public/apps/${appId}`);
+          return true;
+        }
+      } catch (error) {
+        console.warn('Public app fallback check failed:', { appId, error });
+      }
+      return false;
+    }
+
+    const artifactMatch = path.match(ARTIFACT_DEEP_LINK_REGEX);
+    if (artifactMatch?.[1]) {
+      const artifactId = artifactMatch[1];
+      try {
+        const response = await fetch(`${API_BASE}/public/artifacts/${artifactId}`);
+        if (response.ok) {
+          window.location.replace(`/public/artifacts/${artifactId}`);
+          return true;
+        }
+      } catch (error) {
+        console.warn('Public artifact fallback check failed:', { artifactId, error });
+      }
+    }
+
+    return false;
+  }, []);
+
   // Check auth status on mount
   useEffect(() => {
     const checkAuth = async (): Promise<void> => {
@@ -100,6 +137,11 @@ function App(): JSX.Element {
             void useAppStore.getState().fetchUserOrganizations();
           }
         } else if (!hasPersistedUser) {
+          const redirectedToPublic = await maybeRedirectToPublicDeepLink(window.location.pathname);
+          if (redirectedToPublic) {
+            return;
+          }
+
           // No session and no persisted user - check legacy localStorage auth
           const storedUserId = localStorage.getItem('user_id');
           if (storedUserId) {
@@ -169,7 +211,7 @@ function App(): JSX.Element {
       subscription.unsubscribe();
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [maybeRedirectToPublicDeepLink]);
 
   const handleAuthenticatedUser = async (supabaseUser: User, skipOrgUpdate = false): Promise<void> => {
     const email = supabaseUser.email ?? '';


### PR DESCRIPTION
### Motivation
- Ensure publicly shared app/artifact deep links (including org-prefixed paths like `/:handle/artifacts/:id`) load for unauthenticated viewers by routing to the public pages instead of landing on the auth screen.
- Preserve the intended UX for links such as `/basebase/artifacts/:id` or `/acme/apps/:id` when the resource is publicly accessible.

### Description
- Added regex constants `UUID_PATH_SEGMENT`, `APP_DEEP_LINK_REGEX`, and `ARTIFACT_DEEP_LINK_REGEX` in `frontend/src/App.tsx` to detect org-scoped and non-org deep links.
- Implemented `maybeRedirectToPublicDeepLink(path)` which queries `GET ${API_BASE}/public/apps/:id` and `GET ${API_BASE}/public/artifacts/:id` and redirects to `/public/apps/:id` or `/public/artifacts/:id` when the public endpoint responds OK.
- Integrated the new fallback into the auth bootstrap flow so that when there is no session and no persisted user the app will attempt the public deep-link redirect before continuing to the auth or onboarding flows.
- Added the new callback to the `useEffect` dependencies and kept all changes confined to `frontend/src/App.tsx`.

### Testing
- Ran frontend lint: `npm --prefix frontend run lint` and it completed successfully with no reported ESLint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c5aad4e08321a8dd04b03d813aea)