### PR TITLE
Skip public deep-link redirect to avoid endless loop

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -74,6 +74,11 @@ function App(): JSX.Element {
   }, [screen, handleCreateNewOrg]);
 
   const maybeRedirectToPublicDeepLink = useCallback(async (path: string): Promise<boolean> => {
+    if (path.startsWith('/public/')) {
+      console.debug('Skipping deep-link public redirect check for already-public path.', { path });
+      return false;
+    }
+
     const appMatch = path.match(APP_DEEP_LINK_REGEX);
     if (appMatch?.[1]) {
       const appId = appMatch[1];


### PR DESCRIPTION
### Motivation
- Prevent repeated `window.location.replace()` when the current path is already a public page (e.g. `/public/apps/:id` or `/public/artifacts/:id`) which could match the generic deep-link regexes and cause an endless redirect/reload loop.

### Description
- Add an early-return guard in `maybeRedirectToPublicDeepLink` that checks `path.startsWith('/public/')`, logs a debug message, and skips the fallback public redirect checks while keeping existing deep-link behavior for non-public paths.

### Testing
- Ran `npm --prefix frontend run lint` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c831c7e083218ec19f10016febcb)