### PR TITLE
Fix public app pages to fill full browser height

### DIFF
--- a/frontend/src/components/public/PublicAppView.tsx
+++ b/frontend/src/components/public/PublicAppView.tsx
@@ -10,7 +10,7 @@ interface PublicAppViewProps {
 
 export function PublicAppView({ appId }: PublicAppViewProps): JSX.Element {
   return (
-    <div className="min-h-screen bg-surface-950">
+    <div className="h-screen bg-surface-950">
       <SandpackAppRenderer appId={appId} publicMode />
     </div>
   );


### PR DESCRIPTION
### Motivation
- Public app pages at `/public/apps/:id` rendered the embedded app inside a container using `min-h-screen`, which allowed the iframe to inherit an unconstrained height and resulted in the app occupying only part of the browser vertical space; the page should fill the full viewport.

### Description
- Change the page wrapper in `frontend/src/components/public/PublicAppView.tsx` from `min-h-screen` to `h-screen` so the embedded `SandpackAppRenderer` receives a concrete full-viewport height and can render to the full browser window.

### Testing
- Ran the frontend production build with `npm run -C frontend build`, which completed successfully (Vite produced non-blocking chunking warnings but the build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1cc25d418832190e0784569e54dec)