### PR TITLE
Mark private Slack channel conversations as private

### DIFF
--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -100,12 +100,25 @@ def _resolve_conversation_scope(
     revtops_user_id: str | None,
 ) -> str:
     """Resolve conversation scope for newly created or updated conversations."""
+    channel_type: str = (message.messenger_context.get("channel_type") or "").strip().lower()
+    channel_id: str = (message.messenger_context.get("channel_id") or "").strip().upper()
+
+    # Slack private channels use channel_type="group" and channel IDs that start
+    # with "G". These should remain private in our chat UI.
+    is_private_slack_channel: bool = (
+        channel_type in {"group", "private_channel"}
+        or (
+            message.message_type != MessageType.DIRECT
+            and channel_id.startswith("G")
+        )
+    )
+    if is_private_slack_channel:
+        return "private"
+
     if message.message_type != MessageType.DIRECT:
         return "shared"
 
-    channel_type: str | None = message.messenger_context.get("channel_type")
-    normalized_channel_type: str = (channel_type or "").strip().lower()
-    if normalized_channel_type in {"mpim", "groupchat"}:
+    if channel_type in {"mpim", "groupchat"}:
         return "shared"
 
     identity_known: bool = bool(revtops_user_id or message.external_user_id)

--- a/backend/tests/test_workspace_conversation_scope.py
+++ b/backend/tests/test_workspace_conversation_scope.py
@@ -27,6 +27,28 @@ def test_resolve_conversation_scope_shared_for_mentions() -> None:
     assert _resolve_conversation_scope(message, revtops_user_id="11111111-1111-1111-1111-111111111111") == "shared"
 
 
+def test_resolve_conversation_scope_private_for_mentions_in_private_slack_channel() -> None:
+    message = InboundMessage(
+        external_user_id="U123",
+        text="hello",
+        message_type=MessageType.MENTION,
+        messenger_context={"channel_type": "group", "channel_id": "G123456"},
+        message_id="mid-1",
+    )
+    assert _resolve_conversation_scope(message, revtops_user_id="11111111-1111-1111-1111-111111111111") == "private"
+
+
+def test_resolve_conversation_scope_private_for_mentions_in_private_slack_channel_without_type() -> None:
+    message = InboundMessage(
+        external_user_id="U123",
+        text="hello",
+        message_type=MessageType.MENTION,
+        messenger_context={"channel_id": "G123456"},
+        message_id="mid-1",
+    )
+    assert _resolve_conversation_scope(message, revtops_user_id="11111111-1111-1111-1111-111111111111") == "private"
+
+
 def test_resolve_conversation_scope_shared_for_teams_groupchat_direct_message() -> None:
     message = _build_message(MessageType.DIRECT, channel_type="groupChat", external_user_id="U123")
     assert _resolve_conversation_scope(message, revtops_user_id="11111111-1111-1111-1111-111111111111") == "shared"


### PR DESCRIPTION
### Motivation

- Slack private channels and some channel payloads should be treated as private conversations in the UI so messages from those channels don't appear as shared/team chats.

### Description

- Updated `_resolve_conversation_scope` in `backend/messengers/_workspace.py` to inspect `message.messenger_context` for `channel_type` and `channel_id` and mark Slack private channels as `private` when `channel_type` is `group` or `private_channel`, or when a non-DM Slack channel ID starts with `G`.
- Preserved existing behavior for non-DM mentions and multi-party chat types by keeping the `mpim`/`groupchat` and DM handling logic.
- Added two unit tests in `backend/tests/test_workspace_conversation_scope.py` to cover mentions originating from private Slack channels with and without an explicit `channel_type` present.

### Testing

- Ran `pytest -q backend/tests/test_workspace_conversation_scope.py` which executed the new and existing cases and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28f50b1fc8321a79a012beafe017a)