### PR TITLE
Persist only public channel messages for Slack and Teams and add tests

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -333,13 +333,21 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
         if event.get("subtype") in ("message_changed", "message_deleted"):
             return
 
-        # Persist non-DM channel messages as Activity rows
-        if channel_type != "im" and event.get("text", "").strip():
+        # Persist only public channel messages as Activity rows.
+        # Treat private channels and group messages like DMs and skip activity persistence.
+        should_persist_activity: bool = channel_type == "channel"
+        if should_persist_activity and event.get("text", "").strip():
             activity_msg: InboundMessage = _build_inbound_message(
                 event, team_id, MessageType.MENTION,
             )
             asyncio.create_task(
                 _persist_activity(messenger, activity_msg, team_id)
+            )
+        elif channel_type in {"group", "private_channel", "mpim", "im", "groupchat"}:
+            logger.info(
+                "[slack_events] Skipping activity persistence for private/direct message type=%s channel=%s",
+                channel_type,
+                event.get("channel", ""),
             )
 
         is_direct_message: bool = channel_type in {"im", "mpim"}

--- a/backend/api/routes/teams_events.py
+++ b/backend/api/routes/teams_events.py
@@ -322,6 +322,40 @@ def _activity_mentions_bot(activity: dict[str, Any], bot_id: str | None) -> bool
     return False
 
 
+def _is_public_teams_channel_message(activity: dict[str, Any]) -> bool:
+    """Return True only for standard/public Teams channel messages."""
+    conversation: dict[str, Any] = activity.get("conversation") or {}
+    conversation_type: str = (conversation.get("conversationType") or "").strip().lower()
+    if conversation_type != "channel":
+        return False
+
+    channel_data: dict[str, Any] = activity.get("channelData") or {}
+    channel_raw: Any = channel_data.get("channel") if isinstance(channel_data, dict) else {}
+    channel: dict[str, Any] = channel_raw if isinstance(channel_raw, dict) else {}
+    membership_type: str = (channel.get("membershipType") or "").strip().lower()
+
+    # Teams exposes "standard" for public channels; private/shared channels should not be persisted.
+    if membership_type and membership_type != "standard":
+        logger.info(
+            "[teams_events] Skipping activity persistence for non-public channel membership_type=%s conversation_id=%s",
+            membership_type,
+            conversation.get("id", ""),
+        )
+        return False
+
+    return True
+
+
+async def _persist_activity(message: InboundMessage, tenant_id: str) -> None:
+    """Persist a Teams channel message as an Activity row for analytics."""
+    try:
+        org_id: str | None = await TeamsMessenger()._resolve_org_from_workspace(tenant_id)
+        if org_id:
+            await TeamsMessenger().persist_channel_activity(message, org_id)
+    except Exception as exc:
+        logger.error("[teams_events] Failed to persist activity: %s", exc)
+
+
 async def _process_message_activity(activity: dict[str, Any]) -> None:
     """Handle message activity: route to DIRECT, MENTION, or THREAD_REPLY."""
     try:
@@ -348,6 +382,19 @@ async def _process_message_activity(activity: dict[str, Any]) -> None:
 
         if activity.get("from", {}).get("id") == bot_id:
             return
+
+        if _is_public_teams_channel_message(activity):
+            activity_message: InboundMessage = _build_inbound_message(
+                activity,
+                MessageType.MENTION,
+            )
+            asyncio.create_task(_persist_activity(activity_message, tenant_id))
+        else:
+            logger.info(
+                "[teams_events] Not persisting activity for conversation_type=%s conversation_id=%s",
+                conversation_type,
+                conv_id,
+            )
 
         # 1:1 personal chat -> DIRECT
         # (group chats set conversationType=groupChat and/or isGroup=true)

--- a/backend/tests/test_slack_events_direct_messages.py
+++ b/backend/tests/test_slack_events_direct_messages.py
@@ -82,6 +82,86 @@ def test_process_event_callback_passes_thread_ts_for_direct_message_thread(monke
     assert msg.message_id == "1700000000.002"
 
 
+def test_process_event_callback_does_not_persist_activity_for_private_group_channels(monkeypatch) -> None:
+    persisted: list[tuple[str, str]] = []
+
+    async def _fake_is_duplicate_event(_event_id: str) -> bool:
+        return False
+
+    async def _fake_process_inbound(self, _message: InboundMessage):
+        return {"status": "success"}
+
+    async def _fake_persist_activity(_messenger, message: InboundMessage, _team_id: str) -> None:
+        persisted.append(
+            (
+                message.messenger_context.get("channel_type"),
+                message.messenger_context.get("channel_id"),
+            )
+        )
+
+    monkeypatch.setattr(slack_events, "is_duplicate_event", _fake_is_duplicate_event)
+    monkeypatch.setattr(slack_events, "_persist_activity", _fake_persist_activity)
+    monkeypatch.setattr(SlackMessenger, "process_inbound", _fake_process_inbound)
+
+    payload = {
+        "type": "event_callback",
+        "event_id": "EvPrivateGroup1",
+        "team_id": "T123",
+        "event": {
+            "type": "message",
+            "channel_type": "group",
+            "channel": "G123",
+            "user": "U123",
+            "text": "private channel message",
+            "ts": "1700000000.123",
+        },
+    }
+
+    asyncio.run(slack_events._process_event_callback_impl(payload))
+
+    assert persisted == []
+
+
+def test_process_event_callback_persists_activity_for_public_channels(monkeypatch) -> None:
+    persisted: list[tuple[str, str]] = []
+
+    async def _fake_is_duplicate_event(_event_id: str) -> bool:
+        return False
+
+    async def _fake_process_inbound(self, _message: InboundMessage):
+        return {"status": "success"}
+
+    async def _fake_persist_activity(_messenger, message: InboundMessage, _team_id: str) -> None:
+        persisted.append(
+            (
+                message.messenger_context.get("channel_type"),
+                message.messenger_context.get("channel_id"),
+            )
+        )
+
+    monkeypatch.setattr(slack_events, "is_duplicate_event", _fake_is_duplicate_event)
+    monkeypatch.setattr(slack_events, "_persist_activity", _fake_persist_activity)
+    monkeypatch.setattr(SlackMessenger, "process_inbound", _fake_process_inbound)
+
+    payload = {
+        "type": "event_callback",
+        "event_id": "EvPublicChannel1",
+        "team_id": "T123",
+        "event": {
+            "type": "message",
+            "channel_type": "channel",
+            "channel": "C123",
+            "user": "U123",
+            "text": "public channel message",
+            "ts": "1700000000.124",
+        },
+    }
+
+    asyncio.run(slack_events._process_event_callback_impl(payload))
+
+    assert persisted == [("channel", "C123")]
+
+
 def test_process_event_callback_records_failure_when_background_processing_raises(monkeypatch) -> None:
     captured: dict[str, object] = {}
 

--- a/backend/tests/test_teams_events_direct_messages.py
+++ b/backend/tests/test_teams_events_direct_messages.py
@@ -63,3 +63,72 @@ def test_process_message_activity_records_failure_when_processing_raises(monkeyp
     assert captured["was_success"] is False
     assert captured["conversation_id"] == "19:conversation:activity-2"
     assert captured["failure_reason"] == "teams forced failure"
+
+
+def test_process_message_activity_persists_only_public_channel_messages(monkeypatch) -> None:
+    persisted: list[str] = []
+
+    async def _fake_persist_activity(message, _tenant_id: str) -> None:
+        persisted.append(message.messenger_context.get("channel_type") or "")
+
+    async def _fake_process_inbound(self, _message):
+        return {"status": "success"}
+
+    async def _run(activity: dict[str, object]) -> None:
+        await teams_events._process_message_activity(activity)
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(teams_events, "_persist_activity", _fake_persist_activity)
+    monkeypatch.setattr(TeamsMessenger, "process_inbound", _fake_process_inbound)
+
+    standard_channel_activity = {
+        "id": "activity-public-1",
+        "type": "message",
+        "text": "hello public channel",
+        "from": {"id": "29:user", "aadObjectId": "aad-1"},
+        "recipient": {"id": "28:bot"},
+        "conversation": {
+            "id": "19:conversation",
+            "conversationType": "channel",
+            "isGroup": True,
+        },
+        "channelData": {
+            "tenant": {"id": "tenant-1"},
+            "channel": {"membershipType": "standard"},
+        },
+    }
+    private_channel_activity = {
+        "id": "activity-private-1",
+        "type": "message",
+        "text": "hello private channel",
+        "from": {"id": "29:user", "aadObjectId": "aad-1"},
+        "recipient": {"id": "28:bot"},
+        "conversation": {
+            "id": "19:conversation-private",
+            "conversationType": "channel",
+            "isGroup": True,
+        },
+        "channelData": {
+            "tenant": {"id": "tenant-1"},
+            "channel": {"membershipType": "private"},
+        },
+    }
+    personal_chat_activity = {
+        "id": "activity-personal-1",
+        "type": "message",
+        "text": "hello direct chat",
+        "from": {"id": "29:user", "aadObjectId": "aad-1"},
+        "recipient": {"id": "28:bot"},
+        "conversation": {
+            "id": "19:conversation-personal",
+            "conversationType": "personal",
+            "isGroup": False,
+        },
+        "channelData": {"tenant": {"id": "tenant-1"}},
+    }
+
+    asyncio.run(_run(standard_channel_activity))
+    asyncio.run(_run(private_channel_activity))
+    asyncio.run(_run(personal_chat_activity))
+
+    assert persisted == ["channel"]


### PR DESCRIPTION
### Motivation
- Avoid persisting private/group/direct messages as analytics `Activity` rows and only record messages from public channels.
- Ensure consistent behavior across Slack and Teams by treating non-public channels like DMs and skipping activity persistence.

### Description
- Slack: only persist channel messages when `channel_type == "channel"`, skip and log for `group`, `private_channel`, `mpim`, `im`, and similar types, and keep direct message processing unchanged; use `asyncio.create_task(_persist_activity(...))` for background persistence.
- Teams: added helper ` _is_public_teams_channel_message` to detect standard/public channel messages, added `_persist_activity` to resolve org and call `TeamsMessenger().persist_channel_activity`, and updated `_process_message_activity` to persist only when `_is_public_teams_channel_message` returns true and to log when skipping.
- Tests: added unit tests for Slack (`test_process_event_callback_does_not_persist_activity_for_private_group_channels` and `test_process_event_callback_persists_activity_for_public_channels`) and for Teams (`test_process_message_activity_persists_only_public_channel_messages`) to validate persistence behavior.

### Testing
- Ran unit tests in `backend/tests/test_slack_events_direct_messages.py` including the new Slack persistence tests, and they passed.
- Ran unit tests in `backend/tests/test_teams_events_direct_messages.py` including the new Teams persistence test, and they passed.
- Existing direct message processing tests for Slack and Teams were executed and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2c8e18f2c83219d0f9ffdb65bf028)