### PR TITLE
Restore chat PUBLIC/PRIVATE pill as direct scope control

### DIFF
--- a/backend/tests/test_chat_scope_pill_control.py
+++ b/backend/tests/test_chat_scope_pill_control.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_chat_scope_pill_remains_toggle_control() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    chat_component = repo_root / "frontend/src/components/Chat.tsx"
+    source = chat_component.read_text(encoding="utf-8")
+
+    assert "Scope: clickable pill toggle for conversation creator" in source
+    assert "Shared with team — click to make private" in source
+    assert "Private — click to share with team" in source
+    assert "void handleMakePrivate();" in source
+    assert "void handleMakeShared();" in source

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2037,26 +2037,38 @@ export function Chat({
               )}
             </div>
           )}
-          {/* Scope: read-only chip; owner changes visibility from ⋮ menu */}
+          {/* Scope: clickable pill toggle for conversation creator */}
           {chatId && (() => {
             const isShared: boolean = conversationScope === 'shared';
             const chipStatic: string =
               'inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide';
             const chipShared: string = `${chipStatic} bg-primary-500/15 text-primary-400/90`;
             const chipPrivate: string = `${chipStatic} bg-surface-700 text-surface-400`;
+            const nextScopeLabel: string = isShared ? 'private' : 'shared';
 
             return (
-              <span
-                className={`${isShared ? chipShared : chipPrivate} shrink-0 ${scopeToggleSaving ? 'opacity-70' : ''}`}
+              <button
+                type="button"
+                disabled={!canToggleChatScope || scopeToggleSaving}
+                aria-label={`Make conversation ${nextScopeLabel}`}
+                className={`${isShared ? chipShared : chipPrivate} shrink-0 transition-colors disabled:cursor-default ${canToggleChatScope ? 'cursor-pointer hover:brightness-110' : ''} ${scopeToggleSaving ? 'opacity-70' : ''}`}
                 title={
                   canToggleChatScope
                     ? isShared
-                      ? 'Shared with team — use ⋮ menu to make private'
-                      : 'Private — use ⋮ menu to share with team'
+                      ? 'Shared with team — click to make private'
+                      : 'Private — click to share with team'
                     : isShared
                       ? 'Shared with team'
                       : 'Only the conversation creator can change visibility'
                 }
+                onClick={() => {
+                  if (!canToggleChatScope || scopeToggleSaving) return;
+                  if (isShared) {
+                    void handleMakePrivate();
+                    return;
+                  }
+                  void handleMakeShared();
+                }}
               >
                 {scopeToggleSaving ? (
                   <span
@@ -2072,7 +2084,7 @@ export function Chat({
                     Private
                   </>
                 )}
-              </span>
+              </button>
             );
           })()}
           {/* Uncommitted changes indicator */}


### PR DESCRIPTION
### Motivation
- A recent change made the PUBLIC/PRIVATE header pill read-only, removing the direct scope control; this reverts that regression so the pill is the primary toggle for conversation creators.

### Description
- Replaced the read-only scope `span` with an interactive `button` in `frontend/src/components/Chat.tsx` that calls the existing handlers `handleMakeShared` and `handleMakePrivate` and includes an `aria-label` and proper disabled/loading state.
- Updated tooltip copy to indicate click-to-toggle behavior instead of menu-only guidance.
- Added `backend/tests/test_chat_scope_pill_control.py` which asserts the pill comment, tooltip text, and handler invocations remain present to catch regressions.

### Testing
- Ran `pytest -q backend/tests/test_chat_scope_pill_control.py`, which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e31cade49c8321bdf550b48b4b5ad6)