### PR TITLE
Show scope toggle for new conversations

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1587,9 +1587,10 @@ export function Chat({
 
   const canToggleChatScope: boolean =
     userId != null &&
-    conversationCreatorId != null &&
-    conversationCreatorId === userId &&
-    Boolean(chatId);
+    (
+      !chatId ||
+      (conversationCreatorId != null && conversationCreatorId === userId)
+    );
 
   const togglePinChat = useAppStore((s) => s.togglePinChat);
   const pinnedChatIds = useAppStore((s) => s.pinnedChatIds);
@@ -1686,7 +1687,12 @@ export function Chat({
 
   // Convert private conversation to shared (optimistic UI + revert on error)
   const handleMakeShared = useCallback(async () => {
-    if (!chatId || scopePatchInFlightRef.current) return;
+    if (!chatId) {
+      setNewConversationScope('shared');
+      setConversationScope('shared');
+      return;
+    }
+    if (scopePatchInFlightRef.current) return;
     scopePatchInFlightRef.current = true;
 
     const prevScope = conversationScope;
@@ -1732,7 +1738,12 @@ export function Chat({
 
   // Convert shared conversation to private (creator only); optimistic + revert on error
   const handleMakePrivate = useCallback(async () => {
-    if (!chatId || scopePatchInFlightRef.current) return;
+    if (!chatId) {
+      setNewConversationScope('private');
+      setConversationScope('private');
+      return;
+    }
+    if (scopePatchInFlightRef.current) return;
     scopePatchInFlightRef.current = true;
 
     const prevScope = conversationScope;
@@ -2038,8 +2049,8 @@ export function Chat({
             </div>
           )}
           {/* Scope: clickable pill toggle for conversation creator */}
-          {chatId && (() => {
-            const isShared: boolean = conversationScope === 'shared';
+          {(() => {
+            const isShared: boolean = (chatId ? conversationScope : newConversationScope) === 'shared';
             const chipStatic: string =
               'inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium uppercase tracking-wide';
             const chipShared: string = `${chipStatic} bg-primary-500/15 text-primary-400/90`;


### PR DESCRIPTION
### Motivation
- Allow users to change conversation visibility before the first message is sent so new/draft chats can be created as `private` or `shared` without requiring an initial save.
- Keep existing creator-only permission semantics for saved conversations while enabling a sensible UX for unsaved conversations.
- Avoid unnecessary API calls for unsaved conversations by updating local draft state until the conversation is persisted.

### Description
- Updated permission logic for the scope pill by changing `canToggleChatScope` to allow toggling when `chatId` is not yet assigned, while preserving creator-only toggles for existing conversations in `frontend/src/components/Chat.tsx`.
- Made `handleMakeShared` and `handleMakePrivate` set `newConversationScope` and `conversationScope` locally when `chatId` is missing so the UI updates without sending a PATCH request.
- Always render the header scope pill and make it read `newConversationScope` for unsaved chats so the pill reflects the draft scope prior to the first turn.

### Testing
- Ran `pytest -q backend/tests/test_chat_scope_pill_control.py` and the test passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e320d8b9d48321ac77448c324b40ba)