### PR TITLE
Revert conversation header people icon glyph

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2186,7 +2186,7 @@ export function Chat({
                 title={userId ? 'Add or remove people' : 'Sign in to add or remove people'}
               >
                 <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 9v3m0 0v3m0-3h3m-3 0h-3M3 12h3m2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
                 </svg>
               </button>
             </div>


### PR DESCRIPTION
### Motivation
- Restore the previous "little man" participant icon in the top-right of the conversation header by removing an unintended extra horizontal stroke introduced earlier.

### Description
- Replaced the SVG `path` in `frontend/src/components/Chat.tsx` with the prior glyph, while keeping the updated button copy and modal behavior unchanged.

### Testing
- Ran `npm --prefix frontend run lint` in the `frontend` directory and it completed successfully (no lint errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e322935a24832186289151d399ad77)