### PR TITLE
Fix duplicate `model` kwarg in OpenAI chat completion fallback

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -359,7 +359,11 @@ class OpenAIAdapter:
             max_tokens=max_tokens,
         )
         preferred_token_param = next(iter(preferred_token_kwargs))
-        request_kwargs: dict[str, Any] = {**api_kwargs, **preferred_token_kwargs}
+        request_kwargs: dict[str, Any] = {
+            "model": model,
+            **api_kwargs,
+            **preferred_token_kwargs,
+        }
 
         try:
             return await self._client.chat.completions.create(**request_kwargs)
@@ -385,6 +389,7 @@ class OpenAIAdapter:
                 },
             )
             fallback_kwargs: dict[str, Any] = {
+                "model": model,
                 **api_kwargs,
                 fallback_token_param: max_tokens,
             }
@@ -407,7 +412,6 @@ class OpenAIAdapter:
         ] + self.format_messages_for_api(messages)
 
         api_kwargs: dict[str, Any] = {
-            "model": model,
             "messages": api_messages,
             "stream": True,
         }
@@ -422,6 +426,7 @@ class OpenAIAdapter:
             max_tokens=max_tokens,
             **api_kwargs,
         )
+        chunk: Any | None = None
         async for chunk in stream:
             choice = chunk.choices[0] if chunk.choices else None
             if choice is None:

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -6,6 +6,14 @@ import pytest
 from services.llm_adapter import OpenAIAdapter
 
 
+class _EmptyAsyncIterator:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        raise StopAsyncIteration
+
+
 def test_openai_gpt5_uses_max_completion_tokens():
     adapter = OpenAIAdapter(api_key="test-key")
 
@@ -84,3 +92,27 @@ async def test_openai_token_kwarg_falls_back_for_legacy_model_when_needed():
     assert "max_completion_tokens" not in first_call_kwargs
     assert "max_completion_tokens" in second_call_kwargs
     assert "max_tokens" not in second_call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_does_not_pass_duplicate_model_kwarg():
+    adapter = OpenAIAdapter(api_key="test-key")
+    create_mock = AsyncMock(return_value=_EmptyAsyncIterator())
+    adapter._client = SimpleNamespace(  # type: ignore[assignment]
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+    )
+
+    events = [
+        event
+        async for event in adapter.stream(
+            model="gpt-4o-mini",
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=42,
+        )
+    ]
+
+    assert events == []
+    assert create_mock.await_count == 1
+    call_kwargs = create_mock.await_args.kwargs
+    assert call_kwargs["model"] == "gpt-4o-mini"


### PR DESCRIPTION
### Motivation
- Prevent a `TypeError` where `chat.completions.create` received multiple values for the `model` kwarg when `stream()` forwarded `model` and the fallback helper also injected it.
- Ensure the streaming path is robust when the returned async iterator yields no chunks to avoid an `UnboundLocalError` on usage inspection.

### Description
- Always construct `request_kwargs` inside `_create_chat_completion_with_token_fallback` with `"model": model` and the chosen token-limit kwarg so the client receives `model` exactly once for both primary and fallback attempts.
- Remove `model` from `api_kwargs` forwarded by `stream()` so the helper is the single source of the `model` argument.
- Initialize `chunk` to `None` before iterating the stream so post-loop usage checks do not reference an uninitialized variable.
- Add a regression test `test_openai_stream_does_not_pass_duplicate_model_kwarg` and a small `_EmptyAsyncIterator` helper to assert the streaming path calls the client with a single `model` kwarg.

### Testing
- Ran `cd backend && pytest -q tests/test_llm_adapter_openai_token_params.py` and the suite completed successfully with `5 passed`.
- An attempted combined test run including a non-existent file (`tests/test_llm_adapter.py`) reported a missing test file and did not run additional tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4255da5808321a6989491bfd3976e)