### PR TITLE
Retry alternate token kwarg on OpenAI API 400 errors

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Literal, Protocol
 
 from anthropic import APIStatusError as AnthropicAPIStatusError, AsyncAnthropic
-from openai import AsyncOpenAI
+from openai import APIStatusError as OpenAIAPIStatusError, AsyncOpenAI
 
 logger = logging.getLogger(__name__)
 
@@ -343,6 +343,40 @@ class OpenAIAdapter:
             and f"'{token_param_name}'" in message
         )
 
+    @staticmethod
+    def _is_unsupported_token_param_api_error(
+        exc: OpenAIAPIStatusError, *, token_param_name: str
+    ) -> bool:
+        """
+        Return true when the API rejects the chosen token parameter name.
+
+        This surfaces as a 400-level APIStatusError (not a TypeError) when the
+        SDK accepts the kwarg but upstream OpenAI-compatible backends do not.
+        """
+        body: Any = exc.body
+        if not isinstance(body, dict):
+            return False
+
+        error = body.get("error")
+        if not isinstance(error, dict):
+            return False
+
+        message = error.get("message")
+        if not isinstance(message, str):
+            return False
+
+        lowered_message = message.lower()
+        if token_param_name.lower() not in lowered_message:
+            return False
+
+        unsupported_markers = (
+            "unknown parameter",
+            "unsupported parameter",
+            "unrecognized request argument",
+            "extra inputs are not permitted",
+        )
+        return any(marker in lowered_message for marker in unsupported_markers)
+
     async def _create_chat_completion_with_token_fallback(
         self, *, model: str, max_tokens: int, **api_kwargs: Any
     ) -> Any:
@@ -386,6 +420,34 @@ class OpenAIAdapter:
                     "rejected_token_param": preferred_token_param,
                     "fallback_token_param": fallback_token_param,
                     "token_limit": max_tokens,
+                },
+            )
+            fallback_kwargs: dict[str, Any] = {
+                "model": model,
+                **api_kwargs,
+                fallback_token_param: max_tokens,
+            }
+            return await self._client.chat.completions.create(**fallback_kwargs)
+        except OpenAIAPIStatusError as exc:
+            if not self._is_unsupported_token_param_api_error(
+                exc,
+                token_param_name=preferred_token_param,
+            ):
+                raise
+
+            fallback_token_param = (
+                "max_tokens"
+                if preferred_token_param == "max_completion_tokens"
+                else "max_completion_tokens"
+            )
+            logger.warning(
+                "OpenAI API rejected token limit parameter; retrying with fallback",
+                extra={
+                    "model": model,
+                    "rejected_token_param": preferred_token_param,
+                    "fallback_token_param": fallback_token_param,
+                    "token_limit": max_tokens,
+                    "status_code": exc.status_code,
                 },
             )
             fallback_kwargs: dict[str, Any] = {

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -1,7 +1,8 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+from openai import APIStatusError
 
 from services.llm_adapter import OpenAIAdapter
 
@@ -92,6 +93,46 @@ async def test_openai_token_kwarg_falls_back_for_legacy_model_when_needed():
     assert "max_completion_tokens" not in first_call_kwargs
     assert "max_completion_tokens" in second_call_kwargs
     assert "max_tokens" not in second_call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_openai_token_kwarg_falls_back_on_api_unknown_parameter_error():
+    adapter = OpenAIAdapter(api_key="test-key")
+    unknown_param_error = APIStatusError(
+        "unknown parameter",
+        response=Mock(status_code=400, request=Mock()),
+        body={
+            "error": {
+                "message": "Unknown parameter: 'max_completion_tokens'.",
+                "type": "invalid_request_error",
+                "param": "max_completion_tokens",
+            }
+        },
+    )
+    create_mock = AsyncMock(
+        side_effect=[
+            unknown_param_error,
+            SimpleNamespace(id="ok"),
+        ]
+    )
+    adapter._client = SimpleNamespace(  # type: ignore[assignment]
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+    )
+
+    result = await adapter._create_chat_completion_with_token_fallback(
+        model="gpt-5",
+        max_tokens=100,
+        messages=[{"role": "system", "content": "hi"}],
+    )
+
+    assert result.id == "ok"
+    assert create_mock.await_count == 2
+    first_call_kwargs = create_mock.await_args_list[0].kwargs
+    second_call_kwargs = create_mock.await_args_list[1].kwargs
+    assert "max_completion_tokens" in first_call_kwargs
+    assert "max_tokens" not in first_call_kwargs
+    assert "max_tokens" in second_call_kwargs
+    assert "max_completion_tokens" not in second_call_kwargs
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Avoid hard failures when the OpenAI-compatible backend accepts a token kwarg at the SDK layer but rejects it at the API layer (400 errors) by transparently retrying with the alternate token parameter.
- Preserve existing fallback behavior for `TypeError` from the SDK while covering API-level rejection cases that previously caused errors.

### Description
- Import `APIStatusError` as `OpenAIAPIStatusError` and add `_is_unsupported_token_param_api_error` to detect API error payloads that indicate an unknown/unsupported token parameter.
- Extend `_create_chat_completion_with_token_fallback` to catch `OpenAIAPIStatusError` and retry once with the alternate token kwarg (`max_tokens` vs `max_completion_tokens`) when the API indicates an unsupported token parameter, while logging a warning with `status_code`.
- Keep the existing `TypeError`-based fallback logic intact and maintain the same single-retry behavior.
- Add a regression test `test_openai_token_kwarg_falls_back_on_api_unknown_parameter_error` and adjust test imports to simulate `APIStatusError` responses from the client.

### Testing
- Ran `pytest -q backend/tests/test_llm_adapter_openai_token_params.py` and observed `6 passed`.
- The new test simulates a 400 `APIStatusError` with an "unknown parameter" message and verifies the adapter retries with the alternate token kwarg (test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e42f4cf0f08321a70afd9b2681232b)