### PR TITLE
Fix stale model defaults in organization panel

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -223,8 +223,8 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
           llm_primary_model?: string | null;
           llm_cheap_model?: string | null;
           llm_workflow_model?: string | null;
-        }>(`/auth/organizations/${encodeURIComponent(organization.id)}?user_id=${encodeURIComponent(currentUser.id)}`),
-        apiRequest<{ models: Record<string, string> }>('/auth/llm-options'),
+        }>(`/auth/organizations/${encodeURIComponent(organization.id)}?user_id=${encodeURIComponent(currentUser.id)}`, { cache: 'no-store' }),
+        apiRequest<{ models: Record<string, string> }>('/auth/llm-options', { cache: 'no-store' }),
       ]);
 
       if (organizationError) {
@@ -257,7 +257,13 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
   }, [organization.id, currentUser.id]);
 
   useEffect(() => {
+    // Always refresh once on panel mount to avoid stale cross-tab model defaults.
+    void loadFreshModelSettings();
+  }, [loadFreshModelSettings]);
+
+  useEffect(() => {
     if (activeTab !== 'settings') return;
+    // Refresh again when opening settings in case values changed while panel was open.
     void loadFreshModelSettings();
   }, [activeTab, loadFreshModelSettings]);
 


### PR DESCRIPTION
### Motivation
- Users could see out-of-date AI model defaults in the Team/Settings pane after changing models in another tab because the panel only fetched settings when the Settings tab became active and the browser could serve cached responses.

### Description
- Always invoke `loadFreshModelSettings()` once on `OrganizationPanel` mount to ensure the panel starts with fresh model defaults when opened. 
- Keep the existing effect that refreshes when `activeTab === 'settings'` but make it call `loadFreshModelSettings()` so values are re-read if the tab is opened while the panel is already mounted. 
- Force fresh network reads by adding `{ cache: 'no-store' }` to the `apiRequest` calls for `/auth/organizations/:id` and `/auth/llm-options` in `frontend/src/components/OrganizationPanel.tsx`.

### Testing
- Ran `npm --prefix frontend run lint` against the frontend and it completed successfully. 
- Attempted `npm --prefix frontend run eslint -- src/components/OrganizationPanel.tsx` but it failed because the project does not expose an `eslint` npm script (the correct script is `lint`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e431074e508321a5773de5bad198a7)