### PR TITLE
Fix GPT-5 token kwarg detection for prefixed model names

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -320,7 +320,8 @@ class OpenAIAdapter:
     def _build_token_limit_kwargs(self, *, model: str, max_tokens: int) -> dict[str, int]:
         """Map token limit parameter name based on OpenAI model requirements."""
         # Newer reasoning families (e.g. gpt-5 / o-series) reject `max_tokens`.
-        uses_completion_tokens: bool = model.startswith(("gpt-5", "o"))
+        normalized_model: str = model.strip().lower().split("/")[-1]
+        uses_completion_tokens: bool = normalized_model.startswith(("gpt-5", "o"))
         token_param_name: str = (
             "max_completion_tokens" if uses_completion_tokens else "max_tokens"
         )
@@ -328,6 +329,7 @@ class OpenAIAdapter:
             "OpenAI token limit param selected",
             extra={
                 "model": model,
+                "normalized_model": normalized_model,
                 "token_param_name": token_param_name,
                 "token_limit": max_tokens,
             },

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -31,6 +31,15 @@ def test_openai_legacy_models_use_max_tokens():
     }
 
 
+def test_openai_gpt5_with_provider_prefix_uses_max_completion_tokens():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    assert adapter._build_token_limit_kwargs(
+        model="openai/GPT-5-mini",
+        max_tokens=777,
+    ) == {"max_completion_tokens": 777}
+
+
 @pytest.mark.asyncio
 async def test_openai_token_kwarg_falls_back_when_preferred_is_rejected():
     adapter = OpenAIAdapter(api_key="test-key")


### PR DESCRIPTION
### Motivation
- Model names prefixed by a provider (e.g. `openai/GPT-5-mini`) could be misclassified and cause the wrong token parameter (`max_tokens` vs `max_completion_tokens`) to be sent, triggering 400 errors from some OpenAI-compatible backends.
- Normalize model identifiers before family detection to make token-parameter selection robust to provider prefixes and mixed case.

### Description
- Normalize the model string in `OpenAIAdapter._build_token_limit_kwargs` by trimming, lowercasing, and taking the final path segment (`model.strip().lower().split("/")[-1]`) before deciding which token kwarg to use. 
- Use the normalized model to detect GPT-5 / o-series families and choose `max_completion_tokens` when appropriate. 
- Add `normalized_model` to the debug logging to aid future troubleshooting. 
- Add a regression test `test_openai_gpt5_with_provider_prefix_uses_max_completion_tokens` to ensure provider-prefixed and mixed-case GPT-5 model names map to `max_completion_tokens`.

### Testing
- Ran `pytest -q backend/tests/test_llm_adapter_openai_token_params.py` and all tests passed. 
- Test output: `7 passed in 2.84s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e432f9696c8321a05d4c419e9f8b6a)