### PR TITLE
Revert token-kwarg fallback from PR #1034

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Literal, Protocol
 
 from anthropic import APIStatusError as AnthropicAPIStatusError, AsyncAnthropic
-from openai import APIStatusError as OpenAIAPIStatusError, AsyncOpenAI
+from openai import AsyncOpenAI
 
 logger = logging.getLogger(__name__)
 
@@ -336,129 +336,6 @@ class OpenAIAdapter:
         )
         return {token_param_name: max_tokens}
 
-    @staticmethod
-    def _is_unexpected_token_kwarg_error(exc: TypeError, *, token_param_name: str) -> bool:
-        """Return true when OpenAI SDK rejects the chosen token argument name."""
-        message = str(exc)
-        return (
-            "unexpected keyword argument" in message
-            and f"'{token_param_name}'" in message
-        )
-
-    @staticmethod
-    def _is_unsupported_token_param_api_error(
-        exc: OpenAIAPIStatusError, *, token_param_name: str
-    ) -> bool:
-        """
-        Return true when the API rejects the chosen token parameter name.
-
-        This surfaces as a 400-level APIStatusError (not a TypeError) when the
-        SDK accepts the kwarg but upstream OpenAI-compatible backends do not.
-        """
-        body: Any = exc.body
-        if not isinstance(body, dict):
-            return False
-
-        error = body.get("error")
-        if not isinstance(error, dict):
-            return False
-
-        message = error.get("message")
-        if not isinstance(message, str):
-            return False
-
-        lowered_message = message.lower()
-        if token_param_name.lower() not in lowered_message:
-            return False
-
-        unsupported_markers = (
-            "unknown parameter",
-            "unsupported parameter",
-            "unrecognized request argument",
-            "extra inputs are not permitted",
-        )
-        return any(marker in lowered_message for marker in unsupported_markers)
-
-    async def _create_chat_completion_with_token_fallback(
-        self, *, model: str, max_tokens: int, **api_kwargs: Any
-    ) -> Any:
-        """
-        Create a chat completion and transparently retry with the alternate token kwarg.
-
-        Some client/runtime combinations can temporarily disagree on whether
-        `max_tokens` or `max_completion_tokens` is accepted, even for the same model.
-        We optimistically use model-based selection first, then retry once with the
-        alternate parameter only when the SDK raises an unexpected-kwarg TypeError.
-        """
-        preferred_token_kwargs = self._build_token_limit_kwargs(
-            model=model,
-            max_tokens=max_tokens,
-        )
-        preferred_token_param = next(iter(preferred_token_kwargs))
-        request_kwargs: dict[str, Any] = {
-            "model": model,
-            **api_kwargs,
-            **preferred_token_kwargs,
-        }
-
-        try:
-            return await self._client.chat.completions.create(**request_kwargs)
-        except TypeError as exc:
-            if not self._is_unexpected_token_kwarg_error(
-                exc,
-                token_param_name=preferred_token_param,
-            ):
-                raise
-
-            fallback_token_param = (
-                "max_tokens"
-                if preferred_token_param == "max_completion_tokens"
-                else "max_completion_tokens"
-            )
-            logger.warning(
-                "OpenAI chat completion rejected token limit kwarg; retrying with fallback",
-                extra={
-                    "model": model,
-                    "rejected_token_param": preferred_token_param,
-                    "fallback_token_param": fallback_token_param,
-                    "token_limit": max_tokens,
-                },
-            )
-            fallback_kwargs: dict[str, Any] = {
-                "model": model,
-                **api_kwargs,
-                fallback_token_param: max_tokens,
-            }
-            return await self._client.chat.completions.create(**fallback_kwargs)
-        except OpenAIAPIStatusError as exc:
-            if not self._is_unsupported_token_param_api_error(
-                exc,
-                token_param_name=preferred_token_param,
-            ):
-                raise
-
-            fallback_token_param = (
-                "max_tokens"
-                if preferred_token_param == "max_completion_tokens"
-                else "max_completion_tokens"
-            )
-            logger.warning(
-                "OpenAI API rejected token limit parameter; retrying with fallback",
-                extra={
-                    "model": model,
-                    "rejected_token_param": preferred_token_param,
-                    "fallback_token_param": fallback_token_param,
-                    "token_limit": max_tokens,
-                    "status_code": exc.status_code,
-                },
-            )
-            fallback_kwargs: dict[str, Any] = {
-                "model": model,
-                **api_kwargs,
-                fallback_token_param: max_tokens,
-            }
-            return await self._client.chat.completions.create(**fallback_kwargs)
-
     # -- streaming ----------------------------------------------------------
 
     async def stream(
@@ -479,15 +356,15 @@ class OpenAIAdapter:
             "messages": api_messages,
             "stream": True,
         }
+        api_kwargs.update(self._build_token_limit_kwargs(model=model, max_tokens=max_tokens))
         if tools:
             api_kwargs["tools"] = self.format_tools(tools)
 
         tool_calls_accum: dict[int, dict[str, str]] = {}
         current_text_started: bool = False
 
-        stream = await self._create_chat_completion_with_token_fallback(
+        stream = await self._client.chat.completions.create(
             model=model,
-            max_tokens=max_tokens,
             **api_kwargs,
         )
         chunk: Any | None = None
@@ -571,10 +448,10 @@ class OpenAIAdapter:
             {"role": "system", "content": system}
         ] + self.format_messages_for_api(messages)
 
-        response = await self._create_chat_completion_with_token_fallback(
+        response = await self._client.chat.completions.create(
             model=model,
             messages=api_messages,
-            max_tokens=max_tokens,
+            **self._build_token_limit_kwargs(model=model, max_tokens=max_tokens),
         )
         blocks: list[ContentBlock] = self.build_completed_content(response)
         usage = response.usage

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -1,9 +1,7 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock
 
 import pytest
-from openai import APIStatusError
-
 from services.llm_adapter import OpenAIAdapter
 
 
@@ -38,111 +36,6 @@ def test_openai_gpt5_with_provider_prefix_uses_max_completion_tokens():
         model="openai/GPT-5-mini",
         max_tokens=777,
     ) == {"max_completion_tokens": 777}
-
-
-@pytest.mark.asyncio
-async def test_openai_token_kwarg_falls_back_when_preferred_is_rejected():
-    adapter = OpenAIAdapter(api_key="test-key")
-    create_mock = AsyncMock(
-        side_effect=[
-            TypeError(
-                "AsyncCompletions.create() got an unexpected keyword argument "
-                "'max_completion_tokens'"
-            ),
-            SimpleNamespace(id="ok"),
-        ]
-    )
-    adapter._client = SimpleNamespace(  # type: ignore[assignment]
-        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
-    )
-
-    result = await adapter._create_chat_completion_with_token_fallback(
-        model="gpt-5",
-        max_tokens=100,
-        messages=[{"role": "system", "content": "hi"}],
-    )
-
-    assert result.id == "ok"
-    assert create_mock.await_count == 2
-    first_call_kwargs = create_mock.await_args_list[0].kwargs
-    second_call_kwargs = create_mock.await_args_list[1].kwargs
-    assert "max_completion_tokens" in first_call_kwargs
-    assert "max_tokens" not in first_call_kwargs
-    assert "max_tokens" in second_call_kwargs
-    assert "max_completion_tokens" not in second_call_kwargs
-
-
-@pytest.mark.asyncio
-async def test_openai_token_kwarg_falls_back_for_legacy_model_when_needed():
-    adapter = OpenAIAdapter(api_key="test-key")
-    create_mock = AsyncMock(
-        side_effect=[
-            TypeError(
-                "AsyncCompletions.create() got an unexpected keyword argument "
-                "'max_tokens'"
-            ),
-            SimpleNamespace(id="ok"),
-        ]
-    )
-    adapter._client = SimpleNamespace(  # type: ignore[assignment]
-        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
-    )
-
-    result = await adapter._create_chat_completion_with_token_fallback(
-        model="gpt-4o-mini",
-        max_tokens=100,
-        messages=[{"role": "system", "content": "hi"}],
-    )
-
-    assert result.id == "ok"
-    assert create_mock.await_count == 2
-    first_call_kwargs = create_mock.await_args_list[0].kwargs
-    second_call_kwargs = create_mock.await_args_list[1].kwargs
-    assert "max_tokens" in first_call_kwargs
-    assert "max_completion_tokens" not in first_call_kwargs
-    assert "max_completion_tokens" in second_call_kwargs
-    assert "max_tokens" not in second_call_kwargs
-
-
-@pytest.mark.asyncio
-async def test_openai_token_kwarg_falls_back_on_api_unknown_parameter_error():
-    adapter = OpenAIAdapter(api_key="test-key")
-    unknown_param_error = APIStatusError(
-        "unknown parameter",
-        response=Mock(status_code=400, request=Mock()),
-        body={
-            "error": {
-                "message": "Unknown parameter: 'max_completion_tokens'.",
-                "type": "invalid_request_error",
-                "param": "max_completion_tokens",
-            }
-        },
-    )
-    create_mock = AsyncMock(
-        side_effect=[
-            unknown_param_error,
-            SimpleNamespace(id="ok"),
-        ]
-    )
-    adapter._client = SimpleNamespace(  # type: ignore[assignment]
-        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
-    )
-
-    result = await adapter._create_chat_completion_with_token_fallback(
-        model="gpt-5",
-        max_tokens=100,
-        messages=[{"role": "system", "content": "hi"}],
-    )
-
-    assert result.id == "ok"
-    assert create_mock.await_count == 2
-    first_call_kwargs = create_mock.await_args_list[0].kwargs
-    second_call_kwargs = create_mock.await_args_list[1].kwargs
-    assert "max_completion_tokens" in first_call_kwargs
-    assert "max_tokens" not in first_call_kwargs
-    assert "max_tokens" in second_call_kwargs
-    assert "max_completion_tokens" not in second_call_kwargs
-
 
 @pytest.mark.asyncio
 async def test_openai_stream_does_not_pass_duplicate_model_kwarg():


### PR DESCRIPTION
### Motivation
- Avoid transparently retrying chat completions with an alternate token kwarg (`max_tokens` ↔ `max_completion_tokens`) because the code should not swap token-kwarg names at runtime.
- Preserve the existing model-based selection of token parameter names (including provider-prefixed GPT-5 detection) while removing retry/fallback complexity.

### Description
- Removed the token-fallback helpers and flow by deleting `_is_unexpected_token_kwarg_error`, `_is_unsupported_token_param_api_error`, and `_create_chat_completion_with_token_fallback` and their use in `OpenAIAdapter`.
- Restored direct calls to `self._client.chat.completions.create(...)` for both streaming and non-streaming paths and ensured the chosen token kwarg is supplied via `_build_token_limit_kwargs` without retrying with the alternate name.
- Removed the unused `OpenAIAPIStatusError` import and simplified `complete` and `stream` call sites to pass `model` and the token-kwarg mapping explicitly.
- Updated tests in `backend/tests/test_llm_adapter_openai_token_params.py` to remove fallback-specific assertions while keeping coverage for model-based token-param selection and stream call kwarg behavior.

### Testing
- Ran `pytest -q backend/tests/test_llm_adapter_openai_token_params.py`, which completed successfully with `4 passed`.
- No other automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e43610066c8321b0967016498e2ba2)