### PR TITLE
Count model send exceptions as query failures

### DIFF
--- a/backend/messengers/base.py
+++ b/backend/messengers/base.py
@@ -335,6 +335,7 @@ class BaseMessenger(ABC):
 
             full_response: str = ""
             outbound_media_urls: list[str] = []
+            orchestrator_error: Exception | None = None
             try:
                 async for chunk in orchestrator.process_message(
                     message_text,
@@ -347,6 +348,7 @@ class BaseMessenger(ABC):
                     else:
                         full_response += chunk
             except Exception as exc:
+                orchestrator_error = exc
                 logger.exception(
                     "[%s] Orchestrator error conversation=%s",
                     self.meta.slug,
@@ -381,6 +383,8 @@ class BaseMessenger(ABC):
                 "status": "success",
                 "conversation_id": conversation_id,
                 "response_length": len(response_text),
+                "query_failed": orchestrator_error is not None,
+                "failure_reason": str(orchestrator_error) if orchestrator_error else None,
             }
             return result
         except Exception as exc:
@@ -446,6 +450,8 @@ class BaseMessenger(ABC):
             return False
         if not result:
             return False
+        if result.get("query_failed"):
+            return False
         status = result.get("status")
         if status == "success":
             return True
@@ -476,6 +482,8 @@ class BaseMessenger(ABC):
             return str(error)
         if not result:
             return "empty_result"
+        if isinstance(result.get("failure_reason"), str) and result.get("failure_reason"):
+            return str(result["failure_reason"])
 
         if isinstance(result.get("error"), str) and result.get("error"):
             return str(result["error"])

--- a/backend/tests/test_query_outcome_metrics.py
+++ b/backend/tests/test_query_outcome_metrics.py
@@ -32,6 +32,23 @@ def test_failed_query_outcome_classification() -> None:
         result={"status": "success"},
         error=RuntimeError("boom"),
     )
+    assert not BaseMessenger._is_successful_query_outcome(
+        result={"status": "success", "query_failed": True},
+        error=None,
+    )
+
+
+def test_failed_query_outcome_reason_prefers_query_failure_reason() -> None:
+    reason = BaseMessenger._derive_failed_query_reason(
+        result={
+            "status": "success",
+            "query_failed": True,
+            "failure_reason": "provider timeout",
+            "error": "should_not_win",
+        },
+        error=None,
+    )
+    assert reason == "provider timeout"
 
 
 def test_timeout_continuing_is_excluded_from_query_outcome_consideration() -> None:


### PR DESCRIPTION
### Motivation

- Orchestrator/model send exceptions were being surfaced to users as fallback messages but still recorded as successful queries in metrics, skewing rolling success/failure calculations.

### Description

- Capture exceptions raised while streaming from `ChatOrchestrator.process_message` into a local `orchestrator_error` and attach `query_failed` and `failure_reason` to the returned `result` so downstream metrics can detect model/send failures.
- Treat any result with `query_failed=True` as unsuccessful in `_is_successful_query_outcome` so model send/stream failures count as failures even when `status` is `success`.
- Make `_derive_failed_query_reason` prefer the new `failure_reason` field when present so failure attribution reflects the underlying model/send exception.
- Add tests to `backend/tests/test_query_outcome_metrics.py` that assert `query_failed` forces failure classification and that `failure_reason` takes precedence when extracting the failure reason.

### Testing

- Ran `pytest -q backend/tests/test_query_outcome_metrics.py`, and all tests passed: `10 passed`.
- The new tests specifically validate the `query_failed` classification and failure-reason precedence and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4371ce4ec832193f8342784b9bff6)