### PR TITLE
Count degraded stream fallback responses as query failures

### DIFF
--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -723,14 +723,15 @@ class WorkspaceMessenger(BaseMessenger):
         attachment_ids: list[str] | None = None,
         organization_id: str | None = None,
         on_message_posted: Any | None = None,
-    ) -> int:
+    ) -> tuple[int, str | None]:
         """Stream orchestrator output and post text segments incrementally.
 
         Flushes happen when a tool-call boundary arrives, the buffer reaches
         ``STREAM_FLUSH_CHAR_THRESHOLD``, or ``STREAM_FLUSH_INTERVAL_SECONDS``
         elapsed since last flush.
 
-        Returns total character count of all posted text.
+        Returns total character count of all posted text and an optional
+        stream failure reason when fallback copy was emitted.
         """
         ctx: dict[str, Any] = message.messenger_context
         channel_id: str = ctx.get("channel_id", "")
@@ -741,6 +742,7 @@ class WorkspaceMessenger(BaseMessenger):
         total_length: int = 0
         last_flush_at: float = time.monotonic()
         posted_tool_statuses: dict[str, tuple[str, str]] = {}
+        stream_failure_reason: str | None = None
 
         async def _flush(*, reason: str, force: bool = False) -> None:
             nonlocal current_text, total_length, last_flush_at
@@ -794,10 +796,11 @@ class WorkspaceMessenger(BaseMessenger):
                         await _flush(reason="buffer_size" if size_flush else "interval")
         except Exception as exc:
             logger.error("[%s] Error during streaming: %s", self.meta.slug, exc, exc_info=True)
+            stream_failure_reason = str(exc)
             current_text += user_message_for_agent_stream_failure(exc)
 
         await _flush(reason="stream_end", force=True)
-        return total_length
+        return total_length, stream_failure_reason
 
     def format_tool_status_for_display(self, status_text: str) -> str:
         """Format status text for this platform (e.g. Slack may wrap in italics). Default: return as-is."""
@@ -1029,7 +1032,7 @@ class WorkspaceMessenger(BaseMessenger):
                     nonlocal last_message_sent_at
                     last_message_sent_at = time.monotonic()
 
-                response_task: asyncio.Task[int] = asyncio.create_task(
+                response_task: asyncio.Task[tuple[int, str | None]] = asyncio.create_task(
                     self.stream_and_post_responses(
                         orchestrator=orchestrator,
                         message=message,
@@ -1043,13 +1046,16 @@ class WorkspaceMessenger(BaseMessenger):
                     {response_task}, timeout=SLOW_REPLY_TIMEOUT_SECONDS,
                 )
                 if response_task in done:
-                    total: int = response_task.result()
+                    total, stream_failure_reason = response_task.result()
                     await self.remove_typing_indicator(message)
                     result = {
                         "status": "success",
                         "conversation_id": conversation_id,
                         "response_length": total,
+                        "degraded": stream_failure_reason is not None,
                     }
+                    if stream_failure_reason:
+                        result["failure_reason"] = stream_failure_reason
                     return result
 
                 await self._wait_for_slow_reply_window(
@@ -1057,13 +1063,16 @@ class WorkspaceMessenger(BaseMessenger):
                     get_last_message_sent_at=lambda: last_message_sent_at,
                 )
                 if response_task.done():
-                    total = response_task.result()
+                    total, stream_failure_reason = response_task.result()
                     await self.remove_typing_indicator(message)
                     result = {
                         "status": "success",
                         "conversation_id": conversation_id,
                         "response_length": total,
+                        "degraded": stream_failure_reason is not None,
                     }
+                    if stream_failure_reason:
+                        result["failure_reason"] = stream_failure_reason
                     return result
 
                 # Slow path: notify user and continue in background

--- a/backend/messengers/base.py
+++ b/backend/messengers/base.py
@@ -335,6 +335,8 @@ class BaseMessenger(ABC):
 
             full_response: str = ""
             outbound_media_urls: list[str] = []
+            stream_failed: bool = False
+            stream_failure_reason: str | None = None
             try:
                 async for chunk in orchestrator.process_message(
                     message_text,
@@ -352,6 +354,8 @@ class BaseMessenger(ABC):
                     self.meta.slug,
                     conversation_id,
                 )
+                stream_failed = True
+                stream_failure_reason = str(exc)
                 full_response += user_message_for_agent_stream_failure(exc)
 
             # 7. Format and deliver
@@ -381,7 +385,10 @@ class BaseMessenger(ABC):
                 "status": "success",
                 "conversation_id": conversation_id,
                 "response_length": len(response_text),
+                "degraded": stream_failed,
             }
+            if stream_failed:
+                result["failure_reason"] = stream_failure_reason or "stream_failed"
             return result
         except Exception as exc:
             caught_error = exc
@@ -446,6 +453,8 @@ class BaseMessenger(ABC):
             return False
         if not result:
             return False
+        if result.get("degraded") is True:
+            return False
         status = result.get("status")
         if status == "success":
             return True
@@ -476,6 +485,11 @@ class BaseMessenger(ABC):
             return str(error)
         if not result:
             return "empty_result"
+        if result.get("degraded") is True:
+            degraded_reason = result.get("failure_reason")
+            if isinstance(degraded_reason, str) and degraded_reason:
+                return degraded_reason
+            return "stream_failed"
 
         if isinstance(result.get("error"), str) and result.get("error"):
             return str(result["error"])

--- a/backend/tests/test_query_outcome_metrics.py
+++ b/backend/tests/test_query_outcome_metrics.py
@@ -32,12 +32,23 @@ def test_failed_query_outcome_classification() -> None:
         result={"status": "success"},
         error=RuntimeError("boom"),
     )
+    assert not BaseMessenger._is_successful_query_outcome(
+        result={"status": "success", "degraded": True, "failure_reason": "stream_failed"},
+        error=None,
+    )
 
 
 def test_timeout_continuing_is_excluded_from_query_outcome_consideration() -> None:
     assert BaseMessenger._should_skip_query_outcome(result={"status": "timeout_continuing"})
     assert not BaseMessenger._should_skip_query_outcome(result={"status": "success"})
     assert not BaseMessenger._should_skip_query_outcome(result=None)
+
+
+def test_derive_failed_query_reason_prefers_degraded_reason() -> None:
+    assert BaseMessenger._derive_failed_query_reason(
+        result={"status": "success", "degraded": True, "failure_reason": "transport_error"},
+        error=None,
+    ) == "transport_error"
 
 
 def test_get_query_outcome_window_stats() -> None:


### PR DESCRIPTION
### Motivation
- Orchestrator streaming can raise and cause fallback user copy to be emitted, but those degraded responses were historically counted as successes for rolling query outcome metrics.
- The intent is to ensure any time streaming falls back (transport/stream errors) it is treated as a failed/degraded outcome for monitoring and incidenting.

### Description
- Mark messenger outcomes as degraded by adding `degraded: True` and a `failure_reason` when the orchestrator stream raises in `backend/messengers/base.py` and propagate those fields in the result payload. 
- Update the workspace streaming flow in `backend/messengers/_workspace.py` by changing `stream_and_post_responses` to return a tuple ``(total_length, stream_failure_reason)`` and propagate `degraded`/`failure_reason` on both fast and slow completion paths. 
- Classify degraded outcomes as failures in `BaseMessenger._is_successful_query_outcome` and prefer the degraded `failure_reason` in `BaseMessenger._derive_failed_query_reason` so metrics attribute the correct failure reason. 
- Add tests in `backend/tests/test_query_outcome_metrics.py` that assert degraded payloads are treated as failures and that degraded failure reasons are preserved.

### Testing
- Ran `pytest -q tests/test_query_outcome_metrics.py tests/test_anthropic_health.py` and the suite passed with `19 passed`.
- New and existing unit tests exercising query outcome classification and anthropic health behavior all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e437d709fc8321aee25bb9010bc9da)