### PR TITLE
Track workspace stream fallback as query failure

### DIFF
--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -723,14 +723,15 @@ class WorkspaceMessenger(BaseMessenger):
         attachment_ids: list[str] | None = None,
         organization_id: str | None = None,
         on_message_posted: Any | None = None,
-    ) -> int:
+    ) -> tuple[int, bool, str | None]:
         """Stream orchestrator output and post text segments incrementally.
 
         Flushes happen when a tool-call boundary arrives, the buffer reaches
         ``STREAM_FLUSH_CHAR_THRESHOLD``, or ``STREAM_FLUSH_INTERVAL_SECONDS``
         elapsed since last flush.
 
-        Returns total character count of all posted text.
+        Returns:
+            tuple of (total posted character count, query_failed, failure_reason).
         """
         ctx: dict[str, Any] = message.messenger_context
         channel_id: str = ctx.get("channel_id", "")
@@ -739,6 +740,8 @@ class WorkspaceMessenger(BaseMessenger):
 
         current_text: str = ""
         total_length: int = 0
+        query_failed: bool = False
+        failure_reason: str | None = None
         last_flush_at: float = time.monotonic()
         posted_tool_statuses: dict[str, tuple[str, str]] = {}
 
@@ -794,10 +797,12 @@ class WorkspaceMessenger(BaseMessenger):
                         await _flush(reason="buffer_size" if size_flush else "interval")
         except Exception as exc:
             logger.error("[%s] Error during streaming: %s", self.meta.slug, exc, exc_info=True)
+            query_failed = True
+            failure_reason = str(exc)
             current_text += user_message_for_agent_stream_failure(exc)
 
         await _flush(reason="stream_end", force=True)
-        return total_length
+        return total_length, query_failed, failure_reason
 
     def format_tool_status_for_display(self, status_text: str) -> str:
         """Format status text for this platform (e.g. Slack may wrap in italics). Default: return as-is."""
@@ -1043,12 +1048,14 @@ class WorkspaceMessenger(BaseMessenger):
                     {response_task}, timeout=SLOW_REPLY_TIMEOUT_SECONDS,
                 )
                 if response_task in done:
-                    total: int = response_task.result()
+                    total, query_failed, failure_reason = response_task.result()
                     await self.remove_typing_indicator(message)
                     result = {
                         "status": "success",
                         "conversation_id": conversation_id,
                         "response_length": total,
+                        "query_failed": query_failed,
+                        "failure_reason": failure_reason,
                     }
                     return result
 
@@ -1057,12 +1064,14 @@ class WorkspaceMessenger(BaseMessenger):
                     get_last_message_sent_at=lambda: last_message_sent_at,
                 )
                 if response_task.done():
-                    total = response_task.result()
+                    total, query_failed, failure_reason = response_task.result()
                     await self.remove_typing_indicator(message)
                     result = {
                         "status": "success",
                         "conversation_id": conversation_id,
                         "response_length": total,
+                        "query_failed": query_failed,
+                        "failure_reason": failure_reason,
                     }
                     return result
 

--- a/backend/tests/test_workspace_stream_error_query_outcome.py
+++ b/backend/tests/test_workspace_stream_error_query_outcome.py
@@ -1,0 +1,81 @@
+import asyncio
+
+from messengers._workspace import WorkspaceMessenger
+from messengers.base import InboundMessage, MessageType, MessengerMeta, ResponseMode
+
+
+class _TestWorkspaceMessenger(WorkspaceMessenger):
+    meta = MessengerMeta(
+        name="Test",
+        slug="test",
+        response_mode=ResponseMode.STREAMING,
+    )
+
+    def __init__(self) -> None:
+        self.posted_messages: list[dict[str, str | None]] = []
+
+    async def resolve_organization(self, user, message):  # type: ignore[override]
+        raise NotImplementedError
+
+    async def find_or_create_conversation(self, organization_id, user, message):  # type: ignore[override]
+        raise NotImplementedError
+
+    async def download_attachments(self, message):  # type: ignore[override]
+        raise NotImplementedError
+
+    def format_text(self, markdown: str) -> str:
+        return markdown
+
+    async def post_message(
+        self,
+        channel_id: str,
+        text: str,
+        thread_id: str | None = None,
+        *,
+        workspace_id: str | None = None,
+        organization_id: str | None = None,
+    ) -> str | None:
+        self.posted_messages.append(
+            {
+                "channel_id": channel_id,
+                "text": text,
+                "thread_id": thread_id,
+                "workspace_id": workspace_id,
+                "organization_id": organization_id,
+            }
+        )
+        return "posted"
+
+
+class _ExplodingOrchestrator:
+    async def process_message(self, *_args, **_kwargs):
+        if False:
+            yield ""
+        raise RuntimeError("backend stream failed")
+
+
+def test_stream_and_post_responses_marks_query_failed_on_fallback_error_copy() -> None:
+    messenger = _TestWorkspaceMessenger()
+    message = InboundMessage(
+        external_user_id="U123",
+        text="hello",
+        message_type=MessageType.DIRECT,
+        messenger_context={"channel_id": "C123", "thread_ts": "t-1", "workspace_id": "W123"},
+        message_id="m-1",
+    )
+
+    async def _run() -> tuple[int, bool, str | None]:
+        return await messenger.stream_and_post_responses(
+            orchestrator=_ExplodingOrchestrator(),
+            message=message,
+            message_text="hello",
+            attachment_ids=None,
+            organization_id="org-1",
+        )
+
+    total, query_failed, failure_reason = asyncio.run(_run())
+
+    assert query_failed is True
+    assert failure_reason == "backend stream failed"
+    assert total > 0
+    assert messenger.posted_messages[-1]["text"] == "Sorry, something went wrong processing your message. Please try again."


### PR DESCRIPTION
### Motivation
- Streaming orchestrator exceptions were converted into user-facing fallback text but not marked as query failures, causing monitoring to undercount failed turns.
- Preserve the original failure reason so incident/telemetry systems can surface useful debug information.
- Ensure rolling query outcome metrics classify streamed turns that fell back to error copy as failures.

### Description
- Change `WorkspaceMessenger.stream_and_post_responses` return type from `int` to `tuple[int, bool, str | None]` and return `(total_length, query_failed, failure_reason)` when streaming completes; set `query_failed=True` and `failure_reason=str(exc)` inside the streaming `except` handler. (`backend/messengers/_workspace.py`)
- Propagate the returned `query_failed` and `failure_reason` into the streaming `process_inbound` fast-complete and slow-window-complete code paths so the `process_inbound` result includes `query_failed` and `failure_reason`. (`backend/messengers/_workspace.py`)
- Add a regression test that simulates an orchestrator stream exception and asserts that the fallback copy is posted, `query_failed` is `True`, and `failure_reason` preserves the exception text. (`backend/tests/test_workspace_stream_error_query_outcome.py`)

### Testing
- Ran `pytest -q backend/tests/test_workspace_stream_error_query_outcome.py backend/tests/test_query_outcome_metrics.py` and all tests passed (11 passed).
- The new regression test verifies fallback posting and query outcome metadata and passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e438c89cdc832189310d393c308c0e)