### PR TITLE
chore: upgrade openai dependency to 2.32.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,7 +25,7 @@ simple-salesforce==1.12.5
 anthropic==0.76.0
 
 # OpenAI (for embeddings)
-openai==1.12.0
+openai==2.32.0
 
 # Configuration
 pydantic[email]==2.6.1


### PR DESCRIPTION
### Motivation
- Keep the OpenAI Python SDK current for security fixes and newer API features used by code that imports `AsyncOpenAI`.

### Description
- Bumped `openai` in `backend/requirements.txt` from `1.12.0` to `2.32.0`.

### Testing
- Confirmed available versions with `python -m pip index versions openai` and installed `openai==2.32.0`, then verified `from openai import AsyncOpenAI` imports successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e43fa1fbd88321b71b55ef4c97ed76)