### PR TITLE
Fix null chat content for GPT-5 requests

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -478,6 +478,16 @@ class OpenAIAdapter:
         self, messages: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
         """Translate Anthropic-style stored messages to OpenAI chat format."""
+        def _as_text(value: Any) -> str:
+            """Coerce nullable/non-string content into API-safe text."""
+            if value is None:
+                return ""
+            if isinstance(value, str):
+                return value
+            if isinstance(value, (dict, list)):
+                return json.dumps(value, ensure_ascii=False)
+            return str(value)
+
         result: list[dict[str, Any]] = []
         for msg in messages:
             role: str = msg.get("role", "user")
@@ -495,7 +505,7 @@ class OpenAIAdapter:
                             result.append({
                                 "role": "tool",
                                 "tool_call_id": block.get("tool_use_id", ""),
-                                "content": block.get("content", ""),
+                                "content": _as_text(block.get("content", "")),
                             })
                     continue
 
@@ -505,7 +515,9 @@ class OpenAIAdapter:
                     if isinstance(block, dict):
                         btype: str = block.get("type", "")
                         if btype == "text":
-                            openai_parts.append({"type": "text", "text": block.get("text", "")})
+                            openai_parts.append(
+                                {"type": "text", "text": _as_text(block.get("text", ""))}
+                            )
                         elif btype == "image":
                             source = block.get("source", {})
                             media_type: str = source.get("media_type", "image/png")
@@ -527,7 +539,7 @@ class OpenAIAdapter:
                         continue
                     btype = block.get("type", "")
                     if btype == "text":
-                        text_parts.append(block.get("text", ""))
+                        text_parts.append(_as_text(block.get("text", "")))
                     elif btype == "tool_use":
                         tool_calls.append({
                             "id": block.get("id", ""),
@@ -541,7 +553,7 @@ class OpenAIAdapter:
 
                 msg_dict: dict[str, Any] = {
                     "role": "assistant",
-                    "content": "\n".join(text_parts) if text_parts else None,
+                    "content": "\n".join(text_parts),
                 }
                 if tool_calls:
                     msg_dict["tool_calls"] = tool_calls
@@ -549,7 +561,7 @@ class OpenAIAdapter:
                 continue
 
             # Simple string content
-            result.append({"role": role, "content": content})
+            result.append({"role": role, "content": _as_text(content)})
         return result
 
     def build_completed_content(self, raw_response: Any) -> list[ContentBlock]:

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -39,6 +39,35 @@ def test_openai_gpt5_with_provider_prefix_uses_max_completion_tokens():
     ) == {"max_completion_tokens": 777}
 
 
+def test_openai_format_messages_coerces_null_content_to_empty_string():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    formatted = adapter.format_messages_for_api(
+        [
+            {"role": "assistant", "content": [{"type": "tool_use", "id": "x", "name": "fn", "input": {}}]},
+            {"role": "user", "content": None},
+        ]
+    )
+
+    assert formatted[0]["content"] == ""
+    assert formatted[1]["content"] == ""
+
+
+def test_openai_format_messages_coerces_tool_result_null_content_to_string():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    formatted = adapter.format_messages_for_api(
+        [
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "tool-1", "content": None}],
+            }
+        ]
+    )
+
+    assert formatted == [{"role": "tool", "tool_call_id": "tool-1", "content": ""}]
+
+
 @pytest.mark.asyncio
 async def test_openai_stream_does_not_pass_duplicate_model_kwarg():
     adapter = OpenAIAdapter(api_key="test-key")


### PR DESCRIPTION
### Motivation
- GPT-5 / newer OpenAI chat endpoints reject messages where `content` is `null`, causing 400 errors when stored messages contain nullable or non-string payloads.
- Ensure messages translated from internal/Anthropic-style `content_blocks` are always API-safe strings before calling `chat.completions.create`.

### Description
- Add helper `_as_text` inside `OpenAIAdapter.format_messages_for_api` to coerce `None`, non-string, and complex values into strings (JSON-serialize dict/list, `""` for `None`).
- Use `_as_text` for tool-result `content`, text blocks in user/image translations, assistant text parts, and the fallback simple `content` path so `content` is never `None` in the produced API messages.
- Ensure assistant messages that only contain tool calls emit an empty string for `content` instead of `None` while preserving `tool_calls` formatting.
- Add regression tests in `backend/tests/test_llm_adapter_openai_token_params.py` covering null-content coercion for assistant messages and tool-result blocks.

### Testing
- Ran `pytest -q backend/tests/test_llm_adapter_openai_token_params.py`, which executed the new and existing tests.
- Result: `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e440b0a00083218366047d6165602e)