### PR TITLE
Fix OpenAI path selecting Claude default model

### DIFF
--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -91,9 +91,19 @@ async def resolve_llm_config(
         provider, PROVIDER_DEFAULT_MODELS["anthropic"]
     )
     if not primary_model:
-        primary_model = settings.DEFAULT_PRIMARY_MODEL or provider_defaults["primary"]
+        primary_model = _select_compatible_model(
+            requested_model=settings.DEFAULT_PRIMARY_MODEL,
+            provider=provider,
+            fallback_model=provider_defaults["primary"],
+            model_role="primary",
+        )
     if not cheap_model:
-        cheap_model = settings.DEFAULT_CHEAP_MODEL or provider_defaults["cheap"]
+        cheap_model = _select_compatible_model(
+            requested_model=settings.DEFAULT_CHEAP_MODEL,
+            provider=provider,
+            fallback_model=provider_defaults["cheap"],
+            model_role="cheap",
+        )
     if not workflow_model:
         workflow_model = primary_model
 
@@ -122,6 +132,58 @@ def _resolve_api_key(provider: LLMProvider, org_handle: str | None) -> str:
 
     logger.error("No API key found for provider %s (org_handle=%s)", provider, org_handle)
     return ""
+
+
+def _select_compatible_model(
+    *,
+    requested_model: str | None,
+    provider: LLMProvider,
+    fallback_model: str,
+    model_role: str,
+) -> str:
+    """Return a model compatible with provider, falling back when needed."""
+    if not requested_model:
+        return fallback_model
+
+    mapped_provider: str | None = provider_for_model(requested_model)
+    if mapped_provider and mapped_provider != provider:
+        logger.warning(
+            "Ignoring %s model '%s' for provider '%s' (belongs to '%s'); using '%s' instead",
+            model_role,
+            requested_model,
+            provider,
+            mapped_provider,
+            fallback_model,
+        )
+        return fallback_model
+
+    inferred_provider: str | None = _infer_provider_from_model_name(requested_model)
+    if inferred_provider and inferred_provider != provider:
+        logger.warning(
+            "Ignoring %s model '%s' for provider '%s' (inferred '%s'); using '%s' instead",
+            model_role,
+            requested_model,
+            provider,
+            inferred_provider,
+            fallback_model,
+        )
+        return fallback_model
+
+    return requested_model
+
+
+def _infer_provider_from_model_name(model: str) -> str | None:
+    """Infer provider for common model naming conventions."""
+    normalized: str = model.strip().lower()
+    if normalized.startswith("claude"):
+        return "anthropic"
+    if normalized.startswith(("gpt", "o1", "o3", "o4")):
+        return "openai"
+    if normalized.startswith("gemini"):
+        return "gemini"
+    if normalized.startswith("minimax"):
+        return "minimax"
+    return None
 
 
 async def get_org_adapter(

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -1,0 +1,27 @@
+import asyncio
+
+from services.llm_provider import _infer_provider_from_model_name, resolve_llm_config
+
+
+def test_infer_provider_from_model_name() -> None:
+    assert _infer_provider_from_model_name("claude-haiku-4-5-20251001") == "anthropic"
+    assert _infer_provider_from_model_name("gpt-5-mini") == "openai"
+    assert _infer_provider_from_model_name("gemini-2.5-flash") == "gemini"
+    assert _infer_provider_from_model_name("MiniMax-M2.7-highspeed") == "minimax"
+    assert _infer_provider_from_model_name("some-unknown-model") is None
+
+
+def test_resolve_llm_config_uses_provider_defaults_for_mismatched_global_models(monkeypatch) -> None:
+    from services import llm_provider
+
+    monkeypatch.setattr(llm_provider, "_DEFAULT_PROVIDER", "openai")
+    monkeypatch.setitem(llm_provider._GLOBAL_PROVIDER_KEYS, "openai", "test-openai-key")
+    monkeypatch.setattr(llm_provider.settings, "DEFAULT_PRIMARY_MODEL", "claude-opus-4-6")
+    monkeypatch.setattr(llm_provider.settings, "DEFAULT_CHEAP_MODEL", "claude-haiku-4-5-20251001")
+    monkeypatch.setattr(llm_provider.settings, "ALL_MODEL_STRINGS", "")
+
+    config = asyncio.run(resolve_llm_config(None))
+
+    assert config.provider == "openai"
+    assert config.primary_model == "gpt-5"
+    assert config.cheap_model == "gpt-5-mini"


### PR DESCRIPTION
### Motivation
- Prevent sending Anthropic/Claude model names (e.g. `claude-haiku-4-5-20251001`) to OpenAI/Gemini endpoints which causes `openai.NotFoundError` and failed calls.

### Description
- Use a compatibility check when resolving defaults so `DEFAULT_PRIMARY_MODEL` and `DEFAULT_CHEAP_MODEL` are only used if they match the resolved provider, otherwise fall back to the provider's builtin defaults in `resolve_llm_config`.
- Add `_select_compatible_model` to validate model/provider compatibility (checks `ALL_MODEL_STRINGS` mapping and logs warnings when overridden) and `_infer_provider_from_model_name` to catch common naming patterns like `claude`, `gpt*`, `gemini`, and `minimax`.
- Wire the compatibility checks into `backend/services/llm_provider.py` so OpenAI/Gemini/MiniMax never receive Claude defaults.
- Add `backend/tests/test_llm_provider.py` with regression tests for name-based inference and the OpenAI-with-Claude-defaults scenario.

### Testing
- Ran `pytest -q backend/tests/test_llm_provider.py` and it succeeded with `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e442e3b4448321b95ef122ccfd7419)