### PR TITLE
Validate OpenAI tool-call message sequencing and exempt Gemini models

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -336,6 +336,109 @@ class OpenAIAdapter:
         )
         return {token_param_name: max_tokens}
 
+    def _is_openai_model(self, model: str) -> bool:
+        """Return True when a model identifier appears to target OpenAI models."""
+        normalized_model: str = model.strip().lower().split("/")[-1]
+        return not normalized_model.startswith("gemini")
+
+    def _validate_openai_tool_message_sequence(
+        self, messages: list[dict[str, Any]]
+    ) -> None:
+        """Validate Chat Completions tool-call sequencing invariants.
+
+        Expected sequence (excluding system):
+        user -> assistant(with tool_calls) -> tool (one per tool_call_id) -> assistant
+        """
+        pending_tool_call_ids: set[str] = set()
+        seen_tool_call_ids: set[str] = set()
+
+        for index, message in enumerate(messages):
+            role: str = str(message.get("role", ""))
+
+            if role == "assistant":
+                if pending_tool_call_ids:
+                    raise ValueError(
+                        "Invalid OpenAI message sequence: assistant message appeared "
+                        f"before tool results for {sorted(pending_tool_call_ids)} were provided."
+                    )
+
+                tool_calls = message.get("tool_calls")
+                if not tool_calls:
+                    continue
+                if not isinstance(tool_calls, list):
+                    raise ValueError(
+                        "Invalid OpenAI message sequence: assistant.tool_calls must be a list."
+                    )
+
+                current_ids: set[str] = set()
+                for tc in tool_calls:
+                    if not isinstance(tc, dict):
+                        raise ValueError(
+                            "Invalid OpenAI message sequence: assistant.tool_calls entries must be objects."
+                        )
+                    tc_id: str = str(tc.get("id", "")).strip()
+                    if not tc_id:
+                        raise ValueError(
+                            "Invalid OpenAI message sequence: assistant.tool_calls entries must include non-empty id."
+                        )
+                    if tc_id in current_ids:
+                        raise ValueError(
+                            f"Invalid OpenAI message sequence: duplicate tool_call id in assistant message: {tc_id}"
+                        )
+                    current_ids.add(tc_id)
+                    seen_tool_call_ids.add(tc_id)
+
+                pending_tool_call_ids = current_ids
+                logger.debug(
+                    "[OpenAIAdapter] Tool-call sequence pending ids initialized at index=%d ids=%s",
+                    index,
+                    sorted(pending_tool_call_ids),
+                )
+                continue
+
+            if role == "tool":
+                if not pending_tool_call_ids:
+                    raise ValueError(
+                        "Invalid OpenAI message sequence: tool message without a preceding assistant tool_calls message."
+                    )
+                tool_call_id: str = str(message.get("tool_call_id", "")).strip()
+                if not tool_call_id:
+                    raise ValueError(
+                        "Invalid OpenAI message sequence: tool message missing tool_call_id."
+                    )
+                if tool_call_id not in pending_tool_call_ids:
+                    raise ValueError(
+                        "Invalid OpenAI message sequence: tool_call_id "
+                        f"{tool_call_id!r} does not match pending ids {sorted(pending_tool_call_ids)}."
+                    )
+                pending_tool_call_ids.remove(tool_call_id)
+                logger.debug(
+                    "[OpenAIAdapter] Consumed tool result at index=%d tool_call_id=%s remaining=%s",
+                    index,
+                    tool_call_id,
+                    sorted(pending_tool_call_ids),
+                )
+                continue
+
+            # user/system/developer/other roles cannot appear before pending tool results are complete.
+            if pending_tool_call_ids:
+                raise ValueError(
+                    "Invalid OpenAI message sequence: non-tool message role="
+                    f"{role!r} appeared before tool results for {sorted(pending_tool_call_ids)} were provided."
+                )
+
+        if pending_tool_call_ids:
+            raise ValueError(
+                "Invalid OpenAI message sequence: conversation ended before all tool results were provided for "
+                f"{sorted(pending_tool_call_ids)}."
+            )
+
+        logger.debug(
+            "[OpenAIAdapter] Tool-call sequence validation passed for %d messages (tool ids observed=%d)",
+            len(messages),
+            len(seen_tool_call_ids),
+        )
+
     # -- streaming ----------------------------------------------------------
 
     async def stream(
@@ -351,6 +454,8 @@ class OpenAIAdapter:
         api_messages: list[dict[str, Any]] = [
             {"role": "system", "content": system}
         ] + self.format_messages_for_api(messages)
+        if self._is_openai_model(model):
+            self._validate_openai_tool_message_sequence(api_messages[1:])
 
         api_kwargs: dict[str, Any] = {
             "model": model,
@@ -445,6 +550,8 @@ class OpenAIAdapter:
         api_messages: list[dict[str, Any]] = [
             {"role": "system", "content": system}
         ] + self.format_messages_for_api(messages)
+        if self._is_openai_model(model):
+            self._validate_openai_tool_message_sequence(api_messages[1:])
 
         response = await self._client.chat.completions.create(
             model=model,

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -68,6 +68,87 @@ def test_openai_format_messages_coerces_tool_result_null_content_to_string():
     assert formatted == [{"role": "tool", "tool_call_id": "tool-1", "content": ""}]
 
 
+def test_openai_sequence_validator_accepts_valid_tool_pattern():
+    adapter = OpenAIAdapter(api_key="test-key")
+    messages = [
+        {"role": "user", "content": "Find revenue trends"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "run_sql_query", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "{\"rows\": []}"},
+        {"role": "assistant", "content": "Done"},
+    ]
+
+    adapter._validate_openai_tool_message_sequence(messages)
+
+
+def test_openai_sequence_validator_rejects_missing_tool_result():
+    adapter = OpenAIAdapter(api_key="test-key")
+    messages = [
+        {"role": "user", "content": "Find revenue trends"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "run_sql_query", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "assistant", "content": "Done"},
+    ]
+
+    with pytest.raises(ValueError, match="before tool results"):
+        adapter._validate_openai_tool_message_sequence(messages)
+
+
+def test_openai_sequence_validator_rejects_unmatched_tool_call_id():
+    adapter = OpenAIAdapter(api_key="test-key")
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "run_sql_query", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_2", "content": "{\"rows\": []}"},
+    ]
+
+    with pytest.raises(ValueError, match="does not match pending ids"):
+        adapter._validate_openai_tool_message_sequence(messages)
+
+
+def test_openai_sequence_validator_rejects_orphan_tool_message():
+    adapter = OpenAIAdapter(api_key="test-key")
+    messages = [{"role": "tool", "tool_call_id": "call_1", "content": "x"}]
+
+    with pytest.raises(ValueError, match="without a preceding assistant tool_calls"):
+        adapter._validate_openai_tool_message_sequence(messages)
+
+
+def test_openai_model_detection_excludes_gemini():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    assert adapter._is_openai_model("gpt-5")
+    assert adapter._is_openai_model("openai/gpt-5-mini")
+    assert not adapter._is_openai_model("gemini-2.5-pro")
+
+
 @pytest.mark.asyncio
 async def test_openai_stream_does_not_pass_duplicate_model_kwarg():
     adapter = OpenAIAdapter(api_key="test-key")


### PR DESCRIPTION
### Motivation
- Ensure Chat Completions tool-call interactions sent to OpenAI-style models follow a strict sequencing invariant to prevent malformed conversations being forwarded to the API. 
- Avoid applying OpenAI-specific validation to Gemini-style models which use different message semantics.

### Description
- Added `_is_openai_model` to detect OpenAI-like models (returns false for `gemini` identifiers). 
- Implemented `_validate_openai_tool_message_sequence` to enforce the expected message ordering and tool-call invariants and raise clear `ValueError`s for invalid sequences. 
- Hooked the validator into `stream` and `complete` so validation runs only when `_is_openai_model(model)` is true. 
- Added unit tests in `backend/tests/test_llm_adapter_openai_token_params.py` covering valid/invalid tool sequences and model detection for `gemini`.

### Testing
- Ran the modified test file `backend/tests/test_llm_adapter_openai_token_params.py` which includes sync and async tests for the new validator and model detection, and all tests passed. 
- Existing stream-related test `test_openai_stream_does_not_pass_duplicate_model_kwarg` was run and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4457d9b8483219c78d86817458a68)