### PR TITLE
Fix OpenAI message formatting for orphaned tool results

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -489,6 +489,7 @@ class OpenAIAdapter:
             return str(value)
 
         result: list[dict[str, Any]] = []
+        assistant_tool_call_ids: set[str] = set()
         for msg in messages:
             role: str = msg.get("role", "user")
             content: Any = msg.get("content", "")
@@ -502,11 +503,26 @@ class OpenAIAdapter:
                 if has_tool_results:
                     for block in content:
                         if isinstance(block, dict) and block.get("type") == "tool_result":
-                            result.append({
-                                "role": "tool",
-                                "tool_call_id": block.get("tool_use_id", ""),
-                                "content": _as_text(block.get("content", "")),
-                            })
+                            tool_use_id: str = _as_text(block.get("tool_use_id", ""))
+                            tool_content: str = _as_text(block.get("content", ""))
+                            if tool_use_id and tool_use_id in assistant_tool_call_ids:
+                                result.append({
+                                    "role": "tool",
+                                    "tool_call_id": tool_use_id,
+                                    "content": tool_content,
+                                })
+                            else:
+                                # OpenAI rejects `role=tool` messages unless there is a
+                                # preceding assistant message with a matching `tool_calls`.
+                                # Keep the information as user text when history is incomplete.
+                                logger.warning(
+                                    "Dropping orphaned tool_result for OpenAI message formatting",
+                                    extra={"tool_use_id": tool_use_id},
+                                )
+                                result.append({
+                                    "role": "user",
+                                    "content": f"[tool_result:{tool_use_id or 'unknown'}] {tool_content}",
+                                })
                     continue
 
                 # Image/text blocks — translate to OpenAI format
@@ -541,8 +557,11 @@ class OpenAIAdapter:
                     if btype == "text":
                         text_parts.append(_as_text(block.get("text", "")))
                     elif btype == "tool_use":
+                        tool_call_id: str = _as_text(block.get("id", ""))
+                        if tool_call_id:
+                            assistant_tool_call_ids.add(tool_call_id)
                         tool_calls.append({
-                            "id": block.get("id", ""),
+                            "id": tool_call_id,
                             "type": "function",
                             "function": {
                                 "name": block.get("name", ""),

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -65,7 +65,26 @@ def test_openai_format_messages_coerces_tool_result_null_content_to_string():
         ]
     )
 
-    assert formatted == [{"role": "tool", "tool_call_id": "tool-1", "content": ""}]
+    assert formatted == [{"role": "user", "content": "[tool_result:tool-1] "}]
+
+
+def test_openai_format_messages_emits_tool_role_when_tool_use_exists():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    formatted = adapter.format_messages_for_api(
+        [
+            {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "id": "tool-1", "name": "fn", "input": {}}],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "tool-1", "content": None}],
+            },
+        ]
+    )
+
+    assert formatted[1] == {"role": "tool", "tool_call_id": "tool-1", "content": ""}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Prevent OpenAI 400 errors caused by emitting `role: "tool"` messages without a preceding assistant message containing the matching `tool_calls` metadata.

### Description
- Update `OpenAIAdapter.format_messages_for_api` to track assistant `tool_use` IDs and only emit `{"role": "tool"}` when a preceding assistant `tool_calls` entry contains the matching ID.
- When a `tool_result` appears without a matching assistant `tool_use`, log a warning and fall back to preserving the payload as a safe user text message instead of an invalid `role: tool` message.
- Add tracking of assistant tool call IDs when translating `tool_use` blocks so downstream formatting can validate `tool_result` blocks.
- Update tests in `backend/tests/test_llm_adapter_openai_token_params.py` to assert the new safe-fallback behavior and to verify the valid assistant→user tool sequence still emits `role: tool`.

### Testing
- Ran `pytest -q tests/test_llm_adapter_openai_token_params.py`, which completed successfully with `7 passed` in ~2.9s.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e443a0b06c83219099a4afd0c3b4c1)