### PR TITLE
Preserve OpenAI-style tool messages and make message formatting idempotent

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1359,7 +1359,6 @@ class ChatOrchestrator:
 
         # Prepare messages for the target provider's API format
         tool_defs = get_tool_defs_for_context(self.workflow_context)
-        is_anthropic_family: bool = self._llm_config.provider in ("anthropic", "minimax")
 
         while True:
             # Track state for this streaming response
@@ -1371,11 +1370,9 @@ class ChatOrchestrator:
             final_message_received: bool = False
             context_retry_needed = False
 
-            # Translate messages for OpenAI-family providers
-            api_messages: list[dict[str, Any]] = (
-                messages if is_anthropic_family
-                else adapter.format_messages_for_api(messages)  # type: ignore[union-attr]
-            )
+            # Keep provider-agnostic message history here; provider adapters are
+            # responsible for final API translation.
+            api_messages: list[dict[str, Any]] = messages
 
             # Retry loop for transient API errors
             last_error: Exception | None = None

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -493,6 +493,43 @@ class OpenAIAdapter:
             role: str = msg.get("role", "user")
             content: Any = msg.get("content", "")
 
+            # Pass through already-openai tool messages without dropping tool_call_id.
+            if role == "tool":
+                result.append({
+                    "role": "tool",
+                    "tool_call_id": _as_text(msg.get("tool_call_id", "")),
+                    "content": _as_text(content),
+                })
+                continue
+
+            # Idempotency: preserve already-openai assistant tool_calls.
+            if role == "assistant" and isinstance(content, str) and msg.get("tool_calls"):
+                normalized_tool_calls: list[dict[str, Any]] = []
+                for tc in msg.get("tool_calls", []):
+                    if not isinstance(tc, dict):
+                        continue
+                    function = tc.get("function", {}) if isinstance(tc.get("function"), dict) else {}
+                    raw_arguments = function.get("arguments", "")
+                    arguments = (
+                        raw_arguments
+                        if isinstance(raw_arguments, str)
+                        else json.dumps(raw_arguments, ensure_ascii=False)
+                    )
+                    normalized_tool_calls.append({
+                        "id": _as_text(tc.get("id", "")),
+                        "type": "function",
+                        "function": {
+                            "name": _as_text(function.get("name", "")),
+                            "arguments": arguments,
+                        },
+                    })
+                result.append({
+                    "role": "assistant",
+                    "content": _as_text(content),
+                    "tool_calls": normalized_tool_calls,
+                })
+                continue
+
             if role == "user" and isinstance(content, list):
                 # Check for tool_result blocks (Anthropic format → OpenAI tool messages)
                 has_tool_results: bool = any(

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -68,6 +68,42 @@ def test_openai_format_messages_coerces_tool_result_null_content_to_string():
     assert formatted == [{"role": "tool", "tool_call_id": "tool-1", "content": ""}]
 
 
+def test_openai_format_messages_is_idempotent_for_openai_tool_sequence():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    formatted = adapter.format_messages_for_api(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "run_sql_query", "arguments": "{\"query\":\"select 1\"}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_123", "content": "{\"row_count\":1}"},
+        ]
+    )
+
+    assert formatted == [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {"name": "run_sql_query", "arguments": "{\"query\":\"select 1\"}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_123", "content": "{\"row_count\":1}"},
+    ]
+
+
 @pytest.mark.asyncio
 async def test_openai_stream_does_not_pass_duplicate_model_kwarg():
     adapter = OpenAIAdapter(api_key="test-key")


### PR DESCRIPTION
### Motivation
- Ensure the orchestrator keeps message history provider-agnostic and lets adapters perform final API translation to avoid double-conversion.
- Preserve OpenAI-style `tool` messages and assistant `tool_calls` when messages are already in OpenAI format so tool call IDs and arguments are not dropped or re-serialized incorrectly.

### Description
- Stop special-casing Anthropic/OpenAI in the orchestrator by sending the stored `messages` unchanged and delegating format translation to adapters. 
- Update `OpenAIAdapter.format_messages_for_api` to pass through `role: "tool"` messages and keep the `tool_call_id` and `content` intact.
- Make `format_messages_for_api` idempotent for already-OpenAI assistant `tool_calls` by normalizing and preserving `tool_calls` entries and their `function.arguments` as strings.
- Add `test_openai_format_messages_is_idempotent_for_openai_tool_sequence` to verify the adapter preserves OpenAI-style assistant/tool sequences.

### Testing
- Ran `pytest -q backend/tests/test_llm_adapter_openai_token_params.py::test_openai_format_messages_is_idempotent_for_openai_tool_sequence` and it passed.
- Ran `pytest -q backend/tests/test_llm_adapter_openai_token_params.py::test_openai_stream_does_not_pass_duplicate_model_kwarg` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4456fad84832182c8608ec69a04b4)