### PR TITLE
Fix PDF attachments invisible to MiniMax (adapter-layer text extraction)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -44,6 +44,9 @@ jsonschema==4.21.1
 weasyprint==68.0
 markdown==3.8.1
 
+# PDF text extraction (fallback for providers that lack native document blocks)
+pymupdf==1.25.3
+
 # Excel parsing (for chat file attachments)
 openpyxl==3.1.2
 

--- a/backend/services/file_handler.py
+++ b/backend/services/file_handler.py
@@ -308,6 +308,34 @@ def _pdf_block(sf: StoredFile) -> dict[str, Any]:
     }
 
 
+def pdf_to_text_block(sf: StoredFile) -> dict[str, Any]:
+    """Extract PDF text via pymupdf — used as a fallback when the provider
+    doesn't support native ``document`` content blocks."""
+    try:
+        import pymupdf  # noqa: F811
+
+        doc: pymupdf.Document = pymupdf.open(stream=sf.data, filetype="pdf")
+        pages: list[str] = []
+        for page_num in range(len(doc)):
+            page_text: str = doc[page_num].get_text()
+            if page_text.strip():
+                pages.append(f"--- Page {page_num + 1} ---\n{page_text}")
+        doc.close()
+        text: str = "\n\n".join(pages) if pages else "[PDF contained no extractable text]"
+    except Exception as exc:
+        logger.warning("PDF text extraction failed for %s: %s", sf.filename, exc)
+        text = f"[Attached PDF '{sf.filename}' could not be extracted — {exc}]"
+
+    max_chars: int = 200_000
+    if len(text) > max_chars:
+        text = text[:max_chars] + f"\n\n[Truncated — showing first {max_chars:,} characters of {len(text):,} total]"
+
+    return {
+        "type": "text",
+        "text": f"Contents of {sf.filename}:\n\n{text}",
+    }
+
+
 def _xlsx_to_text_block(sf: StoredFile) -> dict[str, Any]:
     """Parse XLSX to CSV text using openpyxl."""
     try:

--- a/backend/services/file_handler.py
+++ b/backend/services/file_handler.py
@@ -300,6 +300,7 @@ def _pdf_block(sf: StoredFile) -> dict[str, Any]:
     b64: str = base64.standard_b64encode(sf.data).decode("ascii")
     return {
         "type": "document",
+        "title": sf.filename,
         "source": {
             "type": "base64",
             "media_type": "application/pdf",

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -307,8 +307,10 @@ class AnthropicAdapter:
             return msg
 
         from services.file_handler import StoredFile, pdf_to_text_block
+        import base64 as _b64
 
         new_blocks: list[dict[str, Any]] = []
+        pdf_counter: int = 0
         for block in content:
             if not isinstance(block, dict) or block.get("type") != "document":
                 new_blocks.append(block)
@@ -319,11 +321,25 @@ class AnthropicAdapter:
                 new_blocks.append(block)
                 continue
 
-            import base64
-            raw_data: bytes = base64.standard_b64decode(source.get("data", ""))
+            pdf_counter += 1
+            filename: str = (
+                block.get("title")
+                or f"attachment-{pdf_counter}.pdf"
+            )
+
+            try:
+                raw_data: bytes = _b64.standard_b64decode(source.get("data", ""))
+            except Exception as exc:
+                logger.warning("Failed to decode PDF base64 for %s: %s", filename, exc)
+                new_blocks.append({
+                    "type": "text",
+                    "text": f"[Attached PDF '{filename}' could not be decoded]",
+                })
+                continue
+
             sf = StoredFile(
                 upload_id="",
-                filename="attachment.pdf",
+                filename=filename,
                 mime_type="application/pdf",
                 size=len(raw_data),
                 data=raw_data,

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -154,11 +154,18 @@ class LLMAdapter(Protocol):
 class AnthropicAdapter:
     """Adapter for Anthropic Messages API (also used by MiniMax via base_url)."""
 
-    def __init__(self, *, api_key: str, base_url: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str | None = None,
+        supports_document_blocks: bool = True,
+    ) -> None:
         kwargs: dict[str, Any] = {"api_key": api_key}
         if base_url is not None:
             kwargs["base_url"] = base_url
         self._client: AsyncAnthropic = AsyncAnthropic(**kwargs)
+        self._supports_document_blocks: bool = supports_document_blocks
 
     # -- streaming ----------------------------------------------------------
 
@@ -172,11 +179,12 @@ class AnthropicAdapter:
         thinking: bool = False,
         max_tokens: int = 32768,
     ) -> AsyncIterator[StreamEvent]:
+        api_messages: list[dict[str, Any]] = self.format_messages_for_api(messages)
         api_kwargs: dict[str, Any] = {
             "model": model,
             "max_tokens": max_tokens,
             "system": system,
-            "messages": messages,
+            "messages": api_messages,
         }
         if tools:
             api_kwargs["tools"] = self.format_tools(tools)
@@ -252,11 +260,12 @@ class AnthropicAdapter:
         messages: list[dict[str, Any]],
         max_tokens: int = 1024,
     ) -> CompletedMessage:
+        api_messages: list[dict[str, Any]] = self.format_messages_for_api(messages)
         response = await self._client.messages.create(
             model=model,
             max_tokens=max_tokens,
             system=system,
-            messages=messages,
+            messages=api_messages,
         )
         blocks: list[ContentBlock] = self.build_completed_content(response)
         return CompletedMessage(
@@ -276,7 +285,52 @@ class AnthropicAdapter:
     def format_messages_for_api(
         self, messages: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
-        return messages
+        if self._supports_document_blocks:
+            return messages
+        return [self._downgrade_document_blocks(msg) for msg in messages]
+
+    @staticmethod
+    def _downgrade_document_blocks(msg: dict[str, Any]) -> dict[str, Any]:
+        """Replace ``document`` content blocks with extracted-text blocks.
+
+        Only user messages can contain multimodal content blocks, so
+        assistant/tool messages are returned unchanged.
+        """
+        content: Any = msg.get("content")
+        if msg.get("role") != "user" or not isinstance(content, list):
+            return msg
+
+        needs_rewrite: bool = any(
+            isinstance(b, dict) and b.get("type") == "document" for b in content
+        )
+        if not needs_rewrite:
+            return msg
+
+        from services.file_handler import StoredFile, pdf_to_text_block
+
+        new_blocks: list[dict[str, Any]] = []
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "document":
+                new_blocks.append(block)
+                continue
+
+            source: dict[str, Any] = block.get("source", {})
+            if source.get("media_type") != "application/pdf":
+                new_blocks.append(block)
+                continue
+
+            import base64
+            raw_data: bytes = base64.standard_b64decode(source.get("data", ""))
+            sf = StoredFile(
+                upload_id="",
+                filename="attachment.pdf",
+                mime_type="application/pdf",
+                size=len(raw_data),
+                data=raw_data,
+            )
+            new_blocks.append(pdf_to_text_block(sf))
+
+        return {**msg, "content": new_blocks}
 
     def build_completed_content(self, raw_response: Any) -> list[ContentBlock]:
         blocks: list[ContentBlock] = []
@@ -630,11 +684,19 @@ class OpenAIAdapter:
 # ---------------------------------------------------------------------------
 
 
+_PROVIDERS_WITHOUT_DOCUMENT_BLOCKS: frozenset[str] = frozenset({"minimax"})
+
+
 def get_adapter(config: LLMConfig) -> AnthropicAdapter | OpenAIAdapter:
     """Create the appropriate adapter for a resolved LLM config."""
     if config.provider in ("anthropic", "minimax"):
         base_url: str | None = config.base_url or PROVIDER_BASE_URLS.get(config.provider)
-        return AnthropicAdapter(api_key=config.api_key, base_url=base_url)
+        supports_docs: bool = config.provider not in _PROVIDERS_WITHOUT_DOCUMENT_BLOCKS
+        return AnthropicAdapter(
+            api_key=config.api_key,
+            base_url=base_url,
+            supports_document_blocks=supports_docs,
+        )
 
     if config.provider in ("openai", "gemini"):
         base_url = config.base_url or PROVIDER_BASE_URLS.get(config.provider)


### PR DESCRIPTION
## Summary
- MiniMax uses an Anthropic-compatible API but silently ignores `document` content blocks (Anthropic's native PDF format), so PDF attachments in Slack DMs were invisible to the model
- Adds a `supports_document_blocks` capability flag to `AnthropicAdapter` (defaults `True` for Anthropic, `False` for MiniMax) that automatically downgrades PDF document blocks to extracted text via pymupdf
- The fallback produces the same text block shape as XLSX/DOCX already use — adding new providers that lack document support is a one-line addition to `_PROVIDERS_WITHOUT_DOCUMENT_BLOCKS`

## Test plan
- [x] Backend tests pass (460/460, 1 pre-existing unrelated failure)
- [x] Frontend build passes
- [ ] Send a PDF attachment in a Slack DM to the Basebase bot on a MiniMax-backed org and verify the bot can see/discuss the PDF contents
- [ ] Verify Anthropic-backed orgs still use native document blocks (no regression)

Made with [Cursor](https://cursor.com)