### PR TITLE
Log when quick/same-family model fallbacks are engaged

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -2083,8 +2083,15 @@ async def _openai_web_search_fallback(
     prompt_context = context_answer or "No useful Perplexity context was available."
     additional_context = (provider_context or "").strip()
 
-    for model in OPENAI_WEB_RESEARCH_FALLBACK_MODELS:
+    for model_index, model in enumerate(OPENAI_WEB_RESEARCH_FALLBACK_MODELS):
         try:
+            if model_index > 0:
+                logger.info(
+                    "[Tools._openai_web_search_fallback] Model fallback engaged (quick/same-family): previous_model=%s selected_model=%s fallback_position=%s",
+                    OPENAI_WEB_RESEARCH_FALLBACK_MODELS[model_index - 1],
+                    model,
+                    model_index + 1,
+                )
             logger.info(
                 "[Tools._openai_web_search_fallback] Running OpenAI fallback with model=%s",
                 model,

--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -143,6 +143,12 @@ def _select_compatible_model(
 ) -> str:
     """Return a model compatible with provider, falling back when needed."""
     if not requested_model:
+        logger.info(
+            "[LLMProvider] Model fallback engaged (quick/same-family): role=%s provider=%s requested_model=<unset> selected_model=%s reason=missing_requested_model",
+            model_role,
+            provider,
+            fallback_model,
+        )
         return fallback_model
 
     mapped_provider: str | None = provider_for_model(requested_model)
@@ -155,6 +161,14 @@ def _select_compatible_model(
             mapped_provider,
             fallback_model,
         )
+        logger.info(
+            "[LLMProvider] Model fallback engaged (quick/same-family): role=%s provider=%s requested_model=%s selected_model=%s reason=provider_mismatch(mapped=%s)",
+            model_role,
+            provider,
+            requested_model,
+            fallback_model,
+            mapped_provider,
+        )
         return fallback_model
 
     inferred_provider: str | None = _infer_provider_from_model_name(requested_model)
@@ -166,6 +180,14 @@ def _select_compatible_model(
             provider,
             inferred_provider,
             fallback_model,
+        )
+        logger.info(
+            "[LLMProvider] Model fallback engaged (quick/same-family): role=%s provider=%s requested_model=%s selected_model=%s reason=provider_mismatch(inferred=%s)",
+            model_role,
+            provider,
+            requested_model,
+            fallback_model,
+            inferred_provider,
         )
         return fallback_model
 

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -25,3 +25,20 @@ def test_resolve_llm_config_uses_provider_defaults_for_mismatched_global_models(
     assert config.provider == "openai"
     assert config.primary_model == "gpt-5"
     assert config.cheap_model == "gpt-5-mini"
+
+
+def test_resolve_llm_config_logs_when_model_fallback_engaged(monkeypatch, caplog) -> None:
+    from services import llm_provider
+
+    monkeypatch.setattr(llm_provider, "_DEFAULT_PROVIDER", "openai")
+    monkeypatch.setitem(llm_provider._GLOBAL_PROVIDER_KEYS, "openai", "test-openai-key")
+    monkeypatch.setattr(llm_provider.settings, "DEFAULT_PRIMARY_MODEL", "claude-opus-4-6")
+    monkeypatch.setattr(llm_provider.settings, "DEFAULT_CHEAP_MODEL", "")
+    monkeypatch.setattr(llm_provider.settings, "ALL_MODEL_STRINGS", "")
+
+    caplog.set_level("INFO")
+    _ = asyncio.run(resolve_llm_config(None))
+
+    assert any(
+        "Model fallback engaged (quick/same-family)" in record.message for record in caplog.records
+    )


### PR DESCRIPTION
### Motivation
- Provide clear console visibility whenever the system falls back to a quick or same-family model during LLM model resolution or OpenAI web-research fallback so operators can audit fallback decisions.
- Improve debugability for model selection paths (missing requested model or provider mismatch) and for multi-model fallback sequencing.

### Description
- Added `INFO` logs in `services.llm_provider._select_compatible_model` when a requested model is missing or when a mapped/inferred provider mismatches the resolved provider, including role, provider, requested and selected model, and a reason tag.
- Added `INFO` logging in `agents.tools._openai_web_search_fallback` to emit the previous and selected model and the fallback position when the fallback loop advances beyond the first model.
- Added a regression test `test_resolve_llm_config_logs_when_model_fallback_engaged` in `backend/tests/test_llm_provider.py` that sets up mismatched defaults and asserts the fallback info log appears.

### Testing
- Ran `pytest -q backend/tests/test_llm_provider.py` and all tests passed (`3 passed`).
- The new test verifies that a log record containing `Model fallback engaged (quick/same-family)` is emitted when fallback logic is exercised.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e50aec1c4c8321a6555f5eaacb2762)