### PR TITLE
Slack: accept channel_id/channelId alias for fetch_channel_history and add logging

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -1241,14 +1241,33 @@ Returns normalized messages for one channel since a cutoff (does not write to th
                 return await self.post_message(channel, text, thread_ts=thread_ts)
             raise ValueError("send_message requires 'channel' or 'user_id' and non-empty text")
         if action == "fetch_channel_history":
-            ch: str | None = params.get("channel")
+            ch: str | None = (
+                params.get("channel")
+                or params.get("channel_id")
+                or params.get("channelId")
+            )
             since_val: str | None = params.get("since")
             if not ch or not str(ch).strip():
-                raise ValueError("fetch_channel_history requires 'channel'")
+                logger.error(
+                    "[slack] fetch_channel_history missing channel params_keys=%s",
+                    sorted(params.keys()),
+                )
+                raise ValueError("fetch_channel_history requires 'channel' (or 'channel_id')")
             if not since_val or not str(since_val).strip():
+                logger.error(
+                    "[slack] fetch_channel_history missing since channel=%s params_keys=%s",
+                    ch,
+                    sorted(params.keys()),
+                )
                 raise ValueError("fetch_channel_history requires 'since' (ISO 8601 datetime)")
             limit_raw: Any = params.get("limit", 1000)
             limit_val: int = int(limit_raw) if limit_raw is not None else 1000
+            logger.info(
+                "[slack] execute_action fetch_channel_history channel=%s since=%s limit=%s",
+                ch,
+                since_val,
+                limit_val,
+            )
             return await self.fetch_channel_history(
                 str(ch).strip(),
                 str(since_val).strip(),

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -73,6 +73,37 @@ def test_execute_action_fetch_channel_history_returns_normalized_messages(monkey
     assert result["count"] == 1
 
 
+
+
+def test_execute_action_fetch_channel_history_accepts_channel_id_alias(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    async def _fake_fetch(
+        channel: str,
+        since: str,
+        *,
+        limit: int = 1000,
+    ) -> dict[str, object]:
+        assert channel == "C123"
+        assert since == "2025-01-01T00:00:00Z"
+        assert limit == 250
+        return {"ok": True, "count": 0, "messages": []}
+
+    monkeypatch.setattr(connector, "fetch_channel_history", _fake_fetch)
+
+    result = asyncio.run(
+        connector.execute_action(
+            "fetch_channel_history",
+            {
+                "channel_id": "C123",
+                "since": "2025-01-01T00:00:00Z",
+                "limit": 250,
+            },
+        )
+    )
+
+    assert result["ok"] is True
+
 def test_execute_action_send_message_accepts_legacy_message_param(monkeypatch) -> None:
     connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
     captured: dict[str, str] = {}


### PR DESCRIPTION
### Motivation
- Tool calls sometimes provide Slack channel context as `channel_id` (or `channelId`) which caused `fetch_channel_history` to raise when only `channel` was checked. This change makes the action handler resilient to common parameter shapes.

### Description
- Updated `SlackConnector.execute_action` for the `fetch_channel_history` action to accept `channel`, `channel_id`, or `channelId` as the channel parameter and to normalize the value before calling `fetch_channel_history` in `backend/connectors/slack.py`.
- Added error logs when required parameters are missing and an info log on successful execution to aid debugging and observability.
- Improved the validation error message to mention the accepted channel keys.
- Added a regression test `test_execute_action_fetch_channel_history_accepts_channel_id_alias` in `backend/tests/test_slack_connector_actions.py` to verify the alias behavior.

### Testing
- Ran `pytest -q backend/tests/test_slack_connector_actions.py` and all tests passed: `10 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e55d18d63c83219a1cc5a77a8c4d75)