### PR TITLE
Recover top-level action params in run_on_connector

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -1151,6 +1151,7 @@ async def _run_on_connector(
     context: dict[str, Any] | None,
 ) -> dict[str, Any]:
     """Dispatch an action to an ACTION-capable connector."""
+    logger.info("[Tools] run_on_connector called with keys=%s", sorted(params.keys()))
     connector: str = (params.get("connector") or "").strip()
     action: str = (params.get("action") or "").strip()
     raw_action_params: Any = params.get("params") or {}
@@ -1162,6 +1163,23 @@ async def _run_on_connector(
             logger.warning("[Tools] run_on_connector: failed to parse params string: %s", exc)
             return {"error": f"params must be a JSON object (parse error: {exc})"}
     action_params: dict[str, Any] = dict(raw_action_params)
+    # Be lenient if the caller accidentally sends action fields at top-level
+    # instead of nesting under `params` (common tool-calling mistake).
+    if not action_params:
+        fallback_params: dict[str, Any] = {
+            key: value
+            for key, value in params.items()
+            if key not in {"connector", "action", "params"}
+        }
+        if fallback_params:
+            logger.info(
+                "[Tools] run_on_connector(%s, %s): recovered %d top-level param(s): %s",
+                connector or "<missing>",
+                action or "<missing>",
+                len(fallback_params),
+                sorted(fallback_params.keys()),
+            )
+            action_params = fallback_params
 
     if not connector:
         return {"error": "connector is required"}

--- a/backend/tests/test_action_ledger.py
+++ b/backend/tests/test_action_ledger.py
@@ -667,6 +667,37 @@ class TestChokepoints:
         mock_intent.assert_called_once()
         mock_outcome.assert_called_once()
 
+    def test_run_on_connector_recovers_top_level_action_params(self) -> None:
+        """_run_on_connector should recover action params accidentally passed at top-level."""
+        from agents import tools
+
+        fake_instance = MagicMock()
+        fake_instance.execute_action = AsyncMock(return_value={"ok": True})
+
+        with patch.object(tools, "_get_connector_instance", new=AsyncMock(return_value=(fake_instance, None))), \
+             patch.object(tools, "check_connector_call", new=AsyncMock(return_value=MagicMock(allowed=True))), \
+             patch("services.action_ledger.record_intent", new=AsyncMock(return_value=uuid.uuid4())), \
+             patch("services.action_ledger.record_outcome", new=AsyncMock()):
+
+            result = asyncio.run(tools._run_on_connector(
+                params={
+                    "connector": "slack",
+                    "action": "fetch_channel_history",
+                    "channel": "C123",
+                    "since": "2026-01-01T00:00:00Z",
+                },
+                organization_id="org-1",
+                user_id="user-1",
+                skip_approval=True,
+                context=None,
+            ))
+
+        assert result == {"ok": True}
+        fake_instance.execute_action.assert_awaited_once_with(
+            "fetch_channel_history",
+            {"channel": "C123", "since": "2026-01-01T00:00:00Z"},
+        )
+
 
 # ---------------------------------------------------------------------------
 # Migration: validate revision chain


### PR DESCRIPTION
### Motivation
- Tool calls sometimes pass action fields (e.g. `channel`, `since`) at the top level instead of under the `params` object, which caused failures like `fetch_channel_history requires 'channel'`.
- Make connector action dispatch more robust to this common calling mistake and improve observability with info-level logging.

### Description
- Added an info log at the start of `_run_on_connector` to show incoming `params` keys (`backend/agents/tools.py`).
- When `params['params']` is empty, collect any other top-level keys (except `connector`, `action`, `params`) and use them as `action_params`, logging the recovered keys; otherwise preserve the existing dispatch path (`backend/agents/tools.py`).
- Added a regression test `test_run_on_connector_recovers_top_level_action_params` to verify that top-level `channel`/`since` are recovered and forwarded to `execute_action` (`backend/tests/test_action_ledger.py`).

### Testing
- Ran the focused test command `pytest -q backend/tests/test_action_ledger.py -k run_on_connector` and it completed successfully with `2 passed` and other tests deselected.
- The new regression test verifies the recovered parameters are passed to the connector's `execute_action` and passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e55d18d63c83219a1cc5a77a8c4d75)