### PR TITLE
Resolve duplicate `organizationId` identifier in Chat component

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -386,28 +386,28 @@ export function Chat({
   const setOrganization = useAppStore((s) => s.setOrganization);
   const [freshPrimaryModel, setFreshPrimaryModel] = useState<string | null>(null);
   const [hasLoadedFreshPrimaryModel, setHasLoadedFreshPrimaryModel] = useState<boolean>(false);
-  const organizationId: string | null = orgInfo?.id ?? null;
+  const resolvedOrganizationId: string | null = orgInfo?.id ?? organizationId ?? null;
   const storedPrimaryModel: string | null = orgInfo?.llmPrimaryModel ?? null;
   const resolvedUserId: string | null = userId ?? currentUser?.id ?? null;
 
   useEffect(() => {
-    if (!organizationId || !resolvedUserId) return;
+    if (!resolvedOrganizationId || !resolvedUserId) return;
 
     let cancelled = false;
     const loadFreshPrimaryModel = async (): Promise<void> => {
       console.info('[Chat] Loading fresh primary model for composer label', {
-        organizationId,
+        organizationId: resolvedOrganizationId,
         userId: resolvedUserId,
       });
       try {
         const { data, error } = await apiRequest<{ llm_primary_model?: string | null }>(
-          `/auth/organizations/${encodeURIComponent(organizationId)}?user_id=${encodeURIComponent(resolvedUserId)}`,
+          `/auth/organizations/${encodeURIComponent(resolvedOrganizationId)}?user_id=${encodeURIComponent(resolvedUserId)}`,
           { cache: 'no-store' },
         );
         if (cancelled) return;
         if (error) {
           console.warn('[Chat] Failed to load fresh primary model for composer label', {
-            organizationId,
+            organizationId: resolvedOrganizationId,
             error,
           });
           return;
@@ -422,7 +422,7 @@ export function Chat({
             llmPrimaryModel: nextPrimaryModel,
           });
           console.info('[Chat] Updated organization model in store from fresh load', {
-            organizationId,
+            organizationId: resolvedOrganizationId,
             previousPrimaryModel: storedPrimaryModel,
             nextPrimaryModel,
           });
@@ -430,7 +430,7 @@ export function Chat({
       } catch (error) {
         if (cancelled) return;
         console.error('[Chat] Unexpected error loading fresh primary model for composer label', {
-          organizationId,
+          organizationId: resolvedOrganizationId,
           error,
         });
       }
@@ -440,7 +440,7 @@ export function Chat({
     return () => {
       cancelled = true;
     };
-  }, [organizationId, resolvedUserId, orgInfo, storedPrimaryModel, setOrganization]);
+  }, [resolvedOrganizationId, resolvedUserId, orgInfo, storedPrimaryModel, setOrganization]);
 
   const configuredPrimaryModel: string | null = storedPrimaryModel;
   const displayPrimaryModel: string | null = hasLoadedFreshPrimaryModel


### PR DESCRIPTION
### Motivation
- The frontend build failed with TypeScript `TS2300` due to a duplicate identifier `organizationId` in `frontend/src/components/Chat.tsx`, blocking production build.
- The change aims to preserve existing behavior while eliminating the name collision between the prop and a locally derived value.

### Description
- Renamed the locally derived organization identifier to `resolvedOrganizationId` and derive it as `orgInfo?.id ?? organizationId ?? null` to keep store-first, prop-fallback resolution.
- Updated the fresh-primary-model effect to use `resolvedOrganizationId` in logging, the API URL (`/auth/organizations/...`), and error handling.
- Updated the effect dependency array to reference `resolvedOrganizationId` instead of the old name to avoid stale closures.
- Modified only `frontend/src/components/Chat.tsx` and preserved existing behavior for `llmPrimaryModel` resolution.

### Testing
- Ran `npm run build` in `frontend/`, and the production build completed successfully (TypeScript `TS2300` error resolved) with non-fatal Vite chunk warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e56d3726dc8321946ff8f100540f68)