### PR TITLE
Support embedded Slack file blocks in inbound flow

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -480,7 +480,7 @@ def _build_inbound_message(
     event_ts: str = event.get("event_ts", "") or event.get("ts", "")
     message_ts: str = event.get("ts", "") or event_ts
     thread_ts: str | None = thread_ts_override or event.get("thread_ts")
-    files: list[dict[str, Any]] = event.get("files", [])
+    files: list[dict[str, Any]] = _extract_files_from_slack_event(event)
     raw_text: str = event.get("text", "") or ""
     mentions: list[dict[str, Any]] = (
         _extract_mentions_from_slack_text(raw_text, bot_user_ids)
@@ -504,6 +504,47 @@ def _build_inbound_message(
         message_id=message_ts,
         mentions=mentions,
     )
+
+
+def _extract_files_from_slack_event(event: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract Slack file objects from top-level ``files`` and embedded blocks."""
+    files: list[dict[str, Any]] = list(event.get("files") or [])
+    seen_file_ids: set[str] = {
+        str(item.get("id") or item.get("file_id") or item.get("external_id") or "").strip()
+        for item in files
+        if isinstance(item, dict)
+    }
+
+    for block in event.get("blocks") or []:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "file":
+            continue
+        if str(block.get("source") or "").strip().lower() != "slack":
+            continue
+
+        external_id: str = str(
+            block.get("external_id")
+            or block.get("file_id")
+            or block.get("id")
+            or ""
+        ).strip()
+        if not external_id or external_id in seen_file_ids:
+            continue
+
+        files.append(
+            {
+                "id": external_id,
+                "external_id": external_id,
+                "source": "slack",
+                "mimetype": block.get("mimetype") or "application/octet-stream",
+                "name": block.get("title") or "slack_file",
+                "size": block.get("size") or 0,
+            }
+        )
+        seen_file_ids.add(external_id)
+
+    return files
 
 
 async def _persist_activity(

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -1496,6 +1496,26 @@ Returns normalized messages for one channel since a cutoff (does not write to th
             raise ValueError(f"Empty response downloading Slack file: {url_private}")
         return data
 
+    async def get_file_info(self, file_id: str) -> dict[str, Any] | None:
+        """Fetch file metadata from Slack ``files.info``."""
+        normalized_file_id: str = str(file_id or "").strip()
+        if not normalized_file_id:
+            return None
+
+        data: dict[str, Any] = await self._make_request(
+            "POST",
+            "files.info",
+            json_data={"file": normalized_file_id},
+        )
+        file_info: dict[str, Any] | None = data.get("file")
+        if file_info is None:
+            logger.warning(
+                "[slack] files.info returned no file payload for file_id=%s",
+                normalized_file_id,
+            )
+            return None
+        return file_info
+
     async def _send_direct_message_once(
         self,
         slack_user_id: str,

--- a/backend/messengers/slack.py
+++ b/backend/messengers/slack.py
@@ -885,13 +885,44 @@ class SlackMessenger(WorkspaceMessenger):
         connector: SlackConnector = await self._get_connector(
             workspace_id, organization_id=organization_id,
         )
-        url_private: str | None = file_info.get("url_private_download") or file_info.get("url_private")
+        normalized_file_info: dict[str, Any] = dict(file_info or {})
+        url_private: str | None = (
+            normalized_file_info.get("url_private_download")
+            or normalized_file_info.get("url_private")
+        )
+        if not url_private:
+            embedded_file_id: str = str(
+                normalized_file_info.get("external_id")
+                or normalized_file_info.get("file_id")
+                or normalized_file_info.get("id")
+                or ""
+            ).strip()
+            if embedded_file_id:
+                try:
+                    fetched_file_info: dict[str, Any] | None = await connector.get_file_info(embedded_file_id)
+                    if fetched_file_info:
+                        normalized_file_info = fetched_file_info
+                        url_private = (
+                            normalized_file_info.get("url_private_download")
+                            or normalized_file_info.get("url_private")
+                        )
+                        logger.info(
+                            "[slack] Resolved embedded file metadata via files.info file_id=%s has_url=%s",
+                            embedded_file_id,
+                            bool(url_private),
+                        )
+                except Exception as exc:
+                    logger.warning(
+                        "[slack] Failed to resolve embedded file metadata file_id=%s: %s",
+                        embedded_file_id,
+                        exc,
+                    )
         if not url_private:
             return None
 
-        filename: str = file_info.get("name", "slack_file")
-        content_type: str = file_info.get("mimetype", "application/octet-stream")
-        size: int = file_info.get("size", 0)
+        filename: str = normalized_file_info.get("name", "slack_file")
+        content_type: str = normalized_file_info.get("mimetype", "application/octet-stream")
+        size: int = normalized_file_info.get("size", 0)
 
         if size > MAX_FILE_SIZE:
             logger.warning("[slack] File %s too large (%d bytes)", filename, size)

--- a/backend/tests/test_slack_events_direct_messages.py
+++ b/backend/tests/test_slack_events_direct_messages.py
@@ -192,3 +192,35 @@ def test_process_event_callback_records_failure_when_background_processing_raise
     assert captured["was_success"] is False
     assert captured["conversation_id"] == "D123:1700000000.002"
     assert captured["failure_reason"] == "test forced failure"
+
+
+def test_build_inbound_message_includes_embedded_slack_file_blocks() -> None:
+    event = {
+        "type": "message",
+        "channel_type": "im",
+        "channel": "D123",
+        "user": "U123",
+        "text": "Please read this",
+        "ts": "1700000000.002",
+        "blocks": [
+            {
+                "type": "file",
+                "external_id": "F0123ABC",
+                "source": "slack",
+                "title": "proposal.pdf",
+                "mimetype": "application/pdf",
+            }
+        ],
+    }
+
+    inbound = slack_events._build_inbound_message(
+        event,
+        "T123",
+        MessageType.DIRECT,
+    )
+
+    assert len(inbound.raw_attachments) == 1
+    attachment = inbound.raw_attachments[0]
+    assert attachment["external_id"] == "F0123ABC"
+    assert attachment["name"] == "proposal.pdf"
+    assert attachment["mimetype"] == "application/pdf"

--- a/backend/tests/test_slack_messenger_embedded_files.py
+++ b/backend/tests/test_slack_messenger_embedded_files.py
@@ -1,0 +1,64 @@
+import asyncio
+
+from messengers.slack import SlackMessenger
+
+
+def test_download_file_fetches_metadata_for_embedded_file(monkeypatch) -> None:
+    messenger = SlackMessenger()
+    captured_file_ids: list[str] = []
+
+    class _FakeConnector:
+        async def get_file_info(self, file_id: str):
+            captured_file_ids.append(file_id)
+            return {
+                "id": file_id,
+                "name": "embed.pdf",
+                "mimetype": "application/pdf",
+                "size": 16,
+                "url_private_download": "https://files.slack.test/download/F111",
+            }
+
+        async def get_oauth_token(self):
+            return ("xoxb-test-token", "conn-1")
+
+    class _FakeResponse:
+        is_redirect = False
+        headers = {"content-type": "application/pdf"}
+        content = b"%PDF-1.7 mockdata"
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, *_args, **_kwargs):
+            return _FakeResponse()
+
+    async def _fake_get_connector(self, workspace_id=None, organization_id=None):
+        return _FakeConnector()
+
+    monkeypatch.setattr(SlackMessenger, "_get_connector", _fake_get_connector)
+    monkeypatch.setattr("httpx.AsyncClient", _FakeAsyncClient)
+
+    async def _run():
+        return await messenger.download_file(
+            {"external_id": "F111", "source": "slack"},
+            workspace_id="T123",
+            organization_id="org-1",
+        )
+
+    result = asyncio.run(_run())
+    assert result is not None
+    data, filename, content_type = result
+    assert data.startswith(b"%PDF")
+    assert filename == "embed.pdf"
+    assert content_type == "application/pdf"
+    assert captured_file_ids == ["F111"]


### PR DESCRIPTION
### Motivation
- Slack sometimes represents uploaded files as embedded `file` blocks inside `event.blocks` rather than top-level `event.files`, which meant those attachments were not available to downstream processing (e.g., PDFs embedded in messages). 

### Description
- Parse embedded Slack `file` blocks by adding `_extract_files_from_slack_event` and use it from `_build_inbound_message` so `InboundMessage.raw_attachments` includes embedded file metadata. 
- Add `SlackConnector.get_file_info(file_id)` to call Slack `files.info` and return file metadata. 
- Enhance `SlackMessenger.download_file` to detect embedded file IDs (`external_id`/`file_id`/`id`), fetch metadata via `files.info` when needed, and then download the authenticated `url_private(_download)` payload. 
- Add unit tests: extend `backend/tests/test_slack_events_direct_messages.py` with a regression for embedded `file` block extraction and add `backend/tests/test_slack_messenger_embedded_files.py` to validate metadata resolution + download with mocked connector/http client. 

### Testing
- Ran `pytest -q backend/tests/test_slack_events_direct_messages.py backend/tests/test_slack_messenger_embedded_files.py` and all tests passed. 
- Test summary: the added/updated tests covering embedded block extraction and download paths succeeded (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e56d9696208321a52e9c9c5f716455)