### PR TITLE
Fix Slack responses dropping additional markdown tables

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -23,6 +23,8 @@ from sqlalchemy import func, select
 _SEPARATOR_ROW_RE: re.Pattern[str] = re.compile(
     r'^\|?[\s\-:|]+\|?$'
 )
+_MARKDOWN_TABLE_CODE_BLOCK_TEMPLATE: str = "```\n{table}\n```"
+_markdown_logger = logging.getLogger(__name__)
 
 
 def _clean_table_lines(raw: str) -> str:
@@ -43,8 +45,8 @@ def markdown_to_mrkdwn(text: str) -> tuple[str, Optional[list[dict[str, Any]]]]:
     """
     from connectors.slack_tables import format_markdown_table_inline
 
-    # Placeholder content: plain string, or (blocks|None, fallback_text) for tables
-    code_blocks: list[str | tuple[Optional[list[dict[str, Any]]], str]] = []
+    # Placeholder content: plain string, or table metadata for later rendering.
+    code_blocks: list[str | dict[str, Any]] = []
     _FENCE_RE: re.Pattern[str] = re.compile(r'```\w*\n(.*?)```', re.DOTALL)
 
     def _extract_fence(match: re.Match[str]) -> str:
@@ -52,7 +54,12 @@ def markdown_to_mrkdwn(text: str) -> tuple[str, Optional[list[dict[str, Any]]]]:
         idx: int = len(code_blocks)
         if '|' in content:
             table_blocks, fallback = format_markdown_table_inline(content)
-            code_blocks.append((table_blocks, fallback))
+            code_blocks.append({
+                "type": "table",
+                "table_blocks": table_blocks,
+                "fallback": fallback,
+                "raw_table": content.strip(),
+            })
         else:
             code_blocks.append('```\n' + content.strip() + '\n```')
         return f'\x00CB{idx}\x00'
@@ -69,7 +76,12 @@ def markdown_to_mrkdwn(text: str) -> tuple[str, Optional[list[dict[str, Any]]]]:
         cleaned: str = _clean_table_lines(match.group(1))
         table_blocks, fallback = format_markdown_table_inline(cleaned)
         idx = len(code_blocks)
-        code_blocks.append((table_blocks, fallback))
+        code_blocks.append({
+            "type": "table",
+            "table_blocks": table_blocks,
+            "fallback": fallback,
+            "raw_table": cleaned.strip(),
+        })
         return f'\x00CB{idx}\x00'
 
     text = _TABLE_RE.sub(_wrap_table, text)
@@ -79,14 +91,36 @@ def markdown_to_mrkdwn(text: str) -> tuple[str, Optional[list[dict[str, Any]]]]:
     text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)', r'<\2|\1>', text)
     text = re.sub(r'^#{1,6}\s+(.+)$', r'*\1*', text, flags=re.MULTILINE)
 
-    # -- Step 4: restore placeholders and collect first table blocks ---------
+    # -- Step 4: restore placeholders and decide whether to use table blocks --
+    table_block_count: int = 0
+    for block in code_blocks:
+        if isinstance(block, dict) and block.get("type") == "table" and block.get("table_blocks") is not None:
+            table_block_count += 1
+
+    use_table_blocks: bool = table_block_count == 1
+    if table_block_count > 1:
+        _markdown_logger.info(
+            "[SlackConnector] Detected %d markdown tables with block representation; "
+            "falling back to inline code blocks so all tables render in one Slack message.",
+            table_block_count,
+        )
+
     out_blocks: Optional[list[dict[str, Any]]] = None
     for i, block in enumerate(code_blocks):
-        if isinstance(block, tuple):
-            table_blocks, fallback = block
-            text = text.replace(f'\x00CB{i}\x00', fallback)
-            if out_blocks is None and table_blocks is not None:
+        if isinstance(block, dict) and block.get("type") == "table":
+            table_blocks = block.get("table_blocks")
+            fallback = str(block.get("fallback") or "")
+            raw_table = str(block.get("raw_table") or "").strip()
+
+            if use_table_blocks and table_blocks is not None and out_blocks is None:
+                text = text.replace(f'\x00CB{i}\x00', fallback)
                 out_blocks = table_blocks
+            else:
+                code_fallback: str = (
+                    _MARKDOWN_TABLE_CODE_BLOCK_TEMPLATE.format(table=raw_table)
+                    if raw_table else fallback
+                )
+                text = text.replace(f'\x00CB{i}\x00', code_fallback)
         else:
             assert isinstance(block, str)
             text = text.replace(f'\x00CB{i}\x00', block)

--- a/backend/tests/test_slack_markdown_to_mrkdwn.py
+++ b/backend/tests/test_slack_markdown_to_mrkdwn.py
@@ -1,0 +1,40 @@
+from connectors.slack import markdown_to_mrkdwn
+
+
+def test_markdown_to_mrkdwn_uses_blocks_for_single_table() -> None:
+    text, blocks = markdown_to_mrkdwn(
+        """
+Summary
+
+| Name | Value |
+| --- | --- |
+| A | 1 |
+| B | 2 |
+""".strip()
+    )
+
+    assert blocks is not None
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "table"
+    assert "Table: 2 rows × 2 columns" in text
+
+
+def test_markdown_to_mrkdwn_falls_back_to_code_blocks_for_multiple_tables() -> None:
+    text, blocks = markdown_to_mrkdwn(
+        """
+First table:
+| Name | Value |
+| --- | --- |
+| A | 1 |
+
+Second table:
+| Team | Score |
+| --- | --- |
+| X | 99 |
+""".strip()
+    )
+
+    assert blocks is None
+    assert text.count("```") >= 4
+    assert "Name | Value" in text
+    assert "Team | Score" in text


### PR DESCRIPTION
### Motivation

- Responses containing multiple Markdown tables were being converted to Slack Block Kit table format and only the first table appeared in the outgoing Slack message, causing users to miss subsequent tables.
- Slack allows a single native table block per message, so when multiple tables exist we need a deterministic fallback that preserves all table content.

### Description

- Updated `markdown_to_mrkdwn` in `backend/connectors/slack.py` to collect table metadata during parsing and count table blocks rather than returning only the first table tuple.
- When exactly one table block is detected the function returns Block Kit table `blocks` as before, and when more than one table block is detected the function falls back to rendering each table as inline code blocks so all tables remain visible in a single Slack message, and added an info log when this fallback is used.
- Added `_MARKDOWN_TABLE_CODE_BLOCK_TEMPLATE` and a module logger, changed internal placeholder representation to include `raw_table`, `fallback`, and `table_blocks`, and updated placeholder restoration to support the new multi-table fallback logic.
- Added tests `backend/tests/test_slack_markdown_to_mrkdwn.py` covering single-table block behavior and multi-table fallback behavior.

### Testing

- Ran `pytest -q backend/tests/test_slack_markdown_to_mrkdwn.py` which succeeded with `2 passed`.
- Ran `pytest -q backend/tests/test_slack_tables.py backend/tests/test_slack_connector_actions.py` which succeeded with `18 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e56e3a7a3c832182cd308a37418cfb)