### PR TITLE
Split Slack multi-table replies into separate messages

### DIFF
--- a/backend/messengers/slack.py
+++ b/backend/messengers/slack.py
@@ -34,11 +34,58 @@ _SLACK_CONTEXT_SUMMARY_MESSAGE_CHAR_LIMIT: int = 220
 _SLACK_CONTEXT_SUMMARY_RECENT_ITEMS: int = 80
 _SLACK_CONTEXT_SUMMARY_TOP_THREADS: int = 10
 _SLACK_CONTEXT_SNAPSHOT_SEPARATOR: str = "\n\n---\n\n"
+_SLACK_FENCE_RE: re.Pattern[str] = re.compile(r"```[\w-]*\n.*?```", re.DOTALL)
+_SLACK_TABLE_RE: re.Pattern[str] = re.compile(
+    r"((?:^(?:\|.+\||[^\n|]+(?:\|[^\n|]+){2,})$\n?)+)",
+    re.MULTILINE,
+)
 
 
 def _normalize_slack_dedupe_text(text: str) -> str:
     """Normalize Slack message text for duplicate detection."""
     return re.sub(r"\s+", "", text or "")
+
+
+def _split_markdown_for_slack_tables(markdown: str) -> list[str]:
+    """Split markdown into chunks so each chunk includes at most one table block."""
+    spans: list[tuple[int, int]] = []
+
+    for fence_match in _SLACK_FENCE_RE.finditer(markdown):
+        fenced_block: str = fence_match.group(0)
+        if "|" in fenced_block:
+            spans.append((fence_match.start(), fence_match.end()))
+
+    def _is_overlapping(start: int, end: int) -> bool:
+        return any(not (end <= span_start or start >= span_end) for span_start, span_end in spans)
+
+    for table_match in _SLACK_TABLE_RE.finditer(markdown):
+        start = table_match.start()
+        end = table_match.end()
+        if _is_overlapping(start, end):
+            continue
+        spans.append((start, end))
+
+    if len(spans) <= 1:
+        return [markdown]
+
+    spans.sort(key=lambda span: span[0])
+    chunks: list[str] = []
+    cursor: int = 0
+
+    for start, end in spans:
+        prefix: str = markdown[cursor:start].strip()
+        if prefix:
+            chunks.append(prefix)
+        table_chunk: str = markdown[start:end].strip()
+        if table_chunk:
+            chunks.append(table_chunk)
+        cursor = end
+
+    suffix: str = markdown[cursor:].strip()
+    if suffix:
+        chunks.append(suffix)
+
+    return chunks or [markdown]
 
 
 class SlackMessenger(WorkspaceMessenger):
@@ -952,18 +999,26 @@ class SlackMessenger(WorkspaceMessenger):
         workspace_id: str | None = None,
         organization_id: str | None = None,
     ) -> None:
-        """Format with markdown_to_mrkdwn and post; use blocks when table is present."""
-        text: str
-        blocks: list[dict[str, Any]] | None
-        text, blocks = markdown_to_mrkdwn(text_to_send)
-        await self.post_message(
-            channel_id=channel_id,
-            text=text,
-            thread_id=thread_id,
-            workspace_id=workspace_id,
-            organization_id=organization_id,
-            blocks=blocks,
-        )
+        """Format markdown for Slack and split messages so each has at most one table."""
+        chunks: list[str] = _split_markdown_for_slack_tables(text_to_send)
+        if len(chunks) > 1:
+            logger.info(
+                "[slack] Splitting outbound markdown into %d Slack messages to keep one table per message",
+                len(chunks),
+            )
+
+        for chunk in chunks:
+            text: str
+            blocks: list[dict[str, Any]] | None
+            text, blocks = markdown_to_mrkdwn(chunk)
+            await self.post_message(
+                channel_id=channel_id,
+                text=text,
+                thread_id=thread_id,
+                workspace_id=workspace_id,
+                organization_id=organization_id,
+                blocks=blocks,
+            )
 
     # ------------------------------------------------------------------
     # Typing indicators (reactions)

--- a/backend/tests/test_slack_messenger_table_splitting.py
+++ b/backend/tests/test_slack_messenger_table_splitting.py
@@ -1,0 +1,69 @@
+import pytest
+
+from messengers.slack import SlackMessenger, _split_markdown_for_slack_tables
+
+
+def test_split_markdown_for_slack_tables_keeps_single_table_message() -> None:
+    markdown = """
+Summary
+
+| Name | Value |
+| --- | --- |
+| A | 1 |
+""".strip()
+
+    assert _split_markdown_for_slack_tables(markdown) == [markdown]
+
+
+def test_split_markdown_for_slack_tables_splits_multi_table_message() -> None:
+    markdown = """
+First table:
+| Name | Value |
+| --- | --- |
+| A | 1 |
+
+Second table:
+| Team | Score |
+| --- | --- |
+| X | 99 |
+""".strip()
+
+    chunks = _split_markdown_for_slack_tables(markdown)
+
+    assert len(chunks) == 4
+    assert chunks[0] == "First table:"
+    assert "Name | Value" in chunks[1]
+    assert chunks[2] == "Second table:"
+    assert "Team | Score" in chunks[3]
+
+
+@pytest.mark.asyncio
+async def test_format_and_post_splits_into_multiple_slack_messages(monkeypatch: pytest.MonkeyPatch) -> None:
+    messenger = SlackMessenger()
+    posted: list[dict[str, object]] = []
+
+    async def _fake_post_message(**kwargs):  # type: ignore[no-untyped-def]
+        posted.append(kwargs)
+        return "123.456"
+
+    monkeypatch.setattr(messenger, "post_message", _fake_post_message)
+
+    await messenger.format_and_post(
+        channel_id="C123",
+        thread_id="T123",
+        text_to_send="""
+First:
+| Name | Value |
+| --- | --- |
+| A | 1 |
+
+Second:
+| Team | Score |
+| --- | --- |
+| X | 99 |
+""".strip(),
+    )
+
+    assert len(posted) == 4
+    # Exactly two messages should include Slack table blocks.
+    assert sum(1 for call in posted if call.get("blocks")) == 2


### PR DESCRIPTION
### Motivation
- Avoid Slack's fallback to inline code blocks when multiple markdown tables appear by ensuring each outbound Slack message contains at most one table to preserve native table rendering. 
- Implement user-requested behavior to split multi-table responses across multiple Slack messages rather than encoding multiple tables into a single message.

### Description
- Added `_SLACK_FENCE_RE` and `_SLACK_TABLE_RE` and implemented `_split_markdown_for_slack_tables` to detect fenced and bare pipe tables and split markdown into chunks so each chunk contains at most one table. 
- Updated `SlackMessenger.format_and_post` to iterate over the chunks, call `markdown_to_mrkdwn` per chunk, and post each chunk separately while logging when a split occurs. 
- Kept existing `markdown_to_mrkdwn` conversion logic so single-table blocks still produce Block Kit table blocks and multi-table inputs now split so each table can render natively. 
- Added tests at `backend/tests/test_slack_messenger_table_splitting.py` covering single-table no-split, multi-table splitting, and end-to-end `format_and_post` multi-message posting.

### Testing
- Ran `pytest -q backend/tests/test_slack_messenger_table_splitting.py backend/tests/test_slack_markdown_to_mrkdwn.py` and all tests passed. 
- Test run result: `5 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e56f83078083218e54d2161cab5c58)