### PR TITLE
Add MIME-aware upload size limits and raise PDF size cap

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -38,7 +38,7 @@ from models.conversation import Conversation
 from models.database import get_admin_session, get_session
 from models.org_member import OrgMember
 from models.user import User
-from services.file_handler import store_file, MAX_FILE_SIZE
+from services.file_handler import max_file_size_for_upload, store_file
 from services.slack_identity import get_slack_user_ids_for_revtops_user
 
 
@@ -1219,17 +1219,21 @@ async def upload_file(
     Upload a file to attach to a chat message.
 
     Files are stored temporarily in memory and consumed when the
-    message is sent via WebSocket. Max size: 10 MB.
+    message is sent via WebSocket.
     """
     if file.filename is None:
         raise HTTPException(status_code=400, detail="Filename is required")
 
     data: bytes = await file.read()
 
-    if len(data) > MAX_FILE_SIZE:
+    max_size_bytes: int = max_file_size_for_upload(
+        filename=file.filename,
+        content_type=file.content_type,
+    )
+    if len(data) > max_size_bytes:
         raise HTTPException(
             status_code=413,
-            detail=f"File exceeds maximum size of {MAX_FILE_SIZE // (1024 * 1024)} MB",
+            detail=f"File exceeds maximum size of {max_size_bytes // (1024 * 1024)} MB",
         )
 
     try:

--- a/backend/messengers/_twilio_phone.py
+++ b/backend/messengers/_twilio_phone.py
@@ -164,7 +164,7 @@ def _is_safe_twilio_media_url(url: str) -> bool:
 
 async def _download_twilio_media(media_items: list[dict[str, str]]) -> list[str]:
     """Download MMS/WhatsApp media from Twilio CDN, return upload IDs."""
-    from services.file_handler import MAX_FILE_SIZE, store_file
+    from services.file_handler import max_file_size_for_upload, store_file
 
     account_sid: str | None = settings.TWILIO_ACCOUNT_SID
     auth_token: str | None = settings.TWILIO_AUTH_TOKEN
@@ -192,12 +192,21 @@ async def _download_twilio_media(media_items: list[dict[str, str]]) -> list[str]
                 resp.raise_for_status()
 
                 data: bytes = resp.content
-                if len(data) > MAX_FILE_SIZE:
-                    logger.warning("MMS media %d (%d bytes) exceeds max — skipping", i, len(data))
-                    continue
-
                 ext: str = content_type.split("/")[-1].split(";")[0]
                 filename: str = f"mms_media_{i}.{ext}"
+                max_size_bytes: int = max_file_size_for_upload(
+                    filename=filename,
+                    content_type=content_type,
+                )
+                if len(data) > max_size_bytes:
+                    logger.warning(
+                        "MMS media %d (%d bytes) exceeds max %d bytes — skipping",
+                        i,
+                        len(data),
+                        max_size_bytes,
+                    )
+                    continue
+
                 stored = store_file(filename=filename, data=data, content_type=content_type)
                 attachment_ids.append(stored.upload_id)
                 logger.info("Downloaded media %d (%s, %d bytes) → %s", i, content_type, len(data), stored.upload_id)

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -663,7 +663,7 @@ class WorkspaceMessenger(BaseMessenger):
     # ------------------------------------------------------------------
 
     async def download_attachments(self, message: InboundMessage) -> list[str]:
-        from services.file_handler import MAX_FILE_SIZE, store_file
+        from services.file_handler import max_file_size_for_upload, store_file
 
         if not message.raw_attachments:
             return []
@@ -681,8 +681,18 @@ class WorkspaceMessenger(BaseMessenger):
             if result is None:
                 continue
             data, filename, content_type = result
-            if len(data) > MAX_FILE_SIZE:
-                logger.warning("[%s] File %s too large (%d bytes)", self.meta.slug, filename, len(data))
+            max_size_bytes: int = max_file_size_for_upload(
+                filename=filename,
+                content_type=content_type,
+            )
+            if len(data) > max_size_bytes:
+                logger.warning(
+                    "[%s] File %s too large (%d bytes > %d bytes)",
+                    self.meta.slug,
+                    filename,
+                    len(data),
+                    max_size_bytes,
+                )
                 continue
             stored = store_file(filename=filename, data=data, content_type=content_type)
             attachment_ids.append(stored.upload_id)

--- a/backend/messengers/slack.py
+++ b/backend/messengers/slack.py
@@ -880,7 +880,7 @@ class SlackMessenger(WorkspaceMessenger):
         organization_id: str | None = None,
     ) -> tuple[bytes, str, str] | None:
         """Download a Slack file using the bot token."""
-        from services.file_handler import MAX_FILE_SIZE
+        from services.file_handler import max_file_size_for_upload
 
         connector: SlackConnector = await self._get_connector(
             workspace_id, organization_id=organization_id,
@@ -893,8 +893,17 @@ class SlackMessenger(WorkspaceMessenger):
         content_type: str = file_info.get("mimetype", "application/octet-stream")
         size: int = file_info.get("size", 0)
 
-        if size > MAX_FILE_SIZE:
-            logger.warning("[slack] File %s too large (%d bytes)", filename, size)
+        max_size_bytes: int = max_file_size_for_upload(
+            filename=filename,
+            content_type=content_type,
+        )
+        if size > max_size_bytes:
+            logger.warning(
+                "[slack] File %s too large (%d bytes > %d bytes)",
+                filename,
+                size,
+                max_size_bytes,
+            )
             return None
 
         try:

--- a/backend/messengers/teams.py
+++ b/backend/messengers/teams.py
@@ -116,7 +116,7 @@ class TeamsMessenger(WorkspaceMessenger):
         organization_id: str | None = None,
     ) -> tuple[bytes, str, str] | None:
         """Download a Teams attachment (contentUrl)."""
-        from services.file_handler import MAX_FILE_SIZE
+        from services.file_handler import max_file_size_for_upload
 
         content_url: str | None = file_info.get("contentUrl") or file_info.get(
             "content"
@@ -129,8 +129,17 @@ class TeamsMessenger(WorkspaceMessenger):
         if result is None:
             return None
         data, filename, ct = result
-        if len(data) > MAX_FILE_SIZE:
-            logger.warning("[teams] File %s too large (%d bytes)", name, len(data))
+        max_size_bytes: int = max_file_size_for_upload(
+            filename=filename or name,
+            content_type=ct or content_type,
+        )
+        if len(data) > max_size_bytes:
+            logger.warning(
+                "[teams] File %s too large (%d bytes > %d bytes)",
+                name,
+                len(data),
+                max_size_bytes,
+            )
             return None
         return (data, filename or name, ct or content_type)
 

--- a/backend/services/file_handler.py
+++ b/backend/services/file_handler.py
@@ -32,8 +32,11 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-# Max file size: 10 MB
+# Max file size for non-PDF uploads: 10 MB
 MAX_FILE_SIZE: int = 10 * 1024 * 1024
+
+# Max file size for PDFs: 25 MB (supports typical ~30-slide decks)
+MAX_PDF_FILE_SIZE: int = 25 * 1024 * 1024
 
 # TTL for stored files: 30 minutes
 FILE_TTL_SECONDS: int = 30 * 60
@@ -107,12 +110,12 @@ def store_file(filename: str, data: bytes, content_type: str | None = None) -> S
         StoredFile with generated upload_id
 
     Raises:
-        ValueError: If file exceeds MAX_FILE_SIZE
+        ValueError: If file exceeds the MIME-aware max size limit
     """
-    if len(data) > MAX_FILE_SIZE:
-        raise ValueError(f"File exceeds maximum size of {MAX_FILE_SIZE // (1024 * 1024)} MB")
-
     mime: str = content_type or mimetypes.guess_type(filename)[0] or "application/octet-stream"
+    max_size_bytes: int = max_file_size_for_upload(filename=filename, content_type=mime)
+    if len(data) > max_size_bytes:
+        raise ValueError(f"File exceeds maximum size of {max_size_bytes // (1024 * 1024)} MB")
     upload_id: str = str(uuid.uuid4())
 
     stored = StoredFile(
@@ -129,6 +132,14 @@ def store_file(filename: str, data: bytes, content_type: str | None = None) -> S
 
     logger.info("Stored file %s (%s, %d bytes) as %s", filename, mime, len(data), upload_id)
     return stored
+
+
+def max_file_size_for_upload(*, filename: str, content_type: str | None) -> int:
+    """Return size ceiling in bytes for an upload based on type."""
+    normalized_ct: str = (content_type or "").strip().lower()
+    lower_name: str = (filename or "").strip().lower()
+    is_pdf: bool = normalized_ct == PDF_MIME or lower_name.endswith(".pdf")
+    return MAX_PDF_FILE_SIZE if is_pdf else MAX_FILE_SIZE
 
 
 def retrieve_file(upload_id: str) -> StoredFile | None:


### PR DESCRIPTION
### Motivation

- Allow larger PDF uploads while keeping other file types limited, and centralize size logic instead of a single hardcoded `MAX_FILE_SIZE` constant.
- Ensure upload size checks are MIME- and filename-aware so different pathways (web upload, Twilio, Slack, Teams, workspace ingestion) apply the correct ceiling.

### Description

- Introduce `MAX_PDF_FILE_SIZE` and a helper `max_file_size_for_upload(*, filename, content_type)` in `services/file_handler.py` and use it from `store_file` to validate uploads.
- Replace imports of the old `MAX_FILE_SIZE` constant with `max_file_size_for_upload` across `backend/api/routes/chat.py`, `backend/messengers/_twilio_phone.py`, `backend/messengers/_workspace.py`, `backend/messengers/slack.py`, and `backend/messengers/teams.py`, and update checks/logging to show actual byte ceilings.
- Update the chat upload endpoint docstring to remove the hardcoded "Max size: 10 MB" text and propagate improved error/log messages and ValueError handling from `store_file`.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e56edc3ba48321b18bdb58fee43947)