### PR TITLE
Refine GitHub connector repo selection and auto identity mapping

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -3183,6 +3183,21 @@ async def confirm_integration(
             user_uuid,
             connection_metadata,
         )
+    if request.provider == "github":
+        async def _map_connected_github_identity() -> None:
+            try:
+                from connectors.github import GitHubConnector
+
+                connector = GitHubConnector(str(org_uuid))
+                await connector.map_connected_user_identity(user_uuid)
+            except Exception:
+                logger.exception(
+                    "Failed to auto-map connected GitHub identity org=%s user_id=%s",
+                    org_uuid,
+                    user_uuid,
+                )
+
+        background_tasks.add_task(_map_connected_github_identity)
 
     return {
         "status": "connected",

--- a/backend/connectors/github.py
+++ b/backend/connectors/github.py
@@ -746,13 +746,19 @@ Use `run_sql_query` on `github_repositories`, `github_commits`, `github_pull_req
 
     async def list_available_repos(self) -> list[dict[str, Any]]:
         """
-        List all repos accessible to the authenticated GitHub token.
+        List repos the connected GitHub user can directly access.
 
         The frontend uses this to let teams choose which repos to track.
         Returns a lightweight list (no commits/PRs fetched yet).
         """
         raw_repos: list[dict[str, Any]] = await self._gh_get_paginated(
-            "/user/repos", params={"sort": "updated", "direction": "desc"}
+            "/user/repos",
+            params={
+                "sort": "updated",
+                "direction": "desc",
+                # Exclude indirect org-member visibility and keep user-owned/collaborator repos.
+                "affiliation": "owner,collaborator",
+            },
         )
         repos: list[dict[str, Any]] = [
             {
@@ -769,6 +775,51 @@ Use `run_sql_query` on `github_repositories`, `github_commits`, `github_pull_req
             for r in raw_repos
         ]
         return repos
+
+    async def map_connected_user_identity(self, user_id: UUID) -> None:
+        """
+        Ensure the connected GitHub account login is mapped to ``user_id``.
+
+        This runs right after OAuth connect so the connection owner is always
+        linked to their own GitHub identity without requiring the mapping wizard.
+        """
+        logger.info(
+            "Ensuring GitHub self identity mapping org=%s user_id=%s",
+            self.organization_id,
+            user_id,
+        )
+        profile: dict[str, Any] = await self._gh_get("/user")
+        github_login_raw: Any = profile.get("login")
+        github_login: str = str(github_login_raw or "").strip()
+        if not github_login:
+            logger.warning(
+                "Skipping GitHub self mapping because /user login was missing org=%s user_id=%s",
+                self.organization_id,
+                user_id,
+            )
+            return
+
+        github_email_raw: Any = profile.get("email")
+        github_email: str | None = str(github_email_raw).strip() if github_email_raw else None
+
+        async with get_session(organization_id=self.organization_id) as session:
+            await self._ensure_github_identity_mapping(
+                session,
+                github_login=github_login,
+                github_email=github_email,
+                user_id=user_id,
+                revtops_email=None,
+                match_source="github_oauth_self",
+            )
+            await session.commit()
+
+        self._login_cache[github_login] = user_id
+        logger.info(
+            "GitHub self identity mapping ensured org=%s user_id=%s github_login=%s",
+            self.organization_id,
+            user_id,
+            github_login,
+        )
 
     # ── QUERY capability ───────────────────────────────────────────────
 

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -335,7 +335,7 @@ export function DataSources(): JSX.Element {
   const [slackVerifyCodeLoading, setSlackVerifyCodeLoading] = useState<boolean>(false);
   const [showSlackVerificationModal, setShowSlackVerificationModal] = useState(false);
   const [showConnectModal, setShowConnectModal] = useState(false);
-  const [identityMappingProvider, setIdentityMappingProvider] = useState<string | null>(null);
+  const [identityMappingProvider, setIdentityMappingProvider] = useState<'slack' | null>(null);
   const [connectSearch, setConnectSearch] = useState('');
   const [showCodeSandboxWarning, setShowCodeSandboxWarning] = useState(false);
 
@@ -688,7 +688,6 @@ export function DataSources(): JSX.Element {
       await fetchGitHubTrackedRepos();
       void fetchIntegrations();
       setGithubReposExpanded(false);
-      setIdentityMappingProvider("github");
     } catch (e) {
       setGithubReposError(e instanceof Error ? e.message : 'Failed to save');
     } finally {
@@ -1675,6 +1674,16 @@ export function DataSources(): JSX.Element {
                   >
                     {githubSaving ? 'Saving…' : 'Save tracked repos'}
                   </button>
+                  <p className="text-xs text-surface-500">
+                    Need to map external users? Organization admins can manage identity mappings in the{' '}
+                    <a
+                      href="/org-settings"
+                      className="text-primary-400 hover:text-primary-300 underline"
+                    >
+                      Team UI
+                    </a>
+                    .
+                  </p>
                 </>
               )}
             </>


### PR DESCRIPTION
### Motivation
- Prevent the connectors page from showing repos a user cannot directly act on by restricting GitHub repo discovery to repos the connected user owns or collaborates on.
- Remove the immediate identity-mapping UX for GitHub from the connectors flow and direct admins to the Team UI for manual mappings.
- Ensure the connecting user is automatically mapped to their GitHub login after OAuth so their own activity is attributed without manual steps.

### Description
- Restrict repo discovery in `GitHubConnector.list_available_repos()` by calling `/user/repos` with `affiliation=owner,collaborator` to return only repos the token owner directly has access to.
- Add `GitHubConnector.map_connected_user_identity(user_id)` which calls `/user`, upserts a row in `user_mappings_for_identity` via `_ensure_github_identity_mapping`, and records `match_source="github_oauth_self"`.
- Trigger the GitHub auto-mapping in `POST /auth/integrations/confirm` by scheduling a background task that invokes `map_connected_user_identity` for the connecting user and logs failures.
- Update the connectors UI (`DataSources.tsx`) to stop launching the GitHub identity mapping wizard after saving tracked repos, narrow the `identityMappingProvider` state to Slack-only, and add a short helper line linking admins to the Team UI at `/org-settings` for manual identity mapping.

### Testing
- Ran `python -m py_compile backend/connectors/github.py backend/api/routes/auth.py` to validate Python syntax, which succeeded.
- Ran frontend lint on the modified file with `npm run lint -- src/components/DataSources.tsx`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6cae069ac8321b1d2dfa6f067088c)