### PR TITLE
Show identity mapping hint when repo selector is collapsed

### DIFF
--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -1674,20 +1674,20 @@ export function DataSources(): JSX.Element {
                   >
                     {githubSaving ? 'Saving…' : 'Save tracked repos'}
                   </button>
-                  <p className="text-xs text-surface-500">
-                    Need to map external users? Organization admins can manage identity mappings in the{' '}
-                    <a
-                      href="/org-settings"
-                      className="text-primary-400 hover:text-primary-300 underline"
-                    >
-                      Team UI
-                    </a>
-                    .
-                  </p>
                 </>
               )}
             </>
           )}
+          <p className="text-xs text-surface-500">
+            If you want to map users other than yourself, admins can manage identity mappings in the{' '}
+            <a
+              href="/org-settings"
+              className="text-primary-400 hover:text-primary-300 underline"
+            >
+              Team UI
+            </a>
+            .
+          </p>
         </div>
       );
     };


### PR DESCRIPTION
### Motivation
- Ensure the identity-mapping helper text is visible even when the GitHub repo selector is collapsed and clarify that admins can map other users.

### Description
- Moved the helper paragraph in `frontend/src/components/DataSources.tsx` out of the expanded-only repo picker branch so it renders regardless of the `githubReposExpanded` state.
- Reworded the copy to: "If you want to map users other than yourself, admins can manage identity mappings in the Team UI." while preserving the existing `Team UI` link to `/org-settings`.

### Testing
- Ran the frontend linter with `cd frontend && npm run -s lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d2824f3083218318a3ee2040e829)