### PR TITLE
Open Team panel from GitHub connector "Team UI" link

### DIFF
--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -258,6 +258,7 @@ async function getResponseErrorMessage(response: Response, fallback: string): Pr
 export function DataSources(): JSX.Element {
   // Get user/org from Zustand (auth state)
   const { user, organization, organizations } = useAppStore();
+  const setCurrentView = useAppStore((state) => state.setCurrentView);
   const fetchUserOrganizations = useAppStore((state) => state.fetchUserOrganizations);
   
 
@@ -1706,12 +1707,13 @@ export function DataSources(): JSX.Element {
           )}
           <p className="text-xs text-surface-500">
             If you want to map users other than yourself, admins can manage identity mappings in the{' '}
-            <a
-              href="/org-settings"
+            <button
+              type="button"
+              onClick={() => setCurrentView('org-settings')}
               className="text-primary-400 hover:text-primary-300 underline"
             >
               Team UI
-            </a>
+            </button>
             .
           </p>
         </div>


### PR DESCRIPTION
### Motivation
- Make the GitHub connector's "Team UI" action open the in-app Team panel instead of navigating away to `/org-settings`, keeping users inside the app shell and matching expected connector UX.

### Description
- Replace the hardcoded anchor `href="/org-settings"` with a button that calls `setCurrentView('org-settings')` from the app store.
- Add the `setCurrentView` selector from `useAppStore` to the `DataSources` component to enable in-app navigation.

### Testing
- Built the frontend with `npm --prefix frontend run build` and the build completed successfully (only existing Vite chunk warnings were reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6e2320f608321907716b12e8e8753)