### PR TITLE
Scope GitHub repo-picker to current user and auto-focus GitHub card after connect

### DIFF
--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -1206,6 +1206,7 @@ async def list_github_repos(
             .where(
                 Integration.organization_id == UUID(organization_id),
                 Integration.connector == "github",
+                Integration.user_id == auth.user_id,
                 Integration.is_active == True,
             )
             .limit(1)
@@ -1216,7 +1217,10 @@ async def list_github_repos(
             )
 
     try:
-        connector: GitHubConnector = GitHubConnector(organization_id)
+        connector: GitHubConnector = GitHubConnector(
+            organization_id,
+            user_id=auth.user_id_str,
+        )
         repos: list[dict[str, Any]] = await connector.list_available_repos()
         return GitHubAvailableReposResponse(
             repos=[GitHubRepoResponse(**r) for r in repos]
@@ -1247,7 +1251,10 @@ async def track_github_repos(
     if not body.github_repo_ids:
         raise HTTPException(status_code=400, detail="No repo IDs provided")
 
-    connector: GitHubConnector = GitHubConnector(organization_id)
+    connector: GitHubConnector = GitHubConnector(
+        organization_id,
+        user_id=auth.user_id_str,
+    )
     tracked: list[dict[str, Any]] = await connector.track_repos(body.github_repo_ids)
     return GitHubTrackedReposResponse(
         repos=[GitHubTrackedRepoResponse(**r) for r in tracked]
@@ -1267,7 +1274,10 @@ async def untrack_github_repos(
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid organization ID")
 
-    connector: GitHubConnector = GitHubConnector(organization_id)
+    connector: GitHubConnector = GitHubConnector(
+        organization_id,
+        user_id=auth.user_id_str,
+    )
     await connector.untrack_repos(body.github_repo_ids)
     return {"status": "ok"}
 

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -10,7 +10,7 @@
  * Uses React Query for server state (integrations list).
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import Nango from '@nangohq/frontend';
 import { HiGlobeAlt, HiUserGroup, HiX, HiCog, HiShare, HiLockClosed, HiChevronDown, HiLightningBolt, HiLink } from 'react-icons/hi';
 import { API_BASE, apiRequest, getAuthenticatedRequestHeaders } from '../lib/api';
@@ -450,6 +450,8 @@ export function DataSources(): JSX.Element {
   const [githubSaving, setGithubSaving] = useState(false);
   const [githubReposExpanded, setGithubReposExpanded] = useState(false);
   const [githubRequiresRepoReview, setGithubRequiresRepoReview] = useState(false);
+  const [githubAutoScrollPending, setGithubAutoScrollPending] = useState(false);
+  const connectorCardRefs = useRef<Record<string, HTMLDivElement | null>>({});
   
   // Live sync progress from WebSocket
   const [syncProgress, setSyncProgress] = useState<Record<string, number>>({});
@@ -532,6 +534,9 @@ export function DataSources(): JSX.Element {
 
   const githubIntegration = rawIntegrations.find((integration) => integration.provider === 'github');
   const githubConnected = Boolean(githubIntegration?.isActive);
+  const githubCurrentUserConnected = rawIntegrations.some(
+    (integration) => integration.provider === 'github' && integration.isActive && integration.currentUserConnected,
+  );
   
   // Handle WebSocket messages for sync progress
   const handleWsMessage = useCallback((message: string) => {
@@ -666,11 +671,11 @@ export function DataSources(): JSX.Element {
   }, [organizationId]);
 
   useEffect(() => {
-    if (githubConnected && organizationId) {
+    if (githubCurrentUserConnected && organizationId) {
       void fetchGitHubAvailableRepos();
       void fetchGitHubTrackedRepos();
     }
-  }, [githubConnected, organizationId, fetchGitHubAvailableRepos, fetchGitHubTrackedRepos]);
+  }, [githubCurrentUserConnected, organizationId, fetchGitHubAvailableRepos, fetchGitHubTrackedRepos]);
 
   useEffect(() => {
     if (!githubConnected) {
@@ -770,6 +775,14 @@ export function DataSources(): JSX.Element {
     };
   });
   const allIntegrations: DisplayIntegration[] = [...integrations, ...availableIntegrationsDisplay];
+
+  useEffect(() => {
+    if (!githubAutoScrollPending || !githubReposExpanded) return;
+    const githubCard = connectorCardRefs.current.github;
+    if (!githubCard) return;
+    githubCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    setGithubAutoScrollPending(false);
+  }, [allIntegrations.length, githubAutoScrollPending, githubReposExpanded]);
 
   // Full list of all connectors for the Add Source modal (from API or fallback)
   const allConnectorsForModal: DisplayIntegration[] = connectorSlugs.map((provider: string): DisplayIntegration => {
@@ -897,6 +910,7 @@ export function DataSources(): JSX.Element {
               if (provider === 'github') {
                 setGithubReposExpanded(true);
                 setGithubRequiresRepoReview(true);
+                setGithubAutoScrollPending(true);
               }
             } catch (confirmError) {
               console.error('Error confirming integration:', confirmError);
@@ -1721,7 +1735,13 @@ export function DataSources(): JSX.Element {
     };
 
     return (
-      <div key={integration.id} className={cardClass}>
+      <div
+        key={integration.id}
+        className={cardClass}
+        ref={(el) => {
+          connectorCardRefs.current[integration.provider] = el;
+        }}
+      >
         <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
           {/* Icon and name row on mobile */}
           <div className="flex items-center gap-3 sm:gap-4">


### PR DESCRIPTION
### Motivation
- Prevent the repo picker from showing repositories accessible via another teammate's GitHub token by scoping repo-listing/tracking/untracking to the authenticated user's GitHub integration.
- Improve post-OAuth UX by expanding the GitHub repo picker and scrolling the page to the GitHub connector so the user can immediately pick repos.
- Ensure the frontend only prefetches repo lists when the current user (not any team member) has an active GitHub connection to match backend ownership semantics.

### Description
- Require `Integration.user_id == auth.user_id` in the GitHub repo listing pre-check and instantiate `GitHubConnector` with `user_id=auth.user_id_str` for `list`, `track`, and `untrack` endpoints in `backend/api/routes/sync.py` so backend repo access is scoped to the current user.
- Update `frontend/src/components/DataSources.tsx` to only prefetch available GitHub repos when the current user has an active GitHub connection (`currentUserConnected`), preventing other users' repos from appearing.
- Add a `connectorCardRefs` map and `githubAutoScrollPending` flag in `DataSources.tsx`, set the flag after a successful GitHub connect, and call `scrollIntoView` when the GitHub repo picker is opened so the UI auto-focuses the GitHub card.
- Wire the connector tile `ref` to populate `connectorCardRefs` so the auto-scroll can find the GitHub card.

### Testing
- Ran Python syntax check: `python -m py_compile backend/api/routes/sync.py` — succeeded.
- Built the frontend: `npm run build` in `frontend/` — build succeeded (Vite chunk-size warnings only).
- No automated UI/browser tests were run; change validated via static build and Python compile checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e714fe5180832188d755eb3edb7e11)