### PR TITLE
Include Slack file references in recent channel history context

### DIFF
--- a/backend/messengers/slack.py
+++ b/backend/messengers/slack.py
@@ -496,15 +496,15 @@ class SlackMessenger(WorkspaceMessenger):
         if len(text_compact) > _SLACK_CONTEXT_MESSAGE_CHAR_LIMIT:
             text_compact = f"{text_compact[:_SLACK_CONTEXT_MESSAGE_CHAR_LIMIT]}…"
 
-        file_names: list[str] = []
+        file_references: list[str] = []
         for file_data in files:
-            file_name: str = str(file_data.get("name") or "").strip()
-            if file_name:
-                file_names.append(file_name)
-        if file_names:
-            file_suffix: str = ", ".join(file_names[:3])
-            if len(file_names) > 3:
-                file_suffix = f"{file_suffix}, +{len(file_names) - 3} more"
+            file_reference: str | None = self._format_slack_file_reference(file_data)
+            if file_reference:
+                file_references.append(file_reference)
+        if file_references:
+            file_suffix: str = "; ".join(file_references[:3])
+            if len(file_references) > 3:
+                file_suffix = f"{file_suffix}; +{len(file_references) - 3} more"
             text_compact = f"{text_compact} [files: {file_suffix}]".strip()
 
         ts_value: str = str(slack_message.get("ts") or "").strip()
@@ -515,6 +515,35 @@ class SlackMessenger(WorkspaceMessenger):
             pass
         user_label: str = str(slack_message.get("user") or slack_message.get("bot_id") or "unknown")
         return f"[{ts_display}] {user_label}: {text_compact}"
+
+    def _format_slack_file_reference(self, file_data: dict[str, Any]) -> str | None:
+        """Render a compact Slack file reference so downstream tools can fetch content."""
+        file_name: str = str(file_data.get("name") or file_data.get("title") or "").strip()
+        file_id: str = str(file_data.get("id") or "").strip()
+        if not file_name and not file_id:
+            return None
+
+        # Prefer auth-gated download URL so agents can retrieve bytes via Slack connector.
+        file_url: str = str(
+            file_data.get("url_private_download")
+            or file_data.get("url_private")
+            or file_data.get("permalink")
+            or ""
+        ).strip()
+        mime_type: str = str(file_data.get("mimetype") or "").strip()
+
+        reference_parts: list[str] = []
+        if file_id:
+            reference_parts.append(f"id={file_id}")
+        if file_url:
+            reference_parts.append(f"url={file_url}")
+        if mime_type:
+            reference_parts.append(f"mimetype={mime_type}")
+        reference_payload: str = ", ".join(reference_parts)
+
+        if reference_payload:
+            return f"{file_name or 'unnamed-file'} <slack_file_ref {reference_payload}>"
+        return file_name or "unnamed-file"
 
     def _summarize_channel_history_if_needed(
         self,

--- a/backend/tests/test_slack_channel_name_resolution.py
+++ b/backend/tests/test_slack_channel_name_resolution.py
@@ -690,3 +690,27 @@ def test_format_channel_history_context_inserts_thread_messages_at_thread_start(
     latest_non_thread_idx = rendered.index("latest non-thread message")
 
     assert starter_idx < reply_one_idx < reply_two_idx < middle_non_thread_idx < latest_non_thread_idx
+
+
+def test_format_single_slack_context_line_includes_file_references():
+    messenger = SlackMessenger()
+    line = messenger._format_single_slack_context_line(
+        {
+            "ts": "1710711602.000",
+            "user": "U3",
+            "text": "Please review this",
+            "files": [
+                {
+                    "id": "F123",
+                    "name": "q1-report.pdf",
+                    "url_private_download": "https://files.slack.com/files-pri/T1-F123/download/q1-report.pdf",
+                    "mimetype": "application/pdf",
+                }
+            ],
+        }
+    )
+
+    assert line is not None
+    assert "q1-report.pdf" in line
+    assert "<slack_file_ref id=F123" in line
+    assert "url=https://files.slack.com/files-pri/T1-F123/download/q1-report.pdf" in line


### PR DESCRIPTION
### Motivation
- When Slack history is attached to agent prompts, historical messages that reference files should surface structured references so the agent can fetch/extract those files if needed.

### Description
- Added `_format_slack_file_reference` to render compact structured file refs (`id=..., url=..., mimetype=...`) and emit them inline as `<slack_file_ref ...>` metadata in history lines in `backend/messengers/slack.py`.
- Replaced simple file-name rendering with `file_references` and preserved compactness by limiting rendered entries and using the existing `+N more` truncation behavior.
- Updated channel-history formatting to include these references in `_format_single_slack_context_line` in `backend/messengers/slack.py`.
- Added a regression test `test_format_single_slack_context_line_includes_file_references` in `backend/tests/test_slack_channel_name_resolution.py` to assert `id` and `url` appear in the formatted line.

### Testing
- Ran `pytest -q backend/tests/test_slack_channel_name_resolution.py` and the file-level tests passed (`21 passed, 2 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7984c22cc832186711715018e9907)