### PR TITLE
Harden chart artifact HTML rendering against XSS injection

### DIFF
--- a/backend/api/routes/artifacts.py
+++ b/backend/api/routes/artifacts.py
@@ -467,7 +467,7 @@ def _generate_chart_html(plotly_json: str, title: str) -> str:
         raise ValueError("Invalid chart payload: 'config' must be a JSON object")
 
     safe_title: str = html.escape(title, quote=True)
-    safe_chart_json: str = json.dumps(chart_spec, ensure_ascii=False)
+    safe_chart_json: str = json.dumps(chart_spec, ensure_ascii=False).replace("</", "<\\/")
 
     return f"""<!DOCTYPE html>
 <html lang="en">

--- a/backend/api/routes/artifacts.py
+++ b/backend/api/routes/artifacts.py
@@ -10,7 +10,9 @@ Provides endpoints to:
 - Download artifacts as files
 - List artifacts in a conversation
 """
-from typing import Optional
+import html
+import json
+from typing import Any, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -328,7 +330,10 @@ async def download_artifact(
             )
         
         elif content_type == "chart":
-            html_content: str = _generate_chart_html(artifact.content, artifact.title or "Chart")
+            try:
+                html_content: str = _generate_chart_html(artifact.content, artifact.title or "Chart")
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
             if not filename.endswith(".html"):
                 filename = filename.rsplit(".", 1)[0] + ".html"
             return Response(
@@ -430,20 +435,46 @@ def _get_extension(content_type: str) -> str:
 def _generate_chart_html(plotly_json: str, title: str) -> str:
     """
     Generate standalone HTML file with embedded Plotly chart.
-    
+
     Args:
         plotly_json: Plotly figure specification as JSON string
         title: Chart title for HTML page
-        
+
     Returns:
         Complete HTML document as string
+
+    Raises:
+        ValueError: If the chart payload is invalid
     """
+    try:
+        chart_spec: Any = json.loads(plotly_json)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Invalid chart JSON payload") from exc
+
+    if not isinstance(chart_spec, dict):
+        raise ValueError("Invalid chart payload: expected a JSON object")
+
+    data = chart_spec.get("data")
+    if not isinstance(data, list):
+        raise ValueError("Invalid chart payload: 'data' must be a JSON array")
+
+    layout = chart_spec.get("layout")
+    if layout is not None and not isinstance(layout, dict):
+        raise ValueError("Invalid chart payload: 'layout' must be a JSON object")
+
+    config = chart_spec.get("config")
+    if config is not None and not isinstance(config, dict):
+        raise ValueError("Invalid chart payload: 'config' must be a JSON object")
+
+    safe_title: str = html.escape(title, quote=True)
+    safe_chart_json: str = json.dumps(chart_spec, ensure_ascii=False)
+
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{title}</title>
+    <title>{safe_title}</title>
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
     <style>
         body {{
@@ -461,8 +492,8 @@ def _generate_chart_html(plotly_json: str, title: str) -> str:
 <body>
     <div id="chart"></div>
     <script>
-        const spec = {plotly_json};
-        Plotly.newPlot('chart', spec.data, spec.layout || {{}}, {{responsive: true}});
+        const spec = {safe_chart_json};
+        Plotly.newPlot('chart', spec.data, spec.layout || {{}}, spec.config || {{responsive: true}});
     </script>
 </body>
 </html>"""

--- a/backend/api/routes/artifacts.py
+++ b/backend/api/routes/artifacts.py
@@ -493,7 +493,7 @@ def _generate_chart_html(plotly_json: str, title: str) -> str:
     <div id="chart"></div>
     <script>
         const spec = {safe_chart_json};
-        Plotly.newPlot('chart', spec.data, spec.layout || {{}}, spec.config || {{responsive: true}});
+        Plotly.newPlot('chart', spec.data, spec.layout || {{}}, {{responsive: true, ...(spec.config || {{}})}});
     </script>
 </body>
 </html>"""

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -14,7 +14,7 @@ from api.routes.public import (
     _public_preview_title,
     share_router,
 )
-from api.routes.artifacts import get_artifact
+from api.routes.artifacts import _generate_chart_html, get_artifact
 from starlette.routing import Match
 from services.public_previews import build_preview_html, decode_data_url_image, render_card_png
 
@@ -191,3 +191,15 @@ def test_api_artifact_route_is_resolved_before_slug_unfurl_route() -> None:
             break
 
     assert matched_endpoint is get_artifact
+
+
+def test_generate_chart_html_escapes_script_termination_sequences() -> None:
+    plotly_json = (
+        '{"data":[{"type":"scatter","text":"<\\/script><script>alert(1)</script>"}],'
+        '"layout":{},"config":{}}'
+    )
+
+    html = _generate_chart_html(plotly_json, "Quarterly report")
+
+    assert "</script><script>alert(1)</script>" not in html
+    assert "<\\/script><script>alert(1)<\\/script>" in html

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -193,6 +193,14 @@ def test_api_artifact_route_is_resolved_before_slug_unfurl_route() -> None:
     assert matched_endpoint is get_artifact
 
 
+def test_generate_chart_html_keeps_responsive_true_when_config_present() -> None:
+    plotly_json = '{"data":[{"type":"scatter","y":[1,2,3]}],"layout":{},"config":{"displayModeBar":false}}'
+
+    html = _generate_chart_html(plotly_json, "Quarterly report")
+
+    assert "{responsive: true, ...(spec.config || {})}" in html
+
+
 def test_generate_chart_html_escapes_script_termination_sequences() -> None:
     plotly_json = (
         '{"data":[{"type":"scatter","text":"<\\/script><script>alert(1)</script>"}],'


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled chart payloads or chart titles from injecting scripts into downloadable artifact HTML and executing in the artifact origin.
- Ensure chart artifacts embed only well-formed Plotly specs and that any invalid payloads are rejected rather than emitted as HTML.
- Reduce risk of leaking browser-local secrets (cookies, localStorage, in-page org data) via crafted artifacts.

### Description
- Import `html` and `json` and parse/validate the stored `plotly_json` payload, enforcing `data` as an array and `layout`/`config` as objects when present.
- HTML-escape the chart title before interpolating into the `<title>` tag and re-serialize the validated chart spec with `json.dumps` before embedding it into the inline `<script>` block.
- Change the chart download path to raise `HTTP 400` for invalid chart payloads by catching `ValueError` from the generator and returning a safe error instead of returning unsafe HTML.
- Adjust `Plotly.newPlot` call to use the validated `spec.config` and fall back to a responsive configuration.

### Testing
- Ran `python -m compileall backend/api/routes/artifacts.py` and the file compiled successfully.
- Ran `pytest -q backend/tests/test_public_previews.py` and all tests passed (`18 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a37f3a18832190515b6bd8bcdfd6)