### PR TITLE
Fix detached App instance in AppsConnector._read

### DIFF
--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -279,12 +279,25 @@ class AppsConnector(BaseConnector):
                 )
             )
             app: App | None = result.scalar_one_or_none()
+            if not app:
+                return {"error": f"App not found: {app_id}"}
 
-        if not app:
-            return {"error": f"App not found: {app_id}"}
+            # Materialize all needed fields while the instance is still bound
+            # to the active SQLAlchemy session. This avoids DetachedInstanceError
+            # when attribute refresh is attempted after context exit.
+            title: str = app.title
+            description: str | None = app.description
+            queries: dict[str, Any] = dict(app.queries or {})
+            frontend_code: str = app.frontend_code
+
+        logger.debug(
+            "[AppsConnector] Read app payload materialized inside session: app_id=%s query_count=%d",
+            app_id,
+            len(queries),
+        )
 
         queries_with_line_numbers: dict[str, Any] = {}
-        for qname, qspec in app.queries.items():
+        for qname, qspec in queries.items():
             queries_with_line_numbers[qname] = {
                 **qspec,
                 "sql_with_lines": self._add_line_numbers(qspec.get("sql", "")),
@@ -293,11 +306,11 @@ class AppsConnector(BaseConnector):
         return {
             "status": "success",
             "app_id": app_id,
-            "title": app.title,
-            "description": app.description,
+            "title": title,
+            "description": description,
             "queries": queries_with_line_numbers,
-            "frontend_code": app.frontend_code,
-            "frontend_code_with_lines": self._add_line_numbers(app.frontend_code),
+            "frontend_code": frontend_code,
+            "frontend_code_with_lines": self._add_line_numbers(frontend_code),
         }
 
     async def _resolve_user_from_external_actor(

--- a/backend/tests/test_apps_connector_owner_resolution.py
+++ b/backend/tests/test_apps_connector_owner_resolution.py
@@ -326,3 +326,63 @@ def test_create_returns_org_handle_scoped_uri_when_handle_present(monkeypatch):
 
     assert result["status"] == "success"
     assert result["uri"].startswith("/acme/apps/")
+
+
+def test_read_materializes_fields_before_session_exit(monkeypatch):
+    org_id = "00000000-0000-0000-0000-000000000010"
+    app_id = "00000000-0000-0000-0000-000000000099"
+
+    class _DetachedAwareApp:
+        def __init__(self) -> None:
+            self.detached = False
+
+        @property
+        def title(self):
+            if self.detached:
+                raise RuntimeError("detached")
+            return "Test App"
+
+        @property
+        def description(self):
+            if self.detached:
+                raise RuntimeError("detached")
+            return "desc"
+
+        @property
+        def queries(self):
+            if self.detached:
+                raise RuntimeError("detached")
+            return {"q1": {"sql": "SELECT 1 AS one", "params": {}}}
+
+        @property
+        def frontend_code(self):
+            if self.detached:
+                raise RuntimeError("detached")
+            return "export default function App(){ return <div/>; }"
+
+    class _ReadSession:
+        def __init__(self, app):
+            self.app = app
+
+        async def execute(self, _query, _params=None):
+            return _FakeExecuteResult(self.app)
+
+    app = _DetachedAwareApp()
+    fake_session = _ReadSession(app)
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        try:
+            yield fake_session
+        finally:
+            app.detached = True
+
+    monkeypatch.setattr("connectors.apps.get_session", _fake_get_session)
+
+    connector = AppsConnector(organization_id=org_id, user_id=None)
+    result = asyncio.run(connector._read(app_id))
+
+    assert result["status"] == "success"
+    assert result["app_id"] == app_id
+    assert result["title"] == "Test App"
+    assert "sql_with_lines" in result["queries"]["q1"]


### PR DESCRIPTION
### Motivation
- `query_on_connector(connector='apps', query='read <app_id>')` could raise `Instance <App ...> is not bound to a Session; attribute refresh operation cannot proceed` because ORM attributes were accessed after the DB session closed.
- The change ensures connector reads return plain Python data and never touch mapped attributes once the session context has exited.

### Description
- In `connectors.apps._read` materialize required `App` fields (`title`, `description`, `queries`, `frontend_code`) while inside the `get_session` context and build the response from those plain values after the session closes.
- Replace post-session access to `app` with the copied local variables and iterate over the materialized `queries` instead of `app.queries`.
- Add a debug log line to trace successful payload materialization: `logger.debug("[AppsConnector] Read app payload materialized inside session: app_id=%s query_count=%d", ...)`.
- Add a regression test `test_read_materializes_fields_before_session_exit` in `backend/tests/test_apps_connector_owner_resolution.py` that simulates a detached `App` instance and verifies `_read` still succeeds.

### Testing
- Ran `pytest -q backend/tests/test_apps_connector_owner_resolution.py`, which passed (`6 passed in 2.89s`).
- The new regression test verifies the specific detached-instance failure mode is prevented by the materialization change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7fc3922d483219bb6229519b31df9)