### PR TITLE
Select scalar columns for chat attachments and preserve ordering

### DIFF
--- a/backend/connectors/linear.py
+++ b/backend/connectors/linear.py
@@ -679,7 +679,14 @@ Use `write_on_connector(connector='linear', operation='...', data={...})` with `
         conversation_id: str,
         attachment_ids: list[str],
     ) -> list[tuple[str, str, bytes]]:
-        """Load attachment bytes scoped to org and conversation; order matches ``attachment_ids``."""
+        """Load attachment bytes scoped to org and conversation; order matches ``attachment_ids``.
+
+        NOTE:
+        We intentionally select scalar columns (not ORM instances) so callers can
+        safely consume results after the DB session context exits. This avoids
+        detached-instance/session-binding errors when attachment bytes are used in
+        follow-up API calls (e.g., Linear uploads).
+        """
         org_uuid: UUID = UUID(self.organization_id)
         conv_uuid: UUID = UUID(conversation_id)
         id_list: list[UUID] = []
@@ -693,27 +700,42 @@ Use `write_on_connector(connector='linear', operation='...', data={...})` with `
 
         async with get_session(organization_id=self.organization_id) as session:
             stmt = (
-                select(ChatAttachment)
+                select(
+                    ChatAttachment.id,
+                    ChatAttachment.filename,
+                    ChatAttachment.mime_type,
+                    ChatAttachment.content,
+                )
                 .join(Conversation, ChatAttachment.conversation_id == Conversation.id)
                 .where(Conversation.organization_id == org_uuid)
                 .where(ChatAttachment.conversation_id == conv_uuid)
                 .where(ChatAttachment.id.in_(id_list))
             )
             result = await session.execute(stmt)
-            rows_db: list[ChatAttachment] = list(result.scalars().all())
+            rows_db: list[tuple[UUID, str, str, bytes]] = list(result.all())
 
-        by_id: dict[UUID, ChatAttachment] = {r.id: r for r in rows_db}
+        by_id: dict[UUID, tuple[str, str, bytes]] = {
+            row_id: (filename, mime_type, content)
+            for row_id, filename, mime_type, content in rows_db
+        }
         ordered: list[tuple[str, str, bytes]] = []
         for uid in id_list:
-            row: ChatAttachment | None = by_id.get(uid)
-            if row is None:
+            row_data: tuple[str, str, bytes] | None = by_id.get(uid)
+            if row_data is None:
                 logger.warning(
                     "[linear] Attachment %s not found or not in conversation %s",
                     uid,
                     conversation_id,
                 )
                 continue
-            ordered.append((row.filename, row.mime_type, row.content))
+            ordered.append(row_data)
+
+        logger.info(
+            "[linear] Loaded %d/%d chat attachments for conversation=%s",
+            len(ordered),
+            len(id_list),
+            conversation_id,
+        )
         return ordered
 
     async def _markdown_block_from_chat_attachments(

--- a/backend/tests/test_linear_issue_attachments.py
+++ b/backend/tests/test_linear_issue_attachments.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
 
 import pytest
+from sqlalchemy.sql import Select
 
 from connectors.linear import (
     LinearConnector,
@@ -22,6 +24,56 @@ def test_normalize_uuid_string_list() -> None:
     assert _normalize_uuid_string_list("  x  ") == ["x"]
     assert _normalize_uuid_string_list([" a ", "b"]) == ["a", "b"]
     assert _normalize_uuid_string_list({}) == []
+
+
+@pytest.mark.asyncio
+async def test_load_chat_attachments_queries_scalar_columns_and_preserves_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Regression test for SQLAlchemy bhk3 detached-instance failures.
+
+    We assert the loader uses scalar column selection (not ORM entity instances),
+    and that output ordering follows `attachment_ids`.
+    """
+    connector = LinearConnector(organization_id="00000000-0000-0000-0000-000000000001")
+    aid_1: str = "11111111-1111-1111-1111-111111111111"
+    aid_2: str = "22222222-2222-2222-2222-222222222222"
+    conv: str = "33333333-3333-3333-3333-333333333333"
+    captured_stmt: Select | None = None
+
+    class _FakeResult:
+        def all(self) -> list[tuple[Any, ...]]:
+            # Return rows in DB order opposite from request order to verify reordering.
+            return [
+                (UUID(aid_2), "b.png", "image/png", b"b"),
+                (UUID(aid_1), "a.txt", "text/plain", b"a"),
+            ]
+
+    class _FakeSession:
+        async def execute(self, stmt: Select) -> _FakeResult:
+            nonlocal captured_stmt
+            captured_stmt = stmt
+            return _FakeResult()
+
+    class _FakeCM:
+        async def __aenter__(self) -> _FakeSession:
+            return _FakeSession()
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+    monkeypatch.setattr("connectors.linear.get_session", lambda **_: _FakeCM())
+
+    loaded = await connector._load_chat_attachments_for_issue(
+        conversation_id=conv,
+        attachment_ids=[aid_1, aid_2],
+    )
+
+    assert loaded == [("a.txt", "text/plain", b"a"), ("b.png", "image/png", b"b")]
+    assert captured_stmt is not None
+    selected_cols = [col.key for col in captured_stmt.selected_columns]
+    assert selected_cols == ["id", "filename", "mime_type", "content"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation

- Avoid SQLAlchemy detached-instance/session-binding errors by returning scalar columns instead of ORM instances when loading chat attachment bytes for use outside the DB session.
- Ensure attachment output ordering matches the requested `attachment_ids` even if DB returns rows in a different order.

### Description

- Change `_load_chat_attachments_for_issue` to `select` scalar columns (`id`, `filename`, `mime_type`, `content`) instead of the `ChatAttachment` ORM entity and consume `result.all()` to get tuples. 
- Build an ID->(filename, mime_type, content) mapping from the scalar rows and reorder results to match the requested `attachment_ids`. 
- Add explanatory docstring note and an informational `logger.info` call that reports how many attachments were loaded vs requested.
- Update callers to continue receiving `list[tuple[str, str, bytes]]` and keep existing behavior for downstream upload code.

### Testing

- Added `test_load_chat_attachments_queries_scalar_columns_and_preserves_order` which mocks the DB session and verifies scalar column selection and correct result ordering, and this test passed. 
- Ran the test file `backend/tests/test_linear_issue_attachments.py` (including `test_upload_bytes_to_linear` and the new regression test) and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e80b956d988321816c0a53590fe616)