### PR TITLE
Fix Slack identity linking, org resolution, and org deletion

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1620,7 +1620,7 @@ async def link_identity(
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ID format")
 
-    async with get_session() as session:
+    async with get_session(organization_id=str(org_uuid)) as session:
         # Verify target user belongs to this org (membership or guest home org)
         target_user: User | None = await session.get(User, target_uuid)
         if not target_user:
@@ -1706,6 +1706,53 @@ async def link_identity(
 
         await session.commit()
 
+    # For Slack identities, also create a messenger_user_mappings record so the
+    # bot's real-time resolver can find the user on subsequent messages.
+    if mapping.source == "slack" and mapping.external_userid:
+        try:
+            from models.messenger_user_mapping import MessengerUserMapping
+            from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+            workspace_id: str | None = None
+            async with get_admin_session() as admin_session:
+                integration_result = await admin_session.execute(
+                    select(Integration)
+                    .where(Integration.organization_id == org_uuid)
+                    .where(Integration.connector == "slack")
+                    .where(Integration.is_active == True)  # noqa: E712
+                    .limit(1)
+                )
+                slack_integration: Integration | None = integration_result.scalar_one_or_none()
+                if slack_integration and slack_integration.extra_data:
+                    workspace_id = (
+                        slack_integration.extra_data.get("team_id")
+                        or slack_integration.extra_data.get("workspace_id")
+                    )
+
+                stmt = pg_insert(MessengerUserMapping).values(
+                    platform="slack",
+                    workspace_id=workspace_id,
+                    external_user_id=mapping.external_userid,
+                    user_id=target_uuid,
+                    organization_id=org_uuid,
+                    external_email=mapping.external_email,
+                    match_source="admin_manual_link",
+                ).on_conflict_do_nothing(
+                    constraint="uq_messenger_user_mappings_platform_ws_extid",
+                )
+                await admin_session.execute(stmt)
+                await admin_session.commit()
+            logger.info(
+                "Created messenger_user_mapping for linked Slack identity org=%s user=%s ext=%s",
+                org_uuid, target_uuid, mapping.external_userid,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to create messenger_user_mapping for linked Slack identity org=%s user=%s ext=%s",
+                org_uuid, target_uuid, mapping.external_userid,
+                exc_info=True,
+            )
+
     return {"status": "linked"}
 
 
@@ -1733,7 +1780,7 @@ async def unlink_identity(
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ID format")
 
-    async with get_session() as session:
+    async with get_session(organization_id=str(org_uuid)) as session:
         requester: User | None = await session.get(User, requester_uuid)
         if not requester or await _get_org_membership(session, requester_uuid, org_uuid) is None:
             raise HTTPException(status_code=403, detail="Not authorized to modify this organization")
@@ -2619,13 +2666,13 @@ async def delete_organization(
             "deals",
             "goals",
             "pipelines",
-            "integrations",
             "github_pull_requests",
             "github_commits",
             "github_repositories",
             "tracker_issues",
             "tracker_projects",
             "tracker_teams",
+            "integrations",
             "meetings",
             "workflow_runs",
             "workflows",

--- a/backend/api/routes/slack_user_mappings.py
+++ b/backend/api/routes/slack_user_mappings.py
@@ -187,18 +187,17 @@ async def list_user_mappings_for_identity(
             .order_by(ExternalIdentityMapping.updated_at.desc(), ExternalIdentityMapping.created_at.desc())
         )
         mappings = result.scalars().all()
-
-    response = [
-        SlackMappingResponse(
-            id=str(mapping.id),
-            external_userid=mapping.external_userid,
-            external_email=mapping.external_email,
-            source=mapping.source,
-            match_source=mapping.match_source,
-            created_at=mapping.created_at.isoformat() + "Z",
-        )
-        for mapping in mappings
-    ]
+        response = [
+            SlackMappingResponse(
+                id=str(mapping.id),
+                external_userid=mapping.external_userid,
+                external_email=mapping.external_email,
+                source=mapping.source,
+                match_source=mapping.match_source,
+                created_at=mapping.created_at.isoformat() + "Z",
+            )
+            for mapping in mappings
+        ]
     return SlackMappingListResponse(mappings=response)
 
 
@@ -228,15 +227,14 @@ async def request_slack_user_mapping_code(
             .order_by(ExternalIdentityMapping.updated_at.desc())
         )
         matched_mappings = result.scalars().all()
-
-    slack_user_candidates: list[str] = []
-    seen_candidates: set[str] = set()
-    for mapping in matched_mappings:
-        candidate = (mapping.external_userid or "").strip()
-        if not candidate or candidate in seen_candidates:
-            continue
-        seen_candidates.add(candidate)
-        slack_user_candidates.append(candidate)
+        slack_user_candidates: list[str] = []
+        seen_candidates: set[str] = set()
+        for mapping in matched_mappings:
+            candidate = (mapping.external_userid or "").strip()
+            if not candidate or candidate in seen_candidates:
+                continue
+            seen_candidates.add(candidate)
+            slack_user_candidates.append(candidate)
 
     logger.info(
         "[user_mappings_for_identity] Lookup Slack mapping for org=%s user=%s email=%s matched=%s",

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -316,6 +316,12 @@ class WorkspaceMessenger(BaseMessenger):
                 self.meta.slug, message.external_user_id, workspace_id,
             )
 
+        await self._ensure_unmapped_identity(
+            organization_id=organization_id,
+            external_user_id=message.external_user_id,
+            external_email=email,
+        )
+
         return await self._resolve_guest_user(organization_id)
 
     def _extract_email_from_profile(self, profile: dict[str, Any]) -> str | None:
@@ -360,6 +366,56 @@ class WorkspaceMessenger(BaseMessenger):
             if guest and getattr(guest, "is_guest", False):
                 return guest
             return None
+
+    async def _ensure_unmapped_identity(
+        self,
+        organization_id: str,
+        external_user_id: str,
+        external_email: str | None,
+    ) -> None:
+        """Create an unmapped ExternalIdentityMapping so admins can manually link it."""
+        from models.external_identity_mapping import ExternalIdentityMapping
+
+        platform: str = self.meta.slug
+        normalized_ext_id: str = external_user_id.strip().upper() if external_user_id else ""
+        if not normalized_ext_id:
+            return
+        try:
+            async with get_admin_session() as session:
+                existing = await session.execute(
+                    select(ExternalIdentityMapping)
+                    .where(ExternalIdentityMapping.organization_id == UUID(organization_id))
+                    .where(ExternalIdentityMapping.source == platform)
+                    .where(ExternalIdentityMapping.external_userid == normalized_ext_id)
+                    .limit(1)
+                )
+                if existing.scalar_one_or_none() is not None:
+                    return
+                now: datetime = datetime.now(UTC).replace(tzinfo=None)
+                mapping = ExternalIdentityMapping(
+                    id=_uuid.uuid4(),
+                    organization_id=UUID(organization_id),
+                    user_id=None,
+                    revtops_email=None,
+                    external_userid=normalized_ext_id,
+                    external_email=external_email,
+                    source=platform,
+                    match_source="messenger_unmatched",
+                    created_at=now,
+                    updated_at=now,
+                )
+                session.add(mapping)
+                await session.commit()
+                logger.info(
+                    "[%s] Created unmapped identity org=%s ext=%s email=%s",
+                    platform, organization_id, normalized_ext_id, external_email,
+                )
+        except Exception:
+            logger.debug(
+                "[%s] Failed to create unmapped identity org=%s ext=%s",
+                platform, organization_id, normalized_ext_id,
+                exc_info=True,
+            )
 
     # ------------------------------------------------------------------
     # Organisation resolution
@@ -414,6 +470,45 @@ class WorkspaceMessenger(BaseMessenger):
             row = result.first()
             if row:
                 org_id = str(row[0])
+
+        # 1b. Validate the bot-install org has an active subscription; if not,
+        #     check Integration table for an org that does (same workspace may
+        #     be connected to a stale org with no credits).
+        if org_id is not None:
+            async with get_admin_session() as session:
+                org_row = await session.execute(
+                    select(Organization.subscription_status).where(
+                        Organization.id == UUID(org_id)
+                    )
+                )
+                status: str | None = (org_row.scalar_one_or_none() or "")
+                if status not in ("active", "trialing"):
+                    alt_result = await session.execute(
+                        select(Integration.organization_id, Organization.subscription_status)
+                        .join(Organization, Organization.id == Integration.organization_id)
+                        .where(Integration.connector == platform)
+                        .where(Integration.is_active == True)  # noqa: E712
+                        .where(Organization.subscription_status.in_(("active", "trialing")))
+                    )
+                    for alt_row in alt_result:
+                        alt_extra_check = await session.execute(
+                            select(Integration.extra_data)
+                            .where(Integration.organization_id == alt_row[0])
+                            .where(Integration.connector == platform)
+                            .where(Integration.is_active == True)  # noqa: E712
+                        )
+                        for (extra_data_row,) in alt_extra_check:
+                            stored_ws: str | None = (extra_data_row or {}).get("team_id") or (extra_data_row or {}).get("workspace_id")
+                            if stored_ws == workspace_id:
+                                logger.info(
+                                    "[%s] Bot-install org %s has no active subscription; "
+                                    "preferring org %s with status=%s for workspace %s",
+                                    platform, org_id, alt_row[0], alt_row[1], workspace_id,
+                                )
+                                org_id = str(alt_row[0])
+                                break
+                        if org_id != str(row[0]):
+                            break
 
         # 2. Fall back to Integration table (for Nango-based installs)
         if org_id is None:

--- a/backend/tests/test_auth_guest_identity_guards.py
+++ b/backend/tests/test_auth_guest_identity_guards.py
@@ -60,7 +60,7 @@ def test_link_identity_rejects_guest_target(monkeypatch):
     )
 
     fake_session = _FakeSession(users={target_user_id: guest_user}, mapping=mapping)
-    monkeypatch.setattr(auth, "get_session", lambda: _FakeSessionContext(fake_session))
+    monkeypatch.setattr(auth, "get_session", lambda **kwargs: _FakeSessionContext(fake_session))
 
     with pytest.raises(HTTPException) as exc:
         asyncio.run(
@@ -92,7 +92,7 @@ def test_unlink_identity_rejects_guest_mapping(monkeypatch):
     )
 
     fake_session = _FakeSession(users={requester_id: requester, guest_user_id: guest_user}, mapping=mapping)
-    monkeypatch.setattr(auth, "get_session", lambda: _FakeSessionContext(fake_session))
+    monkeypatch.setattr(auth, "get_session", lambda **kwargs: _FakeSessionContext(fake_session))
 
     with pytest.raises(HTTPException) as exc:
         asyncio.run(

--- a/backend/tests/test_link_identity_slack.py
+++ b/backend/tests/test_link_identity_slack.py
@@ -94,7 +94,7 @@ def test_link_identity_links_related_slack_mappings(monkeypatch):
     )
 
     fake_session = _FakeSession(target_user, selected_mapping, [related_mapping])
-    monkeypatch.setattr(auth, "get_session", lambda: _FakeSessionContext(fake_session))
+    monkeypatch.setattr(auth, "get_session", lambda **kwargs: _FakeSessionContext(fake_session))
 
     result = asyncio.run(
         auth.link_identity(
@@ -139,7 +139,7 @@ def test_link_identity_non_slack_does_not_attempt_related_linking(monkeypatch):
     )
 
     fake_session = _FakeSession(target_user, selected_mapping, [])
-    monkeypatch.setattr(auth, "get_session", lambda: _FakeSessionContext(fake_session))
+    monkeypatch.setattr(auth, "get_session", lambda **kwargs: _FakeSessionContext(fake_session))
 
     result = asyncio.run(
         auth.link_identity(


### PR DESCRIPTION
## Summary
- Fix RLS issues in link/unlink identity endpoints by passing `organization_id` to `get_session()`
- Auto-create `MessengerUserMapping` when manually linking Slack identities, and create `ExternalIdentityMapping` for unmatched Slack users so admins can link them from the UI
- Prefer orgs with active/trialing subscription when resolving Slack workspace to org (handles duplicate workspace mappings)
- Fix org deletion foreign key constraint by reordering table deletion (github_*/tracker_* before integrations)
- Fix `DetachedInstanceError` in slack_user_mappings by extracting data before closing the session

## Test plan
- [x] All 484 backend tests pass (1 pre-existing failure in `test_public_origin_prefers_forwarded_proxy_headers` unrelated to this PR)
- [x] Frontend build passes

Made with [Cursor](https://cursor.com)