### PR TITLE
Add structured logging for common connector sync failure cases

### DIFF
--- a/backend/tests/test_sync_failure_logging.py
+++ b/backend/tests/test_sync_failure_logging.py
@@ -1,0 +1,70 @@
+import asyncio
+import logging
+from datetime import datetime
+from typing import Any, Optional
+
+from workers.tasks import sync as sync_tasks
+
+
+class FailingConnector:
+    def __init__(
+        self,
+        organization_id: str,
+        user_id: Optional[str] = None,
+        *,
+        sync_since_override: datetime | None = None,
+    ) -> None:
+        self.organization_id = organization_id
+        self.user_id = user_id
+
+    async def sync_all(self) -> dict[str, int]:
+        raise RuntimeError("Slack API error: invalid_auth for test")
+
+    async def mark_sync_started(self) -> None:
+        return None
+
+    async def clear_sync_started(self) -> None:
+        return None
+
+    async def update_last_sync(self, counts: dict[str, int]) -> None:
+        return None
+
+    async def record_error(self, error: str) -> None:
+        return None
+
+
+def test_classify_sync_failure_common_cases() -> None:
+    assert sync_tasks._classify_sync_failure("invalid_auth on upstream")[0] == "auth_or_connection_revoked"
+    assert sync_tasks._classify_sync_failure("429 Too Many Requests")[0] == "upstream_rate_limited"
+    assert sync_tasks._classify_sync_failure("read timeout from upstream")[0] == "upstream_transient_error"
+    assert sync_tasks._classify_sync_failure("totally novel failure")[0] == "unexpected_failure"
+
+
+def test_sync_failure_logging_includes_case_and_context(monkeypatch, caplog) -> None:
+    emitted_events: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def _emit_event(event_type: str, organization_id: str, data: dict[str, Any]) -> None:
+        emitted_events.append((event_type, organization_id, data))
+
+    async def _noop_clear_last_errors(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("workers.events.emit_event", _emit_event)
+    monkeypatch.setattr(sync_tasks, "_clear_last_errors_for_integration", _noop_clear_last_errors)
+    monkeypatch.setattr(
+        "connectors.registry.discover_connectors",
+        lambda: {"slack": FailingConnector},
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = asyncio.run(
+            sync_tasks._sync_integration("11111111-1111-1111-1111-111111111111", "slack")
+        )
+
+    assert result["status"] == "failed"
+    assert any(
+        "Connector sync failed provider=slack" in rec.message
+        and "case=auth_or_connection_revoked" in rec.message
+        for rec in caplog.records
+    )
+    assert any(event[0] == "sync.failed" for event in emitted_events)

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -51,6 +51,60 @@ def _parse_sync_since_iso(iso_str: str | None) -> datetime | None:
     return parsed
 
 
+def _classify_sync_failure(error_message: str) -> tuple[str, int]:
+    """
+    Classify common connector sync failure modes for clearer logging.
+
+    Returns:
+        Tuple of (failure_case, suggested_log_level)
+    """
+    normalized = error_message.lower()
+    if any(
+        snippet in normalized
+        for snippet in (
+            "connection not found",
+            "invalid_auth",
+            "token_revoked",
+            "auth revoked",
+            "account_inactive",
+            "not_authed",
+            "revoked",
+            "unauthorized",
+            "forbidden",
+            "401",
+            "403",
+        )
+    ):
+        return ("auth_or_connection_revoked", logging.WARNING)
+    if any(
+        snippet in normalized
+        for snippet in (
+            "rate limit",
+            "rate_limit",
+            "too many requests",
+            "429",
+        )
+    ):
+        return ("upstream_rate_limited", logging.WARNING)
+    if any(
+        snippet in normalized
+        for snippet in (
+            "timed out",
+            "timeout",
+            "temporarily unavailable",
+            "service unavailable",
+            "bad gateway",
+            "gateway timeout",
+            "502",
+            "503",
+            "504",
+            "connection reset",
+        )
+    ):
+        return ("upstream_transient_error", logging.WARNING)
+    return ("unexpected_failure", logging.ERROR)
+
+
 async def _clear_last_errors_for_integration(
     organization_id: str,
     provider: str,
@@ -218,7 +272,17 @@ async def _sync_integration(
 
     except Exception as e:
         error_msg = str(e)
-        logger.error(f"Sync failed for {provider} in org {organization_id}: {error_msg}")
+        failure_case, log_level = _classify_sync_failure(error_msg)
+        logger.log(
+            log_level,
+            "Connector sync failed provider=%s org=%s user=%s case=%s error=%s",
+            provider,
+            organization_id,
+            user_id,
+            failure_case,
+            error_msg,
+            exc_info=True,
+        )
 
         # Record error in database and clear in-progress flag
         try:


### PR DESCRIPTION
### Motivation
- Improve observability when connector syncs fail by classifying common failure modes and emitting richer logs for troubleshooting.
- Keep existing failure persistence and event emission behavior intact while surfacing actionable context (provider/org/user/case).

### Description
- Add `_classify_sync_failure(error_message: str) -> tuple[str, int]` in `workers/tasks/sync.py` to bucket errors into `auth_or_connection_revoked`, `upstream_rate_limited`, `upstream_transient_error`, and `unexpected_failure` with suggested log levels.
- Replace the generic error log in `_sync_integration` with a structured log call that includes `provider`, `organization_id`, `user_id`, `case`, the original error message, and `exc_info=True` to include stack traces.
- Preserve existing behavior that clears `sync_started_at`, records `last_error`, and emits the `sync.failed` event on error.
- Add `backend/tests/test_sync_failure_logging.py` to validate classification logic and assert the log context is emitted for a simulated failing connector.

### Testing
- Ran `cd backend && pytest -q tests/test_sync_failure_logging.py tests/test_sync_cancellation.py`, and the test run completed successfully with `3 passed, 2 warnings`.
- The new tests assert `_classify_sync_failure` returns expected buckets and that `_sync_integration` emits a log record containing the failure `case` and the `Connector sync failed provider=...` context.
- Existing cancellation behavior is covered by the `tests/test_sync_cancellation.py` regression test which still passes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e82fa2b9508321a37553541506598e)