### PR TITLE
Persist and restore Slack file metadata in activity cache

### DIFF
--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -1243,6 +1243,21 @@ class WorkspaceMessenger(BaseMessenger):
                     "sender_slack_id": message.external_user_id,
                     "thread_ts": thread_id,
                 }
+                raw_files: Any = message.raw_attachments or []
+                if isinstance(raw_files, list):
+                    persisted_files: list[dict[str, Any]] = [
+                        file_data
+                        for file_data in raw_files
+                        if isinstance(file_data, dict)
+                    ]
+                    if persisted_files:
+                        custom_fields["files"] = persisted_files
+                        logger.debug(
+                            "[%s] Persisting %d attachment(s) in activity cache source_id=%s",
+                            self.meta.slug,
+                            len(persisted_files),
+                            source_id,
+                        )
                 if channel_name:
                     custom_fields["channel_name"] = channel_name
 

--- a/backend/messengers/slack.py
+++ b/backend/messengers/slack.py
@@ -359,6 +359,12 @@ class SlackMessenger(WorkspaceMessenger):
             cf: dict[str, Any] = custom_fields or {}
             raw_thread_ts: str = str(cf.get("thread_ts") or "").strip()
             thread_ts: str = raw_thread_ts or ts_value
+            raw_files: Any = cf.get("files")
+            files: list[dict[str, Any]] = (
+                [file_data for file_data in raw_files if isinstance(file_data, dict)]
+                if isinstance(raw_files, list)
+                else []
+            )
             cached_messages.append(
                 {
                     "ts": ts_value,
@@ -366,15 +372,20 @@ class SlackMessenger(WorkspaceMessenger):
                     "is_thread_message": bool(raw_thread_ts),
                     "user": str(cf.get("user_id") or "unknown"),
                     "text": description or "",
-                    "files": [],
+                    "files": files,
                     "reply_count": 0,
                 }
             )
+        file_count: int = sum(
+            len(message.get("files") or [])
+            for message in cached_messages
+        )
         logger.info(
-            "[slack] Loaded channel context from persisted activity cache channel=%s organization=%s messages=%d",
+            "[slack] Loaded channel context from persisted activity cache channel=%s organization=%s messages=%d files=%d",
             channel_id,
             organization_id,
             len(cached_messages),
+            file_count,
         )
         return self._build_channel_context_payload_from_cached_messages(cached_messages)
 

--- a/backend/tests/test_slack_channel_name_resolution.py
+++ b/backend/tests/test_slack_channel_name_resolution.py
@@ -66,6 +66,14 @@ async def test_persist_channel_activity_uses_channel_name():
         message_type=MessageType.DIRECT,
         external_user_id="U123",
         message_id="1710711600.000", # Fixed TS for deterministic testing
+        raw_attachments=[
+            {
+                "id": "F123",
+                "name": "proposal.docx",
+                "url_private_download": "https://files.slack.com/files-pri/T1-F123/download/proposal.docx",
+                "mimetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            }
+        ],
         messenger_context={
             "workspace_id": workspace_id,
             "channel_id": channel_id,
@@ -97,6 +105,8 @@ async def test_persist_channel_activity_uses_channel_name():
         assert passed_values["subject"] == f"#{channel_name}"
         assert passed_values["custom_fields"]["channel_name"] == channel_name
         assert passed_values["custom_fields"]["channel_id"] == channel_id
+        assert passed_values["custom_fields"]["files"][0]["id"] == "F123"
+        assert passed_values["custom_fields"]["files"][0]["name"] == "proposal.docx"
         
 @pytest.mark.asyncio
 async def test_enrich_message_context_does_not_overwrite_existing():
@@ -714,3 +724,52 @@ def test_format_single_slack_context_line_includes_file_references():
     assert "q1-report.pdf" in line
     assert "<slack_file_ref id=F123" in line
     assert "url=https://files.slack.com/files-pri/T1-F123/download/q1-report.pdf" in line
+
+
+@pytest.mark.asyncio
+async def test_get_cached_channel_context_payload_from_activity_preserves_file_metadata():
+    messenger = SlackMessenger()
+    org_id = str(uuid4())
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.all.return_value = [
+        (
+            "C456:1710711600.000",
+            "Hey Guys, here is Farooq's proposal",
+            {
+                "channel_id": "C456",
+                "user_id": "U_JACK",
+                "thread_ts": "1710711600.000",
+                "files": [
+                    {
+                        "id": "F123",
+                        "name": "proposal.docx",
+                        "url_private_download": "https://files.slack.com/files-pri/T1-F123/download/proposal.docx",
+                        "mimetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    }
+                ],
+            },
+            None,
+            None,
+        )
+    ]
+    mock_session.execute.return_value = mock_result
+    mock_session_ctx = MagicMock(
+        __aenter__=AsyncMock(return_value=mock_session),
+        __aexit__=AsyncMock(return_value=None),
+    )
+
+    with patch("messengers.slack.get_admin_session", return_value=mock_session_ctx):
+        payload = await messenger._get_cached_channel_context_payload_from_activity(
+            organization_id=org_id,
+            channel_id="C456",
+        )
+
+    assert payload is not None
+    channel_messages, _thread_expansions = payload
+    assert len(channel_messages) == 1
+    assert channel_messages[0]["files"][0]["id"] == "F123"
+    rendered = messenger._format_single_slack_context_line(channel_messages[0])
+    assert rendered is not None
+    assert "<slack_file_ref id=F123" in rendered


### PR DESCRIPTION
### Motivation

- Channel message attachments were not being persisted to the `Activity` row, so cached activity reconstruction lost file metadata and agents could not see attachments from cached history.

### Description

- Persist `InboundMessage.raw_attachments` into `Activity.custom_fields["files"]` when saving workspace channel activity in `persist_channel_activity` (only dict-like attachment entries are stored) by updating `backend/messengers/_workspace.py`.
- Hydrate cached messages with persisted file metadata when loading activity cache by reading `custom_fields["files"]` and populating the `files` key for each cached message in `backend/messengers/slack.py` instead of hardcoding `files: []`.
- Add informational/debug logging that reports how many files were persisted per activity row and the total recovered file count when loading the cache.
- Add and update tests in `backend/tests/test_slack_channel_name_resolution.py` to verify that `files` metadata is written into `custom_fields` and that cached payloads preserve and render file refs (via `_format_single_slack_context_line`).

### Testing

- Ran the Slack-channel tests: `cd /workspace/basebase/backend && pytest -q tests/test_slack_channel_name_resolution.py`, which completed successfully with `22 passed` and `2 warnings`.
- New/updated unit tests assert persisted `custom_fields["files"]` contains the expected attachment entries and that cache-loaded messages render `<slack_file_ref ...>` references.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e84cda434c83218b57f3e7d740fc93)