### PR TITLE
Handle Slack message permalinks when reading linked file attachments

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -16,6 +16,7 @@ import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 import httpx
 from sqlalchemy import func, select
@@ -23,6 +24,10 @@ from sqlalchemy import func, select
 
 _SEPARATOR_ROW_RE: re.Pattern[str] = re.compile(
     r'^\|?[\s\-:|]+\|?$'
+)
+_SLACK_MESSAGE_PERMALINK_RE: re.Pattern[str] = re.compile(
+    r"^/archives/(?P<channel>[A-Z0-9]+)/p(?P<raw_ts>\d{16,})$",
+    re.IGNORECASE,
 )
 _MARKDOWN_TABLE_CODE_BLOCK_TEMPLATE: str = "```\n{table}\n```"
 _markdown_logger = logging.getLogger(__name__)
@@ -1286,6 +1291,16 @@ Returns normalized messages for one channel since a cutoff (does not write to th
         download_url: str | None = None
 
         if normalized_ref.startswith("http://") or normalized_ref.startswith("https://"):
+            permalink_payload: tuple[str, str] | None = self._parse_slack_message_permalink(
+                normalized_ref
+            )
+            if permalink_payload is not None:
+                channel_id, message_ts = permalink_payload
+                return await self._read_files_from_message_permalink(
+                    channel_id=channel_id,
+                    message_ts=message_ts,
+                    permalink=normalized_ref,
+                )
             download_url = normalized_ref
         else:
             file_data = await self._make_request("GET", "files.info", params={"file": normalized_ref})
@@ -1347,6 +1362,105 @@ Returns normalized messages for one channel since a cutoff (does not write to th
                 "content_base64": encoded,
                 "note": "Binary file returned as base64 because text extraction is not supported for this mime type.",
             },
+        }
+
+    def _parse_slack_message_permalink(self, url: str) -> tuple[str, str] | None:
+        """Return ``(channel_id, message_ts)`` when URL is a Slack message permalink."""
+        try:
+            parsed = urlparse(url)
+        except Exception:
+            return None
+
+        if not parsed.netloc.lower().endswith("slack.com"):
+            return None
+
+        match = _SLACK_MESSAGE_PERMALINK_RE.match(parsed.path)
+        if not match:
+            return None
+
+        channel_id: str = str(match.group("channel") or "").upper()
+        raw_ts: str = str(match.group("raw_ts") or "").strip()
+        if not channel_id or len(raw_ts) < 7:
+            return None
+
+        normalized_ts: str = f"{raw_ts[:-6]}.{raw_ts[-6:]}"
+        return channel_id, normalized_ts
+
+    async def _read_files_from_message_permalink(
+        self,
+        *,
+        channel_id: str,
+        message_ts: str,
+        permalink: str,
+    ) -> dict[str, Any]:
+        """Resolve files attached to a Slack message permalink and return extracted payloads."""
+        logger.info(
+            "[slack] read_file resolving message permalink channel=%s ts=%s",
+            channel_id,
+            message_ts,
+        )
+        try:
+            messages: list[dict[str, Any]] = await self.get_channel_messages(
+                channel_id=channel_id,
+                latest=message_ts,
+                limit=1,
+                inclusive=True,
+            )
+        except Exception as exc:
+            logger.warning(
+                "[slack] Failed to resolve permalink to message channel=%s ts=%s error=%s",
+                channel_id,
+                message_ts,
+                exc,
+            )
+            return {
+                "error": (
+                    f"Slack could not resolve message permalink {permalink}: {exc}"
+                )
+            }
+
+        target_message: dict[str, Any] | None = None
+        for message in messages:
+            if str(message.get("ts") or "").strip() == message_ts:
+                target_message = message
+                break
+        if target_message is None:
+            return {"error": f"No Slack message found for permalink: {permalink}"}
+
+        files: list[dict[str, Any]] = target_message.get("files") or []
+        if not files:
+            return {"error": f"No files are attached to Slack message permalink: {permalink}"}
+
+        extracted_files: list[dict[str, Any]] = []
+        for file_entry in files:
+            file_id: str = str(file_entry.get("id") or "").strip()
+            file_url: str = str(
+                file_entry.get("url_private_download")
+                or file_entry.get("url_private")
+                or ""
+            ).strip()
+            if not file_id and not file_url:
+                continue
+            lookup_ref: str = file_id or file_url
+            file_result: dict[str, Any] = await self._read_file_for_query(lookup_ref)
+            if file_result.get("ok") and isinstance(file_result.get("file"), dict):
+                extracted_files.append(file_result["file"])
+
+        if not extracted_files:
+            return {
+                "error": f"Slack message permalink resolved, but no attached files could be downloaded: {permalink}"
+            }
+
+        return {
+            "ok": True,
+            "source": {
+                "type": "slack_message_permalink",
+                "channel_id": channel_id,
+                "ts": message_ts,
+                "permalink": permalink,
+            },
+            "file": extracted_files[0],
+            "files": extracted_files,
         }
 
     async def execute_action(self, action: str, params: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -122,6 +122,116 @@ def test_query_read_file_by_url_returns_base64_for_binary(monkeypatch) -> None:
     assert "Binary file returned as base64" in result["file"]["note"]
 
 
+def test_query_read_file_from_message_permalink_downloads_attached_files(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    async def _fake_get_channel_messages(
+        channel_id: str,
+        oldest: float | None = None,
+        limit: int = 100,
+        latest: str | None = None,
+        inclusive: bool = False,
+    ) -> list[dict[str, object]]:
+        assert channel_id == "C123ABC45"
+        assert latest == "1711405920.999999"
+        assert limit == 1
+        assert inclusive is True
+        assert oldest is None
+        return [
+            {
+                "ts": "1711405920.999999",
+                "files": [
+                    {
+                        "id": "F111",
+                        "name": "first.txt",
+                        "mimetype": "text/plain",
+                        "url_private_download": "https://files.slack.com/files-pri/T/F111/download/first.txt",
+                    },
+                    {
+                        "id": "F222",
+                        "name": "second.txt",
+                        "mimetype": "text/plain",
+                        "url_private_download": "https://files.slack.com/files-pri/T/F222/download/second.txt",
+                    },
+                ],
+            }
+        ]
+
+    async def _fake_make_request(method: str, endpoint: str, **kwargs: object):
+        assert method == "GET"
+        assert endpoint == "files.info"
+        file_id = (kwargs.get("params") or {}).get("file")
+        if file_id == "F111":
+            return {
+                "ok": True,
+                "file": {
+                    "id": "F111",
+                    "name": "first.txt",
+                    "mimetype": "text/plain",
+                    "url_private_download": "https://files.slack.com/files-pri/T/F111/download/first.txt",
+                },
+            }
+        assert file_id == "F222"
+        return {
+            "ok": True,
+            "file": {
+                "id": "F222",
+                "name": "second.txt",
+                "mimetype": "text/plain",
+                "url_private_download": "https://files.slack.com/files-pri/T/F222/download/second.txt",
+            },
+        }
+
+    async def _fake_download_file(url_private: str) -> bytes:
+        if "F111" in url_private:
+            return b"first content"
+        assert "F222" in url_private
+        return b"second content"
+
+    monkeypatch.setattr(connector, "get_channel_messages", _fake_get_channel_messages)
+    monkeypatch.setattr(connector, "_make_request", _fake_make_request)
+    monkeypatch.setattr(connector, "download_file", _fake_download_file)
+
+    result = asyncio.run(
+        connector.query(
+            "read_file:https://acme.slack.com/archives/C123ABC45/p1711405920999999"
+        )
+    )
+    assert result["ok"] is True
+    assert result["source"]["type"] == "slack_message_permalink"
+    assert result["file"]["filename"] == "first.txt"
+    assert [f["filename"] for f in result["files"]] == ["first.txt", "second.txt"]
+    assert result["files"][0]["content"] == "first content"
+    assert result["files"][1]["content"] == "second content"
+
+
+def test_query_read_file_from_message_permalink_without_attachments_returns_error(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    async def _fake_get_channel_messages(
+        channel_id: str,
+        oldest: float | None = None,
+        limit: int = 100,
+        latest: str | None = None,
+        inclusive: bool = False,
+    ) -> list[dict[str, object]]:
+        assert channel_id == "C999"
+        assert latest == "1711405920.999999"
+        assert oldest is None
+        assert limit == 1
+        assert inclusive is True
+        return [{"ts": "1711405920.999999", "files": []}]
+
+    monkeypatch.setattr(connector, "get_channel_messages", _fake_get_channel_messages)
+
+    result = asyncio.run(
+        connector.query(
+            "read_file:https://acme.slack.com/archives/C999/p1711405920999999"
+        )
+    )
+    assert "No files are attached to Slack message permalink" in result["error"]
+
+
 
 
 def test_execute_action_fetch_channel_history_accepts_channel_id_alias(monkeypatch) -> None:


### PR DESCRIPTION
### Motivation
- Slack message permalinks (e.g. `/archives/<channel>/p<ts>`) were being treated as direct file URLs, so attached files on the linked message could not be resolved or downloaded.
- Improve agent/tool behavior by resolving message permalinks to the referenced message and extracting any attached files for downstream processing.

### Description
- Added `_SLACK_MESSAGE_PERMALINK_RE` and `urlparse` usage plus a `_parse_slack_message_permalink` helper to detect and normalize Slack message permalinks.
- Updated `SlackConnector._read_file_for_query` to detect permalinks and route them to a new `_read_files_from_message_permalink` flow instead of treating them as direct file URLs.
- Implemented `_read_files_from_message_permalink` which fetches the target message via `get_channel_messages`, iterates attached `files`, invokes `._read_file_for_query` for each attachment, and returns a payload containing `file` (first attachment) and `files` (all resolved attachments) or clear error messages for edge cases.
- Added unit tests in `backend/tests/test_slack_connector_actions.py` that mock `get_channel_messages`, `_make_request`, and `download_file` to validate successful multi-file extraction and the error path when a permalink message has no attachments.

### Testing
- Ran the Slack connector unit tests with `pytest -q backend/tests/test_slack_connector_actions.py` and observed all tests pass.
- Result: `14 passed` for the modified test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8728aed548321a3a123a6c676c3c9)