### PR TITLE
Prioritize injected Slack context before connector queries

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -107,6 +107,7 @@ When users refer to Slack scope, distinguish **thread/chat** vs **channel**:
 - "this channel" or "in #channel" → scope to the whole channel.
 
 If the user asks a Slack activity question but says "this" without indicating chat/thread vs channel, ask a brief clarification question before querying.
+If Slack channel/thread history is already included in the current prompt context, check that quoted history first and answer from it when possible before calling Slack connector queries.
 
 Channel-level filter:
 ```sql

--- a/backend/tests/test_slack_scope_prompt.py
+++ b/backend/tests/test_slack_scope_prompt.py
@@ -5,6 +5,7 @@ def test_slack_scope_prompt_mentions_ambiguity_and_thread_filter() -> None:
     prompt = _format_slack_scope_context("C123", "1729364.001")
 
     assert "ask a brief clarification question" in prompt
+    assert "check that quoted history first" in prompt
     assert "custom_fields->>'channel_id' = 'C123'" in prompt
     assert "custom_fields->>'thread_ts' = '1729364.001'" in prompt
     assert "this chat" in prompt


### PR DESCRIPTION
### Motivation
- Ensure the agent prefers quoted/cached Slack channel or thread history already injected into the prompt and avoids unnecessary `query_on_connector` calls to Slack when the answer can be found in that context.

### Description
- Add a guidance line to `_format_slack_scope_context` instructing the model to check quoted Slack channel/thread history first before calling Slack connector queries, and add a regression assertion in `backend/tests/test_slack_scope_prompt.py` to keep this instruction covered.

### Testing
- Ran `pytest -q backend/tests/test_slack_scope_prompt.py` and it passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e0df6aa08321902ecc3dc7762da3)