### PR TITLE
Include all Slack file links when appending current-turn history context

### DIFF
--- a/backend/messengers/slack.py
+++ b/backend/messengers/slack.py
@@ -513,9 +513,10 @@ class SlackMessenger(WorkspaceMessenger):
             if file_reference:
                 file_references.append(file_reference)
         if file_references:
-            file_suffix: str = "; ".join(file_references[:3])
-            if len(file_references) > 3:
-                file_suffix = f"{file_suffix}; +{len(file_references) - 3} more"
+            # Include every file reference for the message so current-turn context
+            # always retains full link metadata (id/url/mimetype) for downstream
+            # file-reading tools.
+            file_suffix: str = "; ".join(file_references)
             text_compact = f"{text_compact} [files: {file_suffix}]".strip()
 
         ts_value: str = str(slack_message.get("ts") or "").strip()

--- a/backend/tests/test_slack_channel_name_resolution.py
+++ b/backend/tests/test_slack_channel_name_resolution.py
@@ -726,6 +726,50 @@ def test_format_single_slack_context_line_includes_file_references():
     assert "url=https://files.slack.com/files-pri/T1-F123/download/q1-report.pdf" in line
 
 
+def test_format_single_slack_context_line_includes_all_file_links_for_message():
+    messenger = SlackMessenger()
+    line = messenger._format_single_slack_context_line(
+        {
+            "ts": "1710711602.000",
+            "user": "U3",
+            "text": "Please review all attachments",
+            "files": [
+                {
+                    "id": "F111",
+                    "name": "first.txt",
+                    "url_private_download": "https://files.slack.com/files-pri/T1-F111/download/first.txt",
+                    "mimetype": "text/plain",
+                },
+                {
+                    "id": "F222",
+                    "name": "second.txt",
+                    "url_private": "https://files.slack.com/files-pri/T1-F222/download/second.txt",
+                    "mimetype": "text/plain",
+                },
+                {
+                    "id": "F333",
+                    "name": "third.txt",
+                    "url_private_download": "https://files.slack.com/files-pri/T1-F333/download/third.txt",
+                    "mimetype": "text/plain",
+                },
+                {
+                    "id": "F444",
+                    "name": "fourth.txt",
+                    "url_private_download": "https://files.slack.com/files-pri/T1-F444/download/fourth.txt",
+                    "mimetype": "text/plain",
+                },
+            ],
+        }
+    )
+
+    assert line is not None
+    assert "url=https://files.slack.com/files-pri/T1-F111/download/first.txt" in line
+    assert "url=https://files.slack.com/files-pri/T1-F222/download/second.txt" in line
+    assert "url=https://files.slack.com/files-pri/T1-F333/download/third.txt" in line
+    assert "url=https://files.slack.com/files-pri/T1-F444/download/fourth.txt" in line
+    assert "+1 more" not in line
+
+
 @pytest.mark.asyncio
 async def test_get_cached_channel_context_payload_from_activity_preserves_file_metadata():
     messenger = SlackMessenger()


### PR DESCRIPTION
### Motivation
- Ensure current-turn history lines include full file link metadata so downstream file-reading tools can access any attached Slack file in the turn.

### Description
- Updated `SlackMessenger._format_single_slack_context_line` to include every file reference for a message instead of truncating to the first three, preserving `url_private_download`/`url_private` and mimetype metadata in the context string.
- Added a regression test `test_format_single_slack_context_line_includes_all_file_links_for_message` to verify that all file URLs appear for messages with more than three files and that the previous `+N more` truncation is not present.
- Kept the compact file reference formatting produced by `_format_slack_file_reference` and only changed how those references are joined into the message context.

### Testing
- Ran `pytest -q backend/tests/test_slack_channel_name_resolution.py -k "includes_file_references or includes_all_file_links_for_message"`, which passed (`2 passed, 21 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e56568cc83218808e7a18248f201)