### PR TITLE
Keep model-family warning visible until organization change

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -206,14 +206,20 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
   const [resendingMemberId, setResendingMemberId] = useState<string | null>(null);
   const [revokingInviteMemberId, setRevokingInviteMemberId] = useState<string | null>(null);
   const [menuOpenMemberId, setMenuOpenMemberId] = useState<string | null>(null);
+  const previousOrganizationIdRef = useRef<string>(organization.id);
 
   useEffect(() => {
+    const organizationChanged = previousOrganizationIdRef.current !== organization.id;
+    previousOrganizationIdRef.current = organization.id;
+
     setOrgName(organization.name);
     setLogoUrl(organization.logoUrl);
     setLlmPrimaryModel(organization.llmPrimaryModel ?? '');
     setLlmCheapModel(organization.llmCheapModel ?? '');
     setLlmWorkflowModel(organization.llmWorkflowModel ?? '');
-    setModelFamilyWarning(null);
+    if (organizationChanged) {
+      setModelFamilyWarning(null);
+    }
     setSettingsSaved(false);
     setExpandedMemberId(null);
     setMenuOpenMemberId(null);


### PR DESCRIPTION
### Motivation
- Prevent the non-blocking model-family warning in Organization settings from being auto-dismissed during the local state refresh after a model selection so users can read it until they close the pane or actually switch organizations.

### Description
- Add `previousOrganizationIdRef` and only clear `modelFamilyWarning` when the active organization id truly changes, in `frontend/src/components/OrganizationPanel.tsx`.

### Testing
- Ran the frontend linter with `cd frontend && npm run lint -- src/components/OrganizationPanel.tsx`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fa3cb90c8321af19484c71872546)