### PR TITLE
Add channel-centric conversation grouping and cursor pagination

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -550,10 +550,16 @@ async def list_conversations(
         )
         result = await session.execute(ordered_query)
         conversations: list[Conversation] = list(result.scalars().all())
+        has_more = len(conversations) > limit
 
-        # Slow path: if we got fewer rows than limit, Slack conversations may
+        # Fast path: if the primary query already proved there is another page,
+        # avoid waiting on Slack fallback and keep cursor metadata as-is.
+        if has_more:
+            conversations = conversations[:limit]
+
+        # Slow path: if we do not yet have a full page, Slack conversations may
         # be missing. Resolve Slack IDs and merge any additional results.
-        if len(conversations) < limit:
+        if not has_more and len(conversations) < limit:
             slack_user_ids = await _get_slack_user_ids(auth, session=session)
             if slack_user_ids:
                 logger.info(
@@ -611,9 +617,9 @@ async def list_conversations(
                     reverse=True,
                 )
 
-        has_more = len(conversations) > limit
-        if has_more:
-            conversations = conversations[:limit]
+            has_more = len(conversations) > limit
+            if has_more:
+                conversations = conversations[:limit]
         next_cursor = None
         if conversations and has_more:
             last = conversations[-1]

--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -337,9 +337,19 @@ async def _refresh_slack_channel_name(
 ) -> None:
     lock_key = f"chat:slack_channel_name_refresh_lock:{workspace_id}:{channel_id}"
     cache_key = _channel_cache_key(workspace_id, channel_id)
-    r = await _get_redis()
+    try:
+        r = await _get_redis()
+    except Exception:
+        return
 
-    if not await r.set(lock_key, "1", ex=_CHANNEL_NAME_SINGLE_FLIGHT_LOCK_SECONDS, nx=True):
+    try:
+        lock_acquired = await r.set(
+            lock_key, "1", ex=_CHANNEL_NAME_SINGLE_FLIGHT_LOCK_SECONDS, nx=True
+        )
+    except Exception:
+        return
+
+    if not lock_acquired:
         return
     try:
         connector = SlackConnector(organization_id=org_id, team_id=workspace_id)
@@ -379,7 +389,10 @@ async def _refresh_slack_channel_name(
             exc,
         )
     finally:
-        await r.delete(lock_key)
+        try:
+            await r.delete(lock_key)
+        except Exception:
+            pass
 
 
 async def _resolve_slack_channel_name(
@@ -583,7 +596,7 @@ async def list_conversations(
         # Slack-only rows that may need to be merged into the visible page.
         slack_user_ids = await _get_slack_user_ids(auth, session=session)
         should_merge_slack = bool(slack_user_ids) and (
-            len(conversations) < limit or has_more
+            len(conversations) < limit or has_more or not cursor
         )
 
         if should_merge_slack:

--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -595,8 +595,13 @@ async def list_conversations(
         # can keep pagination controls enabled immediately while we reconcile
         # Slack-only rows that may need to be merged into the visible page.
         slack_user_ids = await _get_slack_user_ids(auth, session=session)
+        # Slack-only rows must be considered before advancing cursor pagination.
+        # For non-cursor requests, we only reconcile on the first page (offset=0)
+        # to avoid reordering/duplication issues on legacy offset pages. Older
+        # clients should refresh to cursor-based pagination for fully consistent
+        # Slack-aware paging across pages.
         should_merge_slack = bool(slack_user_ids) and (
-            len(conversations) < limit or has_more or not cursor
+            cursor is not None or offset == 0
         )
 
         if should_merge_slack:

--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -550,13 +550,6 @@ async def list_conversations(
         )
         result = await session.execute(ordered_query)
         conversations: list[Conversation] = list(result.scalars().all())
-        has_more = len(conversations) > limit
-        if has_more:
-            conversations = conversations[:limit]
-        next_cursor = None
-        if conversations and has_more:
-            last = conversations[-1]
-            next_cursor = _encode_cursor(last.updated_at, last.id)
 
         # Slow path: if we got fewer rows than limit, Slack conversations may
         # be missing. Resolve Slack IDs and merge any additional results.
@@ -604,15 +597,27 @@ async def list_conversations(
                     )
 
                 slack_result = await session.execute(
-                    slack_query.order_by(Conversation.updated_at.desc()).limit(limit)
+                    slack_query.order_by(
+                        Conversation.updated_at.desc(), Conversation.id.desc()
+                    ).limit(limit + 1)
                 )
                 for conv in slack_result.scalars().all():
                     if conv.id not in seen_ids:
                         conversations.append(conv)
                         seen_ids.add(conv.id)
 
-                conversations.sort(key=lambda c: c.updated_at, reverse=True)
-                conversations = conversations[:limit]
+                conversations.sort(
+                    key=lambda c: (c.updated_at, c.id),
+                    reverse=True,
+                )
+
+        has_more = len(conversations) > limit
+        if has_more:
+            conversations = conversations[:limit]
+        next_cursor = None
+        if conversations and has_more:
+            last = conversations[-1]
+            next_cursor = _encode_cursor(last.updated_at, last.id)
 
         # Collect all participant user IDs to fetch in one query
         all_participant_ids: set[UUID] = set()

--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -70,6 +70,17 @@ async def _get_redis() -> aioredis.Redis:
     return _redis_client
 
 
+def _register_slack_refresh_task(task_key: str, task: asyncio.Task[None]) -> None:
+    """Track a single refresh task per key and clean up after completion."""
+    _slack_channel_refresh_tasks[task_key] = task
+
+    def _cleanup(done_task: asyncio.Task[None]) -> None:
+        if _slack_channel_refresh_tasks.get(task_key) is done_task:
+            _slack_channel_refresh_tasks.pop(task_key, None)
+
+    task.add_done_callback(_cleanup)
+
+
 async def _get_slack_user_ids(
     auth: AuthContext, session: AsyncSession | None = None,
 ) -> set[str]:
@@ -385,7 +396,10 @@ async def _resolve_slack_channel_name(
         r = await _get_redis()
     except Exception:
         return None
-    cached = await r.get(cache_key)
+    try:
+        cached = await r.get(cache_key)
+    except Exception:
+        cached = None
     if cached:
         try:
             payload = json.loads(cached)
@@ -399,8 +413,13 @@ async def _resolve_slack_channel_name(
                 if age_seconds <= _CHANNEL_NAME_HARD_TTL_SECONDS:
                     task_key = f"{workspace_id}:{channel_id}"
                     if task_key not in _slack_channel_refresh_tasks or _slack_channel_refresh_tasks[task_key].done():
-                        _slack_channel_refresh_tasks[task_key] = asyncio.create_task(
-                            _refresh_slack_channel_name(workspace_id, channel_id, org_id, fetched_at_iso),
+                        _register_slack_refresh_task(
+                            task_key,
+                            asyncio.create_task(
+                                _refresh_slack_channel_name(
+                                    workspace_id, channel_id, org_id, fetched_at_iso
+                                ),
+                            ),
                         )
                     return cached_name
         except Exception:
@@ -408,7 +427,10 @@ async def _resolve_slack_channel_name(
 
     # Blocking fallback path.
     await _refresh_slack_channel_name(workspace_id, channel_id, org_id)
-    latest = await r.get(cache_key)
+    try:
+        latest = await r.get(cache_key)
+    except Exception:
+        latest = None
     if latest:
         try:
             payload = json.loads(latest)
@@ -594,7 +616,7 @@ async def list_conversations(
                     )
                 )
 
-            if has_more and conversations:
+            if cursor and has_more and conversations:
                 page_tail = conversations[-1]
                 slack_query = slack_query.where(
                     or_(

--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -531,6 +531,8 @@ async def list_conversations(
             )
 
         limit = max(1, min(limit, 200))
+        cursor_updated_at = None
+        cursor_conversation_id = None
         if cursor:
             cursor_updated_at, cursor_conversation_id = _decode_cursor(cursor)
             query = query.where(
@@ -580,6 +582,16 @@ async def list_conversations(
                     )
                 if scope in ("shared", "private"):
                     slack_query = slack_query.where(Conversation.scope == scope)
+                if cursor_updated_at is not None and cursor_conversation_id is not None:
+                    slack_query = slack_query.where(
+                        or_(
+                            Conversation.updated_at < cursor_updated_at,
+                            and_(
+                                Conversation.updated_at == cursor_updated_at,
+                                Conversation.id < cursor_conversation_id,
+                            ),
+                        )
+                    )
 
                 # Apply same search filter to Slack fallback
                 if normalized_search:

--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -551,85 +551,98 @@ async def list_conversations(
             .limit(limit + 1)
         )
         result = await session.execute(ordered_query)
-        conversations: list[Conversation] = list(result.scalars().all())
-        has_more = len(conversations) > limit
+        primary_rows: list[Conversation] = list(result.scalars().all())
+        primary_has_more = len(primary_rows) > limit
+        has_more = primary_has_more
+        conversations: list[Conversation] = primary_rows[:limit]
 
-        # Fast path: if the primary query already proved there is another page,
-        # avoid waiting on Slack fallback and keep cursor metadata as-is.
-        if has_more:
-            conversations = conversations[:limit]
+        # Optimistically preserve has_more from the primary query so the caller
+        # can keep pagination controls enabled immediately while we reconcile
+        # Slack-only rows that may need to be merged into the visible page.
+        slack_user_ids = await _get_slack_user_ids(auth, session=session)
+        should_merge_slack = bool(slack_user_ids) and (
+            len(conversations) < limit or has_more
+        )
 
-        # Slow path: if we do not yet have a full page, Slack conversations may
-        # be missing. Resolve Slack IDs and merge any additional results.
-        if not has_more and len(conversations) < limit:
-            slack_user_ids = await _get_slack_user_ids(auth, session=session)
-            if slack_user_ids:
-                logger.info(
-                    "[chat] Listing conversations for user=%s with Slack IDs %s",
-                    auth.user_id_str,
-                    sorted(slack_user_ids),
+        if should_merge_slack:
+            logger.info(
+                "[chat] Listing conversations for user=%s with Slack IDs %s",
+                auth.user_id_str,
+                sorted(slack_user_ids),
+            )
+            seen_ids = {c.id for c in conversations}
+            slack_query = (
+                select(Conversation)
+                .where(Conversation.type != "workflow")
+                .where(Conversation.source == "slack")
+                .where(Conversation.source_user_id.in_(slack_user_ids))
+            )
+            if auth.organization_id:
+                slack_query = slack_query.where(
+                    Conversation.organization_id == auth.organization_id
                 )
-                seen_ids = {c.id for c in conversations}
-                slack_query = (
-                    select(Conversation)
-                    .where(Conversation.type != "workflow")
-                    .where(Conversation.source == "slack")
-                    .where(Conversation.source_user_id.in_(slack_user_ids))
-                )
-                if auth.organization_id:
-                    slack_query = slack_query.where(
-                        Conversation.organization_id == auth.organization_id
+            if scope in ("shared", "private"):
+                slack_query = slack_query.where(Conversation.scope == scope)
+            if cursor_updated_at is not None and cursor_conversation_id is not None:
+                slack_query = slack_query.where(
+                    or_(
+                        Conversation.updated_at < cursor_updated_at,
+                        and_(
+                            Conversation.updated_at == cursor_updated_at,
+                            Conversation.id < cursor_conversation_id,
+                        ),
                     )
-                if scope in ("shared", "private"):
-                    slack_query = slack_query.where(Conversation.scope == scope)
-                if cursor_updated_at is not None and cursor_conversation_id is not None:
-                    slack_query = slack_query.where(
-                        or_(
-                            Conversation.updated_at < cursor_updated_at,
-                            and_(
-                                Conversation.updated_at == cursor_updated_at,
-                                Conversation.id < cursor_conversation_id,
-                            ),
-                        )
-                    )
-
-                # Apply same search filter to Slack fallback
-                if normalized_search:
-                    slack_search = f"%{normalized_search}%"
-                    slack_msg_subq = sa_text(
-                        "SELECT DISTINCT conversation_id FROM chat_messages "
-                        "WHERE content ILIKE :st "
-                        "UNION "
-                        "SELECT DISTINCT conversation_id FROM chat_messages, "
-                        "jsonb_array_elements(content_blocks) AS block "
-                        "WHERE block->>'type' = 'text' "
-                        "AND block->>'text' ILIKE :st"
-                    ).bindparams(st=slack_search).columns(column("conversation_id"))
-                    slack_query = slack_query.where(
-                        or_(
-                            Conversation.title.ilike(slack_search),
-                            Conversation.summary.ilike(slack_search),
-                            Conversation.last_message_preview.ilike(slack_search),
-                            Conversation.id.in_(slack_msg_subq),
-                        )
-                    )
-
-                slack_result = await session.execute(
-                    slack_query.order_by(
-                        Conversation.updated_at.desc(), Conversation.id.desc()
-                    ).limit(limit + 1)
-                )
-                for conv in slack_result.scalars().all():
-                    if conv.id not in seen_ids:
-                        conversations.append(conv)
-                        seen_ids.add(conv.id)
-
-                conversations.sort(
-                    key=lambda c: (c.updated_at, c.id),
-                    reverse=True,
                 )
 
-            has_more = len(conversations) > limit
+            if has_more and conversations:
+                page_tail = conversations[-1]
+                slack_query = slack_query.where(
+                    or_(
+                        Conversation.updated_at > page_tail.updated_at,
+                        and_(
+                            Conversation.updated_at == page_tail.updated_at,
+                            Conversation.id > page_tail.id,
+                        ),
+                    )
+                )
+
+            # Apply same search filter to Slack fallback
+            if normalized_search:
+                slack_search = f"%{normalized_search}%"
+                slack_msg_subq = sa_text(
+                    "SELECT DISTINCT conversation_id FROM chat_messages "
+                    "WHERE content ILIKE :st "
+                    "UNION "
+                    "SELECT DISTINCT conversation_id FROM chat_messages, "
+                    "jsonb_array_elements(content_blocks) AS block "
+                    "WHERE block->>'type' = 'text' "
+                    "AND block->>'text' ILIKE :st"
+                ).bindparams(st=slack_search).columns(column("conversation_id"))
+                slack_query = slack_query.where(
+                    or_(
+                        Conversation.title.ilike(slack_search),
+                        Conversation.summary.ilike(slack_search),
+                        Conversation.last_message_preview.ilike(slack_search),
+                        Conversation.id.in_(slack_msg_subq),
+                    )
+                )
+
+            slack_result = await session.execute(
+                slack_query.order_by(
+                    Conversation.updated_at.desc(), Conversation.id.desc()
+                ).limit(limit + 1)
+            )
+            for conv in slack_result.scalars().all():
+                if conv.id not in seen_ids:
+                    conversations.append(conv)
+                    seen_ids.add(conv.id)
+
+            conversations.sort(
+                key=lambda c: (c.updated_at, c.id),
+                reverse=True,
+            )
+
+            has_more = primary_has_more or len(conversations) > limit
             if has_more:
                 conversations = conversations[:limit]
         next_cursor = None

--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -15,6 +15,8 @@ Endpoints:
 - POST /api/chat/upload - Upload a file attachment for chat context
 """
 
+import asyncio
+import base64
 import json
 from datetime import datetime
 from typing import Optional
@@ -36,8 +38,10 @@ from models.chat_attachment import ChatAttachment
 from models.chat_message import ChatMessage
 from models.conversation import Conversation
 from models.database import get_admin_session, get_session
+from models.integration import Integration
 from models.org_member import OrgMember
 from models.user import User
+from connectors.slack import SlackConnector
 from services.file_handler import store_file, MAX_FILE_SIZE
 from services.slack_identity import get_slack_user_ids_for_revtops_user
 
@@ -47,7 +51,13 @@ logger = logging.getLogger(__name__)
 
 _redis_client: aioredis.Redis | None = None
 _SLACK_USER_IDS_TTL = 300  # 5 minutes
+_SLACK_WORKSPACE_ID_TTL = 300  # 5 minutes
+_CHANNEL_NAME_SOFT_TTL_SECONDS = 15 * 60
+_CHANNEL_NAME_HARD_TTL_SECONDS = 24 * 60 * 60
+_CHANNEL_NAME_TTL_JITTER_RATIO = 0.10
+_CHANNEL_NAME_SINGLE_FLIGHT_LOCK_SECONDS = 30
 _WEB_PLATFORM_SLUG = "web"
+_slack_channel_refresh_tasks: dict[str, asyncio.Task[None]] = {}
 
 
 async def _get_redis() -> aioredis.Redis:
@@ -211,6 +221,13 @@ class ConversationResponse(BaseModel):
     participants: list[ParticipantResponse] = []
     match_snippet: Optional[str] = None  # Context around search match
     match_count: int = 0  # Number of times search term appears in conversation
+    workspace_id: Optional[str] = None
+    source: Optional[str] = None
+    source_channel_id: Optional[str] = None
+    normalized_channel_id: Optional[str] = None
+    resolved_channel_name: Optional[str] = None
+    group_bucket_type: str = "uncategorized"
+    group_bucket_key: str = "uncategorized"
 
 
 class ConversationListResponse(BaseModel):
@@ -218,6 +235,187 @@ class ConversationListResponse(BaseModel):
     conversations: list[ConversationResponse]
     total: int
     search_term: Optional[str] = None  # Echo back the search term for highlighting
+    next_cursor: Optional[str] = None
+    has_more: bool = False
+    server_time: str
+
+
+def _normalize_channel_id(source: str | None, source_channel_id: str | None) -> str | None:
+    if source != "slack" or not source_channel_id:
+        return None
+    normalized = str(source_channel_id).strip()
+    if not normalized:
+        return None
+    return normalized.split(":", 1)[0].strip().upper() or None
+
+
+def _derive_bucket(
+    *,
+    source: str | None,
+    scope: str | None,
+    normalized_channel_id: str | None,
+) -> tuple[str, str]:
+    if scope == "private":
+        return ("direct", "direct")
+    if source == "slack" and normalized_channel_id:
+        if normalized_channel_id.startswith("D"):
+            return ("direct", "direct")
+        return ("channel", f"channel:{normalized_channel_id}")
+    return ("uncategorized", "uncategorized")
+
+
+def _encode_cursor(updated_at: datetime, conversation_id: UUID) -> str:
+    payload = {"updated_at": updated_at.isoformat(), "conversation_id": str(conversation_id)}
+    return base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8")
+
+
+def _decode_cursor(cursor: str) -> tuple[datetime, UUID]:
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(cursor.encode("utf-8")).decode("utf-8"))
+        updated_at = datetime.fromisoformat(str(payload["updated_at"]))
+        conv_id = UUID(str(payload["conversation_id"]))
+        return updated_at, conv_id
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid cursor: {exc}") from exc
+
+
+def _channel_cache_key(workspace_id: str, channel_id: str) -> str:
+    return f"chat:slack_channel_name:{workspace_id}:{channel_id}"
+
+
+async def _get_workspace_id_for_org(session: AsyncSession, org_id: str | None) -> str | None:
+    if not org_id:
+        return None
+
+    cache_key = f"chat:slack_workspace_id:{org_id}"
+    try:
+        r = await _get_redis()
+        cached = await r.get(cache_key)
+        if cached:
+            return str(cached)
+    except Exception:
+        pass
+
+    result = await session.execute(
+        select(Integration)
+        .where(Integration.organization_id == UUID(org_id))
+        .where(Integration.connector == "slack")
+        .where(Integration.is_active == True)  # noqa: E712
+        .order_by(Integration.updated_at.desc().nullslast(), Integration.created_at.desc().nullslast())
+        .limit(1)
+    )
+    integration = result.scalar_one_or_none()
+    if not integration:
+        return None
+    extra = integration.extra_data or {}
+    workspace_id = str(extra.get("team_id") or extra.get("workspace_id") or "").strip() or None
+    if workspace_id:
+        try:
+            r = await _get_redis()
+            await r.set(cache_key, workspace_id, ex=_SLACK_WORKSPACE_ID_TTL)
+        except Exception:
+            pass
+    return workspace_id
+
+
+async def _refresh_slack_channel_name(
+    workspace_id: str,
+    channel_id: str,
+    org_id: str,
+    existing_fetched_at_iso: str | None = None,
+) -> None:
+    lock_key = f"chat:slack_channel_name_refresh_lock:{workspace_id}:{channel_id}"
+    cache_key = _channel_cache_key(workspace_id, channel_id)
+    r = await _get_redis()
+
+    if not await r.set(lock_key, "1", ex=_CHANNEL_NAME_SINGLE_FLIGHT_LOCK_SECONDS, nx=True):
+        return
+    try:
+        connector = SlackConnector(organization_id=org_id, team_id=workspace_id)
+        started_at = datetime.utcnow()
+        info = await connector.get_channel_info(channel_id)
+        name = str((info or {}).get("name") or "").strip() or None
+        if not name:
+            return
+        fetched_at = datetime.utcnow()
+        payload = {
+            "name": name,
+            "fetched_at": fetched_at.isoformat(),
+            "source": "slack",
+        }
+        current = await r.get(cache_key)
+        if current:
+            try:
+                cur_payload = json.loads(current)
+                cur_fetched = str(cur_payload.get("fetched_at") or "")
+                if existing_fetched_at_iso and cur_fetched and cur_fetched > existing_fetched_at_iso:
+                    return
+            except Exception:
+                pass
+        ttl_seconds = int(_CHANNEL_NAME_HARD_TTL_SECONDS * (1 + _CHANNEL_NAME_TTL_JITTER_RATIO))
+        await r.set(cache_key, json.dumps(payload), ex=ttl_seconds)
+        logger.info(
+            "[chat.resolver] refreshed workspace=%s channel=%s latency_ms=%d",
+            workspace_id,
+            channel_id,
+            int((datetime.utcnow() - started_at).total_seconds() * 1000),
+        )
+    except Exception as exc:
+        logger.warning(
+            "[chat.resolver] refresh failed workspace=%s channel=%s error=%s",
+            workspace_id,
+            channel_id,
+            exc,
+        )
+    finally:
+        await r.delete(lock_key)
+
+
+async def _resolve_slack_channel_name(
+    org_id: str | None,
+    workspace_id: str | None,
+    channel_id: str | None,
+) -> str | None:
+    if not org_id or not workspace_id or not channel_id:
+        return None
+
+    cache_key = _channel_cache_key(workspace_id, channel_id)
+    now = datetime.utcnow()
+    try:
+        r = await _get_redis()
+    except Exception:
+        return None
+    cached = await r.get(cache_key)
+    if cached:
+        try:
+            payload = json.loads(cached)
+            cached_name = str(payload.get("name") or "").strip() or None
+            fetched_at_iso = str(payload.get("fetched_at") or "").strip()
+            fetched_at = datetime.fromisoformat(fetched_at_iso) if fetched_at_iso else None
+            if cached_name and fetched_at:
+                age_seconds = (now - fetched_at).total_seconds()
+                if age_seconds <= _CHANNEL_NAME_SOFT_TTL_SECONDS:
+                    return cached_name
+                if age_seconds <= _CHANNEL_NAME_HARD_TTL_SECONDS:
+                    task_key = f"{workspace_id}:{channel_id}"
+                    if task_key not in _slack_channel_refresh_tasks or _slack_channel_refresh_tasks[task_key].done():
+                        _slack_channel_refresh_tasks[task_key] = asyncio.create_task(
+                            _refresh_slack_channel_name(workspace_id, channel_id, org_id, fetched_at_iso),
+                        )
+                    return cached_name
+        except Exception:
+            pass
+
+    # Blocking fallback path.
+    await _refresh_slack_channel_name(workspace_id, channel_id, org_id)
+    latest = await r.get(cache_key)
+    if latest:
+        try:
+            payload = json.loads(latest)
+            return str(payload.get("name") or "").strip() or None
+        except Exception:
+            return None
+    return None
 
 
 class ChatMessageResponse(BaseModel):
@@ -279,6 +477,7 @@ async def list_conversations(
     auth: AuthContext = Depends(get_current_auth),
     limit: int = 50,
     offset: int = 0,
+    cursor: Optional[str] = None,
     scope: Optional[str] = None,
     mine: bool = False,
     search: Optional[str] = None,
@@ -331,12 +530,33 @@ async def list_conversations(
                 )
             )
 
-        result = await session.execute(
-            query.order_by(Conversation.updated_at.desc())
-            .offset(offset)
-            .limit(limit)
+        limit = max(1, min(limit, 200))
+        if cursor:
+            cursor_updated_at, cursor_conversation_id = _decode_cursor(cursor)
+            query = query.where(
+                or_(
+                    Conversation.updated_at < cursor_updated_at,
+                    and_(
+                        Conversation.updated_at == cursor_updated_at,
+                        Conversation.id < cursor_conversation_id,
+                    ),
+                )
+            )
+
+        ordered_query = (
+            query.order_by(Conversation.updated_at.desc(), Conversation.id.desc())
+            .offset(offset if not cursor else 0)
+            .limit(limit + 1)
         )
+        result = await session.execute(ordered_query)
         conversations: list[Conversation] = list(result.scalars().all())
+        has_more = len(conversations) > limit
+        if has_more:
+            conversations = conversations[:limit]
+        next_cursor = None
+        if conversations and has_more:
+            last = conversations[-1]
+            next_cursor = _encode_cursor(last.updated_at, last.id)
 
         # Slow path: if we got fewer rows than limit, Slack conversations may
         # be missing. Resolve Slack IDs and merge any additional results.
@@ -451,8 +671,24 @@ async def list_conversations(
                             break
 
         # Build response using cached fields
+        workspace_id = await _get_workspace_id_for_org(session, org_id)
         response_items: list[ConversationResponse] = []
         for conv in conversations:
+            normalized_channel_id = _normalize_channel_id(conv.source, conv.source_channel_id)
+            bucket_type, bucket_key = _derive_bucket(
+                source=conv.source,
+                scope=conv.scope,
+                normalized_channel_id=normalized_channel_id,
+            )
+            resolved_channel_name = await _resolve_slack_channel_name(
+                org_id=org_id,
+                workspace_id=workspace_id if conv.source == "slack" else None,
+                channel_id=normalized_channel_id,
+            ) if bucket_type == "channel" else None
+            if bucket_type == "channel" and not resolved_channel_name:
+                bucket_type = "uncategorized"
+                bucket_key = "uncategorized"
+
             if conv.source == "slack":
                 preview_length = len(conv.last_message_preview or "")
                 logger.debug(
@@ -495,12 +731,22 @@ async def list_conversations(
                 participants=participants,
                 match_snippet=snippet_by_conv_id.get(conv.id),
                 match_count=count_by_conv_id.get(conv.id, 0),
+                workspace_id=workspace_id if conv.source == "slack" else None,
+                source=conv.source,
+                source_channel_id=conv.source_channel_id,
+                normalized_channel_id=normalized_channel_id,
+                resolved_channel_name=resolved_channel_name,
+                group_bucket_type=bucket_type,
+                group_bucket_key=bucket_key,
             ))
 
         return ConversationListResponse(
             conversations=response_items,
             total=len(response_items),
             search_term=normalized_search if normalized_search else None,
+            next_cursor=next_cursor,
+            has_more=has_more,
+            server_time=f"{datetime.utcnow().isoformat()}Z",
         )
 
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -45,7 +45,7 @@ export interface ChatMessage {
 
 export interface ConversationSummary {
   id: string;
-  user_id: string;
+  user_id: string | null;
   title: string | null;
   summary: string | null;
   created_at: string;
@@ -56,12 +56,22 @@ export interface ConversationSummary {
   participants?: Array<{ id: string; name: string | null; email: string; avatar_url?: string | null }>;
   match_snippet?: string | null;
   match_count?: number;
+  workspace_id?: string | null;
+  source?: string | null;
+  source_channel_id?: string | null;
+  normalized_channel_id?: string | null;
+  resolved_channel_name?: string | null;
+  group_bucket_type?: "pinned" | "direct" | "channel" | "uncategorized";
+  group_bucket_key?: string;
 }
 
 export interface ConversationListResponse {
   conversations: ConversationSummary[];
   total: number;
   search_term?: string | null;
+  next_cursor?: string | null;
+  has_more?: boolean;
+  server_time?: string;
 }
 
 export interface ConversationDetailResponse {
@@ -145,8 +155,14 @@ export async function listConversations(
   offset = 0,
   scope?: 'shared' | 'private' | 'mine',
   search?: string,
+  cursor?: string | null,
 ): Promise<ApiResponse<ConversationListResponse>> {
-  const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+  const params = new URLSearchParams({ limit: String(limit) });
+  if (cursor?.trim()) {
+    params.set('cursor', cursor.trim());
+  } else {
+    params.set('offset', String(offset));
+  }
   if (scope === 'shared' || scope === 'private') {
     params.set('scope', scope);
   }

--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -35,6 +35,13 @@ function apiConvToChatSummary(conv: ConversationSummary): ChatSummary {
     })),
     matchSnippet: conv.match_snippet,
     matchCount: conv.match_count ?? 0,
+    workspaceId: conv.workspace_id,
+    source: conv.source,
+    sourceChannelId: conv.source_channel_id,
+    normalizedChannelId: conv.normalized_channel_id,
+    resolvedChannelName: conv.resolved_channel_name,
+    groupBucketType: conv.group_bucket_type,
+    groupBucketKey: conv.group_bucket_key,
   };
 }
 
@@ -67,6 +74,7 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
   const [hasMore, setHasMore] = useState<boolean>(true);
   const [initialLoaded, setInitialLoaded] = useState<boolean>(false);
   const offsetRef = useRef<number>(0);
+  const cursorRef = useRef<string | null>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 
@@ -101,12 +109,13 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
     if (reset) {
       setAllChats([]); // Clear immediately so stale results don't linger
       offsetRef.current = 0;
+      cursorRef.current = null;
     }
     const version = ++searchVersionRef.current;
     const offset = reset ? 0 : offsetRef.current;
     const apiScope = scopeFilter === 'all' ? undefined : scopeFilter;
     try {
-      const { data, error } = await listConversations(PAGE_SIZE, offset, apiScope, committedSearch);
+      const { data, error } = await listConversations(PAGE_SIZE, offset, apiScope, committedSearch, cursorRef.current);
       // Discard response if a newer search has started
       if (version !== searchVersionRef.current) return;
       if (error || !data) {
@@ -125,7 +134,8 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
         });
         offsetRef.current = offset + mapped.length;
       }
-      setHasMore(mapped.length >= PAGE_SIZE);
+      cursorRef.current = data.next_cursor ?? null;
+      setHasMore(Boolean(data.has_more));
     } finally {
       setIsLoadingMore(false);
       setInitialLoaded(true);
@@ -190,12 +200,46 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
   }, [mergedChats, scopeFilter, currentUserId, isSearching]);
 
   // Pinned first
-  const orderedChats = useMemo((): ChatSummary[] => {
-    if (pinnedChatIds.length === 0) return filteredChats;
+  const groupedChats = useMemo(() => {
     const pinnedSet = new Set(pinnedChatIds);
-    const pinned = filteredChats.filter((c) => pinnedSet.has(c.id));
-    const unpinned = filteredChats.filter((c) => !pinnedSet.has(c.id));
-    return [...pinned, ...unpinned];
+    const direct: ChatSummary[] = [];
+    const uncategorized: ChatSummary[] = [];
+    const channels = new Map<string, { label: string; chats: ChatSummary[]; newestTs: number }>();
+    const pinned: ChatSummary[] = [];
+
+    for (const chat of filteredChats) {
+      const ts = chat.lastMessageAt.getTime();
+      if (pinnedSet.has(chat.id)) {
+        pinned.push(chat);
+      }
+      const bucket = chat.groupBucketType ?? 'uncategorized';
+      if (bucket === 'direct') {
+        direct.push(chat);
+        continue;
+      }
+      if (bucket === 'channel' && chat.groupBucketKey) {
+        const current = channels.get(chat.groupBucketKey) ?? {
+          label: chat.resolvedChannelName ?? chat.normalizedChannelId ?? 'Unknown channel',
+          chats: [],
+          newestTs: 0,
+        };
+        current.chats.push(chat);
+        current.newestTs = Math.max(current.newestTs, ts);
+        channels.set(chat.groupBucketKey, current);
+        continue;
+      }
+      uncategorized.push(chat);
+    }
+
+    const byNewest = (a: ChatSummary, b: ChatSummary): number => b.lastMessageAt.getTime() - a.lastMessageAt.getTime();
+    pinned.sort(byNewest);
+    direct.sort(byNewest);
+    uncategorized.sort(byNewest);
+    const sortedChannels = Array.from(channels.entries())
+      .map(([key, value]) => ({ key, ...value, chats: value.chats.sort(byNewest) }))
+      .sort((a, b) => b.newestTs - a.newestTs);
+
+    return { pinned, direct, sortedChannels, uncategorized };
   }, [filteredChats, pinnedChatIds]);
 
   const handleSearchValueChange = useCallback(
@@ -288,7 +332,7 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
                 </div>
               ))}
             </div>
-          ) : orderedChats.length === 0 ? (
+          ) : (groupedChats.pinned.length + groupedChats.direct.length + groupedChats.uncategorized.length + groupedChats.sortedChannels.reduce((acc, section) => acc + section.chats.length, 0)) === 0 ? (
             <div className="text-center py-16">
               {searchQuery ? (
                 <>
@@ -315,16 +359,25 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
             </div>
           ) : (
             <div className="space-y-2">
-              {orderedChats.map((chat) => (
-                <ChatRow
-                  key={chat.id}
-                  chat={chat}
-                  searchTerm={committedSearch}
-                  hasActiveTask={chat.id in activeTasksByConversation}
-                  isPinned={pinnedChatIds.includes(chat.id)}
-                  onSelect={onSelectChat}
-                  onTogglePin={togglePinChat}
-                />
+              {groupedChats.pinned.length > 0 && <Section title="Pinned" />}
+              {groupedChats.pinned.map((chat) => (
+                <ChatRow key={`pinned-${chat.id}`} chat={chat} searchTerm={committedSearch} hasActiveTask={chat.id in activeTasksByConversation} isPinned onSelect={onSelectChat} onTogglePin={togglePinChat} />
+              ))}
+              {groupedChats.direct.length > 0 && <Section title="Direct" />}
+              {groupedChats.direct.map((chat) => (
+                <ChatRow key={chat.id} chat={chat} searchTerm={committedSearch} hasActiveTask={chat.id in activeTasksByConversation} isPinned={pinnedChatIds.includes(chat.id)} onSelect={onSelectChat} onTogglePin={togglePinChat} />
+              ))}
+              {groupedChats.sortedChannels.map((section) => (
+                <div key={section.key}>
+                  <Section title={section.label} />
+                  {section.chats.map((chat) => (
+                    <ChatRow key={chat.id} chat={chat} searchTerm={committedSearch} hasActiveTask={chat.id in activeTasksByConversation} isPinned={pinnedChatIds.includes(chat.id)} onSelect={onSelectChat} onTogglePin={togglePinChat} />
+                  ))}
+                </div>
+              ))}
+              {groupedChats.uncategorized.length > 0 && <Section title="Uncategorized" />}
+              {groupedChats.uncategorized.map((chat) => (
+                <ChatRow key={chat.id} chat={chat} searchTerm={committedSearch} hasActiveTask={chat.id in activeTasksByConversation} isPinned={pinnedChatIds.includes(chat.id)} onSelect={onSelectChat} onTogglePin={togglePinChat} />
               ))}
 
               {/* Infinite scroll sentinel */}
@@ -333,6 +386,11 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
               {isLoadingMore && (
                 <div className="flex justify-center py-4">
                   <div className="w-6 h-6 border-2 border-primary-500 border-t-transparent rounded-full animate-spin" />
+                </div>
+              )}
+              {!hasMore && initialLoaded && (
+                <div className="text-center text-xs text-surface-500 py-2">
+                  All conversations loaded
                 </div>
               )}
             </div>
@@ -458,6 +516,14 @@ function ChatRow({
         </div>
       </div>
     </button>
+  );
+}
+
+function Section({ title }: { title: string }): JSX.Element {
+  return (
+    <div className="pt-2 pb-1 px-1">
+      <h2 className="text-[11px] uppercase tracking-wider text-surface-500 font-semibold">{title}</h2>
+    </div>
   );
 }
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -953,7 +953,7 @@ function ChatAccordion({
       }
       uncategorized.push(chat);
     }
-    const limit = 15;
+    const globalLimit = 50;
     const byNewest = (a: ChatSummary, b: ChatSummary): number => b.lastMessageAt.getTime() - a.lastMessageAt.getTime();
     const channelSections = Array.from(channels.entries())
       .map(([key, value]) => ({ key, label: value.label, chats: value.chats.sort(byNewest), newestTs: value.newestTs }))
@@ -963,11 +963,24 @@ function ChatAccordion({
       direct.length +
       uncategorized.length +
       channelSections.reduce((acc, c) => acc + c.chats.length, 0);
+    let remaining = globalLimit;
+    const take = (items: ChatSummary[]): ChatSummary[] => {
+      if (remaining <= 0) return [];
+      const selected = items.slice(0, remaining);
+      remaining -= selected.length;
+      return selected;
+    };
+    const limitedPinned = take(pinned.sort(byNewest));
+    const limitedDirect = take(direct.sort(byNewest));
+    const limitedChannels = channelSections
+      .map((section) => ({ ...section, chats: take(section.chats) }))
+      .filter((section) => section.chats.length > 0);
+    const limitedUncategorized = take(uncategorized.sort(byNewest));
     return {
-      pinned: pinned.sort(byNewest).slice(0, limit),
-      direct: direct.sort(byNewest).slice(0, limit),
-      uncategorized: uncategorized.sort(byNewest).slice(0, limit),
-      channels: channelSections.map((section) => ({ ...section, chats: section.chats.slice(0, limit) })),
+      pinned: limitedPinned,
+      direct: limitedDirect,
+      uncategorized: limitedUncategorized,
+      channels: limitedChannels,
       flattenCount,
     };
   }, [orderedChats, pinnedChatIds]);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -923,16 +923,53 @@ function ChatAccordion({
     return () => { if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current); };
   }, []);
 
-  const recentSidebarChats = useMemo(() => {
+  const groupedSidebarChats = useMemo(() => {
     const pinnedSet = new Set(pinnedChatIds);
     const sorted = [...orderedChats].sort(
       (a, b) => b.lastMessageAt.getTime() - a.lastMessageAt.getTime(),
     );
-    const pinned = sorted.filter((c) => pinnedSet.has(c.id));
-    const unpinned = sorted.filter((c) => !pinnedSet.has(c.id));
-    const merged = [...pinned, ...unpinned];
+    const direct: ChatSummary[] = [];
+    const uncategorized: ChatSummary[] = [];
+    const channels = new Map<string, { label: string; chats: ChatSummary[]; newestTs: number }>();
+    const pinned: ChatSummary[] = [];
+    for (const chat of sorted) {
+      const ts = chat.lastMessageAt.getTime();
+      if (pinnedSet.has(chat.id)) pinned.push(chat);
+      const bucket = chat.groupBucketType ?? 'uncategorized';
+      if (bucket === 'direct') {
+        direct.push(chat);
+        continue;
+      }
+      if (bucket === 'channel' && chat.groupBucketKey) {
+        const current = channels.get(chat.groupBucketKey) ?? {
+          label: chat.resolvedChannelName ?? chat.normalizedChannelId ?? 'Channel',
+          chats: [],
+          newestTs: 0,
+        };
+        current.chats.push(chat);
+        current.newestTs = Math.max(current.newestTs, ts);
+        channels.set(chat.groupBucketKey, current);
+        continue;
+      }
+      uncategorized.push(chat);
+    }
     const limit = 15;
-    return merged.slice(0, limit);
+    const byNewest = (a: ChatSummary, b: ChatSummary): number => b.lastMessageAt.getTime() - a.lastMessageAt.getTime();
+    const channelSections = Array.from(channels.entries())
+      .map(([key, value]) => ({ key, label: value.label, chats: value.chats.sort(byNewest), newestTs: value.newestTs }))
+      .sort((a, b) => b.newestTs - a.newestTs);
+    const flattenCount =
+      pinned.length +
+      direct.length +
+      uncategorized.length +
+      channelSections.reduce((acc, c) => acc + c.chats.length, 0);
+    return {
+      pinned: pinned.sort(byNewest).slice(0, limit),
+      direct: direct.sort(byNewest).slice(0, limit),
+      uncategorized: uncategorized.sort(byNewest).slice(0, limit),
+      channels: channelSections.map((section) => ({ ...section, chats: section.chats.slice(0, limit) })),
+      flattenCount,
+    };
   }, [orderedChats, pinnedChatIds]);
 
   if (collapsed) return null;
@@ -1034,14 +1071,35 @@ function ChatAccordion({
       </button>
 
       <div className="flex-1 overflow-y-auto scrollbar-thin space-y-0 min-h-0">
-        {recentSidebarChats.length > 0 ? (
-          recentSidebarChats.map((chat) => renderChatItem(chat))
+        {groupedSidebarChats.flattenCount > 0 ? (
+          <>
+            {groupedSidebarChats.pinned.length > 0 && <SidebarSectionHeader title="Pinned" />}
+            {groupedSidebarChats.pinned.map((chat) => renderChatItem(chat))}
+            {groupedSidebarChats.direct.length > 0 && <SidebarSectionHeader title="Direct" />}
+            {groupedSidebarChats.direct.map((chat) => renderChatItem(chat))}
+            {groupedSidebarChats.channels.map((channel) => (
+              <div key={channel.key}>
+                <SidebarSectionHeader title={channel.label} />
+                {channel.chats.map((chat) => renderChatItem(chat))}
+              </div>
+            ))}
+            {groupedSidebarChats.uncategorized.length > 0 && <SidebarSectionHeader title="Uncategorized" />}
+            {groupedSidebarChats.uncategorized.map((chat) => renderChatItem(chat))}
+          </>
         ) : (
           <div className="px-2 py-1.5 text-xs text-surface-500 text-center">
             No conversations yet
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+function SidebarSectionHeader({ title }: { title: string }): JSX.Element {
+  return (
+    <div className="px-2 pt-2 pb-1">
+      <h3 className="text-[10px] uppercase tracking-wider text-surface-500 font-semibold">{title}</h3>
     </div>
   );
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -974,13 +974,13 @@ function ChatAccordion({
 
   if (collapsed) return null;
 
-  const renderChatItem = (chat: ChatSummary): JSX.Element => {
+  const renderChatItem = (chat: ChatSummary, itemKey: string): JSX.Element => {
     const hasActiveTask = chat.id in activeTasksByConversation;
     const isUnread = unreadConversationIds.has(chat.id);
 
     return (
       <div
-        key={chat.id}
+        key={itemKey}
         className={`relative w-full text-left px-2 py-1 rounded-md transition-colors cursor-pointer leading-tight ${
           currentChatId === chat.id
             ? 'bg-surface-800 text-surface-100'
@@ -1074,17 +1074,17 @@ function ChatAccordion({
         {groupedSidebarChats.flattenCount > 0 ? (
           <>
             {groupedSidebarChats.pinned.length > 0 && <SidebarSectionHeader title="Pinned" />}
-            {groupedSidebarChats.pinned.map((chat) => renderChatItem(chat))}
+            {groupedSidebarChats.pinned.map((chat) => renderChatItem(chat, `pinned-${chat.id}`))}
             {groupedSidebarChats.direct.length > 0 && <SidebarSectionHeader title="Direct" />}
-            {groupedSidebarChats.direct.map((chat) => renderChatItem(chat))}
+            {groupedSidebarChats.direct.map((chat) => renderChatItem(chat, `direct-${chat.id}`))}
             {groupedSidebarChats.channels.map((channel) => (
               <div key={channel.key}>
                 <SidebarSectionHeader title={channel.label} />
-                {channel.chats.map((chat) => renderChatItem(chat))}
+                {channel.chats.map((chat) => renderChatItem(chat, `channel-${channel.key}-${chat.id}`))}
               </div>
             ))}
             {groupedSidebarChats.uncategorized.length > 0 && <SidebarSectionHeader title="Uncategorized" />}
-            {groupedSidebarChats.uncategorized.map((chat) => renderChatItem(chat))}
+            {groupedSidebarChats.uncategorized.map((chat) => renderChatItem(chat, `uncategorized-${chat.id}`))}
           </>
         ) : (
           <div className="px-2 py-1.5 text-xs text-surface-500 text-center">

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -388,8 +388,18 @@ export const useChatStore = create<ChatState>()(
               email: string;
               avatar_url?: string | null;
             }>;
+            workspace_id?: string | null;
+            source?: string | null;
+            source_channel_id?: string | null;
+            normalized_channel_id?: string | null;
+            resolved_channel_name?: string | null;
+            group_bucket_type?: "pinned" | "direct" | "channel" | "uncategorized";
+            group_bucket_key?: string;
           }>;
           total: number;
+          next_cursor?: string | null;
+          has_more?: boolean;
+          server_time?: string;
         };
 
         const { data, error } = await apiRequest<ConversationApiResponse>(
@@ -420,6 +430,13 @@ export const useChatStore = create<ChatState>()(
             email: p.email,
             avatarUrl: p.avatar_url,
           })),
+          workspaceId: conv.workspace_id,
+          source: conv.source,
+          sourceChannelId: conv.source_channel_id,
+          normalizedChannelId: conv.normalized_channel_id,
+          resolvedChannelName: conv.resolved_channel_name,
+          groupBucketType: conv.group_bucket_type,
+          groupBucketKey: conv.group_bucket_key,
         });
 
         const recentChats: ChatSummary[] = conversations

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -130,6 +130,13 @@ export interface ChatSummary {
   participants?: Participant[];
   matchSnippet?: string | null; // Search match context snippet
   matchCount?: number; // Number of occurrences in conversation
+  workspaceId?: string | null;
+  source?: string | null;
+  sourceChannelId?: string | null;
+  normalizedChannelId?: string | null;
+  resolvedChannelName?: string | null;
+  groupBucketType?: "pinned" | "direct" | "channel" | "uncategorized";
+  groupBucketKey?: string;
 }
 
 // Workstream (semantic Home) types


### PR DESCRIPTION
### Motivation
- Make the sidebar scalable and deterministic by grouping conversations by stable channel identity and supporting lazy-loading pagination. 
- Prevent stale Slack channel labels from breaking grouping by adding workspace-aware name resolution with bounded stale-while-revalidate semantics.
- Keep the API additive and backward-compatible so existing clients continue to work while enabling the frontend to implement grouped, virtualized lists.

### Description
- Backend: extended `GET /chat/conversations` to return additive grouping and pagination fields (`workspace_id`, `source`, `source_channel_id`, `normalized_channel_id`, `resolved_channel_name`, `group_bucket_type`, `group_bucket_key`, `next_cursor`, `has_more`, `server_time`) and switched to cursor-based pagination with stable ordering `(updated_at DESC, id DESC)` and opaque cursor encoding/decoding.
- Backend: added Slack channel normalization and server-side bucket derivation (`direct`, `channel`, `uncategorized`) and implemented workspace-aware Slack channel-name resolution using Redis with soft/hard TTLs, jitter, single-flight refresh locking and async stale-while-revalidate refresh tasks (`_normalize_channel_id`, `_derive_bucket`, `_resolve_slack_channel_name`, `_refresh_slack_channel_name`, `_get_workspace_id_for_org`).
- Frontend: updated API client types and `listConversations` to accept an optional `cursor` and to read `next_cursor`/`has_more`/`server_time`; extended shared types and store mapping to carry new grouping metadata.
- Frontend UI: updated `ChatsList` to perform cursor-aware infinite loading, de-duplicate incoming pages, and render grouped sections in the order `Pinned`, `Direct`, channel groups (sorted by newest conversation), and `Uncategorized`; updated `Sidebar` chat accordion to render channel-based sections while preserving pinned duplication semantics.

### Testing
- Backend Python syntax check: `python -m py_compile backend/api/routes/chat.py` completed successfully.
- Frontend build: ran `npm run build` in `frontend/` and the production build completed successfully.
- No schema migrations were required and changes are additive/backwards-compatible; no automated unit test suite was executed in this rollout beyond the build/compile validation listed above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fee4092c8321bd69e4179c7d5fce)