### PR TITLE
Clarify artifact create/update guidance and move update instructions to usage_guide

### DIFF
--- a/backend/connectors/artifacts.py
+++ b/backend/connectors/artifacts.py
@@ -81,10 +81,11 @@ class ArtifactConnector(BaseConnector):
                 ],
             ),
         ],
-        description="Create and update downloadable files. IMPORTANT: When the user asks to edit, revise, or update an artifact they're viewing or that was just created, use operation='update' with the artifact_id from the previous result — do NOT create a new artifact.",
+        description="Create and update downloadable files.",
         usage_guide=(
-            "When the user says 'update', 'edit', 'change', 'revise', or 'add to' regarding an artifact from this conversation, "
-            "use operation='update' with artifact_id from your prior create/update result. Creating a new artifact gives a new URL; updating keeps the same one."
+            "When the user says 'update', 'edit', 'change', 'revise', or 'add to' regarding an artifact from this conversation "
+            "(including one they are viewing or that was just created), use operation='update' with artifact_id from your prior "
+            "create/update result. Do NOT create a new artifact. Creating a new artifact gives a new URL; updating keeps the same one."
         ),
     )
 


### PR DESCRIPTION
### Motivation
- Clarify and centralize guidance about when to use the `create` vs `update` operations for artifacts so the connector behavior is unambiguous. 

### Description
- Shortened the public `description` text for the artifact connector and moved the explicit instruction about updating existing artifacts into the `usage_guide` string. 
- Expanded the `usage_guide` wording to explicitly mention artifacts the user is viewing or that were just created, and added the explicit admonition `Do NOT create a new artifact` when an update is intended. 
- Kept the operation parameter definitions for `create` and `update` unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e901fcce9c832182f81c82df6866f0)