### PR TITLE
Default private visibility for DMs/group-DMs and private-channel Apps/Artifacts

### DIFF
--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -415,6 +415,7 @@ class AppsConnector(BaseConnector):
         conversation_id: str | None = data.get("conversation_id")
         user_uuid: UUID | None = None
         conversation_uuid: UUID | None = None
+        visibility: str = "team"
         owner_override_raw: Any = data.get(" app created by")
         owner_override_id: str | None = None
         if owner_override_raw is not None:
@@ -470,20 +471,31 @@ class AppsConnector(BaseConnector):
                             Conversation.user_id,
                             Conversation.source,
                             Conversation.source_user_id,
+                            Conversation.scope,
                         ).where(
                             Conversation.id == conversation_uuid,
                         )
                     )
-                    conversation_record: tuple[UUID | None, str | None, str | None] | None = row.one_or_none()
+                    conversation_record: tuple[UUID | None, str | None, str | None, str | None] | None = row.one_or_none()
                     conversation_user_id: UUID | None = None
                     conversation_source: str | None = None
                     conversation_source_user_id: str | None = None
+                    conversation_scope: str | None = None
                     if conversation_record is not None:
                         (
                             conversation_user_id,
                             conversation_source,
                             conversation_source_user_id,
+                            conversation_scope,
                         ) = conversation_record
+                    normalized_scope: str = (conversation_scope or "").strip().lower()
+                    if normalized_scope == "private":
+                        visibility = "private"
+                        logger.info(
+                            "[AppsConnector] Inherited private visibility from conversation scope: conversation_id=%s scope=%s",
+                            conversation_id,
+                            conversation_scope,
+                        )
                     if conversation_user_id is not None:
                         user_uuid = conversation_user_id
                         logger.info(
@@ -576,6 +588,7 @@ class AppsConnector(BaseConnector):
                 queries=queries,
                 frontend_code=frontend_code,
                 frontend_code_compiled=compiled_code,
+                visibility=visibility,
                 conversation_id=conversation_uuid,
                 message_id=msg_id_str,
             )

--- a/backend/connectors/artifacts.py
+++ b/backend/connectors/artifacts.py
@@ -278,6 +278,7 @@ class ArtifactConnector(BaseConnector):
         artifact_uuid: UUID = uuid4()
         artifact_id_str: str = str(artifact_uuid)
         user_uuid: UUID | None = None
+        visibility: str = "team"
         if message_id:
             try:
                 message_uuid = UUID(message_id)
@@ -327,20 +328,31 @@ class ArtifactConnector(BaseConnector):
                             Conversation.user_id,
                             Conversation.source,
                             Conversation.source_user_id,
+                            Conversation.scope,
                         ).where(
                             Conversation.id == conversation_uuid,
                         )
                     )
-                    conversation_record: tuple[UUID | None, str | None, str | None] | None = row.one_or_none()
+                    conversation_record: tuple[UUID | None, str | None, str | None, str | None] | None = row.one_or_none()
                     conversation_user_id: UUID | None = None
                     conversation_source: str | None = None
                     conversation_source_user_id: str | None = None
+                    conversation_scope: str | None = None
                     if conversation_record is not None:
                         (
                             conversation_user_id,
                             conversation_source,
                             conversation_source_user_id,
+                            conversation_scope,
                         ) = conversation_record
+                    normalized_scope: str = (conversation_scope or "").strip().lower()
+                    if normalized_scope == "private":
+                        visibility = "private"
+                        logger.info(
+                            "[ArtifactConnector] Inherited private visibility from conversation scope: conversation_id=%s scope=%s",
+                            conversation_id,
+                            conversation_scope,
+                        )
                     if conversation_user_id is not None:
                         user_uuid = conversation_user_id
                         logger.info(
@@ -371,6 +383,14 @@ class ArtifactConnector(BaseConnector):
             )
 
         if user_uuid is None:
+            if visibility == "private":
+                visibility = "team"
+                logger.warning(
+                    "[ArtifactConnector] Unable to keep private visibility without an owner; reverting to team visibility: org_id=%s message_id=%s conversation_id=%s",
+                    self.organization_id,
+                    message_id,
+                    conversation_id,
+                )
             logger.warning(
                 "[ArtifactConnector] Artifact owner unresolved; creating ownerless artifact: org_id=%s message_id=%s conversation_id=%s",
                 self.organization_id,
@@ -385,6 +405,7 @@ class ArtifactConnector(BaseConnector):
                 organization_id=UUID(self.organization_id),
                 type="file",
                 title=title,
+                visibility=visibility,
                 content=stored_content,
                 content_type=content_type,
                 mime_type=mime_type,

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -119,7 +119,7 @@ def _resolve_conversation_scope(
         return "shared"
 
     if channel_type in {"mpim", "groupchat"}:
-        return "shared"
+        return "private"
 
     identity_known: bool = bool(revtops_user_id or message.external_user_id)
     return "private" if identity_known else "shared"

--- a/backend/tests/test_apps_connector_owner_resolution.py
+++ b/backend/tests/test_apps_connector_owner_resolution.py
@@ -25,6 +25,7 @@ class _FakeSession:
         *,
         message_user_id: UUID | None,
         conversation_user_id: UUID | None,
+        conversation_scope: str | None = None,
         org_handle: str | None = None,
         conversation_source: str | None = None,
         conversation_source_user_id: str | None = None,
@@ -33,6 +34,7 @@ class _FakeSession:
     ):
         self.message_user_id = message_user_id
         self.conversation_user_id = conversation_user_id
+        self.conversation_scope = conversation_scope
         self.org_handle = org_handle
         self.conversation_source = conversation_source
         self.conversation_source_user_id = conversation_source_user_id
@@ -52,6 +54,7 @@ class _FakeSession:
                     self.conversation_user_id,
                     self.conversation_source,
                     self.conversation_source_user_id,
+                    self.conversation_scope,
                 )
             )
         if "user_mappings_for_identity" in q:
@@ -326,6 +329,49 @@ def test_create_returns_org_handle_scoped_uri_when_handle_present(monkeypatch):
 
     assert result["status"] == "success"
     assert result["uri"].startswith("/acme/apps/")
+
+
+def test_create_sets_private_visibility_for_private_conversation(monkeypatch):
+    org_id = "00000000-0000-0000-0000-000000000010"
+    fake_session = _FakeSession(
+        message_user_id=None,
+        conversation_user_id=UUID("00000000-0000-0000-0000-000000000013"),
+        conversation_scope="private",
+    )
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        yield fake_session
+
+    async def _fake_warm(*_args, **_kwargs):
+        return None
+
+    async def _fake_test_execute_queries(*_args, **_kwargs):
+        return []
+
+    async def _fake_alternate(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr("connectors.apps.get_session", _fake_get_session)
+    monkeypatch.setattr("connectors.apps.warm_public_preview_cache", _fake_warm)
+    monkeypatch.setattr("connectors.apps.get_alternate_slack_user_ids_for_identity", _fake_alternate)
+    monkeypatch.setattr("utils.transpile_jsx.transpile_jsx", lambda _code: (None,))
+    monkeypatch.setattr("connectors.apps.AppsConnector._test_execute_queries", _fake_test_execute_queries)
+
+    connector = AppsConnector(organization_id=org_id, user_id=None)
+    result = asyncio.run(
+        connector._create(
+            {
+                "title": "Private app",
+                "queries": {"q": {"sql": "SELECT 1 AS n", "params": {}}},
+                "frontend_code": "export default function App(){ return <div/>; }",
+                "conversation_id": "00000000-0000-0000-0000-000000000015",
+            }
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_session.added[0].visibility == "private"
 
 
 def test_read_materializes_fields_before_session_exit(monkeypatch):

--- a/backend/tests/test_artifacts_connector_owner_resolution.py
+++ b/backend/tests/test_artifacts_connector_owner_resolution.py
@@ -25,6 +25,7 @@ class _FakeSession:
         *,
         message_user_id: UUID | None,
         conversation_user_id: UUID | None,
+        conversation_scope: str | None = None,
         org_handle: str | None = None,
         conversation_source: str | None = None,
         conversation_source_user_id: str | None = None,
@@ -33,6 +34,7 @@ class _FakeSession:
     ):
         self.message_user_id = message_user_id
         self.conversation_user_id = conversation_user_id
+        self.conversation_scope = conversation_scope
         self.org_handle = org_handle
         self.conversation_source = conversation_source
         self.conversation_source_user_id = conversation_source_user_id
@@ -52,6 +54,7 @@ class _FakeSession:
                     self.conversation_user_id,
                     self.conversation_source,
                     self.conversation_source_user_id,
+                    self.conversation_scope,
                 )
             )
         if "user_mappings_for_identity" in q:
@@ -210,3 +213,83 @@ def test_create_returns_org_handle_scoped_uri_when_handle_present(monkeypatch):
 
     assert result["status"] == "success"
     assert result["uri"].startswith("/acme/artifacts/")
+
+
+def test_create_sets_private_visibility_for_private_conversation(monkeypatch):
+    org_id = "00000000-0000-0000-0000-000000000010"
+    fake_session = _FakeSession(
+        message_user_id=None,
+        conversation_user_id=UUID("00000000-0000-0000-0000-000000000013"),
+        conversation_scope="private",
+    )
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        yield fake_session
+
+    async def _fake_warm(*_args, **_kwargs):
+        return None
+
+    async def _fake_alternate(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr("connectors.artifacts.get_session", _fake_get_session)
+    monkeypatch.setattr("connectors.artifacts.warm_public_preview_cache", _fake_warm)
+    monkeypatch.setattr("connectors.artifacts.get_alternate_slack_user_ids_for_identity", _fake_alternate)
+
+    connector = ArtifactConnector(organization_id=org_id, user_id=None)
+
+    result = asyncio.run(
+        connector._create(
+            {
+                "title": "Private artifact",
+                "filename": "artifact.md",
+                "content_type": "markdown",
+                "content": "hello",
+                "conversation_id": "00000000-0000-0000-0000-000000000015",
+            }
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_session.added[0].visibility == "private"
+
+
+def test_create_reverts_private_visibility_without_owner(monkeypatch):
+    org_id = "00000000-0000-0000-0000-000000000010"
+    fake_session = _FakeSession(
+        message_user_id=None,
+        conversation_user_id=None,
+        conversation_scope="private",
+    )
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        yield fake_session
+
+    async def _fake_warm(*_args, **_kwargs):
+        return None
+
+    async def _fake_alternate(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr("connectors.artifacts.get_session", _fake_get_session)
+    monkeypatch.setattr("connectors.artifacts.warm_public_preview_cache", _fake_warm)
+    monkeypatch.setattr("connectors.artifacts.get_alternate_slack_user_ids_for_identity", _fake_alternate)
+
+    connector = ArtifactConnector(organization_id=org_id, user_id=None)
+
+    result = asyncio.run(
+        connector._create(
+            {
+                "title": "Ownerless private artifact",
+                "filename": "artifact.md",
+                "content_type": "markdown",
+                "content": "hello",
+                "conversation_id": "00000000-0000-0000-0000-000000000015",
+            }
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_session.added[0].visibility == "team"

--- a/backend/tests/test_workspace_conversation_scope.py
+++ b/backend/tests/test_workspace_conversation_scope.py
@@ -17,9 +17,9 @@ def test_resolve_conversation_scope_private_for_known_im_direct_message() -> Non
     assert _resolve_conversation_scope(message, revtops_user_id=None) == "private"
 
 
-def test_resolve_conversation_scope_shared_for_mpim_direct_message() -> None:
+def test_resolve_conversation_scope_private_for_mpim_direct_message() -> None:
     message = _build_message(MessageType.DIRECT, channel_type="mpim", external_user_id="U123")
-    assert _resolve_conversation_scope(message, revtops_user_id="11111111-1111-1111-1111-111111111111") == "shared"
+    assert _resolve_conversation_scope(message, revtops_user_id="11111111-1111-1111-1111-111111111111") == "private"
 
 
 def test_resolve_conversation_scope_shared_for_mentions() -> None:
@@ -49,6 +49,6 @@ def test_resolve_conversation_scope_private_for_mentions_in_private_slack_channe
     assert _resolve_conversation_scope(message, revtops_user_id="11111111-1111-1111-1111-111111111111") == "private"
 
 
-def test_resolve_conversation_scope_shared_for_teams_groupchat_direct_message() -> None:
+def test_resolve_conversation_scope_private_for_teams_groupchat_direct_message() -> None:
     message = _build_message(MessageType.DIRECT, channel_type="groupChat", external_user_id="U123")
-    assert _resolve_conversation_scope(message, revtops_user_id="11111111-1111-1111-1111-111111111111") == "shared"
+    assert _resolve_conversation_scope(message, revtops_user_id="11111111-1111-1111-1111-111111111111") == "private"

--- a/docs/conversation_creation_visibility_flow.md
+++ b/docs/conversation_creation_visibility_flow.md
@@ -1,0 +1,48 @@
+# Conversation Creation & Visibility Flow
+
+This document summarizes how Basebase currently decides conversation scope and how that scope propagates to Apps and Artifacts ("docs") created from that context.
+
+## Core concept: conversation scope
+
+Conversation scope is the high-level access model for chat threads:
+
+- `private`: visible only to the initiating user context.
+- `shared`: visible to participants in a collaborative/shared context.
+
+When messenger conversations are created from inbound events, scope is resolved in `messengers/_workspace.py` via `_resolve_conversation_scope(...)`.
+
+## Messenger defaults
+
+### Direct messages
+
+- 1:1 DMs (`im`/personal direct contexts) create **private** conversations by default.
+- Group DMs (`mpim` in Slack, `groupChat` in Teams) now also create **private** conversations by default.
+
+### Channel/mention contexts
+
+- Public channel mentions continue to create **shared** conversations by default.
+- Private channel contexts (for example Slack private channels) create **private** conversations by default.
+
+## Apps and Artifacts visibility inheritance
+
+When `apps.create` or `artifacts.create` runs with a `conversation_id`, the connector loads the conversation and inherits privacy defaults:
+
+- If originating conversation scope is `private`, the created App/Artifact visibility defaults to `private`.
+- Otherwise, visibility defaults to `team`.
+
+### Owner requirement for private artifacts
+
+Artifacts can be ownerless in certain automated contexts. Private visibility without an owner is not valid for artifact permission semantics, so artifact creation applies this safeguard:
+
+- if requested/inherited visibility is `private` **and** owner cannot be resolved, fallback to `team` visibility.
+
+Apps already require a resolved owner on create, so private visibility inheritance is applied directly when source conversation scope is private.
+
+## End-to-end behavior summary
+
+At a conceptual level:
+
+1. Incoming message context determines conversation scope (`private`/`shared`).
+2. Conversation is created/updated with that scope.
+3. Connector writes (Apps/Artifacts) created from that conversation inherit private defaults from conversation scope.
+4. Additional ownership safety checks enforce valid private visibility behavior for owner-dependent resources.


### PR DESCRIPTION
### Motivation
- Ensure conversations created from direct/group-DM/private-channel contexts default to a private scope so downstream resources inherit appropriate privacy.
- Make Apps and Artifacts created from private conversations private by default to avoid accidental public/team exposure.
- Ensure artifacts do not remain private when there is no resolvable owner, preserving permission semantics.

### Description
- Treat messenger group DMs as private by default by updating `_resolve_conversation_scope` to return `private` for `mpim`/`groupChat` channel types in `backend/messengers/_workspace.py`.
- Propagate conversation scope into connector creates by loading `Conversation.scope` in `backend/connectors/apps.py` and `backend/connectors/artifacts.py`, defaulting `visibility` to `team` and setting it to `private` when the originating conversation scope is `private`.
- Add a safety fallback in `artifacts.create` that reverts `visibility` from `private` to `team` when no owner can be resolved, and log a warning when this occurs.
- Add and update unit tests to cover the new scope and visibility behavior and add documentation `docs/conversation_creation_visibility_flow.md` describing the conversation creation and visibility flow.

### Testing
- Ran `pytest -q backend/tests/test_workspace_conversation_scope.py backend/tests/test_apps_connector_owner_resolution.py backend/tests/test_artifacts_connector_owner_resolution.py` which executed the updated tests.
- Test result: `18 passed` (all tests in the invoked suite passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e904a56d38832193c60e1a6f7d62c5)