### PR TITLE
Add OpenAI gpt-5 404 model fallback to OpenAIAdapter

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Literal, Protocol
 
 from anthropic import APIStatusError as AnthropicAPIStatusError, AsyncAnthropic
-from openai import AsyncOpenAI
+from openai import APIStatusError as OpenAIAPIStatusError, AsyncOpenAI
 
 logger = logging.getLogger(__name__)
 
@@ -422,6 +422,33 @@ class OpenAIAdapter:
         )
         return {token_param_name: max_tokens}
 
+    def _openai_not_found_fallback_models(self, model: str) -> list[str]:
+        """Return same-family model candidates when a model is not found."""
+        normalized_model: str = model.strip().lower()
+        prefix: str = ""
+        base_model: str = normalized_model
+        if "/" in normalized_model:
+            prefix, base_model = normalized_model.split("/", 1)
+            prefix = f"{prefix}/"
+
+        if not base_model.startswith("gpt-5"):
+            return []
+
+        variants: list[str] = []
+        if base_model == "gpt-5":
+            variants.extend(["gpt-5-mini", "gpt-5-nano"])
+        elif base_model == "gpt-5-mini":
+            variants.append("gpt-5-nano")
+
+        fallback_models: list[str] = [f"{prefix}{variant}" for variant in variants if variant != base_model]
+        if fallback_models:
+            logger.warning(
+                "[OpenAIAdapter] Model fallback engaged after 404 not_found: requested_model=%s fallback_candidates=%s",
+                model,
+                fallback_models,
+            )
+        return fallback_models
+
     # -- streaming ----------------------------------------------------------
 
     async def stream(
@@ -439,18 +466,46 @@ class OpenAIAdapter:
         ] + self.format_messages_for_api(messages)
 
         api_kwargs: dict[str, Any] = {
-            "model": model,
             "messages": api_messages,
             "stream": True,
         }
-        api_kwargs.update(self._build_token_limit_kwargs(model=model, max_tokens=max_tokens))
         if tools:
             api_kwargs["tools"] = self.format_tools(tools)
 
         tool_calls_accum: dict[int, dict[str, str]] = {}
         current_text_started: bool = False
 
-        stream = await self._client.chat.completions.create(**api_kwargs)
+        stream: Any = None
+        model_candidates: list[str] = [model, *self._openai_not_found_fallback_models(model)]
+        for idx, candidate_model in enumerate(model_candidates):
+            candidate_kwargs: dict[str, Any] = {
+                **api_kwargs,
+                "model": candidate_model,
+                **self._build_token_limit_kwargs(model=candidate_model, max_tokens=max_tokens),
+            }
+            try:
+                stream = await self._client.chat.completions.create(**candidate_kwargs)
+                if idx > 0:
+                    logger.info(
+                        "[OpenAIAdapter] Stream call succeeded with fallback model=%s requested_model=%s",
+                        candidate_model,
+                        model,
+                    )
+                break
+            except OpenAIAPIStatusError as exc:
+                if exc.status_code == 404 and idx < len(model_candidates) - 1:
+                    logger.warning(
+                        "[OpenAIAdapter] Stream model unavailable (404), retrying fallback. requested_model=%s candidate_model=%s fallback_index=%d/%d",
+                        model,
+                        candidate_model,
+                        idx + 1,
+                        len(model_candidates),
+                    )
+                    continue
+                raise
+
+        if stream is None:
+            raise RuntimeError("OpenAI stream initialization failed without a response stream")
         chunk: Any | None = None
         async for chunk in stream:
             choice = chunk.choices[0] if chunk.choices else None
@@ -532,11 +587,36 @@ class OpenAIAdapter:
             {"role": "system", "content": system}
         ] + self.format_messages_for_api(messages)
 
-        response = await self._client.chat.completions.create(
-            model=model,
-            messages=api_messages,
-            **self._build_token_limit_kwargs(model=model, max_tokens=max_tokens),
-        )
+        response: Any = None
+        model_candidates: list[str] = [model, *self._openai_not_found_fallback_models(model)]
+        for idx, candidate_model in enumerate(model_candidates):
+            try:
+                response = await self._client.chat.completions.create(
+                    model=candidate_model,
+                    messages=api_messages,
+                    **self._build_token_limit_kwargs(model=candidate_model, max_tokens=max_tokens),
+                )
+                if idx > 0:
+                    logger.info(
+                        "[OpenAIAdapter] Complete call succeeded with fallback model=%s requested_model=%s",
+                        candidate_model,
+                        model,
+                    )
+                break
+            except OpenAIAPIStatusError as exc:
+                if exc.status_code == 404 and idx < len(model_candidates) - 1:
+                    logger.warning(
+                        "[OpenAIAdapter] Complete model unavailable (404), retrying fallback. requested_model=%s candidate_model=%s fallback_index=%d/%d",
+                        model,
+                        candidate_model,
+                        idx + 1,
+                        len(model_candidates),
+                    )
+                    continue
+                raise
+
+        if response is None:
+            raise RuntimeError("OpenAI complete call failed without a response")
         blocks: list[ContentBlock] = self.build_completed_content(response)
         usage = response.usage
         return CompletedMessage(

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -1,7 +1,9 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
+from openai import APIStatusError
 
 from services.llm_adapter import OpenAIAdapter
 
@@ -12,6 +14,16 @@ class _EmptyAsyncIterator:
 
     async def __anext__(self):
         raise StopAsyncIteration
+
+
+def _openai_api_status_error(message: str, status_code: int = 404) -> APIStatusError:
+    request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    response = httpx.Response(status_code=status_code, request=request, headers={"x-request-id": "req_test"})
+    return APIStatusError(
+        message=message,
+        response=response,
+        body={"error": {"type": "not_found_error", "message": message}},
+    )
 
 
 def test_openai_gpt5_uses_max_completion_tokens():
@@ -126,3 +138,63 @@ async def test_openai_stream_does_not_pass_duplicate_model_kwarg():
     assert create_mock.await_count == 1
     call_kwargs = create_mock.await_args.kwargs
     assert call_kwargs["model"] == "gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_falls_back_when_gpt5_not_found():
+    adapter = OpenAIAdapter(api_key="test-key")
+    create_mock = AsyncMock(
+        side_effect=[
+            _openai_api_status_error("model: gpt-5"),
+            _EmptyAsyncIterator(),
+        ]
+    )
+    adapter._client = SimpleNamespace(  # type: ignore[assignment]
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+    )
+
+    events = [
+        event
+        async for event in adapter.stream(
+            model="gpt-5",
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=42,
+        )
+    ]
+
+    assert events == []
+    assert create_mock.await_count == 2
+    assert create_mock.await_args_list[0].kwargs["model"] == "gpt-5"
+    assert create_mock.await_args_list[1].kwargs["model"] == "gpt-5-mini"
+
+
+@pytest.mark.asyncio
+async def test_openai_complete_falls_back_when_gpt5_not_found():
+    adapter = OpenAIAdapter(api_key="test-key")
+    completion_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="fallback answer", tool_calls=None))],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=2),
+    )
+    create_mock = AsyncMock(
+        side_effect=[
+            _openai_api_status_error("model: gpt-5"),
+            completion_response,
+        ]
+    )
+    adapter._client = SimpleNamespace(  # type: ignore[assignment]
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+    )
+
+    completed = await adapter.complete(
+        model="gpt-5",
+        system="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=42,
+    )
+
+    assert completed.input_tokens == 1
+    assert completed.output_tokens == 2
+    assert create_mock.await_count == 2
+    assert create_mock.await_args_list[0].kwargs["model"] == "gpt-5"
+    assert create_mock.await_args_list[1].kwargs["model"] == "gpt-5-mini"


### PR DESCRIPTION
### Motivation
- Requests configured with `gpt-5` can fail with `404 not_found` when that model is unavailable, so the adapter should automatically try compatible same-family models to improve reliability.
- Fallback behavior must preserve provider prefixes (e.g. `openai/...`) and be applied consistently for both streaming and non-streaming calls.

### Description
- Added `OpenAIAPIStatusError` import and a new helper `OpenAIAdapter._openai_not_found_fallback_models` that returns same-family fallback candidates (e.g. `gpt-5-mini`, `gpt-5-nano`) while preserving provider prefixes. 
- Updated `OpenAIAdapter.stream` to iterate candidate models, retry on `404` errors, log warnings/info about fallbacks, and initialize the stream with the first successful model. 
- Updated `OpenAIAdapter.complete` to mirror the same candidate-retry logic for non-streaming completions and to log fallback success or warnings. 
- Added unit tests in `backend/tests/test_llm_adapter_openai_token_params.py` to simulate `404` responses and assert retries to `gpt-5-mini`, and adjusted a test completion response shape for compatibility. 
- Modified `backend/services/llm_adapter.py` and `backend/tests/test_llm_adapter_openai_token_params.py` to implement and validate these changes. 

### Testing
- Ran `pytest -q backend/tests/test_llm_adapter_openai_token_params.py` and observed `9 passed` indicating the new fallback tests and existing tests succeeded. 
- The new tests cover both `stream()` and `complete()` fallback paths and assert the adapter retries the expected fallback models. 
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e905519f548321ad8180b02e832b62)