### PR TITLE
Fix workflow model override across providers

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -14,6 +14,7 @@ import asyncio
 import json
 import logging
 import re
+from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any, AsyncGenerator, Sequence
 from uuid import UUID, uuid4
@@ -33,6 +34,7 @@ from services.llm_adapter import (
     get_adapter,
 )
 from services.llm_provider import resolve_llm_config
+from services.llm_provider import provider_for_model, resolve_api_key_for_provider
 from models.chat_attachment import ChatAttachment
 from models.chat_message import ChatMessage
 from models.conversation import Conversation
@@ -1072,7 +1074,6 @@ class ChatOrchestrator:
 
         # Resolve per-org LLM provider/model/key
         self._llm_config = await resolve_llm_config(self.organization_id)
-        self._adapter = get_adapter(self._llm_config)
         is_workflow_run: bool = bool((self.workflow_context or {}).get("is_workflow"))
         workflow_model_override = (self.workflow_context or {}).get("workflow_model_override")
         selected_model: str = (
@@ -1080,6 +1081,27 @@ class ChatOrchestrator:
             if is_workflow_run and workflow_model_override
             else (self._llm_config.workflow_model if is_workflow_run else self._llm_config.primary_model)
         )
+        if is_workflow_run and workflow_model_override:
+            override_provider = provider_for_model(selected_model)
+            if override_provider and override_provider != self._llm_config.provider:
+                previous_provider = self._llm_config.provider
+                override_api_key = await resolve_api_key_for_provider(
+                    override_provider, self.organization_id
+                )
+                self._llm_config = replace(
+                    self._llm_config,
+                    provider=override_provider,  # type: ignore[arg-type]
+                    api_key=override_api_key,
+                    base_url=None,
+                )
+                logger.info(
+                    "[Orchestrator] Switching provider for workflow model override conversation_id=%s previous_provider=%s override_provider=%s selected_model=%s",
+                    self.conversation_id,
+                    previous_provider,
+                    override_provider,
+                    selected_model,
+                )
+        self._adapter = get_adapter(self._llm_config)
 
         logger.info(
             "[Orchestrator] conversation_id=%s provider=%s selected_model=%s is_workflow=%s workflow_model_override=%s",

--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -53,24 +53,17 @@ async def resolve_llm_config(
 
     if organization_id is not None:
         try:
-            from models.database import get_admin_session
-            from models.organization import Organization
-
-            org_uuid: UUID = (
-                organization_id if isinstance(organization_id, UUID) else UUID(str(organization_id))
-            )
-            async with get_admin_session() as session:
-                org = await session.get(Organization, org_uuid)
-                if org is not None:
-                    org_handle = org.handle
-                    if org.llm_provider:
-                        provider = org.llm_provider  # type: ignore[assignment]
-                    if org.llm_primary_model:
-                        primary_model = org.llm_primary_model
-                    if org.llm_cheap_model:
-                        cheap_model = org.llm_cheap_model
-                    if org.llm_workflow_model:
-                        workflow_model = org.llm_workflow_model
+            org = await _load_organization_for_llm(organization_id)
+            if org is not None:
+                org_handle = org.handle
+                if org.llm_provider:
+                    provider = org.llm_provider  # type: ignore[assignment]
+                if org.llm_primary_model:
+                    primary_model = org.llm_primary_model
+                if org.llm_cheap_model:
+                    cheap_model = org.llm_cheap_model
+                if org.llm_workflow_model:
+                    workflow_model = org.llm_workflow_model
         except Exception:
             logger.warning(
                 "Failed to load org LLM config for %s; using global defaults",
@@ -117,6 +110,39 @@ async def resolve_llm_config(
         workflow_model=workflow_model,
         api_key=api_key,
     )
+
+
+async def resolve_api_key_for_provider(
+    provider: LLMProvider,
+    organization_id: str | UUID | None,
+) -> str:
+    """Resolve API key for a specific provider using org-scoped key override if available."""
+    org_handle: str | None = None
+    if organization_id is not None:
+        try:
+            org = await _load_organization_for_llm(organization_id)
+            if org is not None:
+                org_handle = org.handle
+        except Exception:
+            logger.warning(
+                "Failed to load org handle for provider-key lookup organization_id=%s provider=%s",
+                organization_id,
+                provider,
+                exc_info=True,
+            )
+    return _resolve_api_key(provider, org_handle)
+
+
+async def _load_organization_for_llm(organization_id: str | UUID) -> object | None:
+    """Load organization row used by LLM configuration helpers."""
+    from models.database import get_admin_session
+    from models.organization import Organization
+
+    org_uuid: UUID = (
+        organization_id if isinstance(organization_id, UUID) else UUID(str(organization_id))
+    )
+    async with get_admin_session() as session:
+        return await session.get(Organization, org_uuid)
 
 
 def _resolve_api_key(provider: LLMProvider, org_handle: str | None) -> str:

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -1,6 +1,10 @@
 import asyncio
 
-from services.llm_provider import _infer_provider_from_model_name, resolve_llm_config
+from services.llm_provider import (
+    _infer_provider_from_model_name,
+    resolve_api_key_for_provider,
+    resolve_llm_config,
+)
 
 
 def test_infer_provider_from_model_name() -> None:
@@ -42,3 +46,12 @@ def test_resolve_llm_config_logs_when_model_fallback_engaged(monkeypatch, caplog
     assert any(
         "Model fallback engaged (quick/same-family)" in record.message for record in caplog.records
     )
+
+
+def test_resolve_api_key_for_provider_uses_global_key(monkeypatch) -> None:
+    from services import llm_provider
+
+    monkeypatch.setitem(llm_provider._GLOBAL_PROVIDER_KEYS, "gemini", "test-gemini-key")
+
+    key = asyncio.run(resolve_api_key_for_provider("gemini", None))
+    assert key == "test-gemini-key"


### PR DESCRIPTION
### Motivation
- Workflows can specify a per-workflow model override (`llm_model`), but the orchestrator always instantiated the adapter using the organization-level provider, causing failures when the override model belonged to a different provider.
- Runtime provider/key resolution needed to honor per-workflow model choices and org-scoped API key overrides.

### Description
- Orchestrator now detects when a workflow model override is used and, if that model maps to a different provider, resolves the provider and API key and switches the `LLMConfig`/adapter at runtime using `provider_for_model` and `resolve_api_key_for_provider`.
- Added `resolve_api_key_for_provider(...)` and `_load_organization_for_llm(...)` in `services/llm_provider.py` so provider-specific key lookup reuses org-handle lookup and honors `LLM_KEY__<org_handle>` overrides.
- Refactored `resolve_llm_config(...)` to use the shared org loader helper for consistency and clarity.
- Added a regression test `test_resolve_api_key_for_provider_uses_global_key` to `backend/tests/test_llm_provider.py` and updated existing tests to import the new helper.

### Testing
- Ran `pytest -q backend/tests/test_llm_provider.py` and observed `4 passed` which includes the new `test_resolve_api_key_for_provider_uses_global_key` test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e925e7cddc832191ad9e8b5c14cdda)