### PR TITLE
Deep-link connector Team UI to Organization Members tab

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -684,6 +684,13 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
   const [showOrgPanel, setShowOrgPanel] = useState(false);
   const [showProfilePanel, setShowProfilePanel] = useState(false);
   const [orgPanelTab, setOrgPanelTab] = useState<'team' | 'billing' | 'settings'>('team');
+  const orgSettingsInitialTab: 'team' | 'billing' | 'settings' = (() => {
+    if (typeof window === 'undefined') return 'settings';
+    const tab = new URLSearchParams(window.location.search).get('tab')?.toLowerCase();
+    if (tab === 'team' || tab === 'members') return 'team';
+    if (tab === 'billing') return 'billing';
+    return 'settings';
+  })();
 
   // CRM approval results (shared across chats) - use state to trigger re-renders
   const [crmApprovalResults, setCrmApprovalResults] = useState<Map<string, unknown>>(() => new Map());
@@ -2028,7 +2035,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
             key={`org-settings-page-${organization.id}`}
             organization={organization}
             currentUser={user}
-            initialTab="settings"
+            initialTab={orgSettingsInitialTab}
             onClose={() => setCurrentView('home')}
             mode="page"
           />

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -259,6 +259,17 @@ export function DataSources(): JSX.Element {
   // Get user/org from Zustand (auth state)
   const { user, organization, organizations } = useAppStore();
   const setCurrentView = useAppStore((state) => state.setCurrentView);
+
+  const openTeamMembersPanel = useCallback((): void => {
+    const orgHandle =
+      organization?.handle ??
+      (organization?.id
+        ? organizations.find((orgMembership) => orgMembership.id === organization.id)?.handle ?? null
+        : null);
+    const settingsPath = orgHandle ? `/${orgHandle}/settings?tab=members` : '/settings?tab=members';
+    window.history.pushState({}, '', settingsPath);
+    setCurrentView('org-settings');
+  }, [organization?.handle, organization?.id, organizations, setCurrentView]);
   const fetchUserOrganizations = useAppStore((state) => state.fetchUserOrganizations);
   
 
@@ -1723,7 +1734,7 @@ export function DataSources(): JSX.Element {
             If you want to map users other than yourself, admins can manage identity mappings in the{' '}
             <button
               type="button"
-              onClick={() => setCurrentView('org-settings')}
+              onClick={openTeamMembersPanel}
               className="text-primary-400 hover:text-primary-300 underline"
             >
               Team UI


### PR DESCRIPTION
### Motivation
- The helper link in the GitHub connector should take users directly to the organization members subpanel instead of the generic settings view. 
- Support deep-linking so external flows or UI prompts land on the intended `OrganizationPanel` subtab.

### Description
- Added `openTeamMembersPanel` in `frontend/src/components/DataSources.tsx` to push `?tab=members` into the URL and switch the app view to `org-settings` when the Team UI button is clicked. 
- Added `orgSettingsInitialTab` resolution in `frontend/src/components/AppLayout.tsx` which reads `window.location.search` and maps `tab=members` (and `tab=team`) to the `OrganizationPanel` `team` tab, `tab=billing` to `billing`, and falls back to `settings`. 
- Wired the page-mode `OrganizationPanel` usage to pass `initialTab={orgSettingsInitialTab}` so the panel opens on the resolved subtab. 
- Replaced the previous `setCurrentView('org-settings')` call in the DataSources Team UI button with `openTeamMembersPanel` to enable the deep link behavior.

### Testing
- Ran `npm --prefix frontend run lint` and the lint run completed successfully. 
- Verified the changes compile in the frontend TypeScript/React codepaths touched by the edit (no additional automated tests were altered).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9386fcdc48321a5d9ebbfdc9d61ee)