### PR TITLE
Route GitHub connector Team UI link to Members subpanel

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -220,6 +220,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
     currentAppId,
     currentArtifactId,
     recentChats,
+    orgSettingsTab,
   } = useAppStore(
     useShallow((state) => ({
       user: state.user,
@@ -231,6 +232,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       currentAppId: state.currentAppId,
       currentArtifactId: state.currentArtifactId,
       recentChats: state.recentChats,
+      orgSettingsTab: state.orgSettingsTab,
     }))
   );
 
@@ -243,6 +245,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
   // Zustand: Get integrations for connected count badge
   const integrations = useIntegrations();
   const fetchIntegrations = useAppStore((state) => state.fetchIntegrations);
+  const setOrgSettingsTab = useAppStore((state) => state.setOrgSettingsTab);
   const connectedIntegrationsCount = integrations.filter((i) => i.isActive).length;
   
   // Fetch integrations on mount and when org changes
@@ -514,6 +517,21 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
         setAdminPanelTab(adminTabFromPathSegment(segment));
         return;
       }
+      const settingsSubTabMatch = subPath.match(/^settings(?:\/([a-z-]+))?$/i);
+      if (settingsSubTabMatch) {
+        const segment = (settingsSubTabMatch[1] ?? '').toLowerCase();
+        if (segment === 'members' || segment === 'team') {
+          setOrgSettingsTab('team');
+        } else if (segment === 'billing') {
+          setOrgSettingsTab('billing');
+        } else {
+          setOrgSettingsTab('settings');
+        }
+        setCurrentChatId(null);
+        setCurrentView("org-settings");
+        return;
+      }
+
       const viewMap: Record<string, typeof currentView> = {
         chats: "chats",
         connectors: "data-sources",
@@ -524,7 +542,6 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
         documents: "documents",
         changes: "pending-changes",
         activity: "activity-log",
-        settings: "org-settings",
       };
       const view = viewMap[subPath];
       if (view) {
@@ -562,6 +579,21 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       return;
     }
 
+    const legacySettingsSubTabMatch = path.match(/^\/settings(?:\/([a-z-]+))?$/i);
+    if (legacySettingsSubTabMatch) {
+      const segment: string = (legacySettingsSubTabMatch[1] ?? '').toLowerCase();
+      if (segment === 'members' || segment === 'team') {
+        setOrgSettingsTab('team');
+      } else if (segment === 'billing') {
+        setOrgSettingsTab('billing');
+      } else {
+        setOrgSettingsTab('settings');
+      }
+      setCurrentChatId(null);
+      setCurrentView("org-settings");
+      return;
+    }
+
     const viewPaths: Record<string, typeof currentView> = {
       "/": "home",
       "/chat": "chat",
@@ -574,7 +606,6 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       "/documents": "documents",
       "/changes": "pending-changes",
       "/activity": "activity-log",
-      "/settings": "org-settings",
     };
     const matchedView = viewPaths[path];
     if (matchedView) {
@@ -589,6 +620,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
     setCurrentAppId,
     setCurrentView,
     setAdminPanelTab,
+    setOrgSettingsTab,
     openArtifact,
     fetchUserOrganizations,
     switchActiveOrganization,
@@ -668,7 +700,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
           admin: "/admin",
           "pending-changes": "/changes",
           "activity-log": "/activity",
-          "org-settings": "/settings",
+          "org-settings": orgSettingsTab === "team" ? "/settings/members" : orgSettingsTab === "billing" ? "/settings/billing" : "/settings",
         };
         const base: string = viewPaths[currentView];
         newPath = prefix ? `${prefix}${base === "/" ? "" : base}` : base;
@@ -678,7 +710,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
     if (window.location.pathname !== newPath) {
       window.history.pushState({}, "", newPath);
     }
-  }, [currentChatId, currentAppId, currentArtifactId, currentView, adminPanelTab, urlInitialized, orgHandle, organization?.id, organization?.handle, organizations, orgAccessError]);
+  }, [currentChatId, currentAppId, currentArtifactId, currentView, adminPanelTab, orgSettingsTab, urlInitialized, orgHandle, organization?.id, organization?.handle, organizations, orgAccessError]);
   
   // Panels
   const [showOrgPanel, setShowOrgPanel] = useState(false);
@@ -2028,7 +2060,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
             key={`org-settings-page-${organization.id}`}
             organization={organization}
             currentUser={user}
-            initialTab="settings"
+            initialTab={orgSettingsTab}
             onClose={() => setCurrentView('home')}
             mode="page"
           />

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -259,6 +259,7 @@ export function DataSources(): JSX.Element {
   // Get user/org from Zustand (auth state)
   const { user, organization, organizations } = useAppStore();
   const setCurrentView = useAppStore((state) => state.setCurrentView);
+  const setOrgSettingsTab = useAppStore((state) => state.setOrgSettingsTab);
   const fetchUserOrganizations = useAppStore((state) => state.fetchUserOrganizations);
   
 
@@ -1723,7 +1724,10 @@ export function DataSources(): JSX.Element {
             If you want to map users other than yourself, admins can manage identity mappings in the{' '}
             <button
               type="button"
-              onClick={() => setCurrentView('org-settings')}
+              onClick={() => {
+                setOrgSettingsTab('team');
+                setCurrentView('org-settings');
+              }}
               className="text-primary-400 hover:text-primary-300 underline"
             >
               Team UI

--- a/frontend/src/store/uiStore.ts
+++ b/frontend/src/store/uiStore.ts
@@ -37,6 +37,8 @@ export interface UIState {
   lastArtifactUpdateId: string | null;
   /** Active section in Global Admin (sidebar + main panel). */
   adminPanelTab: AdminPanelTab;
+  /** Active section in organization settings page (/settings). */
+  orgSettingsTab: "team" | "billing" | "settings";
   /** Set when org-prefixed URL targets an org the user does not belong to. */
   orgAccessError: OrgAccessErrorState | null;
 
@@ -55,6 +57,7 @@ export interface UIState {
   togglePinChat: (id: string) => void;
   setTheme: (theme: UITheme) => void;
   setAdminPanelTab: (tab: AdminPanelTab) => void;
+  setOrgSettingsTab: (tab: "team" | "billing" | "settings") => void;
   clearOrgAccessError: () => void;
 }
 
@@ -76,6 +79,7 @@ export const useUIStore = create<UIState>()(
       lastArtifactUpdateId: null,
       documentSearchTerm: null,
       adminPanelTab: "dashboard",
+      orgSettingsTab: "settings",
       orgAccessError: null,
 
       // Actions
@@ -124,6 +128,7 @@ export const useUIStore = create<UIState>()(
       },
       setTheme: (theme) => set({ theme }),
       setAdminPanelTab: (adminPanelTab) => set({ adminPanelTab }),
+      setOrgSettingsTab: (orgSettingsTab) => set({ orgSettingsTab }),
       clearOrgAccessError: () => set({ orgAccessError: null }),
     }),
     {


### PR DESCRIPTION
### Motivation
- The helper link shown in the GitHub connector should take admins directly to the team/members area where identity mapping and member management lives, not to a generic settings landing.

### Description
- Add `orgSettingsTab` state and setter to the UI store (`useUIStore`) to represent which subpanel of organization settings should be shown (`team | billing | settings`).
- Update the GitHub connector helper link in `DataSources` to pre-select the Members tab by calling `setOrgSettingsTab('team')` before navigating to the organization settings view (`org-settings`).
- Extend `AppLayout` URL parsing and sync logic to support deep-links and legacy paths for settings sub-tabs (`/settings`, `/settings/members` or `/settings/team`, `/settings/billing`) and to reflect `orgSettingsTab` in generated URLs.
- Wire `OrganizationPanel` page mode to use `orgSettingsTab` as its `initialTab` so the selected subpanel is preserved when opening the full settings page.

### Testing
- Built the frontend to validate TypeScript and bundling with `npm --prefix frontend run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9386fcdc48321a5d9ebbfdc9d61ee)