### PR TITLE
Fix guest-user toggle to use org-scoped DB session

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -2738,7 +2738,7 @@ async def update_guest_user(
     if not user_uuid:
         raise HTTPException(status_code=401, detail="Not authenticated")
 
-    async with get_session() as session:
+    async with get_session(organization_id=org_id) as session:
         requesting_user = await session.get(User, user_uuid)
         if not await _can_administer_org(session, requesting_user, org_uuid):
             raise HTTPException(status_code=403, detail="Org admin or global_admin required for this organization")

--- a/backend/tests/test_auth_guest_identity_guards.py
+++ b/backend/tests/test_auth_guest_identity_guards.py
@@ -106,3 +106,55 @@ def test_unlink_identity_rejects_guest_mapping(monkeypatch):
     assert exc.value.status_code == 403
     assert mapping.user_id == guest_user_id
     assert not fake_session.committed
+
+
+def test_update_guest_user_scopes_session_to_org(monkeypatch):
+    org_id = UUID("12121212-1212-1212-1212-121212121212")
+    requester_id = UUID("34343434-3434-3434-3434-343434343434")
+    guest_user_id = UUID("56565656-5656-5656-5656-565656565656")
+    captured: dict[str, str] = {}
+
+    requester = SimpleNamespace(id=requester_id, is_guest=False)
+    org = SimpleNamespace(id=org_id, guest_user_id=guest_user_id, guest_user_enabled=False)
+    guest_user = SimpleNamespace(id=guest_user_id, guest_organization_id=org_id, is_guest=True)
+
+    class _GuestToggleSession:
+        def __init__(self):
+            self.committed = False
+
+        async def get(self, model, model_id):
+            if model is auth.User:
+                if model_id == requester_id:
+                    return requester
+                if model_id == guest_user_id:
+                    return guest_user
+            if model is auth.Organization and model_id == org_id:
+                return org
+            return None
+
+        async def commit(self):
+            self.committed = True
+
+    guest_toggle_session = _GuestToggleSession()
+
+    def _fake_get_session(**kwargs):
+        captured["organization_id"] = kwargs.get("organization_id")
+        return _FakeSessionContext(guest_toggle_session)
+
+    async def _allow_admin(_session, _user, _org_uuid):
+        return True
+
+    monkeypatch.setattr(auth, "get_session", _fake_get_session)
+    monkeypatch.setattr(auth, "_can_administer_org", _allow_admin)
+
+    result = asyncio.run(
+        auth.update_guest_user(
+            org_id=str(org_id),
+            request=auth.UpdateGuestUserRequest(enabled=True),
+            user_id=str(requester_id),
+        )
+    )
+
+    assert captured["organization_id"] == str(org_id)
+    assert guest_toggle_session.committed is True
+    assert result == {"enabled": True}


### PR DESCRIPTION
### Motivation

- Toggling the organization guest-user was failing with: `Use get_admin_session() for system operations or pass organization_id` because the endpoint opened a DB session without an organization context (missing RLS org scope).
- The change ensures org admins can enable/disable the guest user without hitting RLS/context errors.

### Description

- Update `PATCH /organizations/{org_id}/guest-user` in `backend/api/routes/auth.py` to open the DB session with `get_session(organization_id=org_id)` so the RLS context is set.
- Add a regression test `test_update_guest_user_scopes_session_to_org` in `backend/tests/test_auth_guest_identity_guards.py` that asserts the endpoint passes the `organization_id` into `get_session`, commits, and returns the enabled state.
- Preserve the existing admin check via `_can_administer_org` and the guest-user validation logic.

### Testing

- Ran `pytest -q backend/tests/test_auth_guest_identity_guards.py` and the test suite for that file passed (`3 passed`).
- The new regression test verifying org-scoped session and commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e953ae8ec88321a2fc4f4790930668)