### PR TITLE
Align guest enabled/disabled pill with guest badge

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -1004,7 +1004,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                             <div className="flex items-start gap-3 min-w-0">
                               <Avatar user={member} size="lg" />
                               <div className="flex-1 min-w-0">
-                                <div className="flex items-center gap-2">
+                                <div className="flex items-center gap-2 min-w-0">
                                   <span className="font-medium text-surface-100 truncate">
                                     {displayName}
                                   </span>
@@ -1014,9 +1014,27 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                                     </span>
                                   )}
                                   {isGuest && (
-                                    <span className="px-2 py-0.5 text-xs font-medium bg-sky-500/20 text-sky-200 rounded-full">
-                                      guest
-                                    </span>
+                                    <>
+                                      <span className="px-2 py-0.5 text-xs font-medium bg-sky-500/20 text-sky-200 rounded-full">
+                                        guest
+                                      </span>
+                                      <button
+                                        type="button"
+                                        onClick={() => void handleToggleGuestUser()}
+                                        disabled={updateGuestUserMutation.isPending}
+                                        className={`ml-auto px-2 py-1 text-[10px] font-medium rounded transition-colors disabled:opacity-50 flex-shrink-0 ${
+                                          guestUserEnabled
+                                            ? 'bg-amber-500/20 text-amber-100 hover:bg-amber-500/30'
+                                            : 'bg-surface-700/40 text-surface-200 hover:bg-surface-700/60'
+                                        }`}
+                                      >
+                                        {updateGuestUserMutation.isPending
+                                          ? 'Saving...'
+                                          : guestUserEnabled
+                                            ? 'Enabled'
+                                            : 'Disabled'}
+                                      </button>
+                                    </>
                                   )}
                                 </div>
                                 {member.jobTitle && (
@@ -1082,24 +1100,6 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                             </div>
                             {/* Identity badges */}
                             <div className="flex items-center gap-1.5 flex-wrap">
-                              {isGuest && (
-                                <button
-                                  type="button"
-                                  onClick={() => void handleToggleGuestUser()}
-                                  disabled={updateGuestUserMutation.isPending}
-                                  className={`px-2 py-1 text-[10px] font-medium rounded transition-colors disabled:opacity-50 ${
-                                    guestUserEnabled
-                                      ? 'bg-amber-500/20 text-amber-100 hover:bg-amber-500/30'
-                                      : 'bg-surface-700/40 text-surface-200 hover:bg-surface-700/60'
-                                  }`}
-                                >
-                                  {updateGuestUserMutation.isPending
-                                    ? 'Saving...'
-                                    : guestUserEnabled
-                                      ? 'Enabled'
-                                      : 'Disabled'}
-                                </button>
-                              )}
                               {identities.length > 0 ? (
                                 [...new Set(identities.map((i) => i.source))].map((src) => (
                                   <span


### PR DESCRIPTION
### Motivation
- Ensure the guest enable/disable status pill appears on the same line as the `guest` badge and is aligned to the right edge on both mobile and desktop.
- Remove a duplicated toggle UI that previously lived in the identity badges row to avoid redundant controls and visual clutter.
- Keep existing backend behavior and toggling logic unchanged while improving layout and alignment in the member row.

### Description
- Moved the guest enable/disable button into the primary member name/badge row in `frontend/src/components/OrganizationPanel.tsx` and wrapped the `guest` badge and toggle in a fragment so they render inline together.
- Added `ml-auto` and `flex-shrink-0` to the toggle button classes to pin it to the right edge and preserve layout across screen sizes, and added `min-w-0` on the container for proper truncation.
- Removed the duplicate guest toggle rendering from the lower identity badges section so the status pill appears only next to the `guest` badge.
- Retained the existing handlers and state (`handleToggleGuestUser`, `updateGuestUserMutation`, `guestUserEnabled`) so functionality is unchanged.

### Testing
- Ran lint on the updated file with `cd frontend && npx eslint src/components/OrganizationPanel.tsx`, which completed without lint errors (only an npm environment warning). 
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9697c5fac8321b0870ef5bd954367)