### PR TITLE
Align team member avatar and ellipsis in Team Settings

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -1002,7 +1002,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                           {/* Member row */}
                           <div className="flex flex-col gap-2 p-3">
                             <div className="flex items-start gap-3 min-w-0">
-                              <Avatar user={member} size="lg" />
+                              <Avatar user={member} size="lg" className="mt-1 flex-shrink-0" />
                               <div className="flex-1 min-w-0">
                                 <div className="flex items-center gap-2 min-w-0">
                                   <span className="font-medium text-surface-100 truncate">
@@ -1044,7 +1044,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                               </div>
                               {/* Three-dots menu */}
                               {!isGuest && (
-                                <div className="relative flex-shrink-0">
+                                <div className="relative flex-shrink-0 mt-1">
                                   <button
                                     type="button"
                                     onClick={(e) => { e.stopPropagation(); setMenuOpenMemberId(isMenuOpen ? null : member.id); }}


### PR DESCRIPTION
### Motivation
- Fix vertical misalignment in the Team Settings member rows so the profile avatar and the three-dot (ellipsis) action remain visually aligned with the title/name row.

### Description
- Small UI-only spacing tweak in `frontend/src/components/OrganizationPanel.tsx` adding `mt-1` to the member `Avatar` and the three-dots menu container to nudge both elements down for consistent alignment.

### Testing
- Ran `npm run lint` in `frontend/` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea01a3adf48321a850759e5e4b4234)