### PR TITLE
Align team member avatars and overflow menu vertically

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -1001,8 +1001,8 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                         <div key={member.id} className="rounded-lg bg-surface-800/50">
                           {/* Member row */}
                           <div className="flex flex-col gap-2 p-3">
-                            <div className="flex items-start gap-3 min-w-0">
-                              <Avatar user={member} size="lg" className="mt-1 flex-shrink-0" />
+                            <div className="flex items-center gap-3 min-w-0">
+                              <Avatar user={member} size="lg" className="flex-shrink-0" />
                               <div className="flex-1 min-w-0">
                                 <div className="flex items-center gap-2 min-w-0">
                                   <span className="font-medium text-surface-100 truncate">
@@ -1044,7 +1044,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                               </div>
                               {/* Three-dots menu */}
                               {!isGuest && (
-                                <div className="relative flex-shrink-0 mt-1">
+                                <div className="relative flex-shrink-0 self-center">
                                   <button
                                     type="button"
                                     onClick={(e) => { e.stopPropagation(); setMenuOpenMemberId(isMenuOpen ? null : member.id); }}


### PR DESCRIPTION
### Motivation
- Make member profile portraits vertically centered with the name/title block (so the center of the avatar aligns with titles such as “Chief …”) and keep the three-dot overflow menu aligned with the portrait.

### Description
- In `frontend/src/components/OrganizationPanel.tsx` change the member row wrapper from `items-start` to `items-center`, remove the avatar top offset (`mt-1`) on the `<Avatar>` element, and replace the three-dots menu container `mt-1` with `self-center` so the overflow menu lines up with the avatar circle.

### Testing
- Ran the linter with `cd frontend && npx eslint src/components/OrganizationPanel.tsx`, which completed successfully (only an npm environment warning was shown).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea043e747c83219dac5ee0dad21c4a)