### PR TITLE
Persist self-authored Slack bot DM messages to history and hide them in UI

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -135,12 +135,14 @@ def _classify_message_sender(
     return "other_bot"
 
 
-async def _log_external_dm_message_without_processing(
+async def _log_bot_dm_message_without_processing(
     messenger: SlackMessenger,
     event: dict[str, Any],
     team_id: str,
+    *,
+    sender_category: str,
 ) -> bool:
-    """Attach a bot-authored DM/group-DM message to existing conversation history without agent processing."""
+    """Attach a bot-authored DM/group-DM message to conversation history without agent processing."""
     channel_type: str = str(event.get("channel_type") or "").strip().lower()
     if channel_type not in {"im", "mpim", "groupchat"}:
         return False
@@ -188,7 +190,7 @@ async def _log_external_dm_message_without_processing(
             {
                 "type": "text",
                 "text": content_text,
-                "sender_category": "other_bot",
+                "sender_category": sender_category,
             }
         ]
         if files:
@@ -219,9 +221,10 @@ async def _log_external_dm_message_without_processing(
         await session.commit()
 
     logger.info(
-        "[slack_events] Logged bot-authored DM/group-DM message without processing conversation_id=%s source_channel_id=%s",
+        "[slack_events] Logged bot-authored DM/group-DM message without processing conversation_id=%s source_channel_id=%s sender_category=%s",
         conversation_id,
         source_channel_id,
+        sender_category,
     )
     return True
 
@@ -460,9 +463,16 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
         sender_category: str = _classify_message_sender(payload, event, bot_user_ids)
         if sender_category == "self_bot":
             logger.info(
-                "[slack_events] Ignoring self-authored bot message channel=%s thread=%s",
+                "[slack_events] Handling message as self_bot channel=%s thread=%s type=%s",
                 event.get("channel", ""),
                 event.get("thread_ts"),
+                channel_type,
+            )
+            await _log_bot_dm_message_without_processing(
+                messenger,
+                event,
+                team_id,
+                sender_category=sender_category,
             )
             return
         if sender_category == "other_bot":
@@ -472,7 +482,12 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
                 event.get("thread_ts"),
                 channel_type,
             )
-            await _log_external_dm_message_without_processing(messenger, event, team_id)
+            await _log_bot_dm_message_without_processing(
+                messenger,
+                event,
+                team_id,
+                sender_category=sender_category,
+            )
             return
         if sender_category == "user" and (event.get("bot_id") or event.get("subtype") == "bot_message"):
             # Defensive fallback: if payload is bot-like but classification didn't hit,

--- a/backend/tests/test_slack_events_thread_locking.py
+++ b/backend/tests/test_slack_events_thread_locking.py
@@ -170,20 +170,21 @@ def test_app_mention_keeps_non_bot_user_mentions_in_text(monkeypatch) -> None:
     assert msg.text == "who is <@UJON123>?"
 
 
-def test_dm_bot_message_from_current_app_is_ignored(monkeypatch) -> None:
+def test_dm_bot_message_from_current_app_is_logged_not_processed(monkeypatch) -> None:
     calls: list[dict[str, str]] = []
 
     async def _fake_is_duplicate_event(_event_id: str) -> bool:
         return False
 
-    async def _fake_log_external(*_args, **_kwargs) -> bool:
+    async def _fake_log_external(*_args, **kwargs) -> bool:
+        assert kwargs["sender_category"] == "self_bot"
         calls.append({"called": "yes"})
         return True
 
     monkeypatch.setattr(slack_events, "is_duplicate_event", _fake_is_duplicate_event)
     monkeypatch.setattr(
         slack_events,
-        "_log_external_dm_message_without_processing",
+        "_log_bot_dm_message_without_processing",
         _fake_log_external,
     )
 
@@ -205,7 +206,7 @@ def test_dm_bot_message_from_current_app_is_ignored(monkeypatch) -> None:
     }
 
     asyncio.run(slack_events._process_event_callback_impl(payload))
-    assert calls == []
+    assert len(calls) == 1
 
 
 def test_dm_bot_message_from_external_source_is_logged_not_processed(monkeypatch) -> None:
@@ -215,7 +216,8 @@ def test_dm_bot_message_from_external_source_is_logged_not_processed(monkeypatch
     async def _fake_is_duplicate_event(_event_id: str) -> bool:
         return False
 
-    async def _fake_log_external(*_args, **_kwargs) -> bool:
+    async def _fake_log_external(*_args, **kwargs) -> bool:
+        assert kwargs["sender_category"] == "other_bot"
         calls.append({"called": "yes"})
         return True
 
@@ -226,7 +228,7 @@ def test_dm_bot_message_from_external_source_is_logged_not_processed(monkeypatch
     monkeypatch.setattr(slack_events, "is_duplicate_event", _fake_is_duplicate_event)
     monkeypatch.setattr(
         slack_events,
-        "_log_external_dm_message_without_processing",
+        "_log_bot_dm_message_without_processing",
         _fake_log_external,
     )
     monkeypatch.setattr(SlackMessenger, "process_inbound", _fake_process_inbound)

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -260,6 +260,10 @@ function getMessageSenderCategory(message: ChatMessage): string | null {
   return null;
 }
 
+function isSelfBotAssistantMessage(message: ChatMessage): boolean {
+  return message.role === 'assistant' && getMessageSenderCategory(message) === 'self_bot';
+}
+
 function SummaryPanel({ summary, onClose }: { summary: ConversationSummaryText; onClose: () => void }): JSX.Element {
   return (
     <div className="border-b border-surface-800 bg-surface-900 px-4 md:px-6 py-3">
@@ -664,6 +668,10 @@ export function Chat({
       })
       .map(({ message }) => message);
   }, [pendingMessages, conversationState?.messages]);
+  const visibleMessages = useMemo(
+    () => messages.filter((message) => !isSelfBotAssistantMessage(message)),
+    [messages],
+  );
   const isThinking = pendingThinking || conversationThinking;
   const hasMoreMessages = conversationState?.hasMore ?? false;
 
@@ -2501,7 +2509,7 @@ export function Chat({
                 User context is missing — artifacts and apps may not save correctly. Please refresh or re-sign in.
               </div>
             )}
-            {messages.length === 0 && !isThinking ? (
+            {visibleMessages.length === 0 && !isThinking ? (
               conversationType === 'workflow' ? (
                 // Show loading state for workflow conversations waiting for agent to start
                 <div className="flex-1 flex flex-col items-center justify-center py-20">
@@ -2537,8 +2545,8 @@ export function Chat({
                     </button>
                   </div>
                 )}
-                {messages.map((msg, idx) => {
-                  const prevMsg: ChatMessage | undefined = idx > 0 ? messages[idx - 1] : undefined;
+                {visibleMessages.map((msg, idx) => {
+                  const prevMsg: ChatMessage | undefined = idx > 0 ? visibleMessages[idx - 1] : undefined;
                   const showDivider: boolean = !!prevMsg && prevMsg.role !== msg.role;
                   const isGroupedWithPrevious: boolean = shouldGroupMessageWithPrevious(prevMsg, msg, userId);
                   return (
@@ -2576,7 +2584,7 @@ export function Chat({
                 )}
                 {isThinking && <ThinkingIndicator />}
 
-                {isWorkflowPolling && messages.length > 0 && !isThinking && (
+                {isWorkflowPolling && visibleMessages.length > 0 && !isThinking && (
                   <div className="group/msg flex items-center gap-3 px-5 -mx-5 py-1 text-surface-500">
                     <div className={`${CHAT_MSG_AVATAR} flex items-center justify-center`}>
                       <div className="w-4 h-4 border-2 border-surface-500 border-t-primary-500 rounded-full animate-spin" />


### PR DESCRIPTION
### Motivation
- Ensure bot-authored DM/group-DM messages (including self-authored bot messages) are recorded in conversation history rather than dropped, while still avoiding agent processing.
- Preserve these messages for audit/traceability and allow the UI to omit them from rendered chat to avoid confusing end users.

### Description
- Generalize and rename the persistence helper to `_log_bot_dm_message_without_processing` and add a `sender_category` parameter so both `self_bot` and `other_bot` messages are persisted with their category in `content_blocks` (backend: `backend/api/routes/slack_events.py`).
- Call the new helper for both `self_bot` and `other_bot` paths instead of ignoring `self_bot` messages, and include `sender_category` in the log statement (backend changes).
- Update Slack event unit tests to expect and validate the new behavior and `sender_category` argument (tests: `backend/tests/test_slack_events_thread_locking.py`).
- Filter out assistant messages marked `sender_category === 'self_bot'` from the chat rendering pipeline by adding `isSelfBotAssistantMessage` and using `visibleMessages` for rendering, grouping, and workflow-polling checks (frontend: `frontend/src/components/Chat.tsx`).

### Testing
- Ran `pytest -q backend/tests/test_slack_events_thread_locking.py` and all tests passed (`8 passed`).
- Ran `npx eslint src/components/Chat.tsx` in `frontend` and it completed without errors.
- Attempted `npm run typecheck` in `frontend` but the project has no `typecheck` script defined, so that script run failed; this is a repo configuration detail, not a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab8bd13fc83219ebc938bc0a69106)