### PR TITLE
Fix Slack DM persistence fallback for threaded bot messages

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -32,7 +32,7 @@ from uuid import UUID, uuid4
 import redis.asyncio as redis
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
-from sqlalchemy import select, update
+from sqlalchemy import case, select, update
 
 from config import get_redis_connection_kwargs, settings
 from messengers.base import InboundMessage, MessageType
@@ -149,8 +149,11 @@ async def _log_bot_dm_message_without_processing(
 
     channel_id: str = str(event.get("channel") or "").strip()
     thread_ts: str | None = event.get("thread_ts")
-    source_channel_id: str = f"{channel_id}:{thread_ts}" if thread_ts else channel_id
-    if not source_channel_id:
+    source_channel_candidates: list[str] = _candidate_dm_source_channel_ids(
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+    )
+    if not source_channel_candidates:
         return False
 
     text_body: str = str(event.get("text") or "")
@@ -173,15 +176,25 @@ async def _log_bot_dm_message_without_processing(
             select(Conversation.id)
             .where(Conversation.organization_id == UUID(organization_id))
             .where(Conversation.source == "slack")
-            .where(Conversation.source_channel_id == source_channel_id)
-            .order_by(Conversation.updated_at.desc(), Conversation.id.desc())
+            .where(Conversation.source_channel_id.in_(source_channel_candidates))
+            .order_by(
+                case(
+                    *[
+                        (Conversation.source_channel_id == source_channel_id, index)
+                        for index, source_channel_id in enumerate(source_channel_candidates)
+                    ],
+                    else_=len(source_channel_candidates),
+                ),
+                Conversation.updated_at.desc(),
+                Conversation.id.desc(),
+            )
             .limit(1)
         )
         conversation_id: UUID | None = convo_row.scalar_one_or_none()
         if conversation_id is None:
             logger.info(
-                "[slack_events] No associated conversation for DM/group-DM bot message source_channel_id=%s; skipping persistence",
-                source_channel_id,
+                "[slack_events] No associated conversation for DM/group-DM bot message source_channel_candidates=%s; skipping persistence",
+                source_channel_candidates,
             )
             return False
 
@@ -223,10 +236,29 @@ async def _log_bot_dm_message_without_processing(
     logger.info(
         "[slack_events] Logged bot-authored DM/group-DM message without processing conversation_id=%s source_channel_id=%s sender_category=%s",
         conversation_id,
-        source_channel_id,
+        source_channel_candidates[0],
         sender_category,
     )
     return True
+
+
+def _candidate_dm_source_channel_ids(*, channel_id: str, thread_ts: str | None) -> list[str]:
+    """Return preferred conversation source keys for DM/group-DM bot messages.
+
+    For threaded DM bot messages we first try ``channel:thread_ts`` then fall
+    back to the channel-only key because many historical DM conversations were
+    created without thread binding.
+    """
+    normalized_channel_id: str = str(channel_id or "").strip()
+    if not normalized_channel_id:
+        return []
+
+    candidates: list[str] = []
+    normalized_thread_ts: str = str(thread_ts or "").strip()
+    if normalized_thread_ts:
+        candidates.append(f"{normalized_channel_id}:{normalized_thread_ts}")
+    candidates.append(normalized_channel_id)
+    return candidates
 
 
 async def get_redis() -> redis.Redis:

--- a/backend/tests/test_slack_events_thread_locking.py
+++ b/backend/tests/test_slack_events_thread_locking.py
@@ -277,3 +277,17 @@ def test_classify_message_sender_categories() -> None:
     assert slack_events._classify_message_sender(payload, user_event, bot_user_ids) == "user"
     assert slack_events._classify_message_sender(payload, self_bot_event, bot_user_ids) == "self_bot"
     assert slack_events._classify_message_sender(payload, other_bot_event, bot_user_ids) == "other_bot"
+
+
+def test_candidate_dm_source_channel_ids_prefers_thread_then_channel() -> None:
+    assert slack_events._candidate_dm_source_channel_ids(
+        channel_id="D123",
+        thread_ts="1700000000.111",
+    ) == ["D123:1700000000.111", "D123"]
+
+
+def test_candidate_dm_source_channel_ids_handles_channel_without_thread() -> None:
+    assert slack_events._candidate_dm_source_channel_ids(
+        channel_id="D123",
+        thread_ts=None,
+    ) == ["D123"]


### PR DESCRIPTION
### Motivation
- Bot-authored Slack DMs coming from workflows were sometimes not being saved to the existing DM conversation when the incoming event was a threaded message because the lookup only matched a single `source_channel_id` form.

### Description
- Add helper `
_candidate_dm_source_channel_ids` to produce prioritized lookup keys (`"channel:thread_ts"` then `"channel"`) for DM/group-DM bot messages.
- Update `_log_bot_dm_message_without_processing` to query `Conversation.source_channel_id.in_(...)` and use `order_by(case(...), Conversation.updated_at.desc(), Conversation.id.desc())` so the threaded key is preferred while preserving a fallback to legacy channel-only conversations.
- Introduce `case` import from `sqlalchemy` and improve logging to include the candidate list and the chosen source key used for persistence.
- Add unit tests in `backend/tests/test_slack_events_thread_locking.py` that cover the candidate generation behavior.

### Testing
- Ran `pytest -q backend/tests/test_slack_events_thread_locking.py` to validate the thread-locking and DM candidate behaviors.
- Test run succeeded: `10 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eada6edf348321bf6844565c358ddc)