### PR TITLE
Log Slack inbound events when user_id is missing

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -724,6 +724,15 @@ def _build_inbound_message(
     """Build an :class:`InboundMessage` from a Slack event payload."""
     channel_id: str = event.get("channel", "")
     user_id: str = event.get("user", "")
+    if not user_id:
+        logger.warning(
+            "[slack_events] Incoming Slack message missing user_id channel=%s message_type=%s ts=%s subtype=%s bot_id=%s",
+            channel_id,
+            message_type.value,
+            event.get("ts", "") or event.get("event_ts", ""),
+            event.get("subtype", ""),
+            event.get("bot_id", ""),
+        )
     text: str = text_override if text_override is not None else event.get("text", "")
     event_ts: str = event.get("event_ts", "") or event.get("ts", "")
     message_ts: str = event.get("ts", "") or event_ts


### PR DESCRIPTION
### Motivation
- Improve observability for incoming Slack events that lack an explicit sender so missing-identity cases can be debugged quickly.

### Description
- Add a warning log in `_build_inbound_message` when the incoming Slack event has no `user` (external user id) to record context for the event.
- The log includes `channel_id`, `message_type`, event timestamp (`ts`/`event_ts`), `subtype`, and `bot_id` to aid debugging while preserving existing behavior.
- No changes to message processing flow or return values; messages continue to be built and processed as before.

### Testing
- Ran `python -m compileall backend/api/routes/slack_events.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaed1f50fc8321a4cf71c56abe285b)