### PR TITLE
Fix DM bot logging for private Slack conversations

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -39,7 +39,7 @@ from messengers.base import InboundMessage, MessageType
 from messengers.slack import SlackMessenger
 from models.chat_message import ChatMessage
 from models.conversation import Conversation
-from models.database import get_session
+from models.database import get_admin_session
 
 logger = logging.getLogger(__name__)
 
@@ -196,7 +196,10 @@ async def _log_bot_dm_message_without_processing(
         )
         return False
 
-    async with get_session(organization_id=organization_id) as session:
+    # Use an admin-scoped session here so bot-authored DM messages can still
+    # be attached when the target conversation scope is private. A tenant RLS
+    # session without user context cannot read private conversations.
+    async with get_admin_session() as session:
         convo_row = await session.execute(
             select(Conversation.id)
             .where(Conversation.organization_id == UUID(organization_id))

--- a/backend/tests/test_slack_events_thread_locking.py
+++ b/backend/tests/test_slack_events_thread_locking.py
@@ -1,4 +1,6 @@
 import asyncio
+from contextlib import asynccontextmanager
+from uuid import uuid4
 
 from api.routes import slack_events
 from messengers.base import InboundMessage, MessageType
@@ -291,3 +293,53 @@ def test_candidate_dm_source_channel_ids_handles_channel_without_thread() -> Non
         channel_id="D123",
         thread_ts=None,
     ) == ["D123"]
+
+
+def test_log_bot_dm_message_uses_admin_session_for_private_conversations(monkeypatch) -> None:
+    conversation_id = uuid4()
+    used_admin_session = {"value": False}
+
+    class _FakeResult:
+        def scalar_one_or_none(self):
+            return conversation_id
+
+    class _FakeSession:
+        async def execute(self, *_args, **_kwargs):
+            return _FakeResult()
+
+        def add(self, _row) -> None:
+            return None
+
+        async def commit(self) -> None:
+            return None
+
+    @asynccontextmanager
+    async def _fake_get_admin_session():
+        used_admin_session["value"] = True
+        yield _FakeSession()
+
+    async def _fake_resolve_org(_team_id: str) -> str:
+        return str(uuid4())
+
+    class _FakeMessenger:
+        _resolve_org_from_workspace = staticmethod(_fake_resolve_org)
+
+    monkeypatch.setattr(slack_events, "get_admin_session", _fake_get_admin_session)
+
+    event = {
+        "channel_type": "im",
+        "channel": "D0AA3KFETUY",
+        "text": "bot reply in private convo",
+        "bot_id": "B123",
+    }
+    persisted = asyncio.run(
+        slack_events._log_bot_dm_message_without_processing(
+            _FakeMessenger(),
+            event,
+            "T123",
+            sender_category="self_bot",
+        )
+    )
+
+    assert persisted is True
+    assert used_admin_session["value"] is True


### PR DESCRIPTION
### Motivation
- DM/group-DM bot messages were not being attached to conversations when the target conversation had private scope because a tenant-scoped RLS session without user context could not read private conversations, producing logs like `No associated conversation ... skipping persistence`.

### Description
- Switched from `get_session(...)` to `get_admin_session()` in `backend/api/routes/slack_events.py` for the bot DM persistence path so the code can locate and update private-scope conversations.
- Added an explanatory code comment about why an admin-scoped session is required for this path.
- Added a regression test `test_log_bot_dm_message_uses_admin_session_for_private_conversations` in `backend/tests/test_slack_events_thread_locking.py` that verifies the admin session is used and the persistence path returns success.

### Testing
- Ran `pytest -q backend/tests/test_slack_events_thread_locking.py` which completed successfully with `11 passed, 2 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae8fa7758832199fbd585d9d9be08)