### PR TITLE
Deduplicate overlapping Slack bot message routing logic from PRs #1114/#1115

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -521,23 +521,10 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
     if inner_type == "message":
         channel_type: str | None = event.get("channel_type")
         sender_category: str = _classify_message_sender(payload, event, bot_user_ids)
-        if sender_category == "self_bot":
+        if sender_category in {"self_bot", "other_bot"}:
             logger.info(
-                "[slack_events] Handling message as self_bot channel=%s thread=%s type=%s",
-                event.get("channel", ""),
-                event.get("thread_ts"),
-                channel_type,
-            )
-            await _log_bot_dm_message_without_processing(
-                messenger,
-                event,
-                team_id,
-                sender_category=sender_category,
-            )
-            return
-        if sender_category == "other_bot":
-            logger.info(
-                "[slack_events] Handling message as other_bot channel=%s thread=%s type=%s",
+                "[slack_events] Handling message as %s channel=%s thread=%s type=%s",
+                sender_category,
                 event.get("channel", ""),
                 event.get("thread_ts"),
                 channel_type,


### PR DESCRIPTION
### Motivation
- Two parallel PRs introduced equivalent handling for bot-authored Slack messages, leaving duplicate control flow in the Slack event processing code that increases maintenance burden.

### Description
- Consolidated the separate `self_bot` and `other_bot` branches into a single branch using `if sender_category in {"self_bot", "other_bot"}` in `backend/api/routes/slack_events.py`.
- Updated the log message to include the `sender_category` value and removed the duplicated call site while preserving the call to `_log_bot_dm_message_without_processing` and early `return` behavior.
- Preserved the existing defensive fallback for bot-like payloads classified as `user` and all downstream behavior for activity persistence and thread handling.

### Testing
- Ran `pytest -q backend/tests/test_slack_events_thread_locking.py` and received `11 passed, 2 warnings` (all tests passed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebef7dcac4832184bd9bf5f2ea70d2)