### PR TITLE
Add debug diagnostics when connector sync fails

### DIFF
--- a/backend/tests/test_sync_failure_logging.py
+++ b/backend/tests/test_sync_failure_logging.py
@@ -72,7 +72,7 @@ def test_sync_failure_logging_includes_case_and_context(monkeypatch, caplog) -> 
         lambda: {"slack": FailingConnector},
     )
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.DEBUG):
         result = asyncio.run(
             sync_tasks._sync_integration("11111111-1111-1111-1111-111111111111", "slack")
         )
@@ -81,6 +81,11 @@ def test_sync_failure_logging_includes_case_and_context(monkeypatch, caplog) -> 
     assert any(
         "Connector sync failed provider=slack" in rec.message
         and "case=auth_or_connection_revoked" in rec.message
+        for rec in caplog.records
+    )
+    assert any(
+        "Connector sync failure diagnostics provider=slack" in rec.message
+        and "error_type=RuntimeError" in rec.message
         for rec in caplog.records
     )
     assert any(event[0] == "sync.failed" for event in emitted_events)

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -290,6 +290,16 @@ async def _sync_integration(
     except Exception as e:
         error_msg = str(e)
         failure_case, log_level = _classify_sync_failure(error_msg)
+        logger.debug(
+            "Connector sync failure diagnostics provider=%s org=%s user=%s sync_since_override=%s "
+            "connector_initialized=%s error_type=%s",
+            provider,
+            organization_id,
+            user_id,
+            sync_since_dt.isoformat() if sync_since_dt else None,
+            connector is not None,
+            type(e).__name__,
+        )
         logger.log(
             log_level,
             "Connector sync failed provider=%s org=%s user=%s case=%s error=%s",


### PR DESCRIPTION
### Motivation
- Improve observability for connector sync failures by emitting a debug-level diagnostic log containing contextual details to aid troubleshooting.

### Description
- Add a `logger.debug` call in the exception handler of `_sync_integration` to log `provider`, `organization_id`, `user_id`, `sync_since_override`, whether the connector was initialized, and the exception type in `backend/workers/tasks/sync.py`.
- Preserve the existing `logger.log` call that records the failure case and stack trace so behavior and severity classification remain unchanged.
- Update `backend/tests/test_sync_failure_logging.py` to capture `DEBUG` logs and assert the new diagnostics message (including `error_type=RuntimeError`) is emitted.

### Testing
- Ran `pytest -q backend/tests/test_sync_failure_logging.py`, which completed successfully with `4 passed, 1 warning`.
- The test asserts both the original failure log and the new debug diagnostics line are present in captured logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebeed6cad48321b02e266bf420feff)