### PR TITLE
Ensure Slack posts always include non-empty fallback text

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -133,6 +133,38 @@ def markdown_to_mrkdwn(text: str) -> tuple[str, Optional[list[dict[str, Any]]]]:
 
     return (text, out_blocks)
 
+
+def _extract_fallback_text_from_blocks(blocks: list[dict[str, Any]]) -> str:
+    """Best-effort plain-text fallback extracted from Slack blocks."""
+
+    max_length: int = 280
+    fragments: list[str] = []
+
+    def _walk(node: Any) -> None:
+        if len(" ".join(fragments)) >= max_length:
+            return
+        if isinstance(node, dict):
+            text_value = node.get("text")
+            if isinstance(text_value, str) and text_value.strip():
+                fragments.append(text_value.strip())
+            for key in ("elements", "fields", "accessory", "title"):
+                child = node.get(key)
+                if child is not None:
+                    _walk(child)
+            for value in node.values():
+                if isinstance(value, (dict, list)):
+                    _walk(value)
+            return
+        if isinstance(node, list):
+            for child in node:
+                _walk(child)
+
+    _walk(blocks)
+    fallback: str = " ".join(fragment for fragment in fragments if fragment).strip()
+    if len(fallback) > max_length:
+        fallback = f"{fallback[: max_length - 3].rstrip()}..."
+    return fallback
+
 from api.websockets import broadcast_sync_progress
 from connectors.base import BaseConnector, ExternalConnectionRevokedError, build_connection_removed_message
 from connectors.registry import (
@@ -1539,9 +1571,32 @@ Returns normalized messages for one channel since a cutoff (does not write to th
         else:
             formatted_text, _ = markdown_to_mrkdwn(text)
 
+        normalized_text: str = formatted_text.strip()
+        if not normalized_text and blocks:
+            normalized_text = _extract_fallback_text_from_blocks(blocks)
+            if normalized_text:
+                logger.info(
+                    "[SlackConnector] Derived fallback text from blocks for chat.postMessage channel=%s chars=%d",
+                    channel,
+                    len(normalized_text),
+                )
+            else:
+                normalized_text = "Notification"
+                logger.warning(
+                    "[SlackConnector] Missing fallback text and no extractable text in blocks; using default fallback channel=%s",
+                    channel,
+                )
+        if not normalized_text:
+            logger.error(
+                "[SlackConnector] Refusing to post empty Slack message channel=%s has_blocks=%s",
+                channel,
+                bool(blocks),
+            )
+            raise ValueError("Slack message text must be non-empty")
+
         payload: dict[str, Any] = {
             "channel": channel,
-            "text": formatted_text,
+            "text": normalized_text,
         }
         
         if thread_ts:

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -2,6 +2,8 @@ import asyncio
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
+import pytest
+
 from connectors.slack import SlackConnector
 
 
@@ -388,6 +390,59 @@ def test_post_message_retries_with_org_credentials_on_channel_not_found(monkeypa
     assert result["ok"] is True
     assert calls == ["11111111-1111-1111-1111-111111111111", None]
     assert connector.user_id == "11111111-1111-1111-1111-111111111111"
+
+
+def test_post_message_uses_fallback_text_extracted_from_blocks(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    captured: dict[str, object] = {}
+
+    async def _fake_make_request(method: str, endpoint: str, **kwargs: object):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["json_data"] = kwargs.get("json_data")
+        return {"ok": True, "channel": "C999", "ts": "1.2", "message": {"text": "hello"}}
+
+    monkeypatch.setattr(connector, "_make_request", _fake_make_request)
+
+    result = asyncio.run(
+        connector.post_message(
+            "C999",
+            "",
+            blocks=[
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": "*Deployment finished*"},
+                }
+            ],
+        )
+    )
+
+    assert result["ok"] is True
+    assert captured["method"] == "POST"
+    assert captured["endpoint"] == "chat.postMessage"
+    assert captured["json_data"] == {
+        "channel": "C999",
+        "text": "*Deployment finished*",
+        "blocks": [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "*Deployment finished*"},
+            }
+        ],
+    }
+
+
+def test_post_message_rejects_empty_text_when_blocks_missing(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    async def _fake_make_request(method: str, endpoint: str, **kwargs: object):
+        raise AssertionError("chat.postMessage should not be called for empty message payloads")
+
+    monkeypatch.setattr(connector, "_make_request", _fake_make_request)
+
+    with pytest.raises(ValueError, match="non-empty"):
+        asyncio.run(connector.post_message("C999", ""))
 
 
 def test_send_direct_message_retries_other_slack_identities_on_user_not_found(monkeypatch) -> None:

--- a/backend/tests/test_workflow_send_slack_action.py
+++ b/backend/tests/test_workflow_send_slack_action.py
@@ -27,7 +27,13 @@ class _FakeSlackConnector:
     def __init__(self, **kwargs: object) -> None:
         _FakeSlackConnector.init_kwargs = kwargs
 
-    async def post_message(self, channel: str, text: str, thread_ts: str | None = None) -> dict[str, str]:
+    async def post_message(
+        self,
+        channel: str,
+        text: str,
+        thread_ts: str | None = None,
+        blocks: list[dict[str, object]] | None = None,
+    ) -> dict[str, str]:
         return {"channel": channel, "ts": "123.456", "text": text, "thread_ts": thread_ts or ""}
 
 
@@ -92,3 +98,32 @@ def test_action_send_slack_blocks_unlisted_channel(monkeypatch) -> None:
 
 def test_workflow_slack_target_allows_dm_channel() -> None:
     assert workflows._is_allowed_workflow_slack_target("D12345", ["#ops"]) is True
+
+
+def test_action_send_slack_allows_blocks_without_message(monkeypatch) -> None:
+    integration = SimpleNamespace(
+        nango_connection_id="conn_123",
+        extra_data={"team_id": "T123"},
+    )
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args: object, **_kwargs: object):
+        yield _FakeSession(integration)
+
+    monkeypatch.setattr("models.database.get_session", _fake_get_session)
+    monkeypatch.setattr("connectors.slack.SlackConnector", _FakeSlackConnector)
+
+    async def _run() -> dict[str, object]:
+        return await workflows._action_send_slack(
+            params={
+                "channel": "#alerts",
+                "message": "",
+                "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "hello"}}],
+            },
+            context={"organization_id": "00000000-0000-0000-0000-000000000001"},
+            workflow=None,
+        )
+
+    result = asyncio.run(_run())
+
+    assert result["status"] == "completed"

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -1954,6 +1954,7 @@ async def _action_send_slack(
     
     channel = params.get("channel", "")
     message = params.get("message", "")
+    blocks = params.get("blocks")
     thread_ts = params.get("thread_ts")
     org_id = context.get("organization_id", "")
     
@@ -1963,10 +1964,10 @@ async def _action_send_slack(
             "error": "No channel specified",
         }
     
-    if not message:
+    if not str(message).strip() and not blocks:
         return {
             "status": "failed",
-            "error": "No message specified",
+            "error": "No message or blocks specified",
         }
 
     allowed_channels = _extract_allowed_slack_channels(workflow)
@@ -2041,6 +2042,7 @@ async def _action_send_slack(
             channel=channel,
             text=message,
             thread_ts=thread_ts,
+            blocks=blocks,
         )
         
         logger.info(f"Posted to Slack channel {channel}: {result.get('ts')}")


### PR DESCRIPTION
### Motivation
- Prevent sending empty `text` payloads to Slack when callers supply only Block Kit `blocks`, which can result in blank messages or missing accessibility/fallback content.

### Description
- Added `_extract_fallback_text_from_blocks` in `backend/connectors/slack.py` to derive a best-effort plain-text fallback from Block Kit payloads and enforce a non-empty `text` value before calling `chat.postMessage`.
- When block extraction yields no usable text the connector falls back to a safe default `"Notification"`, and logs the chosen path for observability; the connector now raises `ValueError` if it would otherwise send an empty message.
- Updated `SlackConnector.post_message` to use the derived fallback text (or default) and to set `text` to the normalized non-empty value sent to Slack.
- Updated workflow action handling in `backend/workers/tasks/workflows.py` to accept `blocks` in `send_slack` actions (allow block-only payloads) and to reject requests that provide neither `message` text nor `blocks`.
- Added unit tests to cover fallback extraction, rejection of empty payloads, and workflow block-only posts in `backend/tests/test_slack_connector_actions.py` and `backend/tests/test_workflow_send_slack_action.py`.

### Testing
- Ran unit tests: `pytest -q backend/tests/test_slack_connector_actions.py backend/tests/test_workflow_send_slack_action.py` which completed successfully with `20 passed`.
- Iterated on a failing test (exercising block-text extraction) and fixed traversal to extract nested text, after which the full test run passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec45c288f88321ab8f1d1474458c2a)