### PR TITLE
Upgrade OpenAI default model family to gpt-5.5 and update adapter/fallbacks

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -55,8 +55,8 @@ logger = logging.getLogger(__name__)
 _configured_openai_research_model = (settings.OPENAI_RESEARCH_MODEL or "").strip()
 _preferred_openai_research_model = (
     _configured_openai_research_model
-    if _configured_openai_research_model.startswith("gpt-5")
-    else "gpt-5"
+    if _configured_openai_research_model.startswith("gpt-5.5")
+    else "gpt-5.5"
 )
 
 # Prefer GPT-5 family models for all research synthesis calls.
@@ -64,14 +64,15 @@ OPENAI_WEB_RESEARCH_FALLBACK_MODELS: tuple[str, ...] = tuple(
     dict.fromkeys(
         (
             _preferred_openai_research_model,
+            "gpt-5.5",
             "gpt-5",
-            "gpt-5-mini",
-            "gpt-5-nano",
+            "gpt-5.5-mini",
+            "gpt-5.5-nano",
         )
     )
 )
 
-if _configured_openai_research_model and not _configured_openai_research_model.startswith("gpt-5"):
+if _configured_openai_research_model and not _configured_openai_research_model.startswith("gpt-5.5"):
     logger.warning(
         "[Tools] OPENAI_RESEARCH_MODEL=%s is not GPT-5+. Falling back to GPT-5 family for research synthesis.",
         _configured_openai_research_model,

--- a/backend/config.py
+++ b/backend/config.py
@@ -72,7 +72,7 @@ class Settings(BaseSettings):
 
     # OpenAI (for embeddings + research fallback)
     OPENAI_API_KEY: Optional[str] = None
-    OPENAI_RESEARCH_MODEL: str = "gpt-5"
+    OPENAI_RESEARCH_MODEL: str = "gpt-5.5"
 
     # MiniMax (Anthropic-compatible LLM provider)
     MINIMAX_API_KEY: Optional[str] = None

--- a/backend/connectors/web_search.py
+++ b/backend/connectors/web_search.py
@@ -29,16 +29,17 @@ logger = logging.getLogger(__name__)
 _configured_openai_research_model: str = (settings.OPENAI_RESEARCH_MODEL or "").strip()
 _preferred_openai_research_model: str = (
     _configured_openai_research_model
-    if _configured_openai_research_model.startswith("gpt-5")
-    else "gpt-5"
+    if _configured_openai_research_model.startswith("gpt-5.5")
+    else "gpt-5.5"
 )
 OPENAI_WEB_RESEARCH_FALLBACK_MODELS: tuple[str, ...] = tuple(
     dict.fromkeys(
         (
             _preferred_openai_research_model,
+            "gpt-5.5",
             "gpt-5",
-            "gpt-5-mini",
-            "gpt-5-nano",
+            "gpt-5.5-mini",
+            "gpt-5.5-nano",
         )
     )
 )

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -35,7 +35,7 @@ PROVIDER_BASE_URLS: dict[str, str] = {
 PROVIDER_DEFAULT_MODELS: dict[str, dict[str, str]] = {
     "anthropic": {"primary": "claude-opus-4-6", "cheap": "claude-haiku-4-5-20251001"},
     "minimax": {"primary": "MiniMax-M2.7", "cheap": "MiniMax-M2.7-highspeed"},
-    "openai": {"primary": "gpt-5", "cheap": "gpt-5-mini"},
+    "openai": {"primary": "gpt-5.5", "cheap": "gpt-5.5-mini"},
     "gemini": {"primary": "gemini-2.5-pro", "cheap": "gemini-2.5-flash"},
 }
 
@@ -405,9 +405,9 @@ class OpenAIAdapter:
 
     def _build_token_limit_kwargs(self, *, model: str, max_tokens: int) -> dict[str, int]:
         """Map token limit parameter name based on OpenAI model requirements."""
-        # Newer reasoning families (e.g. gpt-5 / o-series) reject `max_tokens`.
+        # Newer reasoning families (e.g. gpt-5.5 / o-series) reject `max_tokens`.
         normalized_model: str = model.strip().lower().split("/")[-1]
-        uses_completion_tokens: bool = normalized_model.startswith(("gpt-5", "o"))
+        uses_completion_tokens: bool = normalized_model.startswith(("gpt-5.5", "o"))
         token_param_name: str = (
             "max_completion_tokens" if uses_completion_tokens else "max_tokens"
         )
@@ -431,14 +431,14 @@ class OpenAIAdapter:
             prefix, base_model = normalized_model.split("/", 1)
             prefix = f"{prefix}/"
 
-        if not base_model.startswith("gpt-5"):
+        if not base_model.startswith("gpt-5.5"):
             return []
 
         variants: list[str] = []
-        if base_model == "gpt-5":
-            variants.extend(["gpt-5-mini", "gpt-5-nano"])
-        elif base_model == "gpt-5-mini":
-            variants.append("gpt-5-nano")
+        if base_model == "gpt-5.5":
+            variants.extend(["gpt-5", "gpt-5.5-mini", "gpt-5.5-nano"])
+        elif base_model == "gpt-5.5-mini":
+            variants.append("gpt-5.5-nano")
 
         fallback_models: list[str] = [f"{prefix}{variant}" for variant in variants if variant != base_model]
         if fallback_models:

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -431,11 +431,13 @@ class OpenAIAdapter:
             prefix, base_model = normalized_model.split("/", 1)
             prefix = f"{prefix}/"
 
-        if not base_model.startswith("gpt-5.5"):
+        if not base_model.startswith("gpt-5"):
             return []
 
         variants: list[str] = []
-        if base_model == "gpt-5.5":
+        if base_model == "gpt-5":
+            variants.extend(["gpt-5.5", "gpt-5.5-mini", "gpt-5.5-nano"])
+        elif base_model == "gpt-5.5":
             variants.extend(["gpt-5", "gpt-5.5-mini", "gpt-5.5-nano"])
         elif base_model == "gpt-5.5-mini":
             variants.append("gpt-5.5-nano")

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -29,7 +29,7 @@ def _openai_api_status_error(message: str, status_code: int = 404) -> APIStatusE
 def test_openai_gpt5_uses_max_completion_tokens():
     adapter = OpenAIAdapter(api_key="test-key")
 
-    assert adapter._build_token_limit_kwargs(model="gpt-5", max_tokens=1234) == {
+    assert adapter._build_token_limit_kwargs(model="gpt-5.5", max_tokens=1234) == {
         "max_completion_tokens": 1234
     }
 
@@ -46,7 +46,7 @@ def test_openai_gpt5_with_provider_prefix_uses_max_completion_tokens():
     adapter = OpenAIAdapter(api_key="test-key")
 
     assert adapter._build_token_limit_kwargs(
-        model="openai/GPT-5-mini",
+        model="openai/GPT-5.5-mini",
         max_tokens=777,
     ) == {"max_completion_tokens": 777}
 
@@ -145,7 +145,7 @@ async def test_openai_stream_falls_back_when_gpt5_not_found():
     adapter = OpenAIAdapter(api_key="test-key")
     create_mock = AsyncMock(
         side_effect=[
-            _openai_api_status_error("model: gpt-5"),
+            _openai_api_status_error("model: gpt-5.5"),
             _EmptyAsyncIterator(),
         ]
     )
@@ -156,7 +156,7 @@ async def test_openai_stream_falls_back_when_gpt5_not_found():
     events = [
         event
         async for event in adapter.stream(
-            model="gpt-5",
+            model="gpt-5.5",
             system="sys",
             messages=[{"role": "user", "content": "hi"}],
             max_tokens=42,
@@ -165,8 +165,8 @@ async def test_openai_stream_falls_back_when_gpt5_not_found():
 
     assert events == []
     assert create_mock.await_count == 2
-    assert create_mock.await_args_list[0].kwargs["model"] == "gpt-5"
-    assert create_mock.await_args_list[1].kwargs["model"] == "gpt-5-mini"
+    assert create_mock.await_args_list[0].kwargs["model"] == "gpt-5.5"
+    assert create_mock.await_args_list[1].kwargs["model"] == "gpt-5"
 
 
 @pytest.mark.asyncio
@@ -178,7 +178,7 @@ async def test_openai_complete_falls_back_when_gpt5_not_found():
     )
     create_mock = AsyncMock(
         side_effect=[
-            _openai_api_status_error("model: gpt-5"),
+            _openai_api_status_error("model: gpt-5.5"),
             completion_response,
         ]
     )
@@ -187,7 +187,7 @@ async def test_openai_complete_falls_back_when_gpt5_not_found():
     )
 
     completed = await adapter.complete(
-        model="gpt-5",
+        model="gpt-5.5",
         system="sys",
         messages=[{"role": "user", "content": "hi"}],
         max_tokens=42,
@@ -196,5 +196,5 @@ async def test_openai_complete_falls_back_when_gpt5_not_found():
     assert completed.input_tokens == 1
     assert completed.output_tokens == 2
     assert create_mock.await_count == 2
-    assert create_mock.await_args_list[0].kwargs["model"] == "gpt-5"
-    assert create_mock.await_args_list[1].kwargs["model"] == "gpt-5-mini"
+    assert create_mock.await_args_list[0].kwargs["model"] == "gpt-5.5"
+    assert create_mock.await_args_list[1].kwargs["model"] == "gpt-5"

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -198,3 +198,63 @@ async def test_openai_complete_falls_back_when_gpt5_not_found():
     assert create_mock.await_count == 2
     assert create_mock.await_args_list[0].kwargs["model"] == "gpt-5.5"
     assert create_mock.await_args_list[1].kwargs["model"] == "gpt-5"
+
+
+@pytest.mark.asyncio
+async def test_openai_stream_falls_back_from_legacy_gpt5_to_gpt55():
+    adapter = OpenAIAdapter(api_key="test-key")
+    create_mock = AsyncMock(
+        side_effect=[
+            _openai_api_status_error("model: gpt-5"),
+            _EmptyAsyncIterator(),
+        ]
+    )
+    adapter._client = SimpleNamespace(  # type: ignore[assignment]
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+    )
+
+    events = [
+        event
+        async for event in adapter.stream(
+            model="gpt-5",
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=42,
+        )
+    ]
+
+    assert events == []
+    assert create_mock.await_count == 2
+    assert create_mock.await_args_list[0].kwargs["model"] == "gpt-5"
+    assert create_mock.await_args_list[1].kwargs["model"] == "gpt-5.5"
+
+
+@pytest.mark.asyncio
+async def test_openai_complete_falls_back_from_legacy_gpt5_to_gpt55():
+    adapter = OpenAIAdapter(api_key="test-key")
+    completion_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="fallback answer", tool_calls=None))],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=2),
+    )
+    create_mock = AsyncMock(
+        side_effect=[
+            _openai_api_status_error("model: gpt-5"),
+            completion_response,
+        ]
+    )
+    adapter._client = SimpleNamespace(  # type: ignore[assignment]
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+    )
+
+    completed = await adapter.complete(
+        model="gpt-5",
+        system="sys",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=42,
+    )
+
+    assert completed.input_tokens == 1
+    assert completed.output_tokens == 2
+    assert create_mock.await_count == 2
+    assert create_mock.await_args_list[0].kwargs["model"] == "gpt-5"
+    assert create_mock.await_args_list[1].kwargs["model"] == "gpt-5.5"

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -9,7 +9,7 @@ from services.llm_provider import (
 
 def test_infer_provider_from_model_name() -> None:
     assert _infer_provider_from_model_name("claude-haiku-4-5-20251001") == "anthropic"
-    assert _infer_provider_from_model_name("gpt-5-mini") == "openai"
+    assert _infer_provider_from_model_name("gpt-5.5-mini") == "openai"
     assert _infer_provider_from_model_name("gemini-2.5-flash") == "gemini"
     assert _infer_provider_from_model_name("MiniMax-M2.7-highspeed") == "minimax"
     assert _infer_provider_from_model_name("some-unknown-model") is None
@@ -27,8 +27,8 @@ def test_resolve_llm_config_uses_provider_defaults_for_mismatched_global_models(
     config = asyncio.run(resolve_llm_config(None))
 
     assert config.provider == "openai"
-    assert config.primary_model == "gpt-5"
-    assert config.cheap_model == "gpt-5-mini"
+    assert config.primary_model == "gpt-5.5"
+    assert config.cheap_model == "gpt-5.5-mini"
 
 
 def test_resolve_llm_config_logs_when_model_fallback_engaged(monkeypatch, caplog) -> None:

--- a/env.example
+++ b/env.example
@@ -15,7 +15,7 @@ DEFAULT_PRIMARY_MODEL=claude-opus-4-6
 DEFAULT_CHEAP_MODEL=claude-haiku-4-5-20251001
 # Comma-separated allowlist of model names for the org settings UI.
 # Empty = no restriction (free-text input). When set, the frontend shows dropdowns.
-# ALL_MODEL_STRINGS=claude-opus-4-6,claude-haiku-4-5-20251001,gpt-5,gpt-5-mini,gemini-2.5-pro,gemini-2.5-flash,MiniMax-M2.7,MiniMax-M2.7-highspeed
+# ALL_MODEL_STRINGS=claude-opus-4-6,claude-haiku-4-5-20251001,gpt-5.5,gpt-5.5-mini,gemini-2.5-pro,gemini-2.5-flash,MiniMax-M2.7,MiniMax-M2.7-highspeed
 
 # LLM provider API keys
 ANTHROPIC_API_KEY=your_anthropic_api_key
@@ -24,7 +24,7 @@ OPENAI_API_KEY=your_openai_api_key
 # GEMINI_API_KEY=your_gemini_api_key
 
 # OpenAI research model (embeddings + web search fallback, separate from org LLM config)
-OPENAI_RESEARCH_MODEL=gpt-5
+OPENAI_RESEARCH_MODEL=gpt-5.5
 
 # Per-org LLM API key overrides (optional)
 # Resolved by org handle. Falls back to the global provider key above.

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -126,7 +126,7 @@ interface OrganizationPanelProps {
 const MODEL_FAMILY_DEFAULTS: Record<string, { primary: string; fast: string }> = {
   anthropic: { primary: 'claude-opus-4-6', fast: 'claude-haiku-4-5-20251001' },
   minimax: { primary: 'MiniMax-M2.7', fast: 'MiniMax-M2.7-highspeed' },
-  openai: { primary: 'gpt-5', fast: 'gpt-5-mini' },
+  openai: { primary: 'gpt-5.5', fast: 'gpt-5.5-mini' },
   gemini: { primary: 'gemini-2.5-pro', fast: 'gemini-2.5-flash' },
 };
 


### PR DESCRIPTION
### Motivation

- Move the OpenAI/default research model family from `gpt-5` to the newer `gpt-5.5` family as the preferred fallback for research and web synthesis. 
- Ensure token parameter selection and model fallback logic align with the new `gpt-5.5` naming and variant patterns. 
- Update front-end defaults and environment examples to reflect the new default model strings.

### Description

- Changed the global `OPENAI_RESEARCH_MODEL` default to `gpt-5.5` and adjusted checks that previously matched `gpt-5` to match `gpt-5.5` instead (files: `config.py`, `backend/agents/tools.py`, `connectors/web_search.py`, `env.example`).
- Updated the OpenAI model family fallbacks and allowed variant names to include `gpt-5.5` variants and map fallback candidates accordingly inside `OpenAIAdapter` and related fallback lists (files: `services/llm_adapter.py`, `connectors/web_search.py`, `backend/agents/tools.py`).
- Adjusted token-parameter selection logic in `OpenAIAdapter._build_token_limit_kwargs` to treat `gpt-5.5` family as requiring `max_completion_tokens` instead of `max_tokens`.
- Updated provider defaults for OpenAI in `PROVIDER_DEFAULT_MODELS` and the front-end organization model family defaults to `gpt-5.5`/`gpt-5.5-mini` (files: `services/llm_adapter.py`, `frontend/src/components/OrganizationPanel.tsx`).
- Updated unit tests to reflect the `gpt-5.5` naming and fallback behavior (files: `backend/tests/test_llm_adapter_openai_token_params.py`, `backend/tests/test_llm_provider.py`).

### Testing

- Ran unit tests touching the adapter and provider logic, including `tests/test_llm_adapter_openai_token_params.py` and `tests/test_llm_provider.py`, and the updated tests passed under `pytest`.
- Verified the adapter fallback and token-parameter selection logic via the updated tests which simulated OpenAI `not_found` errors and asserted expected fallback model calls succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4557b6188321bebd4ed94158111a)