### PR TITLE
Add 🍒 'Boob left' countdown KPI to seeded CRO dashboard

### DIFF
--- a/backend/scripts/seed_cro_metrics_app.py
+++ b/backend/scripts/seed_cro_metrics_app.py
@@ -170,6 +170,13 @@ export default function CROMetrics() {
       ? `$${(n / 1_000).toFixed(0)}K`
       : `$${Math.round(n)}`;
 
+  const boobLeftDays = useMemo(() => {
+    const now = new Date();
+    const target = new Date("2026-09-10T00:00:00");
+    const msPerDay = 1000 * 60 * 60 * 24;
+    return Math.max(0, Math.ceil((target.getTime() - now.getTime()) / msPerDay));
+  }, []);
+
   return (
     <div style={{ padding: "24px 32px", maxWidth: 1200, margin: "0 auto", fontFamily: "system-ui, sans-serif" }}>
       {/* Period selector */}
@@ -209,6 +216,7 @@ export default function CROMetrics() {
             <KPICard label="Weighted Pipeline" value={fmt(summaryRow.weighted_value ?? 0)} />
             <KPICard label="Avg Deal Size" value={fmt(summaryRow.avg_deal_size ?? 0)} />
             <KPICard label="Win Rate" value={winRow.win_rate_pct ?? 0} suffix="%" />
+            <KPICard label="🍒 Boob left" value={boobLeftDays} suffix=" days" />
           </div>
 
           {/* Deals by stage chart */}


### PR DESCRIPTION
### Motivation
- Provide a simple, visible countdown metric on the seeded CRO dashboard that shows days remaining until 2026-09-10 using the same KPI card pattern as existing metrics.

### Description
- Added a `boobLeftDays` computed value using `useMemo` that calculates days until `2026-09-10T00:00:00` and clamps at `0` in `backend/scripts/seed_cro_metrics_app.py`.
- Rendered the new metric as a KPI card with label `🍒 Boob left` via the existing `KPICard` component and a `" days"` suffix.

### Testing
- Ran `python -m py_compile backend/scripts/seed_cro_metrics_app.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6d84c17c832181a483276d0f5967)