### PR TITLE
Add channel-scoped personality memories with sidebar editor (database migration) 

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1319,10 +1319,10 @@ class ChatOrchestrator:
                 system_prompt += "\n## Channel Personality (Always Apply in this channel)\n"
                 system_prompt += f"- [{channel_personality_memory['id']}] {channel_personality_memory['content']}\n"
                 logger.info(
-                    "[Orchestrator] Memory applied type=channel conversation_id=%s source=%s memory_id=%s",
+                    "[Orchestrator] Memory applied type=channel conversation_id=%s source=%s memory_id_present=%s",
                     self.conversation_id,
                     self.source,
-                    channel_personality_memory["id"],
+                    bool(channel_personality_memory.get("id")),
                 )
 
             # -- User profile section --

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1309,9 +1309,21 @@ class ChatOrchestrator:
             if global_command_memory and is_private_memory_context:
                 system_prompt += "\n## Global Command (Always Apply)\n"
                 system_prompt += f"- [{global_command_memory['id']}] {global_command_memory['content']}\n"
+                logger.info(
+                    "[Orchestrator] Memory applied type=user-direct conversation_id=%s source=%s memory_id=%s",
+                    self.conversation_id,
+                    self.source,
+                    global_command_memory["id"],
+                )
             if channel_personality_memory:
                 system_prompt += "\n## Channel Personality (Always Apply in this channel)\n"
                 system_prompt += f"- [{channel_personality_memory['id']}] {channel_personality_memory['content']}\n"
+                logger.info(
+                    "[Orchestrator] Memory applied type=channel conversation_id=%s source=%s memory_id=%s",
+                    self.conversation_id,
+                    self.source,
+                    channel_personality_memory["id"],
+                )
 
             # -- User profile section --
             if user_memories or phone_number:

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -139,6 +139,30 @@ WHERE source_system = 'slack'
 The activities table contains synced Slack messages with these relevant custom_fields keys: channel_id, channel_name, user_id, thread_ts."""
 
 
+def _normalize_channel_scope_id(source: str | None, source_channel_id: str | None) -> str | None:
+    """Normalize channel identifier for channel-scoped memory lookups."""
+    if not source or not source_channel_id:
+        return None
+    normalized_source = source.strip().lower()
+    normalized_channel_id = str(source_channel_id).strip()
+    if not normalized_channel_id:
+        return None
+    if normalized_source == "slack":
+        return normalized_channel_id.split(":", maxsplit=1)[0].strip() or None
+    return normalized_channel_id
+
+
+def _is_private_memory_context(*, source: str | None, scope: str | None, normalized_channel_id: str | None) -> bool:
+    """Global-command memories should apply only to private web chats and Slack DMs."""
+    normalized_source = (source or "").strip().lower()
+    normalized_scope = (scope or "").strip().lower()
+    if normalized_source == "web" and normalized_scope == "private":
+        return True
+    if normalized_source == "slack" and (normalized_channel_id or "").startswith("D"):
+        return True
+    return False
+
+
 def _should_include_cross_conversation_history(user_message: str) -> bool:
     """Return True when a user explicitly asks for cross-conversation context."""
     if not user_message:
@@ -737,6 +761,8 @@ class ChatOrchestrator:
             "phone_number": getattr(self, "_phone_number", None),
             "participant_job_memories": [],
             "global_command_memory": None,
+            "channel_personality_memory": None,
+            "is_private_memory_context": False,
         }
 
         try:
@@ -753,13 +779,34 @@ class ChatOrchestrator:
                 all_memories: list[Memory] = list(result.scalars().all())
 
                 participant_user_ids: list[UUID] = []
+                conversation_scope: str | None = None
+                conversation_source: str | None = None
+                normalized_channel_id: str | None = None
                 if self.conversation_id:
                     conversation_result = await session.execute(
-                        select(Conversation.participating_user_ids)
+                        select(
+                            Conversation.participating_user_ids,
+                            Conversation.scope,
+                            Conversation.source,
+                            Conversation.source_channel_id,
+                        )
                         .where(Conversation.id == UUID(self.conversation_id))
                         .limit(1)
                     )
-                    participant_user_ids = list(conversation_result.scalar_one_or_none() or [])
+                    conversation_row = conversation_result.one_or_none()
+                    if conversation_row:
+                        participant_user_ids = list(conversation_row[0] or [])
+                        conversation_scope = conversation_row[1]
+                        conversation_source = conversation_row[2]
+                        normalized_channel_id = _normalize_channel_scope_id(
+                            conversation_source,
+                            conversation_row[3],
+                        )
+                        profile["is_private_memory_context"] = _is_private_memory_context(
+                            source=conversation_source,
+                            scope=conversation_scope,
+                            normalized_channel_id=normalized_channel_id,
+                        )
 
                 user_uuid: UUID | None = self._resolve_current_user_uuid()
                 org_uuid: UUID = UUID(self.organization_id)  # type: ignore[arg-type]
@@ -871,6 +918,27 @@ class ChatOrchestrator:
                             self.conversation_id,
                             missing_members,
                         )
+
+                if normalized_channel_id and conversation_source:
+                    normalized_source: str = conversation_source.strip().lower()
+                    channel_memory_result = await session.execute(
+                        select(Memory)
+                        .where(
+                            Memory.organization_id == org_uuid,
+                            Memory.scope_type == "channel",
+                            Memory.scope_source == normalized_source,
+                            Memory.scope_channel_id == normalized_channel_id,
+                            Memory.category == "channel_personality",
+                        )
+                        .order_by(Memory.updated_at.desc().nullslast(), Memory.created_at.desc().nullslast())
+                        .limit(1)
+                    )
+                    channel_personality_memory = channel_memory_result.scalar_one_or_none()
+                    if channel_personality_memory:
+                        profile["channel_personality_memory"] = {
+                            "id": str(channel_personality_memory.id),
+                            "content": channel_personality_memory.content,
+                        }
 
         except Exception:
             logger.warning("Failed to load context profile", exc_info=True)
@@ -1225,9 +1293,11 @@ class ChatOrchestrator:
             reports_to_name: str | None = profile["reports_to_name"]
             phone_number: str | None = profile["phone_number"]
             global_command_memory: dict[str, str] | None = profile.get("global_command_memory")
+            channel_personality_memory: dict[str, str] | None = profile.get("channel_personality_memory")
+            is_private_memory_context: bool = bool(profile.get("is_private_memory_context"))
 
             has_any_context: bool = bool(
-                user_memories or job_memories or global_command_memory
+                user_memories or job_memories or global_command_memory or channel_personality_memory
                 or membership_title or reports_to_name or phone_number
             )
 
@@ -1236,9 +1306,12 @@ class ChatOrchestrator:
                 system_prompt += "\nThese are persisted facts about the user and their role."
                 system_prompt += " Follow preferences. Use manage_memory with action=\"update\" or action=\"delete\" and the [memory_id] shown in brackets to manage entries.\n"
 
-            if global_command_memory:
+            if global_command_memory and is_private_memory_context:
                 system_prompt += "\n## Global Command (Always Apply)\n"
                 system_prompt += f"- [{global_command_memory['id']}] {global_command_memory['content']}\n"
+            if channel_personality_memory:
+                system_prompt += "\n## Channel Personality (Always Apply in this channel)\n"
+                system_prompt += f"- [{channel_personality_memory['id']}] {channel_personality_memory['content']}\n"
 
             # -- User profile section --
             if user_memories or phone_number:
@@ -1277,7 +1350,7 @@ class ChatOrchestrator:
                         system_prompt += f"  - [{mem['id']}] {mem['content']}\n"
 
             # -- Profile completeness signal (guides context-gathering behaviour) --
-            is_private: bool = self.source in ("slack_dm", "web", "sms")
+            is_private: bool = is_private_memory_context
             if is_private:
                 completeness_parts: list[str] = []
 

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1310,10 +1310,10 @@ class ChatOrchestrator:
                 system_prompt += "\n## Global Command (Always Apply)\n"
                 system_prompt += f"- [{global_command_memory['id']}] {global_command_memory['content']}\n"
                 logger.info(
-                    "[Orchestrator] Memory applied type=user-direct conversation_id=%s source=%s memory_id=%s",
+                    "[Orchestrator] Memory applied type=user-direct conversation_id=%s source=%s memory_id_present=%s",
                     self.conversation_id,
                     self.source,
-                    global_command_memory["id"],
+                    bool(global_command_memory.get("id")),
                 )
             if channel_personality_memory:
                 system_prompt += "\n## Channel Personality (Always Apply in this channel)\n"

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -6180,7 +6180,7 @@ async def execute_keep_notes(
 
 
 GLOBAL_COMMAND_CATEGORY = "global_commands"
-GLOBAL_COMMAND_MAX_LENGTH = 400
+GLOBAL_COMMAND_MAX_LENGTH = 800
 SUPPORTED_MEMORY_ENTITY_TYPES = {"user", "organization_member"}
 ORG_LEVEL_MEMORY_ERROR = (
     "Org-level memories are not allowed. "

--- a/backend/api/routes/memories.py
+++ b/backend/api/routes/memories.py
@@ -16,7 +16,19 @@ logger = logging.getLogger(__name__)
 
 GLOBAL_COMMAND_CATEGORY = "global_commands"
 GLOBAL_COMMAND_CATEGORY_ALIASES = {"global_command", "global_commands"}
-GLOBAL_COMMAND_MAX_LENGTH = 400
+GLOBAL_COMMAND_MAX_LENGTH = 800
+CHANNEL_PERSONALITY_CATEGORY = "channel_personality"
+CHANNEL_PERSONALITY_MAX_LENGTH = GLOBAL_COMMAND_MAX_LENGTH
+
+
+def normalize_channel_scope_channel_id(source: str, channel_id: str) -> str:
+    normalized_source = source.strip().lower()
+    normalized_channel_id = channel_id.strip()
+    if not normalized_source or not normalized_channel_id:
+        raise HTTPException(status_code=400, detail="source and channel_id are required")
+    if normalized_source == "slack":
+        return normalized_channel_id.split(":", maxsplit=1)[0].strip()
+    return normalized_channel_id
 
 
 def normalize_memory_category(category: str | None) -> str | None:
@@ -32,9 +44,26 @@ def normalize_memory_category(category: str | None) -> str | None:
 
 def validate_memory_content(content: str, category: str | None) -> None:
     if category == GLOBAL_COMMAND_CATEGORY and len(content) > GLOBAL_COMMAND_MAX_LENGTH:
+        logger.warning(
+            "[Memories API] Validation failed category=%s length=%s max=%s",
+            category,
+            len(content),
+            GLOBAL_COMMAND_MAX_LENGTH,
+        )
         raise HTTPException(
             status_code=400,
             detail=f"Global command memories must be {GLOBAL_COMMAND_MAX_LENGTH} characters or fewer",
+        )
+    if category == CHANNEL_PERSONALITY_CATEGORY and len(content) > CHANNEL_PERSONALITY_MAX_LENGTH:
+        logger.warning(
+            "[Memories API] Validation failed category=%s length=%s max=%s",
+            category,
+            len(content),
+            CHANNEL_PERSONALITY_MAX_LENGTH,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail=f"Channel personality memories must be {CHANNEL_PERSONALITY_MAX_LENGTH} characters or fewer",
         )
 
 
@@ -89,6 +118,7 @@ async def list_memories(organization_id: str, user_id: str) -> MemoryDashboardRe
             .where(
                 Memory.organization_id == org_uuid,
                 Memory.created_by_user_id == user_uuid,
+                Memory.entity_type == "user",
             )
             .order_by(Memory.updated_at.desc().nullslast(), Memory.created_at.desc().nullslast())
         )
@@ -205,4 +235,153 @@ async def delete_user_memory(organization_id: str, memory_id: str, user_id: str)
         await session.commit()
 
     logger.info("[Memories API] Deleted memory %s for user %s", memory_id, user_id)
+    return {"status": "deleted", "memory_id": memory_id}
+
+
+@router.get("/{organization_id}/channel", response_model=MemoryResponse | None)
+async def get_channel_memory(organization_id: str, source: str, channel_id: str) -> MemoryResponse | None:
+    """Get channel personality memory by source + normalized channel identifier."""
+    try:
+        org_uuid = UUID(organization_id)
+        normalized_channel_id = normalize_channel_scope_channel_id(source, channel_id)
+        normalized_source = source.strip().lower()
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    async with get_session(organization_id=organization_id) as session:
+        result = await session.execute(
+            select(Memory)
+            .where(
+                Memory.organization_id == org_uuid,
+                Memory.scope_type == "channel",
+                Memory.scope_source == normalized_source,
+                Memory.scope_channel_id == normalized_channel_id,
+                Memory.category == CHANNEL_PERSONALITY_CATEGORY,
+            )
+            .order_by(Memory.updated_at.desc().nullslast(), Memory.created_at.desc().nullslast())
+            .limit(1)
+        )
+        memory = result.scalar_one_or_none()
+        if not memory:
+            logger.info(
+                "[Memories API] Channel personality miss org=%s source=%s channel_id=%s",
+                organization_id,
+                normalized_source,
+                normalized_channel_id,
+            )
+            return None
+
+        logger.info(
+            "[Memories API] Channel personality hit org=%s source=%s channel_id=%s memory_id=%s",
+            organization_id,
+            normalized_source,
+            normalized_channel_id,
+            memory.id,
+        )
+        return _build_memory_response(memory)
+
+
+@router.put("/{organization_id}/channel", response_model=MemoryResponse)
+async def upsert_channel_memory(
+    organization_id: str,
+    source: str,
+    channel_id: str,
+    request: UpdateMemoryRequest,
+) -> MemoryResponse:
+    """Create/update channel personality memory by source + channel identifier."""
+    content = request.content.strip()
+    if not content:
+        raise HTTPException(status_code=400, detail="content is required")
+    validate_memory_content(content, CHANNEL_PERSONALITY_CATEGORY)
+
+    try:
+        org_uuid = UUID(organization_id)
+        normalized_source = source.strip().lower()
+        normalized_channel_id = normalize_channel_scope_channel_id(source, channel_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    async with get_session(organization_id=organization_id) as session:
+        result = await session.execute(
+            select(Memory).where(
+                Memory.organization_id == org_uuid,
+                Memory.scope_type == "channel",
+                Memory.scope_source == normalized_source,
+                Memory.scope_channel_id == normalized_channel_id,
+                Memory.category == CHANNEL_PERSONALITY_CATEGORY,
+            )
+        )
+        memory = result.scalar_one_or_none()
+        if memory:
+            memory.content = content
+            action = "updated"
+        else:
+            memory = Memory(
+                entity_type="channel",
+                entity_id=None,
+                organization_id=org_uuid,
+                category=CHANNEL_PERSONALITY_CATEGORY,
+                content=content,
+                scope_type="channel",
+                scope_source=normalized_source,
+                scope_channel_id=normalized_channel_id,
+                created_by_user_id=None,
+            )
+            session.add(memory)
+            action = "created"
+
+        await session.commit()
+        await session.refresh(memory)
+        logger.info(
+            "[Memories API] Channel personality %s org=%s source=%s channel_id=%s memory_id=%s",
+            action,
+            organization_id,
+            normalized_source,
+            normalized_channel_id,
+            memory.id,
+        )
+        return _build_memory_response(memory)
+
+
+@router.delete("/{organization_id}/channel")
+async def delete_channel_memory(organization_id: str, source: str, channel_id: str) -> dict[str, str]:
+    """Delete channel personality memory by source + channel identifier."""
+    try:
+        org_uuid = UUID(organization_id)
+        normalized_source = source.strip().lower()
+        normalized_channel_id = normalize_channel_scope_channel_id(source, channel_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    async with get_session(organization_id=organization_id) as session:
+        result = await session.execute(
+            select(Memory).where(
+                Memory.organization_id == org_uuid,
+                Memory.scope_type == "channel",
+                Memory.scope_source == normalized_source,
+                Memory.scope_channel_id == normalized_channel_id,
+                Memory.category == CHANNEL_PERSONALITY_CATEGORY,
+            )
+        )
+        memory = result.scalar_one_or_none()
+        if not memory:
+            logger.info(
+                "[Memories API] Channel personality delete miss org=%s source=%s channel_id=%s",
+                organization_id,
+                normalized_source,
+                normalized_channel_id,
+            )
+            raise HTTPException(status_code=404, detail="Memory not found")
+
+        memory_id = str(memory.id)
+        await session.delete(memory)
+        await session.commit()
+
+    logger.info(
+        "[Memories API] Channel personality deleted org=%s source=%s channel_id=%s memory_id=%s",
+        organization_id,
+        normalized_source,
+        normalized_channel_id,
+        memory_id,
+    )
     return {"status": "deleted", "memory_id": memory_id}

--- a/backend/db/migrations/versions/134_chan_mem_scope.py
+++ b/backend/db/migrations/versions/134_chan_mem_scope.py
@@ -46,6 +46,10 @@ def downgrade() -> None:
     op.drop_index("ux_memories_channel_category", table_name="memories")
     op.drop_index("ix_memories_scope_lookup", table_name="memories")
 
+    # Channel-scoped rows created by this migration can have entity_id=NULL.
+    # Remove them before restoring the original NOT NULL constraint.
+    op.execute(sa.text("DELETE FROM memories WHERE scope_type IS NOT NULL"))
+
     op.alter_column("memories", "entity_id", existing_type=sa.UUID(), nullable=False)
 
     op.drop_column("memories", "scope_channel_id")

--- a/backend/db/migrations/versions/134_chan_mem_scope.py
+++ b/backend/db/migrations/versions/134_chan_mem_scope.py
@@ -1,0 +1,53 @@
+"""Add channel memory scope columns.
+
+Revision ID: 134_chan_mem_scope
+Revises: 133_org_members_self_edit
+Create Date: 2026-04-25
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "134_chan_mem_scope"
+down_revision: Union[str, Sequence[str], None] = "133_org_members_self_edit"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+assert len(revision) <= 32
+assert not isinstance(down_revision, str) or len(down_revision) <= 32
+
+
+def upgrade() -> None:
+    op.add_column("memories", sa.Column("scope_type", sa.String(length=30), nullable=True))
+    op.add_column("memories", sa.Column("scope_source", sa.String(length=30), nullable=True))
+    op.add_column("memories", sa.Column("scope_channel_id", sa.String(length=255), nullable=True))
+
+    op.alter_column("memories", "entity_id", existing_type=sa.UUID(), nullable=True)
+
+    op.create_index(
+        "ix_memories_scope_lookup",
+        "memories",
+        ["organization_id", "scope_type", "scope_source", "scope_channel_id", "category"],
+        unique=False,
+    )
+    op.create_index(
+        "ux_memories_channel_category",
+        "memories",
+        ["organization_id", "scope_type", "scope_source", "scope_channel_id", "category"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ux_memories_channel_category", table_name="memories")
+    op.drop_index("ix_memories_scope_lookup", table_name="memories")
+
+    op.alter_column("memories", "entity_id", existing_type=sa.UUID(), nullable=False)
+
+    op.drop_column("memories", "scope_channel_id")
+    op.drop_column("memories", "scope_source")
+    op.drop_column("memories", "scope_type")

--- a/backend/db/migrations/versions/134_topic_graph.py
+++ b/backend/db/migrations/versions/134_topic_graph.py
@@ -1,0 +1,45 @@
+"""134_topic_graph
+
+Revision ID: 134_topic_graph
+Revises: 133_org_members_self_edit
+Create Date: 2026-04-26
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "134_topic_graph"
+down_revision = "133_org_members_self_edit"
+branch_labels = None
+depends_on = None
+
+assert len(revision) <= 32
+assert not isinstance(down_revision, str) or len(down_revision) <= 32
+
+
+def upgrade() -> None:
+    op.create_table(
+        "topic_graph_snapshots",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("graph_date", sa.Date(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False, server_default="completed"),
+        sa.Column("graph_payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("run_metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("organization_id", "graph_date", name="uq_topic_graph_org_date"),
+    )
+    op.create_index("ix_topic_graph_org_date", "topic_graph_snapshots", ["organization_id", "graph_date"], unique=False)
+    op.create_index("ix_topic_graph_graph_date", "topic_graph_snapshots", ["graph_date"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_topic_graph_graph_date", table_name="topic_graph_snapshots")
+    op.drop_index("ix_topic_graph_org_date", table_name="topic_graph_snapshots")
+    op.drop_table("topic_graph_snapshots")

--- a/backend/db/migrations/versions/135_chan_mem_scope.py
+++ b/backend/db/migrations/versions/135_chan_mem_scope.py
@@ -1,7 +1,7 @@
 """Add channel memory scope columns.
 
-Revision ID: 134_chan_mem_scope
-Revises: 133_org_members_self_edit
+Revision ID: 135_chan_mem_scope
+Revises: 134_topic_graph
 Create Date: 2026-04-25
 """
 
@@ -12,8 +12,8 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-revision: str = "134_chan_mem_scope"
-down_revision: Union[str, Sequence[str], None] = "133_org_members_self_edit"
+revision: str = "135_chan_mem_scope"
+down_revision: Union[str, Sequence[str], None] = "134_topic_graph"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/models/memory.py
+++ b/backend/models/memory.py
@@ -1,4 +1,4 @@
-"""Memory model for persistent agent memories/preferences at user and job (org membership) levels."""
+"""Memory model for persistent agent memories/preferences across multiple scopes."""
 from __future__ import annotations
 
 import uuid
@@ -13,11 +13,19 @@ from models.database import Base
 
 
 class Memory(Base):
-    """Stores persistent memories/preferences scoped to a user or job (org membership)."""
+    """Stores persistent memories/preferences scoped to user/job/channel contexts."""
 
     __tablename__ = "memories"
     __table_args__ = (
         Index("ix_memories_entity", "entity_type", "entity_id"),
+        Index(
+            "ix_memories_scope_lookup",
+            "organization_id",
+            "scope_type",
+            "scope_source",
+            "scope_channel_id",
+            "category",
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -26,9 +34,9 @@ class Memory(Base):
     entity_type: Mapped[str] = mapped_column(
         String(30), nullable=False
     )  # 'user' | 'organization_member'
-    entity_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), nullable=False
-    )  # PK of the associated entity
+    entity_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )  # PK of the associated entity (nullable for non-UUID scopes like channels)
     organization_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("organizations.id", ondelete="CASCADE"),
@@ -37,6 +45,15 @@ class Memory(Base):
     category: Mapped[Optional[str]] = mapped_column(
         String(50), nullable=True
     )  # 'personal', 'preference', 'professional', 'project', etc.
+    scope_type: Mapped[Optional[str]] = mapped_column(
+        String(30), nullable=True
+    )  # 'channel' for channel-scoped memory records
+    scope_source: Mapped[Optional[str]] = mapped_column(
+        String(30), nullable=True
+    )  # e.g. 'slack', 'web'
+    scope_channel_id: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True
+    )  # normalized source channel/thread identifier
     content: Mapped[str] = mapped_column(Text, nullable=False)
     created_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         UUID(as_uuid=True),

--- a/backend/tests/test_memory_policy.py
+++ b/backend/tests/test_memory_policy.py
@@ -153,3 +153,13 @@ def test_execute_save_memory_commits_and_exits_session_on_save(monkeypatch) -> N
     assert saved_memory.content == "Remember my timezone is UTC"
     assert saved_memory.category == "global_commands"
     assert result["status"] == "saved"
+
+
+def test_global_command_limit_allows_800_chars() -> None:
+    long_content = "x" * 800
+    memories_api.validate_memory_content(long_content, memories_api.GLOBAL_COMMAND_CATEGORY)
+
+
+def test_channel_scope_normalization_for_slack_thread_id() -> None:
+    normalized = memories_api.normalize_channel_scope_channel_id("slack", "C12345678:1714691329.001200")
+    assert normalized == "C12345678"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -98,6 +98,16 @@ export interface ChatHistoryResponse {
   messages: ChatMessage[];
 }
 
+export interface ChannelMemoryPayload {
+  id: string;
+  entity_type: string;
+  category: string | null;
+  content: string;
+  created_by_user_id: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
 // =============================================================================
 // Integration Types
 // =============================================================================
@@ -213,6 +223,45 @@ export async function createConversation(
     method: "POST",
     body: JSON.stringify({ title }),
   });
+}
+
+export async function getChannelPersonalityMemory(
+  organizationId: string,
+  source: string,
+  channelId: string,
+): Promise<ApiResponse<ChannelMemoryPayload | null>> {
+  const params = new URLSearchParams({ source, channel_id: channelId });
+  return apiRequest<ChannelMemoryPayload | null>(
+    `/memories/${organizationId}/channel?${params.toString()}`,
+  );
+}
+
+export async function upsertChannelPersonalityMemory(
+  organizationId: string,
+  source: string,
+  channelId: string,
+  content: string,
+): Promise<ApiResponse<ChannelMemoryPayload>> {
+  const params = new URLSearchParams({ source, channel_id: channelId });
+  return apiRequest<ChannelMemoryPayload>(
+    `/memories/${organizationId}/channel?${params.toString()}`,
+    {
+      method: "PUT",
+      body: JSON.stringify({ content }),
+    },
+  );
+}
+
+export async function deleteChannelPersonalityMemory(
+  organizationId: string,
+  source: string,
+  channelId: string,
+): Promise<ApiResponse<{ status: string; memory_id: string }>> {
+  const params = new URLSearchParams({ source, channel_id: channelId });
+  return apiRequest<{ status: string; memory_id: string }>(
+    `/memories/${organizationId}/channel?${params.toString()}`,
+    { method: "DELETE" },
+  );
 }
 
 /**

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1349,6 +1349,7 @@ function ChannelPersonalityPanel({
           : await apiRequest<{ status: string; memory_id: string }>(endpoint, { method: 'DELETE' });
         if (result.error) {
           setError(result.error);
+          setIsDirty(false);
         } else {
           lastSavedRef.current = trimmed;
           setIsDirty(false);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -21,6 +21,8 @@ import { Avatar, type AvatarUser } from './Avatar';
 import { ScopeLockIcon } from './ScopeVisibilityIcons';
 import { APP_NAME, LOGO_PATH, RELEASE_STAGE } from '../lib/brand';
 
+const CHANNEL_PERSONALITY_MAX_LENGTH = 800;
+
 /** Help button and modal for support requests. */
 function HelpButton(): JSX.Element {
   const [showModal, setShowModal] = useState(false);
@@ -898,6 +900,19 @@ function formatRelativeTime(date: Date): string {
   return date.toLocaleDateString();
 }
 
+interface ChannelMemoryResponse {
+  id: string;
+  content: string;
+}
+
+function normalizeChannelIdForMemory(source: string | null | undefined, channelKey: string, normalizedChannelId?: string | null): string {
+  const raw = (normalizedChannelId ?? '').trim() || channelKey.replace(/^channel:/, '').trim();
+  if ((source ?? '').toLowerCase() === 'slack') {
+    return raw.split(':', 1)[0] ?? raw;
+  }
+  return raw;
+}
+
 /** Recent chats: shared + private in one list (recency), pinned first; lock marks private. Row actions live in the chat ⋮ menu. */
 function ChatAccordion({
   collapsed,
@@ -916,8 +931,15 @@ function ChatAccordion({
 }): JSX.Element | null {
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>({});
+  const [channelPersonalityTarget, setChannelPersonalityTarget] = useState<{
+    key: string;
+    label: string;
+    source: string | null;
+    normalizedChannelId: string;
+  } | null>(null);
   const prefetchConversation = useAppStore((s) => s.prefetchConversation);
   const pinnedChatIds = useAppStore((s) => s.pinnedChatIds);
+  const organizationId = useAppStore((s) => s.organization?.id ?? null);
   const unreadConversationIds = useChatStore((s) => s.unreadConversationIds);
 
   useEffect(() => {
@@ -931,7 +953,13 @@ function ChatAccordion({
     );
     const direct: ChatSummary[] = [];
     const uncategorized: ChatSummary[] = [];
-    const channels = new Map<string, { label: string; chats: ChatSummary[]; newestTs: number }>();
+    const channels = new Map<string, {
+      label: string;
+      source: string | null;
+      normalizedChannelId: string | null;
+      chats: ChatSummary[];
+      newestTs: number;
+    }>();
     const pinned: ChatSummary[] = [];
     for (const chat of sorted) {
       const ts = chat.lastMessageAt.getTime();
@@ -944,6 +972,8 @@ function ChatAccordion({
       if (bucket === 'channel' && chat.groupBucketKey) {
         const current = channels.get(chat.groupBucketKey) ?? {
           label: chat.resolvedChannelName ?? chat.normalizedChannelId ?? 'Channel',
+          source: chat.source ?? null,
+          normalizedChannelId: chat.normalizedChannelId ?? null,
           chats: [],
           newestTs: 0,
         };
@@ -957,7 +987,14 @@ function ChatAccordion({
     const globalLimit = 50;
     const byNewest = (a: ChatSummary, b: ChatSummary): number => b.lastMessageAt.getTime() - a.lastMessageAt.getTime();
     const channelSections = Array.from(channels.entries())
-      .map(([key, value]) => ({ key, label: value.label, chats: value.chats.sort(byNewest), newestTs: value.newestTs }))
+      .map(([key, value]) => ({
+        key,
+        label: value.label,
+        source: value.source,
+        normalizedChannelId: value.normalizedChannelId,
+        chats: value.chats.sort(byNewest),
+        newestTs: value.newestTs,
+      }))
       .sort((a, b) => b.newestTs - a.newestTs);
     const flattenCount =
       pinned.length +
@@ -1129,6 +1166,19 @@ function ChatAccordion({
                   title={channel.label}
                   collapsed={isSectionCollapsed(`channel:${channel.key}`)}
                   onToggle={() => toggleSection(`channel:${channel.key}`)}
+                  onOptionsClick={() => {
+                    const normalizedChannelId = normalizeChannelIdForMemory(
+                      channel.source,
+                      channel.key,
+                      channel.normalizedChannelId,
+                    );
+                    setChannelPersonalityTarget({
+                      key: channel.key,
+                      label: channel.label,
+                      source: channel.source,
+                      normalizedChannelId,
+                    });
+                  }}
                 />
                 {!isSectionCollapsed(`channel:${channel.key}`) &&
                   channel.chats.map((chat) => renderChatItem(chat, `channel-${channel.key}-${chat.id}`))}
@@ -1152,6 +1202,15 @@ function ChatAccordion({
           </div>
         )}
       </div>
+      {channelPersonalityTarget && (
+        <ChannelPersonalityPanel
+          organizationId={organizationId}
+          channelName={channelPersonalityTarget.label}
+          source={channelPersonalityTarget.source}
+          normalizedChannelId={channelPersonalityTarget.normalizedChannelId}
+          onClose={() => setChannelPersonalityTarget(null)}
+        />
+      )}
     </div>
   );
 }
@@ -1160,10 +1219,12 @@ function SidebarSectionHeader({
   title,
   collapsed,
   onToggle,
+  onOptionsClick,
 }: {
   title: string;
   collapsed: boolean;
   onToggle: () => void;
+  onOptionsClick?: () => void;
 }): JSX.Element {
   return (
     <div className="px-1 pt-2 pb-1 flex items-center gap-1">
@@ -1184,17 +1245,170 @@ function SidebarSectionHeader({
         </svg>
         <h3 className="truncate text-[10px] uppercase tracking-wider text-surface-500 font-semibold">{title}</h3>
       </button>
-      <button
-        type="button"
-        className="p-1 rounded-md text-surface-500 hover:bg-surface-800/60 hover:text-surface-300 transition-colors"
-        aria-label={`${title} options`}
-      >
-        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-          <circle cx="12" cy="5" r="1.8" />
-          <circle cx="12" cy="12" r="1.8" />
-          <circle cx="12" cy="19" r="1.8" />
-        </svg>
-      </button>
+      {onOptionsClick && (
+        <button
+          type="button"
+          className="p-1 rounded-md text-surface-500 hover:bg-surface-800/60 hover:text-surface-300 transition-colors"
+          aria-label={`${title} options`}
+          onClick={onOptionsClick}
+        >
+          <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="5" cy="12" r="1.8" />
+            <circle cx="12" cy="12" r="1.8" />
+            <circle cx="19" cy="12" r="1.8" />
+          </svg>
+        </button>
+      )}
     </div>
+  );
+}
+
+function ChannelPersonalityPanel({
+  organizationId,
+  channelName,
+  source,
+  normalizedChannelId,
+  onClose,
+}: {
+  organizationId: string | null;
+  channelName: string;
+  source: string | null;
+  normalizedChannelId: string;
+  onClose: () => void;
+}): JSX.Element {
+  const [draft, setDraft] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const lastSavedRef = useRef('');
+  const saveTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    let isActive = true;
+    const load = async (): Promise<void> => {
+      if (!organizationId || !source || !normalizedChannelId) {
+        setError('Channel identity is unavailable for this section.');
+        return;
+      }
+      setIsLoading(true);
+      setError(null);
+      const params = new URLSearchParams({
+        source: source.toLowerCase(),
+        channel_id: normalizedChannelId,
+      });
+      const { data, error: requestError } = await apiRequest<ChannelMemoryResponse | null>(`/memories/${organizationId}/channel?${params.toString()}`);
+      if (!isActive) return;
+      if (requestError) {
+        setError(requestError);
+      } else {
+        const nextValue = data?.content ?? '';
+        setDraft(nextValue);
+        lastSavedRef.current = nextValue;
+      }
+      setIsDirty(false);
+      setIsLoading(false);
+    };
+    void load();
+    return () => {
+      isActive = false;
+      if (saveTimeoutRef.current) {
+        window.clearTimeout(saveTimeoutRef.current);
+      }
+    };
+  }, [organizationId, source, normalizedChannelId]);
+
+  useEffect(() => {
+    if (!isDirty || isLoading || !organizationId || !source || !normalizedChannelId) {
+      return;
+    }
+    if (saveTimeoutRef.current) {
+      window.clearTimeout(saveTimeoutRef.current);
+    }
+    saveTimeoutRef.current = window.setTimeout(() => {
+      const persist = async (): Promise<void> => {
+        if (draft.length > CHANNEL_PERSONALITY_MAX_LENGTH) return;
+        const normalizedSource = source.toLowerCase();
+        const trimmed = draft.trim();
+        if (trimmed === lastSavedRef.current.trim()) {
+          setIsDirty(false);
+          return;
+        }
+        setIsSaving(true);
+        setError(null);
+        const params = new URLSearchParams({
+          source: normalizedSource,
+          channel_id: normalizedChannelId,
+        });
+        const endpoint = `/memories/${organizationId}/channel?${params.toString()}`;
+        const result = trimmed
+          ? await apiRequest<ChannelMemoryResponse>(endpoint, {
+            method: 'PUT',
+            body: JSON.stringify({ content: trimmed }),
+          })
+          : await apiRequest<{ status: string; memory_id: string }>(endpoint, { method: 'DELETE' });
+        if (result.error) {
+          setError(result.error);
+        } else {
+          lastSavedRef.current = trimmed;
+          setIsDirty(false);
+        }
+        setIsSaving(false);
+      };
+      void persist();
+    }, 700);
+    return () => {
+      if (saveTimeoutRef.current) {
+        window.clearTimeout(saveTimeoutRef.current);
+      }
+    };
+  }, [draft, isDirty, isLoading, organizationId, source, normalizedChannelId]);
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 z-40" onClick={onClose} />
+      <div className="fixed right-0 top-0 bottom-0 w-full max-w-md bg-surface-900 border-l border-surface-800 z-50 flex flex-col shadow-2xl">
+        <header className="flex items-center justify-between px-6 py-4 border-b border-surface-800">
+          <h2 className="font-semibold text-surface-100 truncate">{channelName}</h2>
+          <button
+            onClick={onClose}
+            className="p-2 text-surface-400 hover:text-surface-200 hover:bg-surface-800 rounded-lg transition-colors"
+            aria-label="Close channel personality panel"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </header>
+
+        <div className="p-6 space-y-3">
+          <div className="text-xs uppercase tracking-wide text-primary-300">Channel personality</div>
+          <p className="text-xs text-surface-400">Applied on replies in this channel. Maximum {CHANNEL_PERSONALITY_MAX_LENGTH} characters.</p>
+          {isLoading ? (
+            <p className="text-sm text-surface-400">Loading channel personality...</p>
+          ) : (
+            <>
+              <textarea
+                className="w-full min-h-40 rounded-lg bg-surface-800 border border-surface-700 px-3 py-2 text-sm text-surface-100"
+                value={draft}
+                onChange={(e) => {
+                  setDraft(e.target.value);
+                  setIsDirty(true);
+                }}
+                placeholder="e.g. Keep answers concise, action-oriented, and include channel-specific context."
+                maxLength={CHANNEL_PERSONALITY_MAX_LENGTH}
+              />
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-xs text-surface-500">
+                  {draft.length}/{CHANNEL_PERSONALITY_MAX_LENGTH}
+                </span>
+                {isSaving && <span className="text-xs text-surface-500">Saving...</span>}
+              </div>
+            </>
+          )}
+          {error && <p className="text-xs text-red-400">{error}</p>}
+        </div>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
### Motivation

- Persist a per-channel "channel personality" that applies to replies in a channel and is editable in the UI. 
- Reuse the global-command autosave UX for channel-scoped freeform personality while keeping memory storage and lookup additive and backward-compatible. 
- Ensure global command memories are only injected into private contexts, and align frontend/backend/tool max-length validation.

### Description

- Add channel scope to the `memories` model by making `entity_id` nullable and adding `scope_type`, `scope_source`, and `scope_channel_id` columns plus an index for scope lookups, and include migration `134_chan_mem_scope` with revision/down-revision length assertions. (`backend/models/memory.py`, `backend/db/migrations/versions/134_chan_mem_scope.py`)
- Implement channel personality CRUD API endpoints `GET|PUT|DELETE /api/memories/{organization_id}/channel` with channel-id normalization, validation, and structured logging, and introduced `channel_personality` category and max length constants. (`backend/api/routes/memories.py`)
- Increase `GLOBAL_COMMAND_MAX_LENGTH` to `800` and align validation in tools and API; add validation logging for failures. (`backend/agents/tools.py`, `backend/api/routes/memories.py`)
- Update orchestrator to: restrict global-command injection to private web chats and Slack DMs, normalize channel keys, load latest channel personality by normalized channel scope, and inject a `## Channel Personality (Always Apply in this channel)` block into the system prompt. (`backend/agents/orchestrator.py`)
- Frontend sidebar UX changes: replace vertical dots with horizontal 3-dot icon for channel sections, wire options button for channel sections, and add a slide-over `ChannelPersonalityPanel` that loads the channel memory, shows a debounced autosave textarea with max-length counter and saving indicator, and uses optimistic local state. (`frontend/src/components/Sidebar.tsx`)
- Add frontend API client helpers to `get/upsert/delete` channel personality memory. (`frontend/src/api/client.ts`)
- Add unit tests for the updated max-length and channel-id normalization helpers used by the memories API. (`backend/tests/test_memory_policy.py`)

### Testing

- Ran `pytest backend/tests/test_memory_policy.py -q` and all tests passed (`7 passed`).
- Built the frontend with `cd frontend && npm run build` and the build completed successfully (production bundle created).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eceb1941548321a8be34e9a9c10017)