### PR TITLE
Route web-origin chats to Direct bucket

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -268,6 +268,8 @@ def _derive_bucket(
 ) -> tuple[str, str]:
     if scope == "private":
         return ("direct", "direct")
+    if source == _WEB_PLATFORM_SLUG:
+        return ("direct", "direct")
     if source == "slack" and normalized_channel_id:
         if normalized_channel_id.startswith("D"):
             return ("direct", "direct")

--- a/backend/tests/test_chat_bucket_derivation.py
+++ b/backend/tests/test_chat_bucket_derivation.py
@@ -1,0 +1,36 @@
+from api.routes import chat
+
+
+def test_derive_bucket_returns_direct_for_private_scope() -> None:
+    assert chat._derive_bucket(source="slack", scope="private", normalized_channel_id="C123") == (
+        "direct",
+        "direct",
+    )
+
+
+def test_derive_bucket_returns_direct_for_web_source() -> None:
+    assert chat._derive_bucket(source="web", scope="shared", normalized_channel_id=None) == (
+        "direct",
+        "direct",
+    )
+
+
+def test_derive_bucket_returns_channel_for_non_dm_slack_channel() -> None:
+    assert chat._derive_bucket(source="slack", scope="shared", normalized_channel_id="C123") == (
+        "channel",
+        "channel:C123",
+    )
+
+
+def test_derive_bucket_returns_direct_for_slack_dm_channel() -> None:
+    assert chat._derive_bucket(source="slack", scope="shared", normalized_channel_id="D123") == (
+        "direct",
+        "direct",
+    )
+
+
+def test_derive_bucket_returns_uncategorized_for_other_sources() -> None:
+    assert chat._derive_bucket(source="teams", scope="shared", normalized_channel_id=None) == (
+        "uncategorized",
+        "uncategorized",
+    )


### PR DESCRIPTION
### Motivation
- Chats that originate from the web UI should be grouped as direct messages in the left-hand sidebar so they appear in the Direct bucket rather than Uncategorized.

### Description
- Add a `source == _WEB_PLATFORM_SLUG` branch in `_derive_bucket` to return `("direct", "direct")` for web-origin conversations in `backend/api/routes/chat.py`.
- Add focused unit tests in `backend/tests/test_chat_bucket_derivation.py` covering private scope, web source, Slack channel/DM, and non-Slack fallback behavior.

### Testing
- Ran `pytest -q backend/tests/test_chat_bucket_derivation.py`, which passed with `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed928f74848321be95c9dbd8913a31)