### PR TITLE
UJ Graph Magic: add org selector and labeled date controls

### DIFF
--- a/frontend/src/components/UncleJethroGraphMagic.tsx
+++ b/frontend/src/components/UncleJethroGraphMagic.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Cosmograph } from '@cosmograph/react';
 import { apiRequest } from '../lib/api';
+import { useAuthStore, type UserOrganization } from '../store';
 
 const MAX_RANGE_DAYS = 30;
 
@@ -14,7 +15,13 @@ type GraphResponse = {
   run_metadata: { coverage?: { partial?: boolean; warning_text?: string } };
 };
 
+type AdminOrganization = {
+  id: string;
+  name: string;
+};
+
 export function UncleJethroGraphMagic(): JSX.Element {
+  const orgMemberships: UserOrganization[] = useAuthStore((state) => state.organizations);
   const [orgId, setOrgId] = useState('');
   const [startDate, setStartDate] = useState(new Date().toISOString().slice(0, 10));
   const [endDate, setEndDate] = useState(new Date().toISOString().slice(0, 10));
@@ -23,8 +30,37 @@ export function UncleJethroGraphMagic(): JSX.Element {
   const [error, setError] = useState<string | null>(null);
   const [nodeId, setNodeId] = useState<string | null>(null);
   const [snippets, setSnippets] = useState<Array<{ ref: string; snippet: string; event_time: string }>>([]);
+  const [availableOrgs, setAvailableOrgs] = useState<AdminOrganization[]>([]);
 
   const partialWarning = graph?.run_metadata?.coverage?.partial ? 'Partial data: some sources failed' : null;
+
+  useEffect(() => {
+    const fetchOrganizations = async (): Promise<void> => {
+      const { data, error: requestError } = await apiRequest<{ organizations: AdminOrganization[] }>(
+        '/waitlist/admin/organizations?limit=1000',
+      );
+      if (requestError || !data?.organizations?.length) {
+        console.debug('[UJ Graph Magic] Falling back to org memberships for org dropdown', {
+          requestError,
+          membershipCount: orgMemberships.length,
+        });
+        const fallbackOrgs: AdminOrganization[] = orgMemberships.map((org) => ({ id: org.id, name: org.name }));
+        setAvailableOrgs(fallbackOrgs);
+        if (!orgId && fallbackOrgs.length > 0) {
+          setOrgId(fallbackOrgs[0].id);
+        }
+        return;
+      }
+
+      const sortedOrgs: AdminOrganization[] = [...data.organizations].sort((a, b) => a.name.localeCompare(b.name));
+      setAvailableOrgs(sortedOrgs);
+      if (!orgId && sortedOrgs.length > 0) {
+        setOrgId(sortedOrgs[0].id);
+      }
+    };
+
+    void fetchOrganizations();
+  }, [orgMemberships, orgId]);
 
   const canRebuild = useMemo(() => {
     if (!orgId) return false;
@@ -36,6 +72,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
 
   const fetchGraph = async (): Promise<void> => {
     if (!orgId) return;
+    console.debug('[UJ Graph Magic] Fetching graph snapshot', { orgId, selectedDate });
     const { data, error: reqErr } = await apiRequest<GraphResponse>(`/admin-topic-graph/${orgId}/${selectedDate}`);
     if (reqErr || !data) {
       setError(reqErr ?? 'Failed to load graph');
@@ -52,6 +89,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
 
   const rebuild = async (): Promise<void> => {
     if (!canRebuild) return;
+    console.debug('[UJ Graph Magic] Rebuilding graphs for range', { orgId, startDate, endDate });
     const { error: reqErr } = await apiRequest('/admin-topic-graph/rebuild', {
       method: 'POST',
       body: JSON.stringify({ organization_id: orgId, start_date: startDate, end_date: endDate }),
@@ -75,10 +113,31 @@ export function UncleJethroGraphMagic(): JSX.Element {
     <div className="space-y-4">
       <h2 className="text-xl font-semibold text-surface-50">UJ&apos;s Graph Magic</h2>
       <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-        <input className="px-3 py-2 rounded bg-surface-800" placeholder="Organization UUID" value={orgId} onChange={(e) => setOrgId(e.target.value)} />
-        <input type="date" className="px-3 py-2 rounded bg-surface-800" value={selectedDate} onChange={(e) => setSelectedDate(e.target.value)} />
-        <input type="date" className="px-3 py-2 rounded bg-surface-800" value={startDate} onChange={(e) => setStartDate(e.target.value)} />
-        <input type="date" className="px-3 py-2 rounded bg-surface-800" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
+        <label className="flex flex-col gap-1 text-xs text-surface-400">
+          <span>Organization</span>
+          <select
+            className="px-3 py-2 rounded bg-surface-800 text-surface-100"
+            value={orgId}
+            onChange={(e) => setOrgId(e.target.value)}
+          >
+            {availableOrgs.length === 0 && <option value="">No organizations available</option>}
+            {availableOrgs.map((org) => (
+              <option key={org.id} value={org.id}>{org.name}</option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-surface-400">
+          <span>Selected date (graph view)</span>
+          <input type="date" className="px-3 py-2 rounded bg-surface-800" value={selectedDate} onChange={(e) => setSelectedDate(e.target.value)} />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-surface-400">
+          <span>Generate start date</span>
+          <input type="date" className="px-3 py-2 rounded bg-surface-800" value={startDate} onChange={(e) => setStartDate(e.target.value)} />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-surface-400">
+          <span>Generate end date</span>
+          <input type="date" className="px-3 py-2 rounded bg-surface-800" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
+        </label>
       </div>
       <button disabled={!canRebuild} onClick={() => void rebuild()} className="px-3 py-2 rounded bg-primary-600 disabled:opacity-40">Rebuild</button>
       {partialWarning && <p className="text-xs text-amber-400">Partial data: some sources failed</p>}


### PR DESCRIPTION
### Motivation
- Improve usability of UJ's Graph Magic by replacing a raw Organization UUID input with a friendly-name selector.
- Make date semantics explicit by labeling the selected date used for the graph view and the start/end generate range.
- Provide better observability when loading orgs, fetching graph snapshots, and triggering rebuilds.

### Description
- Replaced the free-text `Organization UUID` input with a dropdown populated from the admin organizations endpoint and a fallback to the current user's org memberships. (file: `frontend/src/components/UncleJethroGraphMagic.tsx`)
- Added clear labels for the three date controls: `Selected date (graph view)`, `Generate start date`, and `Generate end date` to avoid confusion between viewing and generation ranges. (file: `frontend/src/components/UncleJethroGraphMagic.tsx`)
- Added lightweight `console.debug` logging around org loading, graph fetch, and rebuild actions to aid debugging. (file: `frontend/src/components/UncleJethroGraphMagic.tsx`)
- Introduced a small `AdminOrganization` type and wired `useAuthStore` to fall back to the user's `organizations` when admin orgs cannot be fetched. (file: `frontend/src/components/UncleJethroGraphMagic.tsx`)

### Testing
- Ran ESLint on the modified file with `npx eslint src/components/UncleJethroGraphMagic.tsx`, which failed in this environment due to ESLint v9 expecting a flat `eslint.config.*` and not picking up the repo config.
- Ran the repo lint script `npm run lint -- src/components/UncleJethroGraphMagic.tsx`, which failed for the same environment/tooling mismatch.
- Attempted `npm run build` in `frontend`, which failed in this container because TypeScript/React types and other frontend dependencies are not resolvable in the runtime image (missing `react`, `zustand`, `@tanstack/react-query`, etc.).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb2fbbee883219dd9368dfc637384)