### PR TITLE
Fix TS2532 undefined access 

### DIFF
--- a/frontend/src/components/UncleJethroGraphMagic.tsx
+++ b/frontend/src/components/UncleJethroGraphMagic.tsx
@@ -46,16 +46,18 @@ export function UncleJethroGraphMagic(): JSX.Element {
         });
         const fallbackOrgs: AdminOrganization[] = orgMemberships.map((org) => ({ id: org.id, name: org.name }));
         setAvailableOrgs(fallbackOrgs);
-        if (!orgId && fallbackOrgs.length > 0) {
-          setOrgId(fallbackOrgs[0].id);
+        const firstFallbackOrg = fallbackOrgs[0];
+        if (!orgId && firstFallbackOrg) {
+          setOrgId(firstFallbackOrg.id);
         }
         return;
       }
 
       const sortedOrgs: AdminOrganization[] = [...data.organizations].sort((a, b) => a.name.localeCompare(b.name));
       setAvailableOrgs(sortedOrgs);
-      if (!orgId && sortedOrgs.length > 0) {
-        setOrgId(sortedOrgs[0].id);
+      const firstSortedOrg = sortedOrgs[0];
+      if (!orgId && firstSortedOrg) {
+        setOrgId(firstSortedOrg.id);
       }
     };
 


### PR DESCRIPTION
### Motivation
- Prevent strict TypeScript `TS2532` errors caused by unguarded indexed access when initializing the selected organization in the graph UI.

### Description
- Replace direct `array[0].id` access in `frontend/src/components/UncleJethroGraphMagic.tsx` with guarded `firstFallbackOrg` and `firstSortedOrg` variables and check them before calling `setOrgId`.
- Preserve existing behavior of auto-selecting the first organization when available while satisfying strict null/undefined safety.

### Testing
- Ran the frontend build with `npm --prefix frontend run build`, which runs `tsc` and `vite build`, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb5afef808321b35c5d78b93e3c46)