### PR TITLE
Increase channel personality limit to 2000 and make textarea auto-grow up to 50%

### DIFF
--- a/backend/api/routes/memories.py
+++ b/backend/api/routes/memories.py
@@ -18,7 +18,7 @@ GLOBAL_COMMAND_CATEGORY = "global_commands"
 GLOBAL_COMMAND_CATEGORY_ALIASES = {"global_command", "global_commands"}
 GLOBAL_COMMAND_MAX_LENGTH = 800
 CHANNEL_PERSONALITY_CATEGORY = "channel_personality"
-CHANNEL_PERSONALITY_MAX_LENGTH = GLOBAL_COMMAND_MAX_LENGTH
+CHANNEL_PERSONALITY_MAX_LENGTH = 2000
 
 
 def normalize_channel_scope_channel_id(source: str, channel_id: str) -> str:

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -21,7 +21,9 @@ import { Avatar, type AvatarUser } from './Avatar';
 import { ScopeLockIcon } from './ScopeVisibilityIcons';
 import { APP_NAME, LOGO_PATH, RELEASE_STAGE } from '../lib/brand';
 
-const CHANNEL_PERSONALITY_MAX_LENGTH = 800;
+const CHANNEL_PERSONALITY_MAX_LENGTH = 2000;
+const CHANNEL_PERSONALITY_TEXTAREA_BASE_HEIGHT_PX = 160;
+const CHANNEL_PERSONALITY_TEXTAREA_MAX_HEIGHT_PX = Math.round(CHANNEL_PERSONALITY_TEXTAREA_BASE_HEIGHT_PX * 1.5);
 
 /** Help button and modal for support requests. */
 function HelpButton(): JSX.Element {
@@ -1292,6 +1294,14 @@ function ChannelPersonalityPanel({
   const [error, setError] = useState<string | null>(null);
   const lastSavedRef = useRef('');
   const saveTimeoutRef = useRef<number | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.style.height = `${CHANNEL_PERSONALITY_TEXTAREA_BASE_HEIGHT_PX}px`;
+    textarea.style.height = `${Math.min(textarea.scrollHeight, CHANNEL_PERSONALITY_TEXTAREA_MAX_HEIGHT_PX)}px`;
+  }, [draft, isLoading]);
 
   useEffect(() => {
     let isActive = true;
@@ -1399,11 +1409,16 @@ function ChannelPersonalityPanel({
           ) : (
             <>
               <textarea
-                className="w-full min-h-40 rounded-lg bg-surface-800 border border-surface-700 px-3 py-2 text-sm text-surface-100"
+                ref={textareaRef}
+                className="w-full rounded-lg bg-surface-800 border border-surface-700 px-3 py-2 text-sm text-surface-100 overflow-y-auto"
                 value={draft}
                 onChange={(e) => {
                   setDraft(e.target.value);
                   setIsDirty(true);
+                }}
+                style={{
+                  minHeight: `${CHANNEL_PERSONALITY_TEXTAREA_BASE_HEIGHT_PX}px`,
+                  maxHeight: `${CHANNEL_PERSONALITY_TEXTAREA_MAX_HEIGHT_PX}px`,
                 }}
                 placeholder="e.g. Keep answers concise, action-oriented, and include channel-specific context."
                 maxLength={CHANNEL_PERSONALITY_MAX_LENGTH}


### PR DESCRIPTION
### Motivation
- Allow richer, longer channel persona instructions by raising the per-channel personality limit beyond the previous 800 characters. 
- Improve the editing experience for long personalities by making the textarea expand with content so users can see more text before needing to scroll.

### Description
- Increase the channel personality limit constant `CHANNEL_PERSONALITY_MAX_LENGTH` to `2000` in `backend/api/routes/memories.py` so API validation allows longer channel memories. 
- Update the UI in `frontend/src/components/Sidebar.tsx` to set `CHANNEL_PERSONALITY_MAX_LENGTH = 2000` and add `CHANNEL_PERSONALITY_TEXTAREA_BASE_HEIGHT_PX` (160px) and a max-height at 1.5× the base height so the composer grows up to 50% taller. 
- Add a textarea ref and inline `minHeight`/`maxHeight` styles and `overflow-y:auto` so the textarea auto-resizes with content up to the max and then becomes scrollable, leaving global command limits unchanged at 800.

### Testing
- Ran `pytest -q backend/tests/test_memory_policy.py` which completed successfully with `7 passed` tests. 
- Ran frontend lint with `npm --prefix frontend run lint` which completed without errors. 
- Manual UI rendering changes were implemented in the sidebar textarea component but visual screenshot capture was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb89952f48321bd9e0850e63be79c)