### PR TITLE
Lower channel personality and global memory limits to 1,000 characters

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -6180,7 +6180,7 @@ async def execute_keep_notes(
 
 
 GLOBAL_COMMAND_CATEGORY = "global_commands"
-GLOBAL_COMMAND_MAX_LENGTH = 800
+GLOBAL_COMMAND_MAX_LENGTH = 1000
 SUPPORTED_MEMORY_ENTITY_TYPES = {"user", "organization_member"}
 ORG_LEVEL_MEMORY_ERROR = (
     "Org-level memories are not allowed. "

--- a/backend/api/routes/memories.py
+++ b/backend/api/routes/memories.py
@@ -16,9 +16,9 @@ logger = logging.getLogger(__name__)
 
 GLOBAL_COMMAND_CATEGORY = "global_commands"
 GLOBAL_COMMAND_CATEGORY_ALIASES = {"global_command", "global_commands"}
-GLOBAL_COMMAND_MAX_LENGTH = 800
+GLOBAL_COMMAND_MAX_LENGTH = 1000
 CHANNEL_PERSONALITY_CATEGORY = "channel_personality"
-CHANNEL_PERSONALITY_MAX_LENGTH = 2000
+CHANNEL_PERSONALITY_MAX_LENGTH = 1000
 
 
 def normalize_channel_scope_channel_id(source: str, channel_id: str) -> str:

--- a/backend/tests/test_memory_policy.py
+++ b/backend/tests/test_memory_policy.py
@@ -155,8 +155,8 @@ def test_execute_save_memory_commits_and_exits_session_on_save(monkeypatch) -> N
     assert result["status"] == "saved"
 
 
-def test_global_command_limit_allows_800_chars() -> None:
-    long_content = "x" * 800
+def test_global_command_limit_allows_1000_chars() -> None:
+    long_content = "x" * 1000
     memories_api.validate_memory_content(long_content, memories_api.GLOBAL_COMMAND_CATEGORY)
 
 

--- a/frontend/src/components/Memories.tsx
+++ b/frontend/src/components/Memories.tsx
@@ -18,7 +18,7 @@ interface MemoryDashboardResponse {
 }
 
 const GLOBAL_COMMAND_CATEGORY = 'global_commands';
-const GLOBAL_COMMAND_MAX_LENGTH = 800;
+const GLOBAL_COMMAND_MAX_LENGTH = 1000;
 
 function formatTime(value: string | null): string {
   if (!value) return 'Unknown time';
@@ -180,7 +180,7 @@ export function Memories(): JSX.Element {
           <>
             <div className="rounded-lg border border-primary-700/40 bg-primary-950/20 p-3">
               <div className="text-xs uppercase tracking-wide text-primary-300 mb-2">Global command</div>
-              <p className="text-xs text-surface-400 mb-2">Applied on every message. Maximum 800 characters.</p>
+              <p className="text-xs text-surface-400 mb-2">Applied on every message. Maximum 1000 characters.</p>
               <textarea
                 ref={globalCommandTextareaRef}
                 className="w-full min-h-20 overflow-hidden rounded-lg bg-surface-800 border border-surface-700 px-3 py-2 text-sm text-surface-100"

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -21,7 +21,7 @@ import { Avatar, type AvatarUser } from './Avatar';
 import { ScopeLockIcon } from './ScopeVisibilityIcons';
 import { APP_NAME, LOGO_PATH, RELEASE_STAGE } from '../lib/brand';
 
-const CHANNEL_PERSONALITY_MAX_LENGTH = 2000;
+const CHANNEL_PERSONALITY_MAX_LENGTH = 1000;
 const CHANNEL_PERSONALITY_TEXTAREA_BASE_HEIGHT_PX = 160;
 const CHANNEL_PERSONALITY_TEXTAREA_MAX_HEIGHT_PX = Math.round(CHANNEL_PERSONALITY_TEXTAREA_BASE_HEIGHT_PX * 1.5);
 


### PR DESCRIPTION
### Motivation
- Align global command memory and channel personality size limits to 1,000 characters as requested to reduce persona and global memory sizes and keep validation consistent across layers.
- Ensure both backend API validation and tool-layer validation enforce the same limits and update frontend UI constraints/copy accordingly.

### Description
- Set `GLOBAL_COMMAND_MAX_LENGTH` from 800 → 1000 in `backend/api/routes/memories.py` and `backend/agents/tools.py` to unify API and tool validation.
- Set `CHANNEL_PERSONALITY_MAX_LENGTH` from 2000 → 1000 in `backend/api/routes/memories.py` and update the channel personality editor limit in `frontend/src/components/Sidebar.tsx`.
- Update frontend global command limit, textarea `maxLength`, and helper copy in `frontend/src/components/Memories.tsx` to reflect the 1000-character cap.
- Adjusted the memory policy unit test `backend/tests/test_memory_policy.py` to validate the new 1000-character global command limit.

### Testing
- Ran `pytest -q backend/tests/test_memory_policy.py`, which passed with `7 passed`.
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eebb358ca4832198e38895a7537b7b)