### PR TITLE
Improve UJ Graph Magic: mention counts, source attribution, centrality and UI/visual updates

### DIFF
--- a/backend/services/topic_graph.py
+++ b/backend/services/topic_graph.py
@@ -4,6 +4,7 @@ import logging
 import math
 import re
 from collections import defaultdict
+from itertools import combinations
 from dataclasses import dataclass
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
@@ -27,6 +28,28 @@ logger = logging.getLogger(__name__)
 PARTIAL_WARNING = "Partial data: some sources failed"
 _TOKEN_RE = re.compile(r"\b[A-Za-z][A-Za-z0-9_\-]{2,}\b")
 _STOP = {"the", "and", "for", "with", "this", "that", "from", "you", "your", "are", "was"}
+
+_SOURCE_FRIENDLY_NAMES: dict[str, str] = {
+    "slack": "Slack",
+    "salesforce": "Salesforce",
+    "hubspot": "HubSpot",
+    "apollo": "Apollo",
+    "linear": "Linear",
+    "github": "GitHub",
+    "jira": "Jira",
+    "gmail": "Gmail",
+    "google_drive": "Google Drive",
+    "google_calendar": "Google Calendar",
+    "microsoft_mail": "Microsoft Mail",
+    "microsoft_calendar": "Microsoft Calendar",
+    "zoom": "Zoom",
+    "asana": "Asana",
+    "teams": "Microsoft Teams",
+}
+
+
+def _connector_friendly_name(source: str) -> str:
+    return _SOURCE_FRIENDLY_NAMES.get(source.lower(), source.replace("_", " ").title())
 
 
 @dataclass
@@ -147,6 +170,7 @@ async def _collect_slack_docs(org_id: str, graph_date: date) -> tuple[list[Candi
                     ChatMessage.content_blocks,
                     ChatMessage.created_at,
                     Conversation.source_channel_id,
+                    Conversation.title,
                 )
                 .join(Conversation, Conversation.id == ChatMessage.conversation_id)
                 .where(
@@ -179,7 +203,12 @@ async def _collect_slack_docs(org_id: str, graph_date: date) -> tuple[list[Candi
                     ingestion_time=created_at,
                 )
             )
-        if r.source_channel_id:
+        channel_name = (r.title or "").strip()
+        if channel_name.startswith("#"):
+            channel_name = channel_name[1:]
+        if channel_name:
+            channels.append(channel_name)
+        elif r.source_channel_id:
             channels.append(str(r.source_channel_id))
     return docs, channels
 
@@ -236,6 +265,8 @@ async def generate_topic_graph_for_org_day(org_id: str, graph_date: date) -> dic
     logger.info("topic_graph.stage=extract org_id=%s docs=%d", org_id, len(docs))
     node_to_docs: dict[str, set[str]] = defaultdict(set)
     node_newest: dict[str, datetime] = {}
+    node_oldest: dict[str, datetime] = {}
+    node_mentions: dict[str, int] = defaultdict(int)
     evidence: dict[str, list[dict[str, Any]]] = defaultdict(list)
 
     extracted_nodes: list[str] = []
@@ -245,11 +276,16 @@ async def generate_topic_graph_for_org_day(org_id: str, graph_date: date) -> dic
         for token in top_tokens:
             extracted_nodes.append(token)
             node_to_docs[token].add(doc.source_ref)
+            node_mentions[token] += 1
             node_newest[token] = max(node_newest.get(token, doc.event_time), doc.event_time)
+            prev_oldest = node_oldest.get(token)
+            if prev_oldest is None or doc.event_time < prev_oldest:
+                node_oldest[token] = doc.event_time
             evidence[token].append(
                 {
                     "ref": doc.source_ref,
                     "source": doc.source,
+                    "source_display": _connector_friendly_name(doc.source),
                     "event_time": doc.event_time.isoformat(),
                     "snippet": doc.text[:400],
                     "relevance": doc.text.lower().count(token.lower()),
@@ -261,30 +297,30 @@ async def generate_topic_graph_for_org_day(org_id: str, graph_date: date) -> dic
 
     merged_docs: dict[str, set[str]] = defaultdict(set)
     merged_newest: dict[str, datetime] = {}
+    merged_mentions: dict[str, int] = defaultdict(int)
     merged_evidence: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
     for node, refs in node_to_docs.items():
         cnode = canonical.get(node, node)
         merged_docs[cnode].update(refs)
-        merged_newest[cnode] = max(merged_newest.get(cnode, node_newest.get(node, datetime.now(timezone.utc))), node_newest.get(node, datetime.now(timezone.utc)))
+        newest = node_newest.get(node, datetime.now(timezone.utc))
+        merged_newest[cnode] = max(merged_newest.get(cnode, newest), newest)
+        merged_mentions[cnode] += node_mentions.get(node, 0)
         merged_evidence[cnode].extend(evidence.get(node, []))
 
-    for n in slack_channels + crm_people + crm_companies:
-        cnode = canonical.get(n, n)
-        merged_docs.setdefault(cnode, set())
-        merged_newest.setdefault(cnode, datetime.now(timezone.utc))
+    for channel_name in slack_channels:
+        cnode = canonical.get(channel_name, channel_name)
+        merged_docs[cnode].add(f"slack_channel:{channel_name}")
+        merged_mentions[cnode] += 1
+        now = datetime.now(timezone.utc)
+        merged_newest.setdefault(cnode, now)
 
-    node_list = sorted(merged_docs.keys())
-    nodes: list[dict[str, Any]] = []
-    for i, node in enumerate(node_list):
-        nodes.append(
-            {
-                "id": node,
-                "label": node,
-                "type": "entity",
-                "heat": round(_heat(len(merged_docs[node]), merged_newest[node]), 6),
-                "unique_doc_count": len(merged_docs[node]),
-            }
-        )
+    for seeded_node in crm_people + crm_companies:
+        cnode = canonical.get(seeded_node, seeded_node)
+        merged_docs.setdefault(cnode, set())
+        merged_mentions.setdefault(cnode, 0)
+        now = datetime.now(timezone.utc)
+        merged_newest.setdefault(cnode, now)
 
     edge_weights: dict[tuple[str, str], float] = defaultdict(float)
     doc_to_nodes: dict[str, set[str]] = defaultdict(set)
@@ -292,10 +328,36 @@ async def generate_topic_graph_for_org_day(org_id: str, graph_date: date) -> dic
         for ref in refs:
             doc_to_nodes[ref].add(node)
     for nodeset in doc_to_nodes.values():
-        ns = sorted(nodeset)
-        for i in range(len(ns)):
-            for j in range(i + 1, len(ns)):
-                edge_weights[(ns[i], ns[j])] += 1.0
+        for a, b in combinations(sorted(nodeset), 2):
+            edge_weights[(a, b)] += 1.0
+
+    centrality: dict[str, int] = defaultdict(int)
+    for a, b in edge_weights:
+        centrality[a] += 1
+        centrality[b] += 1
+
+    node_list = sorted(merged_docs.keys())
+    nodes: list[dict[str, Any]] = []
+    for node in node_list:
+        oldest_source = "Unknown"
+        if merged_evidence.get(node):
+            oldest_row = min(merged_evidence[node], key=lambda row: str(row.get("event_time", "")))
+            oldest_source = str(oldest_row.get("source_display") or oldest_row.get("source") or "Unknown")
+        elif any(str(ref).startswith("slack_channel:") for ref in merged_docs.get(node, set())):
+            oldest_source = "Slack"
+        nodes.append(
+            {
+                "id": node,
+                "label": node,
+                "type": "entity",
+                "heat": round(_heat(len(merged_docs[node]), merged_newest[node]), 6),
+                "unique_doc_count": len(merged_docs[node]),
+                "mention_count": int(merged_mentions.get(node, 0)),
+                "source": oldest_source,
+                "centrality": int(centrality.get(node, 0)),
+            }
+        )
+
     edges = [{"source": a, "target": b, "weight": w} for (a, b), w in sorted(edge_weights.items())]
 
     coverage["partial"] = any(v.get("status") == "failed" for v in coverage["sources"].values())

--- a/frontend/src/components/UncleJethroGraphMagic.tsx
+++ b/frontend/src/components/UncleJethroGraphMagic.tsx
@@ -4,8 +4,9 @@ import { apiRequest } from '../lib/api';
 import { useAuthStore, type UserOrganization } from '../store';
 
 const MAX_RANGE_DAYS = 30;
+const ROYGBIV = ['#e11d48', '#f97316', '#facc15', '#22c55e', '#3b82f6', '#6366f1', '#a855f7'];
 
-type GraphNode = { id: string; label: string; heat: number };
+type GraphNode = { id: string; label: string; heat: number; mention_count?: number; source?: string; centrality?: number; color?: string };
 type GraphEdge = { source: string; target: string; weight: number };
 
 type GraphResponse = {
@@ -29,7 +30,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
   const [graph, setGraph] = useState<GraphResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [nodeId, setNodeId] = useState<string | null>(null);
-  const [snippets, setSnippets] = useState<Array<{ ref: string; snippet: string; event_time: string }>>([]);
+  const [snippets, setSnippets] = useState<Array<{ ref: string; snippet: string; event_time: string; source_display?: string }>>([]);
   const [availableOrgs, setAvailableOrgs] = useState<AdminOrganization[]>([]);
 
   const partialWarning = graph?.run_metadata?.coverage?.partial ? 'Partial data: some sources failed' : null;
@@ -103,18 +104,34 @@ export function UncleJethroGraphMagic(): JSX.Element {
     await fetchGraph();
   };
 
+
+  const graphWithVisuals = useMemo(() => {
+    if (!graph) return null;
+    const nodes = graph.graph.nodes.map((node) => {
+      const mentionCount = Math.max(1, Math.round(node.mention_count ?? 1));
+      return {
+        ...node,
+        mention_count: mentionCount,
+        color: ROYGBIV[Math.floor(Math.random() * ROYGBIV.length)],
+      };
+    });
+    return { ...graph.graph, nodes, edges: graph.graph.edges };
+  }, [graph]);
+
+  const selectedNode = useMemo(() => graphWithVisuals?.nodes.find((n) => n.id === nodeId) ?? null, [graphWithVisuals, nodeId]);
+
   const onNodeClick = async (id: string): Promise<void> => {
     setNodeId(id);
-    const { data } = await apiRequest<{ snippets: Array<{ ref: string; snippet: string; event_time: string }> }>(
+    const { data } = await apiRequest<{ snippets: Array<{ ref: string; snippet: string; event_time: string; source_display?: string }> }>(
       `/admin-topic-graph/${orgId}/${selectedDate}/nodes/${encodeURIComponent(id)}/evidence`
     );
     setSnippets(data?.snippets ?? []);
   };
 
   return (
-    <div className="space-y-4">
+    <div className="h-full min-h-[70vh] flex flex-col gap-4">
       <h2 className="text-xl font-semibold text-surface-50">UJ&apos;s Graph Magic</h2>
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-3 items-end">
         <label className="flex flex-col gap-1 text-xs text-surface-400">
           <span>Organization</span>
           <select
@@ -140,16 +157,26 @@ export function UncleJethroGraphMagic(): JSX.Element {
           <span>Generate end date</span>
           <input type="date" className="px-3 py-2 rounded bg-surface-800" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
         </label>
+        <div className="flex items-end">
+          <button disabled={!canRebuild} onClick={() => void rebuild()} className="w-full md:w-auto px-3 py-2 rounded bg-primary-600 disabled:opacity-40">
+            Rebuild
+          </button>
+        </div>
       </div>
-      <button disabled={!canRebuild} onClick={() => void rebuild()} className="px-3 py-2 rounded bg-primary-600 disabled:opacity-40">Rebuild</button>
       {partialWarning && <p className="text-xs text-amber-400">Partial data: some sources failed</p>}
       {error && <p className="text-sm text-red-400">{error}</p>}
-      <div className="bg-surface-900 border border-surface-800 rounded-lg p-3 h-[480px]">
-        {graph ? (
+      <div className="bg-surface-900 border border-surface-800 rounded-lg p-3 flex-1 min-h-[560px] relative">
+        {graphWithVisuals ? (
           <Cosmograph
-            nodes={graph.graph.nodes}
-            links={graph.graph.edges}
+            nodes={graphWithVisuals.nodes}
+            links={graphWithVisuals.edges}
             nodeLabelAccessor={(n: GraphNode) => n.label}
+            nodeColor={(n: GraphNode) => n.color ?? '#a855f7'}
+            nodeSize={(n: GraphNode) => Math.max(2, n.mention_count ?? 1)}
+            linkWidth={(link: GraphEdge) => Math.max(1, link.weight)}
+            linkColor={(link: GraphEdge) => `rgba(148, 163, 184, ${Math.min(0.85, 0.2 + (link.weight / 8))})`}
+            fitViewOnInit
+            className="h-full w-full"
             onClick={(clickedNode: GraphNode | undefined) => {
               if (!clickedNode?.id) return;
               void onNodeClick(clickedNode.id);
@@ -158,14 +185,22 @@ export function UncleJethroGraphMagic(): JSX.Element {
         ) : (
           <div className="text-surface-400 text-sm">No graph data loaded.</div>
         )}
+        <p className="absolute right-3 bottom-2 text-xs text-surface-500">© Uncle Jethro</p>
       </div>
       {nodeId && (
         <div className="bg-surface-900 border border-surface-800 rounded-lg p-3">
           <h3 className="font-medium mb-2">Node details: {nodeId}</h3>
+          {selectedNode && (
+            <div className="mb-3 grid grid-cols-1 md:grid-cols-3 gap-2 text-xs text-surface-400">
+              <div>Source (oldest mention): <span className="text-surface-200">{selectedNode.source ?? 'Unknown'}</span></div>
+              <div>Mentions: <span className="text-surface-200">{selectedNode.mention_count ?? 0}</span></div>
+              <div>Centrality (edges): <span className="text-surface-200">{selectedNode.centrality ?? 0}</span></div>
+            </div>
+          )}
           <ul className="space-y-2">
             {snippets.map((s) => (
               <li key={s.ref} className="text-sm text-surface-300 border-b border-surface-800 pb-2">
-                <div className="text-xs text-surface-500">{s.event_time} · {s.ref}</div>
+                <div className="text-xs text-surface-500">{s.event_time} · {s.source_display ?? 'Unknown source'} · {s.ref}</div>
                 <div>{s.snippet}</div>
               </li>
             ))}


### PR DESCRIPTION
### Motivation
- Make the topic graph reflect source attribution and per-item mention counts so nodes and channels size correctly and node details show oldest source. 
- Expose node centrality (edge degree) and preserve co-mention edge weights so the visualizer can show connectivity and edge brightness. 
- Improve the UJ Graph Magic UI layout and visuals so the graph fills the pane, rebuild is on the date-controls row, nodes are colored with ROYGBIV and sized by mentions, and the requested copyright label appears. 

### Description
- Backend (`backend/services/topic_graph.py`): add connector-friendly source names, include `source_display` on evidence rows, treat Slack conversation titles (fallback to channel id) as datapoints counted per message, compute `mention_count` for nodes, compute co-mention edge weights using combinations of nodes in the same item, and compute `centrality` as edge-degree; include `mention_count`, `source` (oldest mention), and `centrality` on each node payload. 
- Frontend (`frontend/src/components/UncleJethroGraphMagic.tsx`): move the Rebuild button into the date-picker row (right side), expand the visualizer to fill the pane, add randomized ROYGBIV node colors, size nodes by `mention_count`, render link width/brightness from edge `weight`, show node details including oldest source/mentions/centrality, include `source_display` in snippets, and add a lower-right “© Uncle Jethro” label. 
- Minor: added deterministic helper `_connector_friendly_name` mapping and used `itertools.combinations` for edge generation; adjusted Slack collection query to pull conversation title. 

### Testing
- `python -m py_compile backend/services/topic_graph.py` succeeded. 
- `npx eslint src/components/UncleJethroGraphMagic.tsx` passed (initial warning was addressed). 
- `npx tsc --noEmit` (TypeScript compile) completed successfully. 
- `npm run build` completed successfully and produced a production build. 
- Note: `npm run typecheck` is not defined in the frontend package (attempting that script fails because it is absent).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eebea002b08321bca6922edd2b342b)