### PR TITLE
Accept GPT 5.5 naming variants in org model settings

### DIFF
--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -269,6 +269,18 @@ def _parse_model_map() -> dict[str, str]:
     return result
 
 
+def _model_aliases(model: str) -> tuple[str, ...]:
+    """Return acceptable aliases for known model naming variations."""
+    normalized: str = model.strip()
+    aliases: list[str] = [normalized]
+    # Accept both gpt-5.5 and gpt5.5 naming variants (including mini/nano).
+    if normalized.startswith("gpt-5.5"):
+        aliases.append(normalized.replace("gpt-5.5", "gpt5.5", 1))
+    elif normalized.startswith("gpt5.5"):
+        aliases.append(normalized.replace("gpt5.5", "gpt-5.5", 1))
+    return tuple(dict.fromkeys(aliases))
+
+
 def get_model_provider_map() -> dict[str, str]:
     """Return the full {model_name: provider} map from ALL_MODEL_STRINGS."""
     return _parse_model_map()
@@ -284,7 +296,12 @@ def get_allowed_models() -> list[str]:
 
 def provider_for_model(model: str) -> str | None:
     """Look up the provider for a model name. Returns None if unknown."""
-    return _parse_model_map().get(model) or None
+    model_map: dict[str, str] = _parse_model_map()
+    for alias in _model_aliases(model):
+        provider: str | None = model_map.get(alias)
+        if provider is not None:
+            return provider or None
+    return None
 
 
 def is_model_allowed(model: str) -> bool:
@@ -295,4 +312,4 @@ def is_model_allowed(model: str) -> bool:
     model_map: dict[str, str] = _parse_model_map()
     if not model_map:
         return True
-    return model in model_map
+    return any(alias in model_map for alias in _model_aliases(model))

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -2,6 +2,8 @@ import asyncio
 
 from services.llm_provider import (
     _infer_provider_from_model_name,
+    is_model_allowed,
+    provider_for_model,
     resolve_api_key_for_provider,
     resolve_llm_config,
 )
@@ -55,3 +57,13 @@ def test_resolve_api_key_for_provider_uses_global_key(monkeypatch) -> None:
 
     key = asyncio.run(resolve_api_key_for_provider("gemini", None))
     assert key == "test-gemini-key"
+
+
+def test_model_allowlist_accepts_gpt55_aliases(monkeypatch) -> None:
+    from services import llm_provider
+
+    monkeypatch.setattr(llm_provider.settings, "ALL_MODEL_STRINGS", "gpt5.5:openai,gpt5.5-mini:openai")
+
+    assert is_model_allowed("gpt-5.5")
+    assert is_model_allowed("gpt-5.5-mini")
+    assert provider_for_model("gpt-5.5") == "openai"

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -126,7 +126,7 @@ interface OrganizationPanelProps {
 const MODEL_FAMILY_DEFAULTS: Record<string, { primary: string; fast: string }> = {
   anthropic: { primary: 'claude-opus-4-6', fast: 'claude-haiku-4-5-20251001' },
   minimax: { primary: 'MiniMax-M2.7', fast: 'MiniMax-M2.7-highspeed' },
-  openai: { primary: 'gpt-5.5', fast: 'gpt-5.5-mini' },
+  openai: { primary: 'gpt5.5', fast: 'gpt5.5-mini' },
   gemini: { primary: 'gemini-2.5-pro', fast: 'gemini-2.5-flash' },
 };
 


### PR DESCRIPTION
### Motivation
- Fix failing organization model saves caused by inconsistent GPT-5.5 naming between UI and backend allowlist/provider logic which produced `Model not allowed: gpt-5.5` errors.

### Description
- Change frontend OpenAI family defaults in `frontend/src/components/OrganizationPanel.tsx` to use `gpt5.5` / `gpt5.5-mini` so the family auto-reset no longer emits dashed names the backend might reject.
- Add `_model_aliases` helper in `backend/services/llm_provider.py` and update `provider_for_model` and `is_model_allowed` to accept both `gpt-5.5*` and `gpt5.5*` variants when resolving providers and allowlist checks.
- Add a regression test `test_model_allowlist_accepts_gpt55_aliases` in `backend/tests/test_llm_provider.py` to verify alias behavior for allowlist and provider lookups.

### Testing
- Ran `cd backend && pytest -q tests/test_llm_provider.py` and the suite passed: `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eec2836e708321919161486202eee2)