### PR TITLE
Rename UJ Graph Magic to Graph Magic

### DIFF
--- a/backend/models/topic_graph_snapshot.py
+++ b/backend/models/topic_graph_snapshot.py
@@ -12,7 +12,7 @@ from models.database import Base
 
 
 class TopicGraphSnapshot(Base):
-    """Daily cached org graph snapshot for UJ's Graph Magic."""
+    """Daily cached org graph snapshot for Graph Magic."""
 
     __tablename__ = "topic_graph_snapshots"
     __table_args__ = (

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -12,7 +12,7 @@ import ReactMarkdown from 'react-markdown';
 import { API_BASE, apiRequest, getAuthenticatedRequestHeaders } from '../lib/api';
 import { useDeleteOrganization } from '../hooks';
 import { useAppStore, useAuthStore, useChatStore, type UserProfile, type OrganizationInfo } from '../store';
-import { UncleJethroGraphMagic } from './UncleJethroGraphMagic';
+import { GraphMagic } from './GraphMagic';
 
 // ─── Dashboard types ─────────────────────────────────────────────────────────
 
@@ -2608,7 +2608,7 @@ export function AdminPanel(): JSX.Element {
         )}
 
         {activeTab === 'graph-magic' && (
-          <UncleJethroGraphMagic />
+          <GraphMagic />
         )}
 
         {activeTab === 'jobs' && (

--- a/frontend/src/components/GraphMagic.tsx
+++ b/frontend/src/components/GraphMagic.tsx
@@ -21,7 +21,7 @@ type AdminOrganization = {
   name: string;
 };
 
-export function UncleJethroGraphMagic(): JSX.Element {
+export function GraphMagic(): JSX.Element {
   const orgMemberships: UserOrganization[] = useAuthStore((state) => state.organizations);
   const [orgId, setOrgId] = useState('');
   const [startDate, setStartDate] = useState(new Date().toISOString().slice(0, 10));
@@ -41,7 +41,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
         '/waitlist/admin/organizations?limit=1000',
       );
       if (requestError || !data?.organizations?.length) {
-        console.debug('[UJ Graph Magic] Falling back to org memberships for org dropdown', {
+        console.debug('[Graph Magic] Falling back to org memberships for org dropdown', {
           requestError,
           membershipCount: orgMemberships.length,
         });
@@ -75,7 +75,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
 
   const fetchGraph = async (): Promise<void> => {
     if (!orgId) return;
-    console.debug('[UJ Graph Magic] Fetching graph snapshot', { orgId, selectedDate });
+    console.debug('[Graph Magic] Fetching graph snapshot', { orgId, selectedDate });
     const { data, error: reqErr } = await apiRequest<GraphResponse>(`/admin-topic-graph/${orgId}/${selectedDate}`);
     if (reqErr || !data) {
       setError(reqErr ?? 'Failed to load graph');
@@ -92,7 +92,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
 
   const rebuild = async (): Promise<void> => {
     if (!canRebuild) return;
-    console.debug('[UJ Graph Magic] Rebuilding graphs for range', { orgId, startDate, endDate });
+    console.debug('[Graph Magic] Rebuilding graphs for range', { orgId, startDate, endDate });
     const { error: reqErr } = await apiRequest('/admin-topic-graph/rebuild', {
       method: 'POST',
       body: JSON.stringify({ organization_id: orgId, start_date: startDate, end_date: endDate }),
@@ -130,7 +130,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
 
   return (
     <div className="h-full min-h-0 flex flex-col gap-4">
-      <h2 className="text-xl font-semibold text-surface-50">UJ&apos;s Graph Magic</h2>
+      <h2 className="text-xl font-semibold text-surface-50">Graph Magic</h2>
       <div className="grid grid-cols-1 md:grid-cols-5 gap-3 items-end">
         <label className="flex flex-col gap-1 text-xs text-surface-400">
           <span>Organization</span>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -636,7 +636,7 @@ const GLOBAL_ADMIN_NAV_ITEMS: ReadonlyArray<{
   },
   {
     id: 'graph-magic',
-    label: "UJ's Graph Magic",
+    label: 'Graph Magic',
     icon: (
       <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 19l6-6 4 4 6-10" />


### PR DESCRIPTION
### Motivation
- Remove the personal "UJ"/"Uncle Jethro" naming and standardize the admin graph feature to the neutral name "Graph Magic" across the codebase.

### Description
- Renamed the frontend component file and symbol from `UncleJethroGraphMagic` to `GraphMagic` (`frontend/src/components/GraphMagic.tsx`).
- Updated `AdminPanel` to import and render `GraphMagic` instead of the old component.
- Updated the admin sidebar navigation label from `"UJ's Graph Magic"` to `'Graph Magic'` and changed UI header text accordingly.
- Replaced debug log prefixes containing `UJ` with `[Graph Magic]` and updated the `TopicGraphSnapshot` model docstring to reference `Graph Magic`.

### Testing
- Built the production frontend with `cd frontend && npm run -s build`, which completed successfully (non-blocking bundle warnings only).
- No additional automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed21a244c8321a4e1f8f2fde3b14c)