### PR TITLE
Remove UJ naming from Graph Magic

### DIFF
--- a/backend/models/topic_graph_snapshot.py
+++ b/backend/models/topic_graph_snapshot.py
@@ -12,7 +12,7 @@ from models.database import Base
 
 
 class TopicGraphSnapshot(Base):
-    """Daily cached org graph snapshot for UJ's Graph Magic."""
+    """Daily cached org graph snapshot for Graph Magic."""
 
     __tablename__ = "topic_graph_snapshots"
     __table_args__ = (

--- a/backend/workers/celery_app.py
+++ b/backend/workers/celery_app.py
@@ -168,7 +168,7 @@ if _ENABLE_BEAT:
             "Nightly topic graph schedule disabled: ENABLE_NIGHTLY_TOPIC_GRAPH env var is required and was not set"
         )
     elif nightly_topic_graph_flag.lower() in ("true", "1", "yes"):
-        celery_app.conf.beat_schedule["uncle-jethro-graph-magic-nightly"] = {
+        celery_app.conf.beat_schedule["graph-magic-nightly"] = {
             "task": "workers.tasks.topic_graph.generate_daily_all_orgs",
             "schedule": crontab(minute=0, hour=9),
         }

--- a/env.example
+++ b/env.example
@@ -111,7 +111,7 @@ NUM_GRACE_CREDITS=5
 # Support requests — Slack Incoming Webhook for immediate notification (optional; fallback: email to support@basebase.com)
 # SUPPORT_SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
 
-# UJ's Graph Magic
+# Graph Magic
 ENABLE_NIGHTLY_TOPIC_GRAPH=false
 NIGHTLY_TOPIC_GRAPH_CRON_UTC=0 9 * * *
 TOPIC_GRAPH_USE_CACHED_ONLY=true

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -12,7 +12,7 @@ import ReactMarkdown from 'react-markdown';
 import { API_BASE, apiRequest, getAuthenticatedRequestHeaders } from '../lib/api';
 import { useDeleteOrganization } from '../hooks';
 import { useAppStore, useAuthStore, useChatStore, type UserProfile, type OrganizationInfo } from '../store';
-import { UncleJethroGraphMagic } from './UncleJethroGraphMagic';
+import { GraphMagic } from './GraphMagic';
 
 // ─── Dashboard types ─────────────────────────────────────────────────────────
 
@@ -2608,7 +2608,7 @@ export function AdminPanel(): JSX.Element {
         )}
 
         {activeTab === 'graph-magic' && (
-          <UncleJethroGraphMagic />
+          <GraphMagic />
         )}
 
         {activeTab === 'jobs' && (

--- a/frontend/src/components/GraphMagic.tsx
+++ b/frontend/src/components/GraphMagic.tsx
@@ -30,7 +30,7 @@ type AdminOrganization = {
   name: string;
 };
 
-export function UncleJethroGraphMagic(): JSX.Element {
+export function GraphMagic(): JSX.Element {
   const orgMemberships: UserOrganization[] = useAuthStore((state) => state.organizations);
   const [orgId, setOrgId] = useState('');
   const [startDate, setStartDate] = useState(new Date().toISOString().slice(0, 10));
@@ -51,7 +51,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
         '/waitlist/admin/organizations?limit=1000',
       );
       if (requestError || !data?.organizations?.length) {
-        console.debug('[UJ Graph Magic] Falling back to org memberships for org dropdown', {
+        console.debug('[Graph Magic] Falling back to org memberships for org dropdown', {
           requestError,
           membershipCount: orgMemberships.length,
         });
@@ -85,7 +85,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
 
   const fetchGraph = async (): Promise<void> => {
     if (!orgId) return;
-    console.debug('[UJ Graph Magic] Fetching graph snapshot', { orgId, selectedDate });
+    console.debug('[Graph Magic] Fetching graph snapshot', { orgId, selectedDate });
     const { data, error: reqErr } = await apiRequest<GraphResponse>(`/admin-topic-graph/${orgId}/${selectedDate}`);
     if (reqErr || !data) {
       setError(reqErr ?? 'Failed to load graph');
@@ -102,7 +102,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
 
   const rebuild = async (): Promise<void> => {
     if (!canRebuild) return;
-    console.debug('[UJ Graph Magic] Rebuilding graphs for range', { orgId, startDate, endDate });
+    console.debug('[Graph Magic] Rebuilding graphs for range', { orgId, startDate, endDate });
     const { error: reqErr } = await apiRequest('/admin-topic-graph/rebuild', {
       method: 'POST',
       body: JSON.stringify({ organization_id: orgId, start_date: startDate, end_date: endDate }),
@@ -152,7 +152,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
       };
     });
 
-    console.debug('[UJ Graph Magic] Computed node visuals and importance scores', {
+    console.debug('[Graph Magic] Computed node visuals and importance scores', {
       nodeCount: nodes.length,
       sizeMode,
       minMentions,
@@ -188,7 +188,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
 
   return (
     <div className="h-full min-h-0 flex flex-col gap-4">
-      <h2 className="text-xl font-semibold text-surface-50">UJ&apos;s Graph Magic</h2>
+      <h2 className="text-xl font-semibold text-surface-50">Graph Magic</h2>
       <div className="grid grid-cols-1 md:grid-cols-6 gap-3 items-end">
         <label className="flex flex-col gap-1 text-xs text-surface-400">
           <span>Organization</span>
@@ -255,7 +255,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
         ) : (
           <div className="text-surface-400 text-sm">No graph data loaded.</div>
         )}
-        <p className="absolute right-3 bottom-2 text-xs text-surface-500">© Uncle Jethro</p>
+        <p className="absolute right-3 bottom-2 text-xs text-surface-500">© Graph Magic</p>
       </div>
       {nodeId && (
         <div className="bg-surface-900 border border-surface-800 rounded-lg p-3">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -636,7 +636,7 @@ const GLOBAL_ADMIN_NAV_ITEMS: ReadonlyArray<{
   },
   {
     id: 'graph-magic',
-    label: "UJ's Graph Magic",
+    label: "Graph Magic",
     icon: (
       <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 19l6-6 4 4 6-10" />


### PR DESCRIPTION
### Motivation
- Consolidate product-facing and internal naming by removing the `UJ` / `Uncle Jethro` references so the feature is consistently presented as “Graph Magic.”
- Ensure labels, logs, and configuration keys match the updated naming to avoid confusion across frontend, backend, and deployment configs.

### Description
- Renamed the admin UI component from `UncleJethroGraphMagic` to `GraphMagic` and moved the file to `frontend/src/components/GraphMagic.tsx`, updating imports and usage in `AdminPanel` accordingly.
- Replaced UJ-specific UI strings and debug prefixes with `Graph Magic` in the frontend (component header, debug logs, and footer copyright).
- Updated the sidebar navigation label to `Graph Magic` and adjusted related references in `frontend/src/components/Sidebar.tsx` and `frontend/src/components/AdminPanel.tsx`.
- Updated backend and config text to match the new name by changing the model docstring in `backend/models/topic_graph_snapshot.py`, the Celery beat schedule key to `graph-magic-nightly` in `backend/workers/celery_app.py`, and the env comment in `env.example`.

### Testing
- Ran frontend lint: `npm --prefix frontend run lint -- src/components/GraphMagic.tsx src/components/AdminPanel.tsx src/components/Sidebar.tsx`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed59de33483218cf03093709a3b3b)