### PR TITLE
Restrict UJ graph date selector to available snapshot dates

### DIFF
--- a/backend/api/routes/topic_graph.py
+++ b/backend/api/routes/topic_graph.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from api.auth_middleware import AuthContext, require_global_admin
-from services.topic_graph import get_node_evidence, get_topic_graph_snapshot
+from services.topic_graph import get_node_evidence, get_topic_graph_snapshot, list_topic_graph_snapshot_dates
 from workers.tasks.topic_graph import rebuild_org_date_range
 
 router = APIRouter()
@@ -37,6 +37,24 @@ async def get_graph_snapshot(
         "status": snapshot.status,
         "graph": snapshot.graph_payload,
         "run_metadata": snapshot.run_metadata,
+    }
+
+
+@router.get("/{organization_id}/snapshot-dates")
+async def get_graph_snapshot_dates(
+    organization_id: str,
+    auth: AuthContext = Depends(require_global_admin),
+) -> dict[str, Any]:
+    dates = await list_topic_graph_snapshot_dates(organization_id)
+    logger.info(
+        "topic_graph.stage=list_snapshot_dates org_id=%s count=%d by=%s",
+        organization_id,
+        len(dates),
+        auth.user_id,
+    )
+    return {
+        "organization_id": organization_id,
+        "snapshot_dates": [d.isoformat() for d in dates],
     }
 
 

--- a/backend/services/topic_graph.py
+++ b/backend/services/topic_graph.py
@@ -10,7 +10,7 @@ from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import Select, and_, delete, func, select, text
+from sqlalchemy import Select, and_, delete, desc, func, select, text
 from sqlalchemy.dialects.postgresql import insert
 
 from config import settings
@@ -429,6 +429,16 @@ async def get_topic_graph_snapshot(org_id: str, graph_date: date) -> TopicGraphS
             )
         )
         return row.scalar_one_or_none()
+
+
+async def list_topic_graph_snapshot_dates(org_id: str) -> list[date]:
+    async with get_admin_session() as session:
+        rows = await session.execute(
+            select(TopicGraphSnapshot.graph_date)
+            .where(TopicGraphSnapshot.organization_id == UUID(org_id))
+            .order_by(desc(TopicGraphSnapshot.graph_date))
+        )
+        return [row[0] for row in rows.all()]
 
 
 def _rank_evidence(evidence_rows: list[dict[str, Any]], node_id: str) -> list[dict[str, Any]]:

--- a/frontend/src/components/UncleJethroGraphMagic.tsx
+++ b/frontend/src/components/UncleJethroGraphMagic.tsx
@@ -25,6 +25,11 @@ type GraphResponse = {
   run_metadata: { coverage?: { partial?: boolean; warning_text?: string } };
 };
 
+type SnapshotDatesResponse = {
+  organization_id: string;
+  snapshot_dates: string[];
+};
+
 type AdminOrganization = {
   id: string;
   name: string;
@@ -42,6 +47,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
   const [sizeMode, setSizeMode] = useState<NodeSizeMode>('composite');
   const [snippets, setSnippets] = useState<Array<{ ref: string; snippet: string; event_time: string; source_display?: string }>>([]);
   const [availableOrgs, setAvailableOrgs] = useState<AdminOrganization[]>([]);
+  const [snapshotDates, setSnapshotDates] = useState<string[]>([]);
 
   const partialWarning = graph?.run_metadata?.coverage?.partial ? 'Partial data: some sources failed' : null;
 
@@ -84,7 +90,7 @@ export function UncleJethroGraphMagic(): JSX.Element {
   }, [orgId, startDate, endDate]);
 
   const fetchGraph = async (): Promise<void> => {
-    if (!orgId) return;
+    if (!orgId || !selectedDate) return;
     console.debug('[UJ Graph Magic] Fetching graph snapshot', { orgId, selectedDate });
     const { data, error: reqErr } = await apiRequest<GraphResponse>(`/admin-topic-graph/${orgId}/${selectedDate}`);
     if (reqErr || !data) {
@@ -98,6 +104,40 @@ export function UncleJethroGraphMagic(): JSX.Element {
   useEffect(() => {
     void fetchGraph();
   // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId, selectedDate]);
+
+  useEffect(() => {
+    const fetchSnapshotDates = async (): Promise<void> => {
+      if (!orgId) {
+        setSnapshotDates([]);
+        setGraph(null);
+        return;
+      }
+      console.debug('[UJ Graph Magic] Fetching available snapshot dates', { orgId });
+      const { data, error: reqErr } = await apiRequest<SnapshotDatesResponse>(`/admin-topic-graph/${orgId}/snapshot-dates`);
+      if (reqErr || !data) {
+        console.debug('[UJ Graph Magic] Could not load snapshot dates', { orgId, reqErr });
+        setSnapshotDates([]);
+        setGraph(null);
+        return;
+      }
+      setSnapshotDates(data.snapshot_dates);
+      if (data.snapshot_dates.length === 0) {
+        setGraph(null);
+      }
+      if (!data.snapshot_dates.includes(selectedDate)) {
+        const latestDate = data.snapshot_dates[0];
+        if (latestDate) {
+          console.debug('[UJ Graph Magic] Resetting selected date to latest available snapshot', {
+            orgId,
+            previousDate: selectedDate,
+            latestDate,
+          });
+          setSelectedDate(latestDate);
+        }
+      }
+    };
+    void fetchSnapshotDates();
   }, [orgId, selectedDate]);
 
   const rebuild = async (): Promise<void> => {
@@ -205,7 +245,22 @@ export function UncleJethroGraphMagic(): JSX.Element {
         </label>
         <label className="flex flex-col gap-1 text-xs text-surface-400">
           <span>Selected date (graph view)</span>
-          <input type="date" className="px-3 py-2 rounded bg-surface-800" value={selectedDate} onChange={(e) => setSelectedDate(e.target.value)} />
+          <select
+            className="px-3 py-2 rounded bg-surface-800 text-surface-100"
+            value={snapshotDates.includes(selectedDate) ? selectedDate : ''}
+            onChange={(e) => setSelectedDate(e.target.value)}
+            disabled={snapshotDates.length === 0}
+          >
+            {snapshotDates.length === 0 ? (
+              <option value="">No snapshots available</option>
+            ) : (
+              snapshotDates.map((snapshotDate) => (
+                <option key={snapshotDate} value={snapshotDate}>
+                  {snapshotDate}
+                </option>
+              ))
+            )}
+          </select>
         </label>
         <label className="flex flex-col gap-1 text-xs text-surface-400">
           <span>Generate start date</span>


### PR DESCRIPTION
### Motivation
- Prevent the UJ Graph Magic UI from allowing a selected date for which there is no saved graph snapshot, avoiding failed fetches and confusing UX.
- Provide a reliable source of truth for available snapshot dates from the backend so the frontend can present only valid options.

### Description
- Added a service helper `list_topic_graph_snapshot_dates(org_id)` that queries `topic_graph_snapshots` and returns available `graph_date`s ordered newest-first. 
- Exposed a new admin API endpoint `GET /api/admin-topic-graph/{organization_id}/snapshot-dates` which returns the snapshot dates for an organization and logs the query. 
- Reworked the UJ Graph Magic UI to fetch snapshot dates per-org and replace the free-form `type="date"` input with a dropdown populated only with `snapshot_dates`, disable the selector when there are none, auto-reset `selectedDate` to the latest snapshot when the current selection is invalid, and clear the graph state when no snapshots exist. 
- Tightened `fetchGraph` to require both `orgId` and `selectedDate` and added debug logging around snapshot-date loading and date correction behavior.

### Testing
- Ran `python -m compileall backend/api/routes/topic_graph.py backend/services/topic_graph.py` which completed successfully. 
- Ran frontend lint `npm run -s lint -- src/components/UncleJethroGraphMagic.tsx` which completed successfully. 
- No automated unit tests were added; existing compile/lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed5f7c3cc8321beb63bf1bc7c9391)