### PR TITLE
Restrict Graph Magic date selector to existing snapshot dates

### DIFF
--- a/backend/api/routes/topic_graph.py
+++ b/backend/api/routes/topic_graph.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from api.auth_middleware import AuthContext, require_global_admin
-from services.topic_graph import get_node_evidence, get_topic_graph_snapshot
+from services.topic_graph import get_node_evidence, get_topic_graph_snapshot, list_topic_graph_snapshot_dates
 from workers.tasks.topic_graph import rebuild_org_date_range
 
 router = APIRouter()
@@ -54,6 +54,24 @@ async def get_graph_node_evidence(
         "graph_date": d.isoformat(),
         "node_id": node_id,
         "snippets": snippets,
+    }
+
+
+@router.get("/{organization_id}/dates")
+async def get_graph_snapshot_dates(
+    organization_id: str,
+    auth: AuthContext = Depends(require_global_admin),
+) -> dict[str, Any]:
+    dates = await list_topic_graph_snapshot_dates(organization_id)
+    logger.info(
+        "topic_graph.stage=list_dates org_id=%s date_count=%d by=%s",
+        organization_id,
+        len(dates),
+        auth.user_id,
+    )
+    return {
+        "organization_id": organization_id,
+        "dates": [d.isoformat() for d in dates],
     }
 
 

--- a/backend/services/topic_graph.py
+++ b/backend/services/topic_graph.py
@@ -431,6 +431,16 @@ async def get_topic_graph_snapshot(org_id: str, graph_date: date) -> TopicGraphS
         return row.scalar_one_or_none()
 
 
+async def list_topic_graph_snapshot_dates(org_id: str) -> list[date]:
+    async with get_admin_session() as session:
+        rows = await session.execute(
+            select(TopicGraphSnapshot.graph_date)
+            .where(TopicGraphSnapshot.organization_id == UUID(org_id))
+            .order_by(TopicGraphSnapshot.graph_date.desc())
+        )
+        return [r[0] for r in rows.all()]
+
+
 def _rank_evidence(evidence_rows: list[dict[str, Any]], node_id: str) -> list[dict[str, Any]]:
     dedup: dict[str, dict[str, Any]] = {}
     for row in evidence_rows:

--- a/frontend/src/components/GraphMagic.tsx
+++ b/frontend/src/components/GraphMagic.tsx
@@ -25,6 +25,11 @@ type GraphResponse = {
   run_metadata: { coverage?: { partial?: boolean; warning_text?: string } };
 };
 
+type GraphSnapshotDatesResponse = {
+  organization_id: string;
+  dates: string[];
+};
+
 type AdminOrganization = {
   id: string;
   name: string;
@@ -36,6 +41,7 @@ export function GraphMagic(): JSX.Element {
   const [startDate, setStartDate] = useState(new Date().toISOString().slice(0, 10));
   const [endDate, setEndDate] = useState(new Date().toISOString().slice(0, 10));
   const [selectedDate, setSelectedDate] = useState(new Date().toISOString().slice(0, 10));
+  const [availableSnapshotDates, setAvailableSnapshotDates] = useState<string[]>([]);
   const [graph, setGraph] = useState<GraphResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [nodeId, setNodeId] = useState<string | null>(null);
@@ -84,7 +90,7 @@ export function GraphMagic(): JSX.Element {
   }, [orgId, startDate, endDate]);
 
   const fetchGraph = async (): Promise<void> => {
-    if (!orgId) return;
+    if (!orgId || !selectedDate) return;
     console.debug('[Graph Magic] Fetching graph snapshot', { orgId, selectedDate });
     const { data, error: reqErr } = await apiRequest<GraphResponse>(`/admin-topic-graph/${orgId}/${selectedDate}`);
     if (reqErr || !data) {
@@ -99,6 +105,40 @@ export function GraphMagic(): JSX.Element {
     void fetchGraph();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [orgId, selectedDate]);
+
+  useEffect(() => {
+    const fetchSnapshotDates = async (): Promise<void> => {
+      if (!orgId) {
+        setAvailableSnapshotDates([]);
+        return;
+      }
+      console.debug('[Graph Magic] Fetching available snapshot dates', { orgId });
+      const { data, error: reqErr } = await apiRequest<GraphSnapshotDatesResponse>(`/admin-topic-graph/${orgId}/dates`);
+      if (reqErr || !data) {
+        console.debug('[Graph Magic] Failed to fetch snapshot dates', { orgId, reqErr });
+        setAvailableSnapshotDates([]);
+        setError(reqErr ?? 'Failed to load available snapshot dates');
+        return;
+      }
+      const dates = data.dates ?? [];
+      setAvailableSnapshotDates(dates);
+      if (dates.length === 0) {
+        setSelectedDate('');
+        setGraph(null);
+        setSnippets([]);
+        setNodeId(null);
+        setError('No graph snapshots available for this organization.');
+        return;
+      }
+      setError(null);
+      setSelectedDate((currentSelectedDate) => {
+        if (dates.includes(currentSelectedDate)) return currentSelectedDate;
+        return dates[0] ?? currentSelectedDate;
+      });
+    };
+
+    void fetchSnapshotDates();
+  }, [orgId]);
 
   const rebuild = async (): Promise<void> => {
     if (!canRebuild) return;
@@ -205,7 +245,22 @@ export function GraphMagic(): JSX.Element {
         </label>
         <label className="flex flex-col gap-1 text-xs text-surface-400">
           <span>Selected date (graph view)</span>
-          <input type="date" className="px-3 py-2 rounded bg-surface-800" value={selectedDate} onChange={(e) => setSelectedDate(e.target.value)} />
+          <select
+            className="px-3 py-2 rounded bg-surface-800 text-surface-100"
+            value={selectedDate}
+            onChange={(e) => setSelectedDate(e.target.value)}
+            disabled={availableSnapshotDates.length === 0}
+          >
+            {availableSnapshotDates.length === 0 ? (
+              <option value="">No snapshots available</option>
+            ) : (
+              availableSnapshotDates.map((snapshotDate) => (
+                <option key={snapshotDate} value={snapshotDate}>
+                  {snapshotDate}
+                </option>
+              ))
+            )}
+          </select>
         </label>
         <label className="flex flex-col gap-1 text-xs text-surface-400">
           <span>Generate start date</span>


### PR DESCRIPTION
### Motivation
- Prevent users from selecting a graph date for which no persisted topic-graph snapshot exists to avoid 404s and confusing UI state.
- Make the Graph Magic admin UI explicit about which snapshot dates are available and show a clear empty-state when none exist.

### Description
- Added a service helper `list_topic_graph_snapshot_dates(org_id)` in `backend/services/topic_graph.py` that queries `topic_graph_snapshots` and returns snapshot dates ordered newest-first.
- Added a new admin API endpoint `GET /api/admin-topic-graph/{organization_id}/dates` in `backend/api/routes/topic_graph.py` which returns the list of persisted snapshot dates for an organization and logs the request.
- Updated the `GraphMagic` component (`frontend/src/components/GraphMagic.tsx`) to fetch available snapshot dates per org, change the graph-view control from a free-form `<input type="date">` to a constrained `<select>` populated from the backend, and disable/show an error when no snapshots are available.
- Ensured `selectedDate` is kept in sync with available dates (preferring the current selection if still valid, otherwise selecting the newest snapshot) and avoided calling the snapshot API when no date is selected.

### Testing
- Ran frontend lint: `npm run lint -- src/components/GraphMagic.tsx`, which completed successfully.
- Compiled backend modules: `python -m compileall backend/api/routes/topic_graph.py backend/services/topic_graph.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eed6f2e1408321864a1a6b60ab1d90)