### PR TITLE
Remove Graph Magic page title heading

### DIFF
--- a/frontend/src/components/GraphMagic.tsx
+++ b/frontend/src/components/GraphMagic.tsx
@@ -240,7 +240,6 @@ export function GraphMagic(): JSX.Element {
 
   return (
     <div className="h-full min-h-0 flex flex-col gap-4">
-      <h2 className="text-xl font-semibold text-surface-50">Graph Magic</h2>
       <div className="grid grid-cols-1 md:grid-cols-6 gap-3 items-end">
         <label className="flex flex-col gap-1 text-xs text-surface-400">
           <span>Organization</span>


### PR DESCRIPTION
### Motivation
- Remove the redundant page title and the vertical gap it introduced so the controls start at the top of the Graph Magic page.

### Description
- Deleted the `h2` heading `<h2 className="text-xl font-semibold text-surface-50">Graph Magic</h2>` from `frontend/src/components/GraphMagic.tsx` so the controls grid begins immediately.

### Testing
- No automated tests were run because this is a UI-only markup change; manual/local UI verification is recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eedaa6fb8c8321b812984bf4bfddf0)