### PR TITLE
GraphMagic: Move Generate button, align size/repulsion controls, and ensure repulsion takes effect

### DIFF
--- a/frontend/src/components/GraphMagic.tsx
+++ b/frontend/src/components/GraphMagic.tsx
@@ -10,9 +10,9 @@ const GRAPH_SIMULATION = {
   linkSpring: 0.7,
 } as const;
 const REPULSION_LEVELS = {
-  weak: 0.18,
-  medium: 0.34,
-  strong: 0.58,
+  weak: 0.12,
+  medium: 0.55,
+  strong: 1.35,
 } as const;
 
 type GraphNode = { id: string; label: string; heat: number; mention_count?: number; source?: string; centrality?: number; color?: string };
@@ -251,7 +251,7 @@ export function GraphMagic(): JSX.Element {
 
   return (
     <div className="h-full min-h-0 flex flex-col gap-4">
-      <div className="grid grid-cols-1 md:grid-cols-7 gap-3 items-end">
+      <div className="grid grid-cols-1 md:grid-cols-8 gap-3 items-end">
         <label className="flex flex-col gap-1 text-xs text-surface-400">
           <span>Organization</span>
           <select
@@ -294,10 +294,15 @@ export function GraphMagic(): JSX.Element {
           <span>Generate end date</span>
           <input type="date" className="px-3 py-2 rounded bg-surface-800" value={endDate} onChange={(e) => setEndDate(e.target.value)} />
         </label>
+        <div className="flex items-end">
+          <button disabled={!canRebuild} onClick={() => void rebuild()} className="w-full md:w-auto px-3 py-2 rounded bg-primary-600 disabled:opacity-40">
+            Generate
+          </button>
+        </div>
         <label className="flex flex-col gap-1 text-xs text-surface-400">
           <span>Node size mode</span>
           <select
-            className="w-1/2 min-w-[9rem] px-3 py-2 rounded bg-surface-800 text-surface-100"
+            className="w-full px-3 py-2 rounded bg-surface-800 text-surface-100"
             value={sizeMode}
             onChange={(e) => setSizeMode(e.target.value as NodeSizeMode)}
           >
@@ -309,7 +314,7 @@ export function GraphMagic(): JSX.Element {
         <label className="flex flex-col gap-1 text-xs text-surface-400">
           <span>Node repulsion</span>
           <select
-            className="w-1/2 min-w-[9rem] px-3 py-2 rounded bg-surface-800 text-surface-100"
+            className="w-full px-3 py-2 rounded bg-surface-800 text-surface-100"
             value={repulsionLevel}
             onChange={(e) => setRepulsionLevel(e.target.value as RepulsionLevel)}
           >
@@ -318,17 +323,13 @@ export function GraphMagic(): JSX.Element {
             <option value="strong">Strong</option>
           </select>
         </label>
-        <div className="flex items-end">
-          <button disabled={!canRebuild} onClick={() => void rebuild()} className="w-full md:w-auto px-3 py-2 rounded bg-primary-600 disabled:opacity-40">
-            Rebuild
-          </button>
-        </div>
       </div>
       {partialWarning && <p className="text-xs text-amber-400">Partial data: some sources failed</p>}
       {error && <p className="text-sm text-red-400">{error}</p>}
       <div className="bg-surface-900 border border-surface-800 rounded-lg p-3 flex-1 min-h-[68vh] relative">
         {graphWithVisuals ? (
           <Cosmograph
+            key={`graph-${orgId}-${selectedDate}-${repulsionLevel}`}
             nodes={graphWithVisuals.nodes}
             links={graphWithVisuals.edges}
             nodeLabelAccessor={(n: GraphNode) => n.label}


### PR DESCRIPTION
### Motivation
- Make the generate action sit directly after the generate date range inputs and place the node size and repulsion selectors adjacent for clearer UX. 
- Ensure changing the repulsion selector actually updates the rendered simulation rather than silently doing nothing. 

### Description
- Updated `frontend/src/components/GraphMagic.tsx` to change the control grid from `md:grid-cols-7` to `md:grid-cols-8` so layout can accommodate the reordered controls. 
- Moved the generate action button so it appears immediately after the start/end date inputs and renamed the label from `Rebuild` to `Generate`. 
- Made the Node size mode and Node repulsion selects full-width within their columns for consistent adjacent alignment. 
- Tuned `REPULSION_LEVELS` constants to increase separation between weak/medium/strong values. 
- Added a `key` on the `Cosmograph` component that includes `orgId`, `selectedDate`, and `repulsionLevel` so changing repulsion remounts the graph and reapplies simulation settings immediately. 

### Testing
- Ran `npm run lint` in the `frontend/` directory and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eedf73b19483219a3d0df96f0b3672)