### PR TITLE
Align node details popover to left edge and reduce width

### DIFF
--- a/frontend/src/components/GraphMagic.tsx
+++ b/frontend/src/components/GraphMagic.tsx
@@ -360,7 +360,7 @@ export function GraphMagic(): JSX.Element {
               aria-label="Close node details"
               onClick={closeNodeDetails}
             />
-            <div className="absolute inset-x-3 top-3 md:left-1/2 md:right-auto md:w-[min(820px,calc(100%-1.5rem))] md:-translate-x-1/2 z-10 bg-surface-900 border border-surface-700 rounded-lg p-3 shadow-2xl max-h-[70vh] overflow-y-auto">
+            <div className="absolute left-3 top-3 w-[calc(100%-1.5rem)] md:w-[min(738px,calc((100%-1.5rem)*0.9))] z-10 bg-surface-900 border border-surface-700 rounded-lg p-3 shadow-2xl max-h-[70vh] overflow-y-auto">
               <div className="flex items-start justify-between gap-3 mb-2">
                 <h3 className="font-medium">Node details: {nodeId}</h3>
                 <button


### PR DESCRIPTION
### Motivation
- The node details popover should open anchored to the graph's left edge and be slightly narrower to avoid overlapping the center of the graph view.

### Description
- Changed the popover container in `GraphMagic` to use left-aligned positioning (`left-3 top-3`) and switched the responsive width from `md:left-1/2 ... md:-translate-x-1/2` to a left-anchored width of `w-[calc(100%-1.5rem)] md:w-[min(738px,calc((100%-1.5rem)*0.9))]`, which makes it 10% narrower on medium+ screens.

### Testing
- Ran frontend linter with `npm --prefix frontend run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee01465f08321a139b4a691f7ddee)