### PR TITLE
Show GPT-5.5 explicitly in model selection UI

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -25,6 +25,7 @@ import { getConversation, updateConversation, uploadChatFile, type UploadRespons
 import { useIsMobile } from '../hooks';
 import { useTeamMembers, type TeamMember } from '../hooks/useOrganization';
 import { API_BASE, apiRequest, getAuthenticatedRequestHeaders } from '../lib/api';
+import { formatModelNameForUi } from '../lib/modelDisplay';
 
 import { crossTab } from '../lib/crossTab';
 import { APP_NAME, LOGO_PATH } from '../lib/brand';
@@ -466,8 +467,8 @@ export function Chat({
     : configuredPrimaryModel;
   const activeModelName: string | null = conversationState?.activeModelName ?? displayPrimaryModel;
   const activeModelLabel: string | null = conversationState?.activeModelName
-    ? `Running: ${conversationState.activeModelName}`
-    : (displayPrimaryModel ? `Default: ${displayPrimaryModel}` : null);
+    ? `Running: ${formatModelNameForUi(conversationState.activeModelName)}`
+    : (displayPrimaryModel ? `Default: ${formatModelNameForUi(displayPrimaryModel)}` : null);
 
   // Get actions from Zustand (stable references)
   const addConversationMessage = useAppStore((s) => s.addConversationMessage);

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -18,6 +18,7 @@ import { useAppStore } from '../store';
 import { useTeamMembers, useUpdateOrganization, useLinkIdentity, useUnlinkIdentity, useUpdateGuestUser, useUpdateMemberRole, useDeleteMember, useDeleteOrganization, organizationKeys } from '../hooks';
 import type { TeamMember, IdentityMapping } from '../hooks';
 import { apiRequest } from '../lib/api';
+import { formatModelNameForUi } from '../lib/modelDisplay';
 import { Avatar } from './Avatar';
 import { SubscriptionSetup } from './SubscriptionSetup';
 
@@ -126,7 +127,7 @@ interface OrganizationPanelProps {
 const MODEL_FAMILY_DEFAULTS: Record<string, { primary: string; fast: string }> = {
   anthropic: { primary: 'claude-opus-4-6', fast: 'claude-haiku-4-5-20251001' },
   minimax: { primary: 'MiniMax-M2.7', fast: 'MiniMax-M2.7-highspeed' },
-  openai: { primary: 'gpt5.5', fast: 'gpt5.5-mini' },
+  openai: { primary: 'gpt-5.5', fast: 'gpt-5.5-mini' },
   gemini: { primary: 'gemini-2.5-pro', fast: 'gemini-2.5-flash' },
 };
 
@@ -733,7 +734,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
       const primaryFamily = inferModelFamily(nextPrimary);
       if (selectedCheapFamily && primaryFamily && selectedCheapFamily !== primaryFamily) {
         nextPrimary = resolveFamilyDefaultModel(selectedCheapFamily, 'primary');
-        warningMessage = `Fast model family changed to ${selectedCheapFamily}, so primary model was reset to that family default (${nextPrimary || 'default'}).`;
+        warningMessage = `Fast model family changed to ${selectedCheapFamily}, so primary model was reset to that family default (${nextPrimary ? formatModelNameForUi(nextPrimary) : 'default'}).`;
       }
     }
 
@@ -742,7 +743,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
       const cheapFamily = inferModelFamily(nextCheap);
       if (selectedPrimaryFamily && cheapFamily && selectedPrimaryFamily !== cheapFamily) {
         nextCheap = resolveFamilyDefaultModel(selectedPrimaryFamily, 'fast');
-        warningMessage = `Primary model family changed to ${selectedPrimaryFamily}, so fast model was reset to that family default (${nextCheap || 'default'}).`;
+        warningMessage = `Primary model family changed to ${selectedPrimaryFamily}, so fast model was reset to that family default (${nextCheap ? formatModelNameForUi(nextCheap) : 'default'}).`;
       }
     }
 
@@ -1557,7 +1558,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                         >
                           <option value="">Default</option>
                           {Object.entries(llmModelMap).map(([model, provider]) => (
-                            <option key={model} value={model}>{model} ({provider})</option>
+                            <option key={model} value={model}>{formatModelNameForUi(model)} ({provider})</option>
                           ))}
                         </select>
                         <p className="text-xs text-surface-500 mt-1">Leave blank for provider default</p>
@@ -1571,7 +1572,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                         >
                           <option value="">Default</option>
                           {Object.entries(llmModelMap).map(([model, provider]) => (
-                            <option key={model} value={model}>{model} ({provider})</option>
+                            <option key={model} value={model}>{formatModelNameForUi(model)} ({provider})</option>
                           ))}
                         </select>
                         <p className="text-xs text-surface-500 mt-1">Used for summaries, titles, and background tasks</p>
@@ -1590,7 +1591,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                         >
                           <option value="">Default</option>
                           {Object.entries(llmModelMap).map(([model, provider]) => (
-                            <option key={model} value={model}>{model} ({provider})</option>
+                            <option key={model} value={model}>{formatModelNameForUi(model)} ({provider})</option>
                           ))}
                         </select>
                         <p className="text-xs text-surface-500 mt-1">Used only for workflow runs; regular chat turns keep using your primary model</p>

--- a/frontend/src/components/Workflows.tsx
+++ b/frontend/src/components/Workflows.tsx
@@ -13,6 +13,7 @@ import { useState, useEffect, useRef, useMemo, useCallback, type KeyboardEvent }
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAppStore } from '../store';
 import { apiRequest } from '../lib/api';
+import { formatModelNameForUi } from '../lib/modelDisplay';
 import { useTeamMembers } from '../hooks/useOrganization';
 import { GallerySearchInput } from './shared/GallerySearchInput';
 import { useViewMode } from '../hooks/useViewMode';
@@ -1067,7 +1068,7 @@ function WorkflowModal({
                   >
                     <option value="">Default workflow model</option>
                     {Object.entries(llmModelMap).map(([model, provider]) => (
-                      <option key={model} value={model}>{model} ({provider})</option>
+                      <option key={model} value={model}>{formatModelNameForUi(model)} ({provider})</option>
                     ))}
                   </select>
                   <p className="text-xs text-surface-500 mt-1">

--- a/frontend/src/lib/modelDisplay.ts
+++ b/frontend/src/lib/modelDisplay.ts
@@ -1,0 +1,15 @@
+export function formatModelNameForUi(modelName: string): string {
+  const normalized: string = modelName.trim();
+  const lower: string = normalized.toLowerCase();
+
+  // Ensure GPT-5.5 variants are always shown with the explicit 5.5 marker.
+  if (lower === 'gpt-5.5' || lower === 'gpt5.5') return 'GPT-5.5';
+  if (lower === 'gpt-5.5-mini' || lower === 'gpt5.5-mini') return 'GPT-5.5 mini';
+  if (lower === 'gpt-5.5-nano' || lower === 'gpt5.5-nano') return 'GPT-5.5 nano';
+
+  if (lower === 'gpt-5') return 'GPT-5';
+  if (lower.startsWith('gpt-')) return `GPT-${normalized.slice(4)}`;
+  if (lower.startsWith('gpt')) return `GPT-${normalized.slice(3)}`;
+
+  return normalized;
+}


### PR DESCRIPTION
### Motivation
- The UI should clearly display GPT-5.5 variants (not as `GPT-5`) when users select models so the composer, org settings, and workflow dropdowns reflect the correct family/version.

### Description
- Added a shared formatter `formatModelNameForUi` in `frontend/src/lib/modelDisplay.ts` to normalize model strings and render `gpt-5.5` variants as `GPT-5.5`, `GPT-5.5 mini`, and `GPT-5.5 nano`.
- Updated the chat composer label in `frontend/src/components/Chat.tsx` to use `formatModelNameForUi` for the `Running:` / `Default:` active model text.
- Updated `frontend/src/components/OrganizationPanel.tsx` to use `formatModelNameForUi` in model dropdowns and family-reset warning messages and canonicalized OpenAI defaults to `gpt-5.5` / `gpt-5.5-mini`.
- Updated `frontend/src/components/Workflows.tsx` to use `formatModelNameForUi` for the workflow model override dropdown.

### Testing
- Ran the frontend production build with `npm --prefix frontend run build`, which completed successfully (TypeScript build + `vite build`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee0ca9e9083219de420b18fa6f47f)