### PR TITLE
Fix GPT-5.5 token parameter usage and tighten GPT-5 fallback behavior

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 _configured_openai_research_model = (settings.OPENAI_RESEARCH_MODEL or "").strip()
 _preferred_openai_research_model = (
     _configured_openai_research_model
-    if _configured_openai_research_model.startswith("gpt-5.5")
+    if _configured_openai_research_model.startswith(("gpt-5.5", "gpt5.5"))
     else "gpt-5.5"
 )
 
@@ -72,7 +72,7 @@ OPENAI_WEB_RESEARCH_FALLBACK_MODELS: tuple[str, ...] = tuple(
     )
 )
 
-if _configured_openai_research_model and not _configured_openai_research_model.startswith("gpt-5.5"):
+if _configured_openai_research_model and not _configured_openai_research_model.startswith(("gpt-5.5", "gpt5.5")):
     logger.warning(
         "[Tools] OPENAI_RESEARCH_MODEL=%s is not GPT-5+. Falling back to GPT-5 family for research synthesis.",
         _configured_openai_research_model,

--- a/backend/connectors/web_search.py
+++ b/backend/connectors/web_search.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 _configured_openai_research_model: str = (settings.OPENAI_RESEARCH_MODEL or "").strip()
 _preferred_openai_research_model: str = (
     _configured_openai_research_model
-    if _configured_openai_research_model.startswith("gpt-5.5")
+    if _configured_openai_research_model.startswith(("gpt-5.5", "gpt5.5"))
     else "gpt-5.5"
 )
 OPENAI_WEB_RESEARCH_FALLBACK_MODELS: tuple[str, ...] = tuple(

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -405,9 +405,9 @@ class OpenAIAdapter:
 
     def _build_token_limit_kwargs(self, *, model: str, max_tokens: int) -> dict[str, int]:
         """Map token limit parameter name based on OpenAI model requirements."""
-        # Newer reasoning families (e.g. gpt-5.5 / o-series) reject `max_tokens`.
+        # Newer reasoning families (e.g. gpt-5 / gpt-5.5 / o-series) reject `max_tokens`.
         normalized_model: str = model.strip().lower().split("/")[-1]
-        uses_completion_tokens: bool = normalized_model.startswith(("gpt-5.5", "o"))
+        uses_completion_tokens: bool = normalized_model.startswith(("gpt-5", "gpt5", "o"))
         token_param_name: str = (
             "max_completion_tokens" if uses_completion_tokens else "max_tokens"
         )
@@ -431,16 +431,18 @@ class OpenAIAdapter:
             prefix, base_model = normalized_model.split("/", 1)
             prefix = f"{prefix}/"
 
-        if not base_model.startswith("gpt-5"):
+        if not base_model.startswith(("gpt-5", "gpt5")):
             return []
 
+        canonical_base_model: str = base_model.replace("gpt5", "gpt-5", 1) if base_model.startswith("gpt5") else base_model
+
         variants: list[str] = []
-        if base_model == "gpt-5":
-            variants.extend(["gpt-5.5", "gpt-5.5-mini", "gpt-5.5-nano"])
-        elif base_model == "gpt-5.5":
+        if canonical_base_model == "gpt-5.5":
             variants.extend(["gpt-5", "gpt-5.5-mini", "gpt-5.5-nano"])
-        elif base_model == "gpt-5.5-mini":
+        elif canonical_base_model == "gpt-5.5-mini":
             variants.append("gpt-5.5-nano")
+        elif canonical_base_model == "gpt-5.5-nano":
+            variants.append("gpt-5")
 
         fallback_models: list[str] = [f"{prefix}{variant}" for variant in variants if variant != base_model]
         if fallback_models:

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -42,6 +42,22 @@ def test_openai_legacy_models_use_max_tokens():
     }
 
 
+
+
+def test_openai_legacy_gpt5_uses_max_completion_tokens():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    assert adapter._build_token_limit_kwargs(model="gpt-5", max_tokens=333) == {
+        "max_completion_tokens": 333
+    }
+
+
+def test_openai_non_hyphenated_gpt55_uses_max_completion_tokens():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    assert adapter._build_token_limit_kwargs(model="gpt5.5", max_tokens=222) == {
+        "max_completion_tokens": 222
+    }
 def test_openai_gpt5_with_provider_prefix_uses_max_completion_tokens():
     adapter = OpenAIAdapter(api_key="test-key")
 
@@ -198,63 +214,3 @@ async def test_openai_complete_falls_back_when_gpt5_not_found():
     assert create_mock.await_count == 2
     assert create_mock.await_args_list[0].kwargs["model"] == "gpt-5.5"
     assert create_mock.await_args_list[1].kwargs["model"] == "gpt-5"
-
-
-@pytest.mark.asyncio
-async def test_openai_stream_falls_back_from_legacy_gpt5_to_gpt55():
-    adapter = OpenAIAdapter(api_key="test-key")
-    create_mock = AsyncMock(
-        side_effect=[
-            _openai_api_status_error("model: gpt-5"),
-            _EmptyAsyncIterator(),
-        ]
-    )
-    adapter._client = SimpleNamespace(  # type: ignore[assignment]
-        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
-    )
-
-    events = [
-        event
-        async for event in adapter.stream(
-            model="gpt-5",
-            system="sys",
-            messages=[{"role": "user", "content": "hi"}],
-            max_tokens=42,
-        )
-    ]
-
-    assert events == []
-    assert create_mock.await_count == 2
-    assert create_mock.await_args_list[0].kwargs["model"] == "gpt-5"
-    assert create_mock.await_args_list[1].kwargs["model"] == "gpt-5.5"
-
-
-@pytest.mark.asyncio
-async def test_openai_complete_falls_back_from_legacy_gpt5_to_gpt55():
-    adapter = OpenAIAdapter(api_key="test-key")
-    completion_response = SimpleNamespace(
-        choices=[SimpleNamespace(message=SimpleNamespace(content="fallback answer", tool_calls=None))],
-        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=2),
-    )
-    create_mock = AsyncMock(
-        side_effect=[
-            _openai_api_status_error("model: gpt-5"),
-            completion_response,
-        ]
-    )
-    adapter._client = SimpleNamespace(  # type: ignore[assignment]
-        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
-    )
-
-    completed = await adapter.complete(
-        model="gpt-5",
-        system="sys",
-        messages=[{"role": "user", "content": "hi"}],
-        max_tokens=42,
-    )
-
-    assert completed.input_tokens == 1
-    assert completed.output_tokens == 2
-    assert create_mock.await_count == 2
-    assert create_mock.await_args_list[0].kwargs["model"] == "gpt-5"
-    assert create_mock.await_args_list[1].kwargs["model"] == "gpt-5.5"


### PR DESCRIPTION
### Motivation
- Resolve the runtime 400 error where GPT-5.5 family requests were being sent with `max_tokens` instead of `max_completion_tokens`. 
- Ensure fallback direction aligns with intent: prefer GPT-5.5 variants and only fall back to GPT-5 when necessary. 
- Accept non-hyphenated model name variants (e.g. `gpt5.5`) in research-model normalization.

### Description
- Updated `OpenAIAdapter._build_token_limit_kwargs` to treat `gpt-5`, `gpt5`, `gpt-5.5` and `o`-series as families that require `max_completion_tokens` instead of `max_tokens` (file: `backend/services/llm_adapter.py`).
- Tightened `_openai_not_found_fallback_models` so fallback candidates are generated from canonicalized base names and `gpt-5` is only used as a fallback target for 5.5-family requests (file: `backend/services/llm_adapter.py`).
- Accepted `gpt5.5` alias in research model normalization checks used by tools and the web-search connector (files: `backend/agents/tools.py`, `backend/connectors/web_search.py`).
- Adjusted tests in `backend/tests/test_llm_adapter_openai_token_params.py` to add coverage for `gpt-5` and non-hyphenated `gpt5.5` token-param behavior and removed reverse fallback tests that no longer reflect the desired one-way fallback.

### Testing
- Ran `pytest -q backend/tests/test_llm_adapter_openai_token_params.py backend/tests/test_llm_provider.py` and all tests passed (`16 passed`).
- Verified the updated adapter logic via unit tests that assert `max_completion_tokens` is used for `gpt-5`, `gpt-5.5`, and `gpt5.5` variants and that fallback ordering is as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee3edac1083219a02fc4b7bb1e551)