### PR TITLE
Fix LLM provider inference, clean up model dropdown labels, and double graph repulsion

### DIFF
--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -77,6 +77,8 @@ async def resolve_llm_config(
         inferred_model: str | None = primary_model or cheap_model
         if inferred_model:
             inferred: str | None = provider_for_model(inferred_model)
+            if not inferred:
+                inferred = _infer_provider_from_model_name(inferred_model)
             if inferred:
                 provider = inferred  # type: ignore[assignment]
 

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -69,3 +69,33 @@ def test_model_allowlist_accepts_gpt55_aliases(monkeypatch) -> None:
     assert is_model_allowed("gpt-5.5")
     assert is_model_allowed("gpt-5.5-mini")
     assert provider_for_model("gpt-5.5") == "openai"
+
+
+def test_resolve_llm_config_infers_provider_from_model_prefix_when_allowlist_omits_provider(
+    monkeypatch,
+) -> None:
+    from services import llm_provider
+
+    monkeypatch.setattr(llm_provider, "_DEFAULT_PROVIDER", "anthropic")
+    monkeypatch.setitem(llm_provider._GLOBAL_PROVIDER_KEYS, "openai", "test-openai-key")
+    monkeypatch.setattr(llm_provider.settings, "DEFAULT_PRIMARY_MODEL", "")
+    monkeypatch.setattr(llm_provider.settings, "DEFAULT_CHEAP_MODEL", "")
+    monkeypatch.setattr(llm_provider.settings, "ALL_MODEL_STRINGS", "gpt-5.5")
+
+    class _Org:
+        handle = "acme"
+        llm_provider = None
+        llm_primary_model = "gpt-5.5"
+        llm_cheap_model = "gpt-5.5-mini"
+        llm_workflow_model = None
+
+    async def _fake_load_org(_organization_id):
+        return _Org()
+
+    monkeypatch.setattr(llm_provider, "_load_organization_for_llm", _fake_load_org)
+
+    config = asyncio.run(resolve_llm_config("00000000-0000-0000-0000-000000000001"))
+
+    assert config.provider == "openai"
+    assert config.primary_model == "gpt-5.5"
+    assert config.cheap_model == "gpt-5.5-mini"

--- a/frontend/src/components/GraphMagic.tsx
+++ b/frontend/src/components/GraphMagic.tsx
@@ -10,9 +10,9 @@ const GRAPH_SIMULATION = {
   linkSpring: 0.7,
 } as const;
 const REPULSION_LEVELS = {
-  weak: 0.12,
-  medium: 0.55,
-  strong: 1.35,
+  weak: 0.24,
+  medium: 1.1,
+  strong: 2.7,
 } as const;
 
 type GraphNode = {

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -1558,7 +1558,9 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                         >
                           <option value="">Default</option>
                           {Object.entries(llmModelMap).map(([model, provider]) => (
-                            <option key={model} value={model}>{formatModelNameForUi(model)} ({provider})</option>
+                            <option key={model} value={model}>
+                              {provider ? `${formatModelNameForUi(model)} (${provider})` : formatModelNameForUi(model)}
+                            </option>
                           ))}
                         </select>
                         <p className="text-xs text-surface-500 mt-1">Leave blank for provider default</p>
@@ -1572,7 +1574,9 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                         >
                           <option value="">Default</option>
                           {Object.entries(llmModelMap).map(([model, provider]) => (
-                            <option key={model} value={model}>{formatModelNameForUi(model)} ({provider})</option>
+                            <option key={model} value={model}>
+                              {provider ? `${formatModelNameForUi(model)} (${provider})` : formatModelNameForUi(model)}
+                            </option>
                           ))}
                         </select>
                         <p className="text-xs text-surface-500 mt-1">Used for summaries, titles, and background tasks</p>
@@ -1591,7 +1595,9 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                         >
                           <option value="">Default</option>
                           {Object.entries(llmModelMap).map(([model, provider]) => (
-                            <option key={model} value={model}>{formatModelNameForUi(model)} ({provider})</option>
+                            <option key={model} value={model}>
+                              {provider ? `${formatModelNameForUi(model)} (${provider})` : formatModelNameForUi(model)}
+                            </option>
                           ))}
                         </select>
                         <p className="text-xs text-surface-500 mt-1">Used only for workflow runs; regular chat turns keep using your primary model</p>

--- a/frontend/src/components/Workflows.tsx
+++ b/frontend/src/components/Workflows.tsx
@@ -1068,7 +1068,9 @@ function WorkflowModal({
                   >
                     <option value="">Default workflow model</option>
                     {Object.entries(llmModelMap).map(([model, provider]) => (
-                      <option key={model} value={model}>{formatModelNameForUi(model)} ({provider})</option>
+                      <option key={model} value={model}>
+                        {provider ? `${formatModelNameForUi(model)} (${provider})` : formatModelNameForUi(model)}
+                      </option>
                     ))}
                   </select>
                   <p className="text-xs text-surface-500 mt-1">


### PR DESCRIPTION
### Motivation
- Magic Graph node repulsion felt too low and should be stronger for clearer layouts.  
- Model dropdowns rendered an empty provider/family suffix like `GPT-5.5 ()` when provider metadata was missing.  
- Orchestrator/adapter errors occurred when orgs used model names like `gpt-5.5` but the allowlist entries omitted explicit `:provider` mappings, causing the code to stay on the default provider and trigger 404s from the wrong API provider.

### Description
- Doubled the Magic Graph node repulsion presets in `frontend/src/components/GraphMagic.tsx` (weak `0.12 → 0.24`, medium `0.55 → 1.1`, strong `1.35 → 2.7`).  
- Updated UI model select labels in `frontend/src/components/OrganizationPanel.tsx` and `frontend/src/components/Workflows.tsx` to render `formatModelNameForUi(model)` alone when provider metadata is empty, avoiding empty `()` output.  
- Improved provider inference in `backend/services/llm_provider.py` so when `provider_for_model(...)` yields no mapping, the code falls back to `_infer_provider_from_model_name(...)` to infer providers from model name prefixes (e.g., `gpt-*` → `openai`).  
- Added a regression test `test_resolve_llm_config_infers_provider_from_model_prefix_when_allowlist_omits_provider` in `backend/tests/test_llm_provider.py` to cover the provider inference case.

### Testing
- Ran `pytest -q backend/tests/test_llm_provider.py` which completed successfully with `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee98400c48321bd98ded29cb82b01)