### PR TITLE
Treat Qwen as a model family and reconcile provider/model selection to avoid mismatches

### DIFF
--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -72,9 +72,13 @@ async def resolve_llm_config(
                 exc_info=True,
             )
 
+    requested_primary_model: str | None = primary_model or settings.DEFAULT_PRIMARY_MODEL
+    requested_cheap_model: str | None = cheap_model or settings.DEFAULT_CHEAP_MODEL
+    requested_workflow_model: str | None = workflow_model
+
     # Infer provider from model when not explicitly set
     if provider == _DEFAULT_PROVIDER:
-        inferred_model: str | None = primary_model or cheap_model
+        inferred_model: str | None = requested_primary_model or requested_cheap_model
         if inferred_model:
             inferred: str | None = provider_for_model(inferred_model)
             if inferred:
@@ -84,22 +88,57 @@ async def resolve_llm_config(
     provider_defaults: dict[str, str] = PROVIDER_DEFAULT_MODELS.get(
         provider, PROVIDER_DEFAULT_MODELS["anthropic"]
     )
-    if not primary_model:
+    primary_model = _select_compatible_model(
+        requested_model=requested_primary_model,
+        provider=provider,
+        fallback_model=provider_defaults["primary"],
+        model_role="primary",
+    )
+    cheap_model = _select_compatible_model(
+        requested_model=requested_cheap_model,
+        provider=provider,
+        fallback_model=provider_defaults["cheap"],
+        model_role="cheap",
+    )
+    workflow_model = (
+        _select_compatible_model(
+            requested_model=requested_workflow_model,
+            provider=provider,
+            fallback_model=primary_model,
+            model_role="workflow",
+        )
+        if requested_workflow_model
+        else primary_model
+    )
+
+    resolved_provider: str | None = provider_for_model(primary_model) or _infer_provider_from_model_name(primary_model)
+    if resolved_provider and resolved_provider != provider:
+        logger.warning(
+            "Switching provider to match resolved primary model '%s': %s -> %s",
+            primary_model,
+            provider,
+            resolved_provider,
+        )
+        provider = resolved_provider  # type: ignore[assignment]
+        provider_defaults = PROVIDER_DEFAULT_MODELS.get(provider, PROVIDER_DEFAULT_MODELS["anthropic"])
         primary_model = _select_compatible_model(
-            requested_model=settings.DEFAULT_PRIMARY_MODEL,
+            requested_model=primary_model,
             provider=provider,
             fallback_model=provider_defaults["primary"],
             model_role="primary",
         )
-    if not cheap_model:
         cheap_model = _select_compatible_model(
-            requested_model=settings.DEFAULT_CHEAP_MODEL,
+            requested_model=cheap_model,
             provider=provider,
             fallback_model=provider_defaults["cheap"],
             model_role="cheap",
         )
-    if not workflow_model:
-        workflow_model = primary_model
+        workflow_model = _select_compatible_model(
+            requested_model=workflow_model,
+            provider=provider,
+            fallback_model=primary_model,
+            model_role="workflow",
+        )
 
     # Resolve API key: org-specific env var → global provider key
     api_key: str = _resolve_api_key(provider, org_handle)

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -52,6 +52,24 @@ def test_resolve_llm_config_logs_when_model_fallback_engaged(monkeypatch, caplog
     )
 
 
+def test_resolve_llm_config_switches_provider_for_qwen_primary(monkeypatch) -> None:
+    from services import llm_provider
+
+    monkeypatch.setattr(llm_provider, "_DEFAULT_PROVIDER", "anthropic")
+    monkeypatch.setitem(llm_provider._GLOBAL_PROVIDER_KEYS, "anthropic", "test-anthropic-key")
+    monkeypatch.setitem(llm_provider._GLOBAL_PROVIDER_KEYS, "qwen", "test-qwen-key")
+    monkeypatch.setattr(llm_provider.settings, "DEFAULT_PRIMARY_MODEL", "qwen3-max")
+    monkeypatch.setattr(llm_provider.settings, "DEFAULT_CHEAP_MODEL", "qwen-flash")
+    monkeypatch.setattr(llm_provider.settings, "ALL_MODEL_STRINGS", "qwen3-max:qwen,qwen-flash:qwen")
+
+    config = asyncio.run(resolve_llm_config(None))
+
+    assert config.provider == "qwen"
+    assert config.primary_model == "qwen3-max"
+    assert config.cheap_model == "qwen-flash"
+    assert config.workflow_model == "qwen3-max"
+
+
 def test_resolve_api_key_for_provider_uses_global_key(monkeypatch) -> None:
     from services import llm_provider
 

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -129,6 +129,7 @@ const MODEL_FAMILY_DEFAULTS: Record<string, { primary: string; fast: string }> =
   minimax: { primary: 'MiniMax-M2.7', fast: 'MiniMax-M2.7-highspeed' },
   openai: { primary: 'gpt-5.5', fast: 'gpt-5.5-mini' },
   gemini: { primary: 'gemini-2.5-pro', fast: 'gemini-2.5-flash' },
+  qwen: { primary: 'qwen3-max', fast: 'qwen-flash' },
 };
 
 const isOpenAICheapLikeModel = (modelName: string): boolean => {
@@ -684,6 +685,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
       if (normalized.startsWith('claude')) return 'anthropic';
       if (normalized.startsWith('minimax')) return 'minimax';
       if (normalized.startsWith('gemini')) return 'gemini';
+      if (normalized.startsWith('qwen') || normalized.startsWith('qwq')) return 'qwen';
       if (normalized.startsWith('gpt') || normalized.startsWith('o1') || normalized.startsWith('o3') || normalized.startsWith('o4')) return 'openai';
       return null;
     };


### PR DESCRIPTION
### Motivation
- UI should treat QWEN models as a single family so primary/fast model selection keeps QWEN choices grouped and doesn't reset across families.  
- Prevent runtime 404s where the app attempted to call the Anthropic adapter with a QWEN model by ensuring provider and model selection are reconciled before adapter creation.

### Description
- Added Qwen family defaults and UI family inference in `frontend/src/components/OrganizationPanel.tsx` so `qwen*`/`qwq*` model names map to the `qwen` family and `MODEL_FAMILY_DEFAULTS` includes `qwen` with `qwen3-max`/`qwen-flash` defaults.  
- Hardened backend model resolution in `backend/services/llm_provider.py` to: always run compatibility checks for requested models (including org-provided values), infer provider from requested defaults, and reconcile/switch the provider when the resolved primary model belongs to a different provider family to avoid calling the wrong adapter.  
- Added a regression test in `backend/tests/test_llm_provider.py` (`test_resolve_llm_config_switches_provider_for_qwen_primary`) to assert that `resolve_llm_config` switches to `qwen` when QWEN models are selected.  

### Testing
- Ran `pytest -q backend/tests/test_llm_provider.py` and all tests passed.  
- `6 passed in 2.09s` for the modified test module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeea063e108321994c9e8e5a13a4fd)