### PR TITLE
Fix Qwen model family detection and defaults

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -38,7 +38,7 @@ PROVIDER_DEFAULT_MODELS: dict[str, dict[str, str]] = {
     "minimax": {"primary": "MiniMax-M2.7", "cheap": "MiniMax-M2.7-highspeed"},
     "openai": {"primary": "gpt-5.5", "cheap": "gpt-5.5-mini"},
     "gemini": {"primary": "gemini-2.5-pro", "cheap": "gemini-2.5-flash"},
-    "qwen": {"primary": "qwen3-max", "cheap": "qwen-flash"},
+    "qwen": {"primary": "qwen3-coder-plus", "cheap": "qwen3-30b-a3b-instruct-2507"},
 }
 
 

--- a/env.example
+++ b/env.example
@@ -15,7 +15,7 @@ DEFAULT_PRIMARY_MODEL=claude-opus-4-6
 DEFAULT_CHEAP_MODEL=claude-haiku-4-5-20251001
 # Comma-separated allowlist of model names for the org settings UI.
 # Empty = no restriction (free-text input). When set, the frontend shows dropdowns.
-# ALL_MODEL_STRINGS=claude-opus-4-6,claude-haiku-4-5-20251001,gpt-5.5,gpt-5.5-mini,gemini-2.5-pro,gemini-2.5-flash,MiniMax-M2.7,MiniMax-M2.7-highspeed,qwen3-max,qwen-flash
+# ALL_MODEL_STRINGS=claude-opus-4-6,claude-haiku-4-5-20251001,gpt-5.5,gpt-5.5-mini,gemini-2.5-pro,gemini-2.5-flash,MiniMax-M2.7,MiniMax-M2.7-highspeed,qwen3-coder-plus,qwen3-30b-a3b-instruct-2507
 
 # LLM provider API keys
 ANTHROPIC_API_KEY=your_anthropic_api_key

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -691,7 +691,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
       if (normalized.startsWith('claude')) return 'anthropic';
       if (normalized.startsWith('minimax')) return 'minimax';
       if (normalized.startsWith('gemini')) return 'gemini';
-      if (normalized.startsWith('qwen')) return 'qwen';
+      if (normalized.startsWith('qwen') || normalized.startsWith('qwq')) return 'qwen';
       if (normalized.startsWith('gpt') || normalized.startsWith('o1') || normalized.startsWith('o3') || normalized.startsWith('o4')) return 'openai';
       return null;
     };


### PR DESCRIPTION
### Motivation
- Prevent UI family-selection mismatches for QWEN-adjacent model names and avoid runtime 404s caused by an unavailable QWEN default model.

### Description
- Update backend `PROVIDER_DEFAULT_MODELS` for `qwen` to use `qwen3-coder-plus` and `qwen3-30b-a3b-instruct-2507`, treat `qwq*` model name prefixes as part of the `qwen` family in the frontend `OrganizationPanel` inference logic, and align the `env.example` `ALL_MODEL_STRINGS` sample with the new QWEN model IDs.

### Testing
- Ran `pytest -q backend/tests/test_llm_provider.py` which completed successfully (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeeae8291c832189b5be1e8d6be039)