### PR TITLE
Skip unavailable `gpt-5.5-nano` in OpenAI fallback chain

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -67,7 +67,6 @@ OPENAI_WEB_RESEARCH_FALLBACK_MODELS: tuple[str, ...] = tuple(
             "gpt-5.5",
             "gpt-5",
             "gpt-5.5-mini",
-            "gpt-5.5-nano",
         )
     )
 )

--- a/backend/connectors/web_search.py
+++ b/backend/connectors/web_search.py
@@ -39,7 +39,6 @@ OPENAI_WEB_RESEARCH_FALLBACK_MODELS: tuple[str, ...] = tuple(
             "gpt-5.5",
             "gpt-5",
             "gpt-5.5-mini",
-            "gpt-5.5-nano",
         )
     )
 )

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -440,11 +440,11 @@ class OpenAIAdapter:
 
         variants: list[str] = []
         if canonical_base_model == "gpt-5.5":
-            variants.extend(["gpt-5", "gpt-5.5-mini", "gpt-5.5-nano"])
+            variants.extend(["gpt-5", "gpt-5.5-mini"])
         elif canonical_base_model == "gpt-5.5-mini":
-            variants.append("gpt-5.5-nano")
-        elif canonical_base_model == "gpt-5.5-nano":
             variants.append("gpt-5")
+        elif canonical_base_model == "gpt-5.5-nano":
+            variants.extend(["gpt-5.5-mini", "gpt-5"])
 
         fallback_models: list[str] = [f"{prefix}{variant}" for variant in variants if variant != base_model]
         if fallback_models:

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -58,6 +58,19 @@ def test_openai_non_hyphenated_gpt55_uses_max_completion_tokens():
     assert adapter._build_token_limit_kwargs(model="gpt5.5", max_tokens=222) == {
         "max_completion_tokens": 222
     }
+
+
+def test_openai_not_found_fallbacks_skip_unavailable_nano_variant():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    assert adapter._openai_not_found_fallback_models("gpt-5.5") == ["gpt-5", "gpt-5.5-mini"]
+    assert adapter._openai_not_found_fallback_models("gpt-5.5-mini") == ["gpt-5"]
+    assert adapter._openai_not_found_fallback_models("gpt-5.5-nano") == [
+        "gpt-5.5-mini",
+        "gpt-5",
+    ]
+
+
 def test_openai_gpt5_with_provider_prefix_uses_max_completion_tokens():
     adapter = OpenAIAdapter(api_key="test-key")
 


### PR DESCRIPTION
### Motivation
- Runtime calls to `gpt-5.5-nano` can produce 404 `model_not_found` errors when the model alias is not available in an environment, causing streaming calls to fail.  
- The goal is to avoid retrying into an unavailable `gpt-5.5-nano` variant and provide a more reliable fallback path within the GPT-5 family.

### Description
- Removed `gpt-5.5-nano` from the `OPENAI_WEB_RESEARCH_FALLBACK_MODELS` lists in `backend/agents/tools.py` and `backend/connectors/web_search.py`.  
- Updated `OpenAIAdapter._openai_not_found_fallback_models` in `backend/services/llm_adapter.py` to stop inserting `gpt-5.5-nano` as a fallback for `gpt-5.5` requests and to prefer the chain `gpt-5.5-mini` then `gpt-5`, while mapping `gpt-5.5-nano` fallbacks to `gpt-5.5-mini` then `gpt-5`.  
- Added `test_openai_not_found_fallbacks_skip_unavailable_nano_variant` to `backend/tests/test_llm_adapter_openai_token_params.py` to assert the new fallback behavior.

### Testing
- Ran `pytest -q backend/tests/test_llm_adapter_openai_token_params.py` and the test suite completed successfully with `12 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeec613e8883219d0c3c725421987e)