### PR TITLE
Adjust GPT-5.5-mini fallback ordering

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -442,7 +442,7 @@ class OpenAIAdapter:
         if canonical_base_model == "gpt-5.5":
             variants.extend(["gpt-5", "gpt-5.5-mini"])
         elif canonical_base_model == "gpt-5.5-mini":
-            variants.append("gpt-5")
+            variants.extend(["gpt-5-mini", "gpt-5"])
         elif canonical_base_model == "gpt-5.5-nano":
             variants.extend(["gpt-5.5-mini", "gpt-5"])
 

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -64,7 +64,7 @@ def test_openai_not_found_fallbacks_skip_unavailable_nano_variant():
     adapter = OpenAIAdapter(api_key="test-key")
 
     assert adapter._openai_not_found_fallback_models("gpt-5.5") == ["gpt-5", "gpt-5.5-mini"]
-    assert adapter._openai_not_found_fallback_models("gpt-5.5-mini") == ["gpt-5"]
+    assert adapter._openai_not_found_fallback_models("gpt-5.5-mini") == ["gpt-5-mini", "gpt-5"]
     assert adapter._openai_not_found_fallback_models("gpt-5.5-nano") == [
         "gpt-5.5-mini",
         "gpt-5",


### PR DESCRIPTION
### Motivation
- Prefer the `gpt-5-mini` sibling as the first fallback for `gpt-5.5-mini` requests so the adapter tries the smaller same-family variant before falling back to `gpt-5`.

### Description
- Updated `_openai_not_found_fallback_models` in `backend/services/llm_adapter.py` to return `['gpt-5-mini', 'gpt-5']` for `gpt-5.5-mini` requests.
- Updated the corresponding unit expectation in `backend/tests/test_llm_adapter_openai_token_params.py` to match the new fallback order.

### Testing
- Ran `pytest -q backend/tests/test_llm_adapter_openai_token_params.py`, which completed successfully (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeeed0fb5c83219700e204edc5873b)