### PR TITLE
Fix fast model auto-selection for Anthropic and Qwen family switches

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -135,15 +135,17 @@ const MODEL_FAMILY_DEFAULTS: Record<string, { primary: string; fast: string }> =
   minimax: { primary: 'MiniMax-M2.7', fast: 'MiniMax-M2.7-highspeed' },
   openai: { primary: 'gpt-5.5', fast: 'gpt-5.5-mini' },
   gemini: { primary: 'gemini-2.5-pro', fast: 'gemini-2.5-flash' },
-  alibaba: { primary: 'qwen3-coder-plus', fast: 'qwen3-30b-a3b-instruct-2507' },
+  alibaba: { primary: 'qwen3-coder-plus', fast: 'qwen3-flash' },
 };
 
-const isOpenAICheapLikeModel = (modelName: string): boolean => {
+const isFastModelCandidate = (modelName: string): boolean => {
   const normalized = modelName.trim().toLowerCase();
   return (
     normalized.includes('mini')
     || normalized.includes('nano')
     || normalized.includes('flash')
+    || normalized.includes('haiku')
+    || normalized.includes('sonnet')
     || normalized.includes('turbo')
     || normalized.includes('speed')
   );
@@ -710,10 +712,21 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
       if (familyModels.length > 0) {
         const firstFamilyModel: string = familyModels[0] ?? '';
         const desiredModelPredicate = (modelName: string): boolean => (
-          modelRole === 'fast' ? isOpenAICheapLikeModel(modelName) : !isOpenAICheapLikeModel(modelName)
+          modelRole === 'fast' ? isFastModelCandidate(modelName) : !isFastModelCandidate(modelName)
         );
         const familySpecificDefault = familyModels.find((modelName) => desiredModelPredicate(modelName));
         if (familySpecificDefault) return familySpecificDefault;
+        const defaults = MODEL_FAMILY_DEFAULTS[family];
+        if (defaults) {
+          const fallbackModel = modelRole === 'primary' ? defaults.primary : defaults.fast;
+          console.warn('[OrganizationPanel] No role-specific allowlisted family model found, using hardcoded family default', {
+            family,
+            modelRole,
+            fallbackModel,
+            allowedFamilyModels: familyModels,
+          });
+          return fallbackModel;
+        }
         console.info('[OrganizationPanel] No role-specific family model found, using first allowed model', {
           family,
           modelRole,


### PR DESCRIPTION
### Motivation
- Ensure fast-tier auto-selection picks intended fast variants (e.g., Claude Haiku and Qwen Flash) when switching model families rather than selecting another primary variant.
- Make the fast/cheap detection heuristic aware of Anthropic naming (e.g., `haiku`/`sonnet`) so primary→fast pairing behaves correctly.
- Prefer hardcoded family defaults when an allowlist contains family models but none match the requested role to produce predictable fallbacks.

### Description
- Update `MODEL_FAMILY_DEFAULTS` for the Alibaba family to use `qwen3-flash` as the fast default instead of `qwen3-30b-a3b-instruct-2507` in `frontend/src/components/OrganizationPanel.tsx`.
- Rename and broaden the fast-model predicate to `isFastModelCandidate` and include `haiku` and `sonnet` as fast-tier indicators so Anthropic fast tiers are detected.
- Change `resolveFamilyDefaultModel` logic so that when allowlisted family models exist but none match the desired role it falls back to the hardcoded family default (with a warning log) before using the first allowlisted model.

### Testing
- Ran frontend linter via `npm --prefix frontend run lint` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef063af40832183c96ca221330431)