### PR TITLE
Show compact All Chats count on small screens

### DIFF
--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -270,8 +270,11 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
           <div className="flex items-center gap-3 flex-shrink-0">
             {initialLoaded ? (
               <span className="text-sm text-surface-500">
-                {mergedChats.length} conversation{mergedChats.length !== 1 ? 's' : ''}
-                {hasMore ? '+' : ''}
+                <span className="sm:hidden">{mergedChats.length}{hasMore ? '+' : ''}</span>
+                <span className="hidden sm:inline">
+                  {mergedChats.length} conversation{mergedChats.length !== 1 ? 's' : ''}
+                  {hasMore ? '+' : ''}
+                </span>
               </span>
             ) : null}
             <button type="button" onClick={onNewChat} className="btn-primary flex items-center gap-2">


### PR DESCRIPTION
### Motivation
- On small screens the All Chats header should show a compact numeric count (e.g. `30+`) instead of the full phrase (`30 conversations+`) to reduce visual clutter.

### Description
- Update `frontend/src/components/ChatsList.tsx` to render a compact count inside a `sm:hidden` span and keep the existing full-label rendering inside a `hidden sm:inline` span so desktops are unchanged.
- Change is purely presentational and does not modify conversation loading, filtering, or data structures.

### Testing
- Ran `cd frontend && npx eslint src/components/ChatsList.tsx`, which completed successfully.
- `cd frontend && npm run -s eslint src/components/ChatsList.tsx` returned a non-zero exit in this environment with no output, but the direct `npx eslint` invocation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7b00d7d08321b9af52b5923f67d1)