### PR TITLE
Persist Graph Magic selection state in URL query params

### DIFF
--- a/frontend/src/components/GraphMagic.tsx
+++ b/frontend/src/components/GraphMagic.tsx
@@ -65,19 +65,75 @@ type AdminOrganization = {
   name: string;
 };
 
+const GRAPH_MAGIC_QUERY_KEYS = {
+  orgId: 'gm_org',
+  startDate: 'gm_start',
+  endDate: 'gm_end',
+  selectedDate: 'gm_selected',
+  sizeMode: 'gm_size',
+  repulsionLevel: 'gm_repulsion',
+} as const;
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+const getTodayIsoDate = (): string => new Date().toISOString().slice(0, 10);
+
+const readGraphMagicStateFromUri = (): {
+  orgId: string;
+  startDate: string;
+  endDate: string;
+  selectedDate: string;
+  sizeMode: NodeSizeMode;
+  repulsionLevel: RepulsionLevel;
+} => {
+  if (typeof window === 'undefined') {
+    const today = getTodayIsoDate();
+    return {
+      orgId: '',
+      startDate: today,
+      endDate: today,
+      selectedDate: today,
+      sizeMode: 'composite',
+      repulsionLevel: 'weak',
+    };
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const today = getTodayIsoDate();
+  const rawSizeMode = params.get(GRAPH_MAGIC_QUERY_KEYS.sizeMode);
+  const rawRepulsionLevel = params.get(GRAPH_MAGIC_QUERY_KEYS.repulsionLevel);
+  const validStartDate = params.get(GRAPH_MAGIC_QUERY_KEYS.startDate);
+  const validEndDate = params.get(GRAPH_MAGIC_QUERY_KEYS.endDate);
+  const validSelectedDate = params.get(GRAPH_MAGIC_QUERY_KEYS.selectedDate);
+
+  return {
+    orgId: params.get(GRAPH_MAGIC_QUERY_KEYS.orgId) ?? '',
+    startDate: validStartDate && DATE_PATTERN.test(validStartDate) ? validStartDate : today,
+    endDate: validEndDate && DATE_PATTERN.test(validEndDate) ? validEndDate : today,
+    selectedDate: validSelectedDate && DATE_PATTERN.test(validSelectedDate) ? validSelectedDate : today,
+    sizeMode: rawSizeMode === 'mentions' || rawSizeMode === 'centrality' || rawSizeMode === 'composite'
+      ? rawSizeMode
+      : 'composite',
+    repulsionLevel: rawRepulsionLevel === 'weak' || rawRepulsionLevel === 'medium' || rawRepulsionLevel === 'strong'
+      ? rawRepulsionLevel
+      : 'weak',
+  };
+};
+
 export function GraphMagic(): JSX.Element {
   const orgMemberships: UserOrganization[] = useAuthStore((state) => state.organizations);
-  const [orgId, setOrgId] = useState('');
-  const [startDate, setStartDate] = useState(new Date().toISOString().slice(0, 10));
-  const [endDate, setEndDate] = useState(new Date().toISOString().slice(0, 10));
-  const [selectedDate, setSelectedDate] = useState(new Date().toISOString().slice(0, 10));
+  const uriState = useMemo(() => readGraphMagicStateFromUri(), []);
+  const [orgId, setOrgId] = useState(uriState.orgId);
+  const [startDate, setStartDate] = useState(uriState.startDate);
+  const [endDate, setEndDate] = useState(uriState.endDate);
+  const [selectedDate, setSelectedDate] = useState(uriState.selectedDate);
   const [availableSnapshotDates, setAvailableSnapshotDates] = useState<string[]>([]);
   const [isLoadingSnapshotDates, setIsLoadingSnapshotDates] = useState(false);
   const [graph, setGraph] = useState<GraphResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [nodeId, setNodeId] = useState<string | null>(null);
-  const [sizeMode, setSizeMode] = useState<NodeSizeMode>('composite');
-  const [repulsionLevel, setRepulsionLevel] = useState<RepulsionLevel>('weak');
+  const [sizeMode, setSizeMode] = useState<NodeSizeMode>(uriState.sizeMode);
+  const [repulsionLevel, setRepulsionLevel] = useState<RepulsionLevel>(uriState.repulsionLevel);
   const [snippets, setSnippets] = useState<Array<{ ref: string; snippet: string; event_time: string; source_display?: string }>>([]);
   const [availableOrgs, setAvailableOrgs] = useState<AdminOrganization[]>([]);
 
@@ -137,6 +193,44 @@ export function GraphMagic(): JSX.Element {
     void fetchGraph();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [orgId, selectedDate]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const params = new URLSearchParams(window.location.search);
+    const nextValues: Record<string, string> = {
+      [GRAPH_MAGIC_QUERY_KEYS.orgId]: orgId,
+      [GRAPH_MAGIC_QUERY_KEYS.startDate]: startDate,
+      [GRAPH_MAGIC_QUERY_KEYS.endDate]: endDate,
+      [GRAPH_MAGIC_QUERY_KEYS.selectedDate]: selectedDate,
+      [GRAPH_MAGIC_QUERY_KEYS.sizeMode]: sizeMode,
+      [GRAPH_MAGIC_QUERY_KEYS.repulsionLevel]: repulsionLevel,
+    };
+
+    Object.entries(nextValues).forEach(([key, value]) => {
+      if (value) {
+        params.set(key, value);
+        return;
+      }
+      params.delete(key);
+    });
+
+    const nextQueryString = params.toString();
+    const nextUri = `${window.location.pathname}${nextQueryString ? `?${nextQueryString}` : ''}${window.location.hash}`;
+    const currentUri = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+
+    if (nextUri !== currentUri) {
+      window.history.replaceState(window.history.state, '', nextUri);
+      console.debug('[Graph Magic] Updated URI selection state', {
+        orgId,
+        startDate,
+        endDate,
+        selectedDate,
+        sizeMode,
+        repulsionLevel,
+      });
+    }
+  }, [orgId, startDate, endDate, selectedDate, sizeMode, repulsionLevel]);
 
   useEffect(() => {
     const fetchSnapshotDates = async (): Promise<void> => {


### PR DESCRIPTION
### Motivation
- Make Graph Magic selections deep-linkable and shareable by embedding UI selection state in the URI so reloads and links preserve the current view.
- Ensure the component initializes to safe, validated values when query params are present to avoid invalid dates or enum values affecting the UI.

### Description
- Added query key constants `gm_org`, `gm_start`, `gm_end`, `gm_selected`, `gm_size`, and `gm_repulsion` and a URI parsing helper `readGraphMagicStateFromUri` in `frontend/src/components/GraphMagic.tsx` to parse and validate six selection values.
- Hydrated initial component state (`orgId`, `startDate`, `endDate`, `selectedDate`, `sizeMode`, `repulsionLevel`) from the parsed URI with date format validation and enum fallbacks.
- Added an effect that syncs those six values back into the URL using `history.replaceState` while preserving other query params and the location hash, and emits debug logs when the URI is updated.
- Kept existing fetch and rebuild behavior unchanged and validated that URI reads/writes are guarded for server-side environments.

### Testing
- Ran the frontend linter with `npm --prefix frontend run lint` and it completed successfully.
- No automated unit tests were added for this change and no browser/UI screenshot tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efaaf325548321b3cd1af6f60f7b70)