### PR TITLE
Bump Qwen model defaults and strings to 3.6

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -38,7 +38,7 @@ PROVIDER_DEFAULT_MODELS: dict[str, dict[str, str]] = {
     "minimax": {"primary": "MiniMax-M2.7", "cheap": "MiniMax-M2.7-highspeed"},
     "openai": {"primary": "gpt-5.5", "cheap": "gpt-5.5-mini"},
     "gemini": {"primary": "gemini-2.5-pro", "cheap": "gemini-2.5-flash"},
-    "qwen": {"primary": "qwen3-coder-plus", "cheap": "qwen3-30b-a3b-instruct-2507"},
+    "qwen": {"primary": "qwen3.6-coder-plus", "cheap": "qwen3.6-30b-a3b-instruct-2507"},
 }
 
 

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -14,7 +14,7 @@ def test_infer_provider_from_model_name() -> None:
     assert _infer_provider_from_model_name("gpt-5.5-mini") == "openai"
     assert _infer_provider_from_model_name("gemini-2.5-flash") == "gemini"
     assert _infer_provider_from_model_name("MiniMax-M2.7-highspeed") == "minimax"
-    assert _infer_provider_from_model_name("qwen3-max") == "qwen"
+    assert _infer_provider_from_model_name("qwen3.6-max") == "qwen"
     assert _infer_provider_from_model_name("qwq-plus") == "qwen"
     assert _infer_provider_from_model_name("some-unknown-model") is None
 

--- a/env.example
+++ b/env.example
@@ -15,7 +15,7 @@ DEFAULT_PRIMARY_MODEL=claude-opus-4-6
 DEFAULT_CHEAP_MODEL=claude-haiku-4-5-20251001
 # Comma-separated allowlist of model names for the org settings UI.
 # Empty = no restriction (free-text input). When set, the frontend shows dropdowns.
-# ALL_MODEL_STRINGS=claude-opus-4-6,claude-haiku-4-5-20251001,gpt-5.5,gpt-5.5-mini,gemini-2.5-pro,gemini-2.5-flash,MiniMax-M2.7,MiniMax-M2.7-highspeed,qwen3-coder-plus,qwen3-30b-a3b-instruct-2507
+# ALL_MODEL_STRINGS=claude-opus-4-6,claude-haiku-4-5-20251001,gpt-5.5,gpt-5.5-mini,gemini-2.5-pro,gemini-2.5-flash,MiniMax-M2.7,MiniMax-M2.7-highspeed,qwen3.6-coder-plus,qwen3.6-30b-a3b-instruct-2507
 
 # LLM provider API keys
 ANTHROPIC_API_KEY=your_anthropic_api_key

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -135,7 +135,7 @@ const MODEL_FAMILY_DEFAULTS: Record<string, { primary: string; fast: string }> =
   minimax: { primary: 'MiniMax-M2.7', fast: 'MiniMax-M2.7-highspeed' },
   openai: { primary: 'gpt-5.5', fast: 'gpt-5.5-mini' },
   gemini: { primary: 'gemini-2.5-pro', fast: 'gemini-2.5-flash' },
-  alibaba: { primary: 'qwen3-coder-plus', fast: 'qwen3-flash' },
+  alibaba: { primary: 'qwen3.6-coder-plus', fast: 'qwen3.6-flash' },
 };
 
 const isFastModelCandidate = (modelName: string): boolean => {


### PR DESCRIPTION
### Motivation
- Upgrade the Qwen model identifiers used across the codebase from 3.x names to the newer `qwen3.6-*` naming to align backend defaults, frontend UI defaults, and documentation.  
- Ensure runtime configuration is kept in sync by reminding to update any environment variables (for example `ALL_MODEL_STRINGS`, any explicit Qwen model env vars, and the `VCAR` env var) to the new `qwen3.6-*` names.

### Description
- Changed the Qwen provider default models in `backend/services/llm_adapter.py` to `{"primary": "qwen3.6-coder-plus", "cheap": "qwen3.6-30b-a3b-instruct-2507"}`.  
- Updated the frontend organization model-family defaults in `frontend/src/components/OrganizationPanel.tsx` to use `qwen3.6-coder-plus` and `qwen3.6-flash`.  
- Updated the example `ALL_MODEL_STRINGS` line in `env.example` to reference `qwen3.6-coder-plus` and `qwen3.6-30b-a3b-instruct-2507`.  
- Adjusted the LLM provider inference unit test in `backend/tests/test_llm_provider.py` to assert on `qwen3.6-max` so tests reflect the new naming.

### Testing
- Ran the unit test file `backend/tests/test_llm_provider.py` with `pytest -q backend/tests/test_llm_provider.py`, and all tests passed (`6 passed`).  
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efdb70f0fc8321bb01766c110b4278)