### PR TITLE
Normalize 'alibaba' LLM provider alias to 'qwen'

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -811,22 +811,27 @@ _PROVIDERS_WITHOUT_DOCUMENT_BLOCKS: frozenset[str] = frozenset({
     "gemini",
     "qwen",
 })
+_PROVIDER_ALIASES: dict[str, str] = {
+    "alibaba": "qwen",
+}
 
 
 def get_adapter(config: LLMConfig) -> AnthropicAdapter | OpenAIAdapter:
     """Create the appropriate adapter for a resolved LLM config."""
-    if config.provider in ("anthropic", "minimax"):
-        base_url: str | None = config.base_url or PROVIDER_BASE_URLS.get(config.provider)
-        supports_docs: bool = config.provider not in _PROVIDERS_WITHOUT_DOCUMENT_BLOCKS
+    provider: str = _PROVIDER_ALIASES.get(config.provider, config.provider)
+
+    if provider in ("anthropic", "minimax"):
+        base_url: str | None = config.base_url or PROVIDER_BASE_URLS.get(provider)
+        supports_docs: bool = provider not in _PROVIDERS_WITHOUT_DOCUMENT_BLOCKS
         return AnthropicAdapter(
             api_key=config.api_key,
             base_url=base_url,
             supports_document_blocks=supports_docs,
         )
 
-    if config.provider in ("openai", "gemini", "qwen"):
-        base_url = config.base_url or PROVIDER_BASE_URLS.get(config.provider)
-        supports_docs: bool = config.provider not in _PROVIDERS_WITHOUT_DOCUMENT_BLOCKS
+    if provider in ("openai", "gemini", "qwen"):
+        base_url = config.base_url or PROVIDER_BASE_URLS.get(provider)
+        supports_docs: bool = provider not in _PROVIDERS_WITHOUT_DOCUMENT_BLOCKS
         return OpenAIAdapter(
             api_key=config.api_key,
             base_url=base_url,

--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -37,6 +37,9 @@ _GLOBAL_PROVIDER_KEYS: dict[str, str | None] = {
 }
 
 _DEFAULT_PROVIDER: LLMProvider = "anthropic"
+_PROVIDER_ALIASES: dict[str, LLMProvider] = {
+    "alibaba": "qwen",
+}
 
 
 async def resolve_llm_config(
@@ -58,7 +61,7 @@ async def resolve_llm_config(
             if org is not None:
                 org_handle = org.handle
                 if org.llm_provider:
-                    provider = org.llm_provider  # type: ignore[assignment]
+                    provider = _normalize_provider(org.llm_provider)
                 if org.llm_primary_model:
                     primary_model = org.llm_primary_model
                 if org.llm_cheap_model:
@@ -133,7 +136,7 @@ async def resolve_api_key_for_provider(
                 provider,
                 exc_info=True,
             )
-    return _resolve_api_key(provider, org_handle)
+    return _resolve_api_key(_normalize_provider(provider), org_handle)
 
 
 async def _load_organization_for_llm(organization_id: str | UUID) -> object | None:
@@ -161,6 +164,15 @@ def _resolve_api_key(provider: LLMProvider, org_handle: str | None) -> str:
 
     logger.error("No API key found for provider %s (org_handle=%s)", provider, org_handle)
     return ""
+
+
+def _normalize_provider(provider: str | LLMProvider) -> LLMProvider:
+    """Normalize provider aliases to canonical provider names."""
+    normalized: str = provider.strip().lower()
+    aliased: LLMProvider | None = _PROVIDER_ALIASES.get(normalized)
+    if aliased:
+        return aliased
+    return normalized  # type: ignore[return-value]
 
 
 def _select_compatible_model(
@@ -268,7 +280,7 @@ def _parse_model_map() -> dict[str, str]:
             continue
         if ":" in entry:
             model, provider = entry.rsplit(":", 1)
-            result[model.strip()] = provider.strip()
+            result[model.strip()] = _normalize_provider(provider.strip())
         else:
             result[entry] = ""
     return result

--- a/backend/tests/test_llm_adapter_provider_alias.py
+++ b/backend/tests/test_llm_adapter_provider_alias.py
@@ -1,0 +1,15 @@
+from services.llm_adapter import LLMConfig, OpenAIAdapter, get_adapter
+
+
+def test_get_adapter_supports_alibaba_provider_alias() -> None:
+    config = LLMConfig(
+        provider="alibaba",  # type: ignore[arg-type]
+        primary_model="qwen3.6-plus",
+        cheap_model="qwen3-30b-a3b-instruct-2507",
+        workflow_model="qwen3.6-plus",
+        api_key="test-key",
+    )
+
+    adapter = get_adapter(config)
+
+    assert isinstance(adapter, OpenAIAdapter)

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -19,6 +19,14 @@ def test_infer_provider_from_model_name() -> None:
     assert _infer_provider_from_model_name("some-unknown-model") is None
 
 
+def test_provider_for_model_normalizes_alibaba_alias(monkeypatch) -> None:
+    from services import llm_provider
+
+    monkeypatch.setattr(llm_provider.settings, "ALL_MODEL_STRINGS", "qwen3-max:alibaba")
+
+    assert provider_for_model("qwen3-max") == "qwen"
+
+
 def test_resolve_llm_config_uses_provider_defaults_for_mismatched_global_models(monkeypatch) -> None:
     from services import llm_provider
 
@@ -33,6 +41,34 @@ def test_resolve_llm_config_uses_provider_defaults_for_mismatched_global_models(
     assert config.provider == "openai"
     assert config.primary_model == "gpt-5.5"
     assert config.cheap_model == "gpt-5.5-mini"
+
+
+def test_resolve_llm_config_normalizes_alibaba_provider_alias(monkeypatch) -> None:
+    from services import llm_provider
+
+    monkeypatch.setattr(llm_provider, "_DEFAULT_PROVIDER", "anthropic")
+    monkeypatch.setitem(llm_provider._GLOBAL_PROVIDER_KEYS, "qwen", "test-qwen-key")
+    monkeypatch.setattr(llm_provider.settings, "DEFAULT_PRIMARY_MODEL", "")
+    monkeypatch.setattr(llm_provider.settings, "DEFAULT_CHEAP_MODEL", "")
+    monkeypatch.setattr(llm_provider.settings, "ALL_MODEL_STRINGS", "")
+
+    class _Org:
+        handle = "acme"
+        llm_provider = "alibaba"
+        llm_primary_model = None
+        llm_cheap_model = None
+        llm_workflow_model = None
+
+    async def _fake_load_org(_organization_id):
+        return _Org()
+
+    monkeypatch.setattr(llm_provider, "_load_organization_for_llm", _fake_load_org)
+
+    config = asyncio.run(resolve_llm_config("00000000-0000-0000-0000-000000000001"))
+
+    assert config.provider == "qwen"
+    assert config.primary_model == "qwen3.6-plus"
+    assert config.cheap_model == "qwen3-30b-a3b-instruct-2507"
 
 
 def test_resolve_llm_config_logs_when_model_fallback_engaged(monkeypatch, caplog) -> None:


### PR DESCRIPTION
### Motivation
- Fix runtime error `Unsupported LLM provider: alibaba` by recognizing that Alibaba-hosted Qwen models use the `alibaba` provider alias and should behave like `qwen` at runtime.

### Description
- Add `_PROVIDER_ALIASES` and `_normalize_provider` in `backend/services/llm_provider.py` and use it when resolving `org.llm_provider` and when resolving provider API keys so `alibaba` maps to `qwen`.
- Normalize provider values parsed from `ALL_MODEL_STRINGS` so entries like `model:alibaba` map to the canonical `qwen` provider in the model-provider map.
- Add `_PROVIDER_ALIASES` handling in `backend/services/llm_adapter.py` and normalize the provider before selecting `AnthropicAdapter` vs `OpenAIAdapter` so a direct `LLMConfig(provider="alibaba")` returns the OpenAI-compatible Qwen adapter.
- Add regression tests in `backend/tests/test_llm_provider.py` and new `backend/tests/test_llm_adapter_provider_alias.py` to cover allowlist alias parsing, org-level alias normalization, and adapter-factory alias support.

### Testing
- Ran `cd backend && pytest -q tests/test_llm_provider.py tests/test_llm_adapter_provider_alias.py` and received `9 passed` (all tests succeeded).
- The new tests exercise `provider_for_model`, `resolve_llm_config`, and `get_adapter` code paths to validate alias normalization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efea3448b08321a111f7734616c565)