### PR TITLE
Add Fireflies GraphQL request diagnostics and better sync error logging

### DIFF
--- a/backend/connectors/fireflies.py
+++ b/backend/connectors/fireflies.py
@@ -10,6 +10,7 @@ Responsibilities:
 """
 
 import logging
+import time
 import uuid
 from datetime import datetime, timedelta
 from typing import Any, Optional
@@ -63,19 +64,63 @@ class FirefliesConnector(BaseConnector):
         if variables:
             payload["variables"] = variables
 
+        started_at = time.monotonic()
+        op_name = "unknown"
+        if "query " in query:
+            try:
+                op_name = query.split("query ", 1)[1].split("(", 1)[0].strip() or "unknown"
+            except Exception:
+                op_name = "unknown"
+
+        logger.debug(
+            "Fireflies GraphQL request start org=%s user=%s op=%s timeout_seconds=30 variables_keys=%s",
+            self.organization_id,
+            self.user_id,
+            op_name,
+            list(variables.keys()) if variables else [],
+        )
         async with httpx.AsyncClient() as client:
-            response = await client.post(
-                FIREFLIES_API_BASE,
-                headers=headers,
-                json=payload,
-                timeout=30.0,
-            )
-            response.raise_for_status()
-            data: dict[str, Any] = response.json()
+            try:
+                response = await client.post(
+                    FIREFLIES_API_BASE,
+                    headers=headers,
+                    json=payload,
+                    timeout=30.0,
+                )
+                elapsed_ms = int((time.monotonic() - started_at) * 1000)
+                logger.debug(
+                    "Fireflies GraphQL response received org=%s user=%s op=%s status=%s elapsed_ms=%s request_id=%s",
+                    self.organization_id,
+                    self.user_id,
+                    op_name,
+                    response.status_code,
+                    elapsed_ms,
+                    response.headers.get("x-request-id") or response.headers.get("cf-ray"),
+                )
+                response.raise_for_status()
+                data: dict[str, Any] = response.json()
+            except Exception:
+                elapsed_ms = int((time.monotonic() - started_at) * 1000)
+                logger.exception(
+                    "Fireflies GraphQL request failed org=%s user=%s op=%s elapsed_ms=%s timeout_seconds=30",
+                    self.organization_id,
+                    self.user_id,
+                    op_name,
+                    elapsed_ms,
+                )
+                raise
 
             if "errors" in data:
                 errors = data["errors"]
                 error_msg = errors[0].get("message", "Unknown GraphQL error") if errors else "Unknown error"
+                logger.warning(
+                    "Fireflies GraphQL returned errors org=%s user=%s op=%s errors_count=%s first_error=%s",
+                    self.organization_id,
+                    self.user_id,
+                    op_name,
+                    len(errors),
+                    error_msg,
+                )
                 raise ValueError(f"Fireflies API error: {error_msg}")
 
             return data.get("data", {})

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -289,16 +289,19 @@ async def _sync_integration(
 
     except Exception as e:
         error_msg = str(e)
+        if not error_msg:
+            error_msg = f"{type(e).__name__} args={getattr(e, 'args', ())!r}"
         failure_case, log_level = _classify_sync_failure(error_msg)
         logger.debug(
             "Connector sync failure diagnostics provider=%s org=%s user=%s sync_since_override=%s "
-            "connector_initialized=%s error_type=%s",
+            "connector_initialized=%s error_type=%s error_repr=%r",
             provider,
             organization_id,
             user_id,
             sync_since_dt.isoformat() if sync_since_dt else None,
             connector is not None,
             type(e).__name__,
+            e,
         )
         logger.log(
             log_level,


### PR DESCRIPTION
### Motivation
- Fireflies connector was failing with a recurring ~30s pattern that matches the request timeout in the GraphQL client, so richer diagnostics are required to distinguish timeout/transport/HTTP/GraphQL issues.

### Description
- Add detailed timing and contextual logging to `FirefliesConnector._graphql_request`: capture `op_name`, `started_at`/`elapsed_ms`, variable keys, HTTP status, and upstream request ids when present, and log request start/response/exception events.
- Log GraphQL `errors[]` metadata (errors count and first message) before raising a `ValueError` so GraphQL-side problems are visible in logs.
- Improve worker-level sync failure diagnostics in `workers.tasks.sync._sync_integration` by providing a fallback `error_msg` when `str(e)` is empty and including the exception `repr` in the debug line.
- These changes are observability-only and do not change retry behavior, timeouts, or data flow.

### Testing
- Compiled modified modules with `python -m compileall backend/connectors/fireflies.py backend/workers/tasks/sync.py` and compilation succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0473943e8832183106373fd77b3d8)