### PR TITLE
Fix detached SQLAlchemy Meeting instance failures in Zoom sync

### DIFF
--- a/backend/connectors/zoom.py
+++ b/backend/connectors/zoom.py
@@ -14,6 +14,9 @@ from datetime import date, datetime, timedelta
 from typing import Any, Optional
 
 import httpx
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.exc import NoInspectionAvailable
+from sqlalchemy.orm.exc import DetachedInstanceError
 
 from connectors.base import BaseConnector
 from connectors.registry import AuthType, Capability, ConnectorMeta, ConnectorScope
@@ -26,6 +29,26 @@ TRANSCRIPT_FILE_TYPES = {"TRANSCRIPT", "VTT"}
 MAX_TRANSCRIPT_LENGTH = 4000
 
 logger = logging.getLogger(__name__)
+
+
+def _safe_meeting_id(meeting_record: Any) -> uuid.UUID:
+    """Extract meeting UUID without triggering lazy loads on detached ORM rows."""
+    try:
+        state = sa_inspect(meeting_record)
+        identity = getattr(state, "identity", None)
+        if identity and identity[0] is not None:
+            return uuid.UUID(str(identity[0]))
+    except NoInspectionAvailable:
+        pass
+
+    raw_id = getattr(getattr(meeting_record, "__dict__", {}), "get", lambda _k: None)("id")
+    if raw_id is not None:
+        return uuid.UUID(str(raw_id))
+
+    try:
+        return uuid.UUID(str(meeting_record.id))
+    except DetachedInstanceError as exc:
+        raise ValueError("Meeting record id is unavailable on detached SQLAlchemy instance") from exc
 
 
 class ZoomConnector(BaseConnector):
@@ -231,9 +254,10 @@ class ZoomConnector(BaseConnector):
                         title=topic,
                         status="completed",
                     )
+                    meeting_record_id: uuid.UUID = _safe_meeting_id(meeting_record)
                     logger.info(
                         "Matched Zoom recording to meeting",
-                        extra={"meeting_id": meeting_record.id, "zoom_meeting_id": meeting_id},
+                        extra={"meeting_id": meeting_record_id, "zoom_meeting_id": meeting_id},
                     )
 
                     for transcript_file in transcript_files:
@@ -286,7 +310,7 @@ class ZoomConnector(BaseConnector):
                                     )
                                     session.add(activity)
 
-                                activity.meeting_id = meeting_record.id
+                                activity.meeting_id = meeting_record_id
                                 activity.type = "zoom_transcript"
                                 activity.subject = topic
                                 activity.description = transcript_text[:MAX_TRANSCRIPT_LENGTH]

--- a/backend/tests/test_zoom_connector.py
+++ b/backend/tests/test_zoom_connector.py
@@ -1,0 +1,53 @@
+import uuid
+
+import pytest
+from sqlalchemy.exc import NoInspectionAvailable
+from sqlalchemy.orm.exc import DetachedInstanceError
+
+from connectors import zoom
+
+
+class _State:
+    def __init__(self, identity):
+        self.identity = identity
+
+
+class _DetachedMeeting:
+    @property
+    def id(self):
+        raise DetachedInstanceError("detached")
+
+
+def test_safe_meeting_id_uses_sqlalchemy_identity(monkeypatch):
+    meeting_id = uuid.uuid4()
+    monkeypatch.setattr(zoom, "sa_inspect", lambda _obj: _State((meeting_id,)))
+
+    result = zoom._safe_meeting_id(_DetachedMeeting())
+
+    assert result == meeting_id
+
+
+def test_safe_meeting_id_uses_dict_fallback(monkeypatch):
+    meeting_id = uuid.uuid4()
+    monkeypatch.setattr(
+        zoom,
+        "sa_inspect",
+        lambda _obj: (_ for _ in ()).throw(NoInspectionAvailable("no inspection")),
+    )
+    obj = type("MeetingLike", (), {})()
+    obj.id = meeting_id
+
+    result = zoom._safe_meeting_id(obj)
+
+    assert result == meeting_id
+
+
+def test_safe_meeting_id_raises_for_detached_without_any_id(monkeypatch):
+    monkeypatch.setattr(
+        zoom,
+        "sa_inspect",
+        lambda _obj: (_ for _ in ()).throw(NoInspectionAvailable("no inspection")),
+    )
+
+    with pytest.raises(ValueError):
+        zoom._safe_meeting_id(_DetachedMeeting())


### PR DESCRIPTION
### Motivation

- Zoom sync could raise SQLAlchemy errors like "Instance <Meeting ...> is not bound to a Session" when accessing `meeting_record.id` on a detached ORM instance, causing connector sync failures and noisy logs.
- The change aims to avoid triggering lazy-refresh attribute access on detached `Meeting` rows so transcript upserts remain reliable and robust.

### Description

- Add a safe extractor ` _safe_meeting_id(meeting_record)` in `backend/connectors/zoom.py` that prefers SQLAlchemy identity metadata and falls back to JSON-dict or attribute access without forcing lazy loads.
- Use the stable `meeting_record_id` extracted by the helper for logging and assign it to `activity.meeting_id` during Zoom transcript upserts.
- Add focused unit tests in `backend/tests/test_zoom_connector.py` covering identity-based extraction, the dict/attribute fallback, and the failure case when no id is available.

### Testing

- Ran the unit tests for the new helper with `pytest -q tests/test_zoom_connector.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0499432fc83219a57923f51cf9732)