### PR TITLE
Improve sync timeout failure classification and logging

### DIFF
--- a/backend/tests/test_sync_failure_logging.py
+++ b/backend/tests/test_sync_failure_logging.py
@@ -33,11 +33,39 @@ class FailingConnector:
         return None
 
 
+class TimeoutFailingConnector:
+    def __init__(
+        self,
+        organization_id: str,
+        user_id: Optional[str] = None,
+        *,
+        sync_since_override: datetime | None = None,
+    ) -> None:
+        self.organization_id = organization_id
+        self.user_id = user_id
+
+    async def sync_all(self) -> dict[str, int]:
+        raise TimeoutError()
+
+    async def mark_sync_started(self) -> None:
+        return None
+
+    async def clear_sync_started(self) -> None:
+        return None
+
+    async def update_last_sync(self, counts: dict[str, int]) -> None:
+        return None
+
+    async def record_error(self, error: str) -> None:
+        return None
+
+
 def test_classify_sync_failure_common_cases() -> None:
     assert sync_tasks._classify_sync_failure("invalid_auth on upstream")[0] == "auth_or_connection_revoked"
     assert sync_tasks._classify_sync_failure("429 Too Many Requests")[0] == "upstream_rate_limited"
     assert sync_tasks._classify_sync_failure("read timeout from upstream")[0] == "upstream_transient_error"
     assert sync_tasks._classify_sync_failure("totally novel failure")[0] == "unexpected_failure"
+    assert sync_tasks._classify_sync_failure("", TimeoutError())[0] == "upstream_transient_error"
 
 
 def test_should_retry_sync_failure_only_for_transient_cases() -> None:
@@ -86,6 +114,39 @@ def test_sync_failure_logging_includes_case_and_context(monkeypatch, caplog) -> 
     assert any(
         "Connector sync failure diagnostics provider=slack" in rec.message
         and "error_type=RuntimeError" in rec.message
+        for rec in caplog.records
+    )
+    assert any(event[0] == "sync.failed" for event in emitted_events)
+
+
+def test_timeout_without_error_message_is_classified_retryable(monkeypatch, caplog) -> None:
+    emitted_events: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def _emit_event(event_type: str, organization_id: str, data: dict[str, Any]) -> None:
+        emitted_events.append((event_type, organization_id, data))
+
+    async def _noop_clear_last_errors(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("workers.events.emit_event", _emit_event)
+    monkeypatch.setattr(sync_tasks, "_clear_last_errors_for_integration", _noop_clear_last_errors)
+    monkeypatch.setattr(
+        "connectors.registry.discover_connectors",
+        lambda: {"fireflies": TimeoutFailingConnector},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        result = asyncio.run(
+            sync_tasks._sync_integration("11111111-1111-1111-1111-111111111111", "fireflies")
+        )
+
+    assert result["status"] == "failed"
+    assert result["failure_case"] == "upstream_transient_error"
+    assert result["error_type"] == "TimeoutError"
+    assert any(
+        "Connector sync failed provider=fireflies" in rec.message
+        and "case=upstream_transient_error" in rec.message
+        and "error_type=TimeoutError" in rec.message
         for rec in caplog.records
     )
     assert any(event[0] == "sync.failed" for event in emitted_events)

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -55,7 +55,10 @@ def _parse_sync_since_iso(iso_str: str | None) -> datetime | None:
     return parsed
 
 
-def _classify_sync_failure(error_message: str) -> tuple[str, int]:
+def _classify_sync_failure(
+    error_message: str,
+    error: BaseException | None = None,
+) -> tuple[str, int]:
     """
     Classify common connector sync failure modes for clearer logging.
 
@@ -63,6 +66,14 @@ def _classify_sync_failure(error_message: str) -> tuple[str, int]:
         Tuple of (failure_case, suggested_log_level)
     """
     normalized = error_message.lower()
+    if error is not None:
+        error_type_name = type(error).__name__.lower()
+        if (
+            isinstance(error, TimeoutError)
+            or "timeout" in error_type_name
+            or "timedout" in error_type_name
+        ):
+            return ("upstream_transient_error", logging.WARNING)
     if any(
         snippet in normalized
         for snippet in (
@@ -289,24 +300,27 @@ async def _sync_integration(
 
     except Exception as e:
         error_msg = str(e)
-        failure_case, log_level = _classify_sync_failure(error_msg)
+        failure_case, log_level = _classify_sync_failure(error_msg, e)
+        error_type = type(e).__name__
         logger.debug(
             "Connector sync failure diagnostics provider=%s org=%s user=%s sync_since_override=%s "
-            "connector_initialized=%s error_type=%s",
+            "connector_initialized=%s error_type=%s error_repr=%r",
             provider,
             organization_id,
             user_id,
             sync_since_dt.isoformat() if sync_since_dt else None,
             connector is not None,
-            type(e).__name__,
+            error_type,
+            e,
         )
         logger.log(
             log_level,
-            "Connector sync failed provider=%s org=%s user=%s case=%s error=%s",
+            "Connector sync failed provider=%s org=%s user=%s case=%s error_type=%s error=%s",
             provider,
             organization_id,
             user_id,
             failure_case,
+            error_type,
             error_msg,
             exc_info=True,
         )
@@ -339,6 +353,8 @@ async def _sync_integration(
             "organization_id": organization_id,
             "provider": provider,
             "error": error_msg,
+            "failure_case": failure_case,
+            "error_type": error_type,
         }
 
 
@@ -466,7 +482,9 @@ def sync_integration(
     )
     if result.get("status") == "failed":
         error_message: str = str(result.get("error") or "")
-        failure_case, _ = _classify_sync_failure(error_message)
+        failure_case: str = str(result.get("failure_case") or "")
+        if not failure_case:
+            failure_case, _ = _classify_sync_failure(error_message)
         retries_so_far: int = int(getattr(self.request, "retries", 0) or 0)
         if _should_retry_sync_failure(failure_case):
             delay_seconds = _compute_sync_retry_delay_seconds(retries_so_far)


### PR DESCRIPTION
### Motivation
- Timeout exceptions were being classified solely by message text, which meant blank or non-descriptive timeout exceptions were labeled `unexpected_failure` instead of retryable transient errors. 
- Logs produced `error=` with empty values making postmortem debugging harder without including the exception type or repr. 

### Description
- Extend `_classify_sync_failure` to accept an optional `error` argument and detect timeout exceptions by `isinstance(error, TimeoutError)` or by inspecting the exception type name, classifying them as `upstream_transient_error` (retryable). 
- Enrich failure diagnostics by logging `error_type` and the exception representation in the debug diagnostic line and by including `error_type` in the main failure log message. 
- Return `failure_case` and `error_type` from `_sync_integration` on failure and update `sync_integration` to prefer the authoritative `failure_case` from the result before falling back to message-only classification. 
- Add tests in `backend/tests/test_sync_failure_logging.py` to verify classification from exception type and that timeout failures with empty error messages are treated as retryable and logged with `error_type`. 

### Testing
- Ran `pytest -q backend/tests/test_sync_failure_logging.py` and all tests passed (`5 passed, 2 warnings`). 
- Verified logs include `error_type` and `case` entries and that timeout cases produce `failure_case == "upstream_transient_error"` and `error_type == "TimeoutError"` in the task result.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f049b6f0d883219ecf84e8c49252e5)