### PR TITLE
Improve sync timeout failure logging and classification

### DIFF
--- a/backend/tests/test_sync_failure_logging.py
+++ b/backend/tests/test_sync_failure_logging.py
@@ -37,6 +37,7 @@ def test_classify_sync_failure_common_cases() -> None:
     assert sync_tasks._classify_sync_failure("invalid_auth on upstream")[0] == "auth_or_connection_revoked"
     assert sync_tasks._classify_sync_failure("429 Too Many Requests")[0] == "upstream_rate_limited"
     assert sync_tasks._classify_sync_failure("read timeout from upstream")[0] == "upstream_transient_error"
+    assert sync_tasks._classify_sync_failure("TimeoutError args=()")[0] == "upstream_transient_error"
     assert sync_tasks._classify_sync_failure("totally novel failure")[0] == "unexpected_failure"
 
 
@@ -89,3 +90,64 @@ def test_sync_failure_logging_includes_case_and_context(monkeypatch, caplog) -> 
         for rec in caplog.records
     )
     assert any(event[0] == "sync.failed" for event in emitted_events)
+
+
+class EmptyTimeoutConnector:
+    def __init__(
+        self,
+        organization_id: str,
+        user_id: Optional[str] = None,
+        *,
+        sync_since_override: datetime | None = None,
+    ) -> None:
+        self.organization_id = organization_id
+        self.user_id = user_id
+
+    async def sync_all(self) -> dict[str, int]:
+        raise TimeoutError()
+
+    async def mark_sync_started(self) -> None:
+        return None
+
+    async def clear_sync_started(self) -> None:
+        return None
+
+    async def update_last_sync(self, counts: dict[str, int]) -> None:
+        return None
+
+    async def record_error(self, error: str) -> None:
+        return None
+
+
+def test_empty_timeout_error_is_logged_and_classified_retryable(monkeypatch, caplog) -> None:
+    async def _emit_event(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    async def _noop_clear_last_errors(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("workers.events.emit_event", _emit_event)
+    monkeypatch.setattr(sync_tasks, "_clear_last_errors_for_integration", _noop_clear_last_errors)
+    monkeypatch.setattr(
+        "connectors.registry.discover_connectors",
+        lambda: {"fireflies": EmptyTimeoutConnector},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        result = asyncio.run(
+            sync_tasks._sync_integration("11111111-1111-1111-1111-111111111111", "fireflies")
+        )
+
+    assert result["status"] == "failed"
+    assert result["error"] == "TimeoutError args=()"
+    assert any(
+        "Connector sync raised exception with empty message provider=fireflies" in rec.message
+        and "failure_case=upstream_transient_error" in rec.message
+        and "retryable=True" in rec.message
+        for rec in caplog.records
+    )
+    assert any(
+        "Connector sync failed provider=fireflies" in rec.message
+        and "case=upstream_transient_error" in rec.message
+        for rec in caplog.records
+    )

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -95,6 +95,10 @@ def _classify_sync_failure(error_message: str) -> tuple[str, int]:
         for snippet in (
             "timed out",
             "timeout",
+            "timeouterror",
+            "deadline exceeded",
+            "read timed out",
+            "connect timeout",
             "temporarily unavailable",
             "service unavailable",
             "bad gateway",
@@ -288,13 +292,17 @@ async def _sync_integration(
         }
 
     except Exception as e:
-        error_msg = str(e)
+        raw_error_msg = str(e)
+        error_msg = raw_error_msg.strip()
         if not error_msg:
             error_msg = f"{type(e).__name__} args={getattr(e, 'args', ())!r}"
-        failure_case, log_level = _classify_sync_failure(error_msg)
+        classify_input = f"{type(e).__name__}: {error_msg}"
+        failure_case, log_level = _classify_sync_failure(classify_input)
+        retryable = _should_retry_sync_failure(failure_case)
         logger.debug(
             "Connector sync failure diagnostics provider=%s org=%s user=%s sync_since_override=%s "
-            "connector_initialized=%s error_type=%s error_repr=%r",
+            "connector_initialized=%s error_type=%s error_repr=%r raw_error=%r "
+            "normalized_error=%s failure_case=%s retryable=%s",
             provider,
             organization_id,
             user_id,
@@ -302,7 +310,23 @@ async def _sync_integration(
             connector is not None,
             type(e).__name__,
             e,
+            raw_error_msg,
+            error_msg,
+            failure_case,
+            retryable,
         )
+        if not raw_error_msg.strip():
+            logger.warning(
+                "Connector sync raised exception with empty message provider=%s org=%s user=%s "
+                "error_type=%s synthesized_error=%s failure_case=%s retryable=%s",
+                provider,
+                organization_id,
+                user_id,
+                type(e).__name__,
+                error_msg,
+                failure_case,
+                retryable,
+            )
         logger.log(
             log_level,
             "Connector sync failed provider=%s org=%s user=%s case=%s error=%s",


### PR DESCRIPTION
### Motivation
- Timeout and deadline-style connector errors were sometimes classified as `unexpected_failure` and not retried, producing unhelpful blank `error=` logs in failure records.
- Make transient upstream timeouts reliably retryable and surface richer diagnostics to aid debugging.

### Description
- Expand `_classify_sync_failure` to recognize additional timeout/deadline variants (e.g., `timeouterror`, `deadline exceeded`, `read timed out`, `connect timeout`) and map them to `upstream_transient_error` so they are treated as retryable. (changed in `backend/workers/tasks/sync.py`)
- Normalize exception handling in `_sync_integration` by stripping the raw exception message, synthesizing a fallback (`TypeName args=()`) when empty, and classifying based on `ExceptionType: message` to improve detection. (changed in `backend/workers/tasks/sync.py`)
- Log richer diagnostics including the raw error, normalized error, `failure_case`, and whether the failure is `retryable`, and emit a dedicated warning when the original exception message is empty to avoid blank `error=` entries. (changed in `backend/workers/tasks/sync.py`)
- Add tests covering timeout classification and the empty-message `TimeoutError` behavior to ensure the transient/retryable path and logs are produced. (added to `backend/tests/test_sync_failure_logging.py`)

### Testing
- Ran `pytest -q backend/tests/test_sync_failure_logging.py` and all tests passed: `5 passed, 2 warnings`.
- The new tests assert that `TimeoutError args=()` is classified as `upstream_transient_error` and that an empty-message `TimeoutError` produces the synthesized error text and retryable/transient logging entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f04abf7f5c8321bd0842a9d62288e4)