### PR TITLE
Allow popups from sandboxed app iframe

### DIFF
--- a/frontend/src/components/apps/SandpackAppRenderer.tsx
+++ b/frontend/src/components/apps/SandpackAppRenderer.tsx
@@ -7,7 +7,8 @@
  * 3. SDK + Plot shim inlined (no module bundler needed)
  * 4. Basebase's code has imports stripped (everything is already in scope)
  *
- * The iframe uses sandbox="allow-scripts" for security isolation.
+ * The iframe uses a restrictive sandbox while allowing popups so app links
+ * with target="_blank" / window.open() can open in a new tab.
  */
 
 import { useEffect, useState, useCallback, useRef } from "react";
@@ -424,7 +425,7 @@ export function SandpackAppRenderer({
       <iframe
         ref={iframeRef}
         srcDoc={srcdoc}
-        sandbox="allow-scripts allow-same-origin"
+        sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
         style={{
           width: "100%",
           height: "100%",


### PR DESCRIPTION
### Motivation
- App links using `target="_blank"` and `window.open()` were blocked by the iframe sandbox and need to open in a new tab. 
- Change should enable popup behavior while preserving script and same-origin sandbox protections.

### Description
- Update `frontend/src/components/apps/SandpackAppRenderer.tsx` header comment to document popup behavior intent. 
- Add `allow-popups` and `allow-popups-to-escape-sandbox` to the iframe `sandbox` attribute while keeping `allow-scripts` and `allow-same-origin`.

### Testing
- Ran `npm run build` from `frontend/` and the build completed successfully. 
- The build emitted chunk-size/dynamic-import warnings but no errors, and the updated component compiled into the production bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0e53de0088321ba6279c9401d318b)