### PR TITLE
Slack: accept aliases and default 'since' for fetch_channel_history

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -183,20 +183,23 @@ def _parse_since_iso_to_utc_timestamp(raw: str) -> float:
     """Parse ISO 8601 or Unix timestamp strings to a UTC Unix timestamp for Slack ``oldest``."""
     s: str = raw.strip()
 
-    # Slack ``oldest`` commonly arrives as a Unix ts string like "1711405920.999999".
+    # Prefer ISO parsing first to preserve valid basic-date inputs like "20250101".
+    iso_candidate: str = s[:-1] + "+00:00" if s.endswith("Z") else s
+    dt: datetime | None = None
     try:
-        return float(s)
+        dt = datetime.fromisoformat(iso_candidate)
     except ValueError:
         pass
 
-    if s.endswith("Z"):
-        s = s[:-1] + "+00:00"
-    dt: datetime = datetime.fromisoformat(s)
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    else:
-        dt = dt.astimezone(timezone.utc)
-    return dt.timestamp()
+    if dt is not None:
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return dt.timestamp()
+
+    # Slack ``oldest`` commonly arrives as a Unix ts string like "1711405920.999999".
+    return float(s)
 
 
 class SlackConnector(BaseConnector):

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -180,8 +180,15 @@ logger = logging.getLogger(__name__)
 
 
 def _parse_since_iso_to_utc_timestamp(raw: str) -> float:
-    """Parse an ISO 8601 datetime string to a UTC Unix timestamp for Slack ``oldest``."""
+    """Parse ISO 8601 or Unix timestamp strings to a UTC Unix timestamp for Slack ``oldest``."""
     s: str = raw.strip()
+
+    # Slack ``oldest`` commonly arrives as a Unix ts string like "1711405920.999999".
+    try:
+        return float(s)
+    except ValueError:
+        pass
+
     if s.endswith("Z"):
         s = s[:-1] + "+00:00"
     dt: datetime = datetime.fromisoformat(s)

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -1524,9 +1524,15 @@ Returns normalized messages for one channel since a cutoff (does not write to th
             )
             since_val: Any = None
             for key in ("since", "since_iso", "start_time", "oldest"):
-                if key in params and params.get(key) is not None:
-                    since_val = params.get(key)
-                    break
+                if key not in params:
+                    continue
+                candidate_since_val: Any = params.get(key)
+                if candidate_since_val is None:
+                    continue
+                if isinstance(candidate_since_val, str) and not candidate_since_val.strip():
+                    continue
+                since_val = candidate_since_val
+                break
             if not ch or not str(ch).strip():
                 logger.error(
                     "[slack] fetch_channel_history missing channel params_keys=%s",

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -14,7 +14,7 @@ import base64
 import logging
 import re
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 from urllib.parse import urlparse
 
@@ -1515,7 +1515,12 @@ Returns normalized messages for one channel since a cutoff (does not write to th
                 or params.get("channel_id")
                 or params.get("channelId")
             )
-            since_val: str | None = params.get("since")
+            since_val: str | None = (
+                params.get("since")
+                or params.get("since_iso")
+                or params.get("start_time")
+                or params.get("oldest")
+            )
             if not ch or not str(ch).strip():
                 logger.error(
                     "[slack] fetch_channel_history missing channel params_keys=%s",
@@ -1523,12 +1528,14 @@ Returns normalized messages for one channel since a cutoff (does not write to th
                 )
                 raise ValueError("fetch_channel_history requires 'channel' (or 'channel_id')")
             if not since_val or not str(since_val).strip():
-                logger.error(
-                    "[slack] fetch_channel_history missing since channel=%s params_keys=%s",
+                default_since: str = (datetime.now(timezone.utc) - timedelta(days=7)).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+                logger.warning(
+                    "[slack] fetch_channel_history missing since; defaulting to last 7 days channel=%s params_keys=%s default_since=%s",
                     ch,
                     sorted(params.keys()),
+                    default_since,
                 )
-                raise ValueError("fetch_channel_history requires 'since' (ISO 8601 datetime)")
+                since_val = default_since
             limit_raw: Any = params.get("limit", 1000)
             limit_val: int = int(limit_raw) if limit_raw is not None else 1000
             logger.info(

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -1522,19 +1522,18 @@ Returns normalized messages for one channel since a cutoff (does not write to th
                 or params.get("channel_id")
                 or params.get("channelId")
             )
-            since_val: str | None = (
-                params.get("since")
-                or params.get("since_iso")
-                or params.get("start_time")
-                or params.get("oldest")
-            )
+            since_val: Any = None
+            for key in ("since", "since_iso", "start_time", "oldest"):
+                if key in params and params.get(key) is not None:
+                    since_val = params.get(key)
+                    break
             if not ch or not str(ch).strip():
                 logger.error(
                     "[slack] fetch_channel_history missing channel params_keys=%s",
                     sorted(params.keys()),
                 )
                 raise ValueError("fetch_channel_history requires 'channel' (or 'channel_id')")
-            if not since_val or not str(since_val).strip():
+            if since_val is None or not str(since_val).strip():
                 default_since: str = (datetime.now(timezone.utc) - timedelta(days=7)).replace(microsecond=0).isoformat().replace("+00:00", "Z")
                 logger.warning(
                     "[slack] fetch_channel_history missing since; defaulting to last 7 days channel=%s params_keys=%s default_since=%s",

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -264,6 +264,55 @@ def test_execute_action_fetch_channel_history_accepts_channel_id_alias(monkeypat
     )
 
     assert result["ok"] is True
+
+def test_execute_action_fetch_channel_history_accepts_since_alias(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    async def _fake_fetch(channel: str, since: str, *, limit: int = 1000) -> dict[str, object]:
+        assert channel == "C123"
+        assert since == "2025-01-01T00:00:00Z"
+        assert limit == 1000
+        return {"ok": True, "count": 0, "messages": []}
+
+    monkeypatch.setattr(connector, "fetch_channel_history", _fake_fetch)
+
+    result = asyncio.run(
+        connector.execute_action(
+            "fetch_channel_history",
+            {
+                "channel": "C123",
+                "since_iso": "2025-01-01T00:00:00Z",
+            },
+        )
+    )
+
+    assert result["ok"] is True
+
+
+def test_execute_action_fetch_channel_history_defaults_since_when_missing(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    async def _fake_fetch(channel: str, since: str, *, limit: int = 1000) -> dict[str, object]:
+        assert channel == "C123"
+        parsed = datetime.fromisoformat(since.replace("Z", "+00:00"))
+        delta = datetime.now(timezone.utc) - parsed
+        assert timedelta(days=6) <= delta <= timedelta(days=8)
+        assert limit == 1000
+        return {"ok": True, "count": 0, "messages": []}
+
+    monkeypatch.setattr(connector, "fetch_channel_history", _fake_fetch)
+
+    result = asyncio.run(
+        connector.execute_action(
+            "fetch_channel_history",
+            {
+                "channel": "C123",
+            },
+        )
+    )
+
+    assert result["ok"] is True
+
 
 def test_execute_action_send_message_accepts_legacy_message_param(monkeypatch) -> None:
     connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -324,6 +324,31 @@ def test_execute_action_fetch_channel_history_accepts_since_alias(monkeypatch) -
     assert result["ok"] is True
 
 
+def test_execute_action_fetch_channel_history_skips_blank_since_uses_alias(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    async def _fake_fetch(channel: str, since: str, *, limit: int = 1000) -> dict[str, object]:
+        assert channel == "C123"
+        assert since == "2025-01-02T00:00:00Z"
+        assert limit == 1000
+        return {"ok": True, "count": 0, "messages": []}
+
+    monkeypatch.setattr(connector, "fetch_channel_history", _fake_fetch)
+
+    result = asyncio.run(
+        connector.execute_action(
+            "fetch_channel_history",
+            {
+                "channel": "C123",
+                "since": "   ",
+                "since_iso": "2025-01-02T00:00:00Z",
+            },
+        )
+    )
+
+    assert result["ok"] is True
+
+
 def test_execute_action_fetch_channel_history_defaults_since_when_missing(monkeypatch) -> None:
     connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
 

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -349,6 +349,30 @@ def test_execute_action_fetch_channel_history_defaults_since_when_missing(monkey
     assert result["ok"] is True
 
 
+def test_execute_action_fetch_channel_history_preserves_oldest_zero(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    async def _fake_fetch(channel: str, since: str, *, limit: int = 1000) -> dict[str, object]:
+        assert channel == "C123"
+        assert since == "0"
+        assert limit == 1000
+        return {"ok": True, "count": 0, "messages": []}
+
+    monkeypatch.setattr(connector, "fetch_channel_history", _fake_fetch)
+
+    result = asyncio.run(
+        connector.execute_action(
+            "fetch_channel_history",
+            {
+                "channel": "C123",
+                "oldest": 0,
+            },
+        )
+    )
+
+    assert result["ok"] is True
+
+
 def test_execute_action_send_message_accepts_legacy_message_param(monkeypatch) -> None:
     connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
     captured: dict[str, str] = {}

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -64,6 +64,38 @@ def test_fetch_channel_history_accepts_unix_timestamp_since(monkeypatch) -> None
         "latest": None,
         "inclusive": False,
     }
+
+
+def test_fetch_channel_history_prefers_iso_basic_date_over_unix_seconds(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    captured: dict[str, object] = {}
+
+    async def _fake_get_channel_messages(
+        channel_id: str,
+        oldest: float | None = None,
+        limit: int = 100,
+        latest: str | None = None,
+        inclusive: bool = False,
+    ) -> list[dict[str, object]]:
+        captured["channel_id"] = channel_id
+        captured["oldest"] = oldest
+        captured["limit"] = limit
+        captured["latest"] = latest
+        captured["inclusive"] = inclusive
+        return []
+
+    monkeypatch.setattr(connector, "get_channel_messages", _fake_get_channel_messages)
+
+    result = asyncio.run(connector.fetch_channel_history("C123", "20250101", limit=20))
+
+    assert result["ok"] is True
+    assert captured["channel_id"] == "C123"
+    assert captured["limit"] == 20
+    assert captured["latest"] is None
+    assert captured["inclusive"] is False
+    assert captured["oldest"] == pytest.approx(1735689600.0)
+
 def test_execute_action_fetch_channel_history_returns_normalized_messages(monkeypatch) -> None:
     connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
 

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -29,6 +29,41 @@ def test_execute_action_send_message_can_initiate_dm_with_user_id(monkeypatch) -
     assert captured == {"slack_user_id": "U123", "text": "Hi from Basebase"}
 
 
+
+
+def test_fetch_channel_history_accepts_unix_timestamp_since(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    captured: dict[str, object] = {}
+
+    async def _fake_get_channel_messages(
+        channel_id: str,
+        oldest: float | None = None,
+        limit: int = 100,
+        latest: str | None = None,
+        inclusive: bool = False,
+    ) -> list[dict[str, object]]:
+        captured["channel_id"] = channel_id
+        captured["oldest"] = oldest
+        captured["limit"] = limit
+        captured["latest"] = latest
+        captured["inclusive"] = inclusive
+        return []
+
+    monkeypatch.setattr(connector, "get_channel_messages", _fake_get_channel_messages)
+
+    result = asyncio.run(
+        connector.fetch_channel_history("C123", "1711405920.999999", limit=20)
+    )
+
+    assert result["ok"] is True
+    assert captured == {
+        "channel_id": "C123",
+        "oldest": 1711405920.999999,
+        "limit": 20,
+        "latest": None,
+        "inclusive": False,
+    }
 def test_execute_action_fetch_channel_history_returns_normalized_messages(monkeypatch) -> None:
     connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
 


### PR DESCRIPTION
### Motivation

- Calling the Slack action `fetch_channel_history` failed when callers omitted the `since` parameter or used alternate keys, causing hard errors and brittle integrations.

### Description

- Updated `SlackConnector.execute_action` to accept common alias keys `since_iso`, `start_time`, and `oldest` in addition to `since` when handling the `fetch_channel_history` action.
- When no cutoff is provided the code now defaults to an ISO8601 timestamp for the last 7 days and emits a warning log with context instead of raising an error.
- Preserved existing channel validation and limit handling and forwarded the resolved `since` string into `fetch_channel_history` unchanged.
- Changes made in `backend/connectors/slack.py` and added tests in `backend/tests/test_slack_connector_actions.py`.

### Testing

- Added `test_execute_action_fetch_channel_history_accepts_since_alias` which verifies alias forwarding, and `test_execute_action_fetch_channel_history_defaults_since_when_missing` which verifies defaulting to ~7 days ago. 
- Ran `pytest -q backend/tests/test_slack_connector_actions.py` and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c6c8a94083219750f8ae8274073b)