### PR TITLE
Show "You" badge on current user's team list row (BAS-569)

### DIFF
--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -1064,6 +1064,14 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                                   <span className="font-medium text-surface-100 truncate">
                                     {displayName}
                                   </span>
+                                  {member.id === currentUser.id && (
+                                    <span
+                                      aria-label="You"
+                                      className="px-2 py-0.5 text-xs font-medium bg-surface-700 text-surface-200 rounded-full"
+                                    >
+                                      You
+                                    </span>
+                                  )}
                                   {isAdmin && (
                                     <span className="px-2 py-0.5 text-xs font-medium bg-primary-500/20 text-primary-400 rounded-full">
                                       admin


### PR DESCRIPTION
## Summary
- Add a small "You" pill next to the current user's name in the team list (Organization Panel) so the logged-in user can spot themselves at a glance.
- Styled to match the existing `admin` / `guest` pills (surface-700 background, rounded-full, same sizing).
- Uses `member.id === currentUser.id` for the comparison, matching the existing "is this me?" checks elsewhere in the file. (The Linear ticket suggested email comparison — ID is stricter and consistent with existing patterns; happy to switch if you prefer.)
- Pill includes `aria-label="You"` for screen readers.

Linear: BAS-569

## Test plan
- [ ] Open the Organization Panel team list. Confirm a "You" pill appears next to your own row and no others.
- [ ] Confirm the pill appears alongside `admin` / `guest` pills when applicable, without breaking layout on narrow widths.
- [ ] Invited (pending) rows are unaffected — the current user can't be in invited state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)