### PR TITLE
Make auth screen scrollable on small viewports (BAS-604)

### DIFF
--- a/frontend/src/components/Auth.tsx
+++ b/frontend/src/components/Auth.tsx
@@ -186,13 +186,14 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4">
+    <div className="h-full overflow-y-auto">
       {/* Background effects */}
       <div className="fixed inset-0 overflow-hidden pointer-events-none">
         <div className="absolute -top-1/2 -right-1/4 w-[800px] h-[800px] rounded-full bg-gradient-to-br from-primary-600/20 to-transparent blur-3xl" />
         <div className="absolute -bottom-1/4 -left-1/4 w-[600px] h-[600px] rounded-full bg-gradient-to-tr from-emerald-600/10 to-transparent blur-3xl" />
       </div>
 
+      <div className="min-h-full flex items-center justify-center p-4">
       <div className="relative z-10 w-full max-w-md">
         {/* Back button */}
         <button
@@ -509,6 +510,7 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
             )}
           </p>
         </div>
+      </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Global CSS in `frontend/src/index.css` locks `html` / `body` / `#root` to `overflow-hidden` (chat-app shell pattern — every pane manages its own scroll). `Auth.tsx` didn't, so on viewports shorter than the form (mobile, zoomed-in desktop) the `min-h-screen flex items-center` wrapper clamped content to the viewport and bled the top/bottom — including the submit button — off-screen with no way to scroll.
- Fix: wrap the centering layer in `h-full overflow-y-auto` and swap `min-h-screen` → `min-h-full` on the inner wrapper. Short forms still center; tall forms grow past the viewport and the outer scrolls.
- Diff is intentionally minimal — children of the new wrapper are not re-indented to keep the change reviewable.

Linear: BAS-604

## Test plan
- [ ] Open the auth screen on a tall viewport — form is vertically centered as before.
- [ ] Resize the browser short (e.g. ~500px tall) — page becomes scrollable, "Back to home" reachable at top, "Sign Up" CTA reachable at bottom.
- [ ] Repeat on mobile / zoomed-in desktop / with browser dev tools narrow viewport.
- [ ] Verify both signin and signup modes (toggle at the bottom) and the invite-context layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)