### PR TITLE
Fix provider switching for cross-family workflow models

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1192,25 +1192,26 @@ class ChatOrchestrator:
             if is_workflow_run and workflow_model_override
             else (self._llm_config.workflow_model if is_workflow_run else self._llm_config.primary_model)
         )
-        if is_workflow_run and workflow_model_override:
-            override_provider = provider_for_model(selected_model)
-            if override_provider and override_provider != self._llm_config.provider:
+        if is_workflow_run:
+            selected_model_provider = provider_for_model(selected_model)
+            if selected_model_provider and selected_model_provider != self._llm_config.provider:
                 previous_provider = self._llm_config.provider
                 override_api_key = await resolve_api_key_for_provider(
-                    override_provider, self.organization_id
+                    selected_model_provider, self.organization_id
                 )
                 self._llm_config = replace(
                     self._llm_config,
-                    provider=override_provider,  # type: ignore[arg-type]
+                    provider=selected_model_provider,  # type: ignore[arg-type]
                     api_key=override_api_key,
                     base_url=None,
                 )
                 logger.info(
-                    "[Orchestrator] Switching provider for workflow model override conversation_id=%s previous_provider=%s override_provider=%s selected_model=%s",
+                    "[Orchestrator] Switching provider for workflow-selected model conversation_id=%s previous_provider=%s selected_provider=%s selected_model=%s workflow_model_override=%s",
                     self.conversation_id,
                     previous_provider,
-                    override_provider,
+                    selected_model_provider,
                     selected_model,
+                    workflow_model_override,
                 )
         self._adapter = get_adapter(self._llm_config)
 


### PR DESCRIPTION
### Motivation
- Workflows can fail with 404 model-not-found errors when the selected workflow model belongs to a different provider family than the organization's default (e.g., org default Anthropic but workflow selects an OpenAI model). 

### Description
- Update `ChatOrchestrator` to infer the provider from the selected workflow model for any workflow run (not only when `workflow_model_override` is explicitly present). 
- Resolve an API key for the inferred provider via `resolve_api_key_for_provider` and replace the LLM config provider/api key and reset `base_url` before building the adapter. 
- Improve logging to include the selected provider, selected model, and whether a per-workflow override was present. 
- Preserve adapter construction via `get_adapter(self._llm_config)` after any provider switch.

### Testing
- Ran `pytest -q backend/tests/test_llm_provider.py backend/tests/test_orchestrator_identity.py` and both tests passed. 
- Test summary: `10 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c78395288321868278993a14a230)