### PR TITLE
Mention Gemini meeting notes in Google Drive connector copy (BAS-456)

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -2869,7 +2869,7 @@ async def get_available_integrations() -> AvailableIntegrationsResponse:
             {"id": "microsoft_calendar", "name": "Microsoft Calendar", "description": "Outlook calendar events and meetings", "scope": "user"},
             {"id": "microsoft_mail", "name": "Microsoft Mail", "description": "Outlook emails and communications", "scope": "user"},
             {"id": "salesforce", "name": "Salesforce", "description": "CRM - Opportunities, Accounts", "scope": "user"},
-            {"id": "google_drive", "name": "Google Drive", "description": "Sync files from Google Drive — search and read Docs, Sheets, Slides", "scope": "user"},
+            {"id": "google_drive", "name": "Google Drive", "description": "Docs, Sheets, Slides, and Gemini meeting notes from Drive", "scope": "user"},
             {"id": "apollo", "name": "Apollo.io", "description": "Data enrichment - Update contact job titles, companies, emails", "scope": "user"},
             {"id": "github", "name": "GitHub", "description": "Track repos, commits, and pull requests by team", "scope": "user"},
             {"id": "linear", "name": "Linear", "description": "Issue tracking - sync and manage teams, projects, and issues", "scope": "user"},

--- a/backend/connectors/google_drive.py
+++ b/backend/connectors/google_drive.py
@@ -247,7 +247,6 @@ class GoogleDriveConnector(BaseConnector):
         scope=ConnectorScope.USER,
         entity_types=["files"],
         capabilities=[Capability.SYNC, Capability.QUERY, Capability.ACTION],
-        description="Google Drive – Docs, Sheets, Slides, and Gemini meeting notes",
         query_description=(
             "Search or read Google Drive files. "
             "Prefix with 'search:' to search by file name (e.g. 'search:quarterly report') or by type: use 'search:spreadsheet', 'search:document', or 'search:presentation' to list files of that type. "
@@ -331,7 +330,7 @@ class GoogleDriveConnector(BaseConnector):
             ),
         ],
         nango_integration_id="google-drive",
-        description="Google Drive – file metadata sync, search, read, create folders/files, and edit",
+        description="Google Drive – Docs, Sheets, Slides, and Gemini meeting notes",
         usage_guide="""# Google Drive Usage Guide
 
 ## Query format (query_on_connector)

--- a/backend/connectors/google_drive.py
+++ b/backend/connectors/google_drive.py
@@ -247,6 +247,7 @@ class GoogleDriveConnector(BaseConnector):
         scope=ConnectorScope.USER,
         entity_types=["files"],
         capabilities=[Capability.SYNC, Capability.QUERY, Capability.ACTION],
+        description="Google Drive – Docs, Sheets, Slides, and Gemini meeting notes",
         query_description=(
             "Search or read Google Drive files. "
             "Prefix with 'search:' to search by file name (e.g. 'search:quarterly report') or by type: use 'search:spreadsheet', 'search:document', or 'search:presentation' to list files of that type. "

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -59,7 +59,7 @@ const INTEGRATION_CONFIG_FALLBACK: Record<string, IntegrationConfigEntry> = {
   microsoft_mail: { name: 'Microsoft Mail', description: 'Outlook emails and communications', icon: 'microsoft_mail', color: 'from-sky-500 to-sky-600', scope: 'user' },
   fireflies: { name: 'Fireflies', description: 'Meeting transcriptions and notes', icon: 'fireflies', color: 'from-violet-500 to-violet-600', scope: 'user' },
   granola: { name: 'Granola', description: 'AI meeting notes, transcripts, and action items', icon: '/connector-icons/granola.png', color: 'from-lime-500 to-green-600', scope: 'user' },
-  google_drive: { name: 'Google Drive', description: 'Sync files — search and read Docs, Sheets, Slides from Drive', icon: 'google_drive', color: 'from-yellow-500 to-amber-500', scope: 'user' },
+  google_drive: { name: 'Google Drive', description: 'Docs, Sheets, Slides, and Gemini meeting notes from Drive', icon: 'google_drive', color: 'from-yellow-500 to-amber-500', scope: 'user' },
   apollo: { name: 'Apollo.io', description: 'Data enrichment - Contact titles, companies, emails', icon: 'apollo', color: 'from-yellow-400 to-yellow-500', scope: 'user' },
   github: { name: 'GitHub', description: 'Track repos, commits, and pull requests by team', icon: 'github', color: 'from-gray-600 to-gray-700', scope: 'user' },
   linear: { name: 'Linear', description: 'Issue tracking - sync and manage teams, projects, and issues', icon: 'linear', color: 'from-indigo-500 to-violet-600', scope: 'user' },


### PR DESCRIPTION
## Summary
Cro Metrics demo feedback: users hunt for a Gemini tile when their Google Meet / Hangouts notes are actually stored as Google Docs and synced via the Google Drive connector. This updates the connector's description copy so it's discoverable.

- `backend/connectors/google_drive.py` — set `ConnectorMeta.description = "Google Drive – Docs, Sheets, Slides, and Gemini meeting notes"`. This is the canonical source: it's returned by the `/connectors` list endpoint and rendered in the Add-a-Connector tile.
- `frontend/src/components/DataSources.tsx` — mirror the copy in `INTEGRATION_CONFIG_FALLBACK` so the offline/fallback string stays in sync.

Linear: BAS-456

## Test plan
- [ ] Open the Add-a-Connector flow and confirm the Google Drive tile description now reads "Docs, Sheets, Slides, and Gemini meeting notes from Drive" (or the backend variant if API-driven).
- [ ] Confirm no other connector tile copy regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)