### PR TITLE
Support provider switching for workflow LLM actions with approximate model allowlist + tests

### DIFF
--- a/backend/tests/test_workflow_llm_provider_switch.py
+++ b/backend/tests/test_workflow_llm_provider_switch.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services.llm_adapter import LLMConfig
+from workers.tasks import workflows
+
+
+@pytest.mark.asyncio
+async def test_action_llm_switches_provider_for_cross_family_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "services.llm_provider.resolve_llm_config",
+        AsyncMock(
+            return_value=LLMConfig(
+                provider="anthropic",
+                primary_model="claude-opus-4-6",
+                cheap_model="claude-haiku-4-5-20251001",
+                workflow_model="claude-opus-4-6",
+                api_key="anthropic-key",
+            )
+        ),
+        raising=False,
+    )
+
+    monkeypatch.setattr(
+        "services.llm_provider.provider_for_model",
+        lambda model: "openai" if model == "gpt-5.5" else None,
+    )
+    monkeypatch.setattr(
+        "services.llm_provider.resolve_api_key_for_provider",
+        AsyncMock(return_value="openai-key"),
+    )
+
+    monkeypatch.setattr(
+        "access_control.check_external_api",
+        AsyncMock(return_value=SimpleNamespace(allowed=True, deny_reason=None)),
+    )
+
+    captured = {}
+
+    class _Adapter:
+        async def complete(self, **kwargs):
+            captured["model"] = kwargs["model"]
+            return SimpleNamespace(content_blocks=[])
+
+    def _get_adapter(cfg: LLMConfig) -> _Adapter:
+        captured["provider"] = cfg.provider
+        return _Adapter()
+
+    monkeypatch.setattr("services.llm_provider.get_adapter", _get_adapter)
+    monkeypatch.setattr(workflows, "report_anthropic_call_success", AsyncMock())
+
+    result = await workflows._action_llm(
+        params={"prompt": "Hello", "model": "gpt-5.5"},
+        context={"organization_id": "org-1", "user_id": "user-1"},
+    )
+
+    assert result["status"] == "completed"
+    assert captured["provider"] == "openai"
+    assert captured["model"] == "gpt-5.5"
+
+
+@pytest.mark.asyncio
+async def test_action_llm_switches_provider_for_approximate_allowlisted_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "services.llm_provider.resolve_llm_config",
+        AsyncMock(
+            return_value=LLMConfig(
+                provider="anthropic",
+                primary_model="claude-opus-4-6",
+                cheap_model="claude-haiku-4-5-20251001",
+                workflow_model="claude-opus-4-6",
+                api_key="anthropic-key",
+            )
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr("services.llm_provider.provider_for_model", lambda _model: None)
+    monkeypatch.setattr(
+        "services.llm_provider.get_model_provider_map",
+        lambda: {"gpt-5.5-mini": "openai"},
+    )
+    monkeypatch.setattr(
+        "services.llm_provider.resolve_api_key_for_provider",
+        AsyncMock(return_value="openai-key"),
+    )
+    monkeypatch.setattr(
+        "access_control.check_external_api",
+        AsyncMock(return_value=SimpleNamespace(allowed=True, deny_reason=None)),
+    )
+
+    captured = {}
+
+    class _Adapter:
+        async def complete(self, **kwargs):
+            captured["model"] = kwargs["model"]
+            return SimpleNamespace(content_blocks=[])
+
+    def _get_adapter(cfg: LLMConfig) -> _Adapter:
+        captured["provider"] = cfg.provider
+        return _Adapter()
+
+    monkeypatch.setattr("services.llm_provider.get_adapter", _get_adapter)
+    monkeypatch.setattr(workflows, "report_anthropic_call_success", AsyncMock())
+
+    result = await workflows._action_llm(
+        params={"prompt": "Hello", "model": "gpt-5.5-mini-2026-04-14"},
+        context={"organization_id": "org-1", "user_id": "user-1"},
+    )
+
+    assert result["status"] == "completed"
+    assert captured["provider"] == "openai"
+    assert captured["model"] == "gpt-5.5-mini-2026-04-14"

--- a/backend/tests/test_workflow_llm_provider_switch.py
+++ b/backend/tests/test_workflow_llm_provider_switch.py
@@ -114,3 +114,56 @@ async def test_action_llm_switches_provider_for_approximate_allowlisted_model(mo
     assert result["status"] == "completed"
     assert captured["provider"] == "openai"
     assert captured["model"] == "gpt-5.5-mini-2026-04-14"
+
+
+@pytest.mark.asyncio
+async def test_action_llm_does_not_switch_provider_for_truncated_model_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "services.llm_provider.resolve_llm_config",
+        AsyncMock(
+            return_value=LLMConfig(
+                provider="anthropic",
+                primary_model="claude-opus-4-6",
+                cheap_model="claude-haiku-4-5-20251001",
+                workflow_model="claude-opus-4-6",
+                api_key="anthropic-key",
+            )
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr("services.llm_provider.provider_for_model", lambda _model: None)
+    monkeypatch.setattr(
+        "services.llm_provider.get_model_provider_map",
+        lambda: {"gpt-5.5-mini": "openai"},
+    )
+    monkeypatch.setattr(
+        "services.llm_provider.resolve_api_key_for_provider",
+        AsyncMock(return_value="openai-key"),
+    )
+    monkeypatch.setattr(
+        "access_control.check_external_api",
+        AsyncMock(return_value=SimpleNamespace(allowed=True, deny_reason=None)),
+    )
+
+    captured = {}
+
+    class _Adapter:
+        async def complete(self, **kwargs):
+            captured["model"] = kwargs["model"]
+            return SimpleNamespace(content_blocks=[])
+
+    def _get_adapter(cfg: LLMConfig) -> _Adapter:
+        captured["provider"] = cfg.provider
+        return _Adapter()
+
+    monkeypatch.setattr("services.llm_provider.get_adapter", _get_adapter)
+    monkeypatch.setattr(workflows, "report_anthropic_call_success", AsyncMock())
+
+    result = await workflows._action_llm(
+        params={"prompt": "Hello", "model": "gpt-5"},
+        context={"organization_id": "org-1", "user_id": "user-1"},
+    )
+
+    assert result["status"] == "completed"
+    assert captured["provider"] == "anthropic"
+    assert captured["model"] == "gpt-5"

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -230,10 +230,10 @@ def _resolve_requested_provider_with_fallback(
         allowlisted_lookup_key = _normalize_model_lookup_key(allowlisted_model)
         if not allowlisted_lookup_key:
             continue
-        approximate_match = (
-            model_lookup_key.startswith(allowlisted_lookup_key)
-            or allowlisted_lookup_key.startswith(model_lookup_key)
-        )
+        # Only allow requested-model extensions of allowlisted base names.
+        # Do not allow reverse-prefix matches (e.g., "gpt-5" matching
+        # allowlisted "gpt-5.5-mini"), which can bypass allowlist intent.
+        approximate_match = model_lookup_key.startswith(allowlisted_lookup_key)
         if approximate_match and allowlisted_provider != configured_provider:
             logger.info(
                 "[Workflow] Resolved provider via approximate allowlist model match requested_model=%s allowlisted_model=%s configured_provider=%s resolved_provider=%s",

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -202,6 +202,50 @@ def _coerce_preview_text(value: Any, *, max_length: int = 500) -> str | None:
     return f"{text[:max_length]}…"
 
 
+def _normalize_model_lookup_key(model: str) -> str:
+    """Normalize model names for rough/approximate allowlist matching."""
+    normalized = (model or "").strip().lower()
+    return "".join(ch for ch in normalized if ch.isalnum())
+
+
+def _resolve_requested_provider_with_fallback(
+    *,
+    model: str,
+    configured_provider: str,
+    provider_for_model_fn: Any,
+    model_provider_map: dict[str, str],
+) -> str | None:
+    """Resolve provider for model with exact + approximate allowlist matching."""
+    resolved_provider = provider_for_model_fn(model)
+    if resolved_provider:
+        return resolved_provider
+
+    model_lookup_key = _normalize_model_lookup_key(model)
+    if not model_lookup_key:
+        return None
+
+    for allowlisted_model, allowlisted_provider in model_provider_map.items():
+        if not allowlisted_provider:
+            continue
+        allowlisted_lookup_key = _normalize_model_lookup_key(allowlisted_model)
+        if not allowlisted_lookup_key:
+            continue
+        approximate_match = (
+            model_lookup_key.startswith(allowlisted_lookup_key)
+            or allowlisted_lookup_key.startswith(model_lookup_key)
+        )
+        if approximate_match and allowlisted_provider != configured_provider:
+            logger.info(
+                "[Workflow] Resolved provider via approximate allowlist model match requested_model=%s allowlisted_model=%s configured_provider=%s resolved_provider=%s",
+                model,
+                allowlisted_model,
+                configured_provider,
+                allowlisted_provider,
+            )
+            return allowlisted_provider
+    return None
+
+
 def _extract_messenger_connector_call_details(
     tool_payload: dict[str, Any],
 ) -> dict[str, Any] | None:
@@ -1841,7 +1885,14 @@ async def _action_llm(
     """Call an LLM for processing."""
     from access_control import RightsContext, check_external_api
     from config import settings
-    from services.llm_provider import resolve_llm_config, get_adapter
+    from services.llm_adapter import LLMConfig
+    from services.llm_provider import (
+        get_adapter,
+        get_model_provider_map,
+        provider_for_model,
+        resolve_api_key_for_provider,
+        resolve_llm_config,
+    )
 
     prompt = params.get("prompt", "")
     org_id: str = context.get("organization_id") or ""
@@ -1853,10 +1904,34 @@ async def _action_llm(
     llm_config = await resolve_llm_config(org_id or None)
     model: str = params.get("model", llm_config.primary_model)
 
-    if not llm_config.api_key:
+    requested_provider = _resolve_requested_provider_with_fallback(
+        model=model,
+        configured_provider=llm_config.provider,
+        provider_for_model_fn=provider_for_model,
+        model_provider_map=get_model_provider_map(),
+    )
+    effective_config = llm_config
+    if requested_provider and requested_provider != llm_config.provider:
+        logger.info(
+            "[Workflow] Switching LLM provider for model-specific workflow action organization_id=%s configured_provider=%s requested_model=%s requested_provider=%s",
+            org_id,
+            llm_config.provider,
+            model,
+            requested_provider,
+        )
+        requested_api_key = await resolve_api_key_for_provider(requested_provider, org_id or None)
+        effective_config = LLMConfig(
+            provider=requested_provider,
+            primary_model=llm_config.primary_model,
+            cheap_model=llm_config.cheap_model,
+            workflow_model=llm_config.workflow_model,
+            api_key=requested_api_key,
+        )
+
+    if not effective_config.api_key:
         return {
             "status": "failed",
-            "error": f"No API key configured for provider {llm_config.provider}",
+            "error": f"No API key configured for provider {effective_config.provider}",
         }
 
     rights_ctx = RightsContext(
@@ -1867,7 +1942,7 @@ async def _action_llm(
     )
     rights_result = await check_external_api(
         rights_ctx,
-        llm_config.provider,
+        effective_config.provider,
         {"model": model, "prompt_length": len(prompt)},
     )
     if not rights_result.allowed:
@@ -1876,7 +1951,7 @@ async def _action_llm(
             "error": rights_result.deny_reason or "External API call not allowed",
         }
 
-    adapter = get_adapter(llm_config)
+    adapter = get_adapter(effective_config)
     try:
         completed = await adapter.complete(
             model=model,


### PR DESCRIPTION
### Motivation

- Allow workflow LLM actions to switch to a different provider when a requested model maps to another provider, including approximate/rough allowlist matches for model name variants.
- Ensure provider switching is safe by resolving API keys and re-checking external API rights for the effective provider.

### Description

- Added `_normalize_model_lookup_key` and `_resolve_requested_provider_with_fallback` helpers to perform exact and approximate allowlist matching against `get_model_provider_map()` and `provider_for_model` to determine a requested provider for a model.
- Updated `_action_llm` to compute a `requested_provider`, build an `effective_config` (with `LLMConfig` and resolved API key via `resolve_api_key_for_provider`) when switching providers, and use `effective_config` for rights checks and adapter initialization.
- Adjusted imports in `workers/tasks/workflows.py` to use the new helper functions and `LLMConfig` and added informational logging when switching providers.
- Added unit tests `backend/tests/test_workflow_llm_provider_switch.py` with async tests that validate provider switching for a cross-family model and for an approximate allowlisted model name, using `monkeypatch` to stub provider resolution, API keys, rights checks, and the adapter.

### Testing

- Ran unit tests for the new test file with `pytest backend/tests/test_workflow_llm_provider_switch.py` and the tests passed.
- Existing LLM workflow behavior is preserved when no provider switch is needed as covered by the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2db9ce69c8321a6f0ba721e57980c)