### PR TITLE
Fix workflow model override provider resolution

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -34,7 +34,11 @@ from services.llm_adapter import (
     get_adapter,
 )
 from services.llm_provider import resolve_llm_config
-from services.llm_provider import provider_for_model, resolve_api_key_for_provider
+from services.llm_provider import (
+    get_model_provider_map,
+    provider_for_model,
+    resolve_api_key_for_provider,
+)
 from models.chat_attachment import ChatAttachment
 from models.chat_message import ChatMessage
 from models.conversation import Conversation
@@ -43,6 +47,41 @@ from models.memory import Memory
 from services.anthropic_health import report_anthropic_call_failure, report_anthropic_call_success
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_model_lookup_key(model: str) -> str:
+    """Normalize model names for approximate allowlist matching."""
+    normalized = (model or "").strip().lower()
+    return "".join(ch for ch in normalized if ch.isalnum())
+
+
+def _resolve_provider_for_workflow_selected_model(*, model: str, configured_provider: str) -> str | None:
+    """Resolve provider with exact then approximate allowlist matching for workflow model overrides."""
+    direct_provider = provider_for_model(model)
+    if direct_provider:
+        return direct_provider
+
+    model_lookup_key = _normalize_model_lookup_key(model)
+    if not model_lookup_key:
+        return None
+
+    for allowlisted_model, allowlisted_provider in get_model_provider_map().items():
+        if not allowlisted_provider:
+            continue
+        allowlisted_lookup_key = _normalize_model_lookup_key(allowlisted_model)
+        if not allowlisted_lookup_key:
+            continue
+        if model_lookup_key.startswith(allowlisted_lookup_key) and allowlisted_provider != configured_provider:
+            logger.info(
+                "[Orchestrator] Resolved provider via approximate allowlist model match selected_model=%s allowlisted_model=%s configured_provider=%s resolved_provider=%s",
+                model,
+                allowlisted_model,
+                configured_provider,
+                allowlisted_provider,
+            )
+            return allowlisted_provider
+
+    return None
 
 
 def _json_dumps(payload: Any) -> str:
@@ -1193,7 +1232,10 @@ class ChatOrchestrator:
             else (self._llm_config.workflow_model if is_workflow_run else self._llm_config.primary_model)
         )
         if is_workflow_run:
-            selected_model_provider = provider_for_model(selected_model)
+            selected_model_provider = _resolve_provider_for_workflow_selected_model(
+                model=selected_model,
+                configured_provider=self._llm_config.provider,
+            )
             if selected_model_provider and selected_model_provider != self._llm_config.provider:
                 previous_provider = self._llm_config.provider
                 override_api_key = await resolve_api_key_for_provider(

--- a/backend/tests/test_orchestrator_workflow_model_provider_switch.py
+++ b/backend/tests/test_orchestrator_workflow_model_provider_switch.py
@@ -1,0 +1,47 @@
+from agents import orchestrator
+
+
+def test_resolve_provider_for_workflow_selected_model_uses_exact_match(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        orchestrator,
+        "provider_for_model",
+        lambda model: "openai" if model == "gpt-5.5" else None,
+    )
+    monkeypatch.setattr(orchestrator, "get_model_provider_map", lambda: {})
+
+    resolved = orchestrator._resolve_provider_for_workflow_selected_model(
+        model="gpt-5.5",
+        configured_provider="anthropic",
+    )
+
+    assert resolved == "openai"
+
+
+def test_resolve_provider_for_workflow_selected_model_uses_approximate_allowlist(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(orchestrator, "provider_for_model", lambda _model: None)
+    monkeypatch.setattr(orchestrator, "get_model_provider_map", lambda: {"gpt-5.5-mini": "openai"})
+
+    resolved = orchestrator._resolve_provider_for_workflow_selected_model(
+        model="gpt-5.5-mini-2026-04-14",
+        configured_provider="anthropic",
+    )
+
+    assert resolved == "openai"
+
+
+def test_resolve_provider_for_workflow_selected_model_rejects_truncated_prefix(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(orchestrator, "provider_for_model", lambda _model: None)
+    monkeypatch.setattr(orchestrator, "get_model_provider_map", lambda: {"gpt-5.5-mini": "openai"})
+
+    resolved = orchestrator._resolve_provider_for_workflow_selected_model(
+        model="gpt-5",
+        configured_provider="anthropic",
+    )
+
+    assert resolved is None


### PR DESCRIPTION
### Motivation
- Workflow runs using a per-workflow model override could still select the wrong provider and fail with model 404s because previous fixes only handled the `action_llm` path and not the orchestrator's workflow override path.
- The orchestrator needs the same exact + approximate allowlist provider resolution used elsewhere so individual workflow overrides behave consistently.

### Description
- Add `_resolve_provider_for_workflow_selected_model(...)` to `backend/agents/orchestrator.py` to resolve a model's provider via `provider_for_model(...)` first and then approximate allowlist matching via `get_model_provider_map()` with the same safe prefix-direction checks.
- Replace the direct `provider_for_model(...)` call in `ChatOrchestrator.process_message` with the new helper so workflow `llm_model` overrides can switch `LLMConfig` provider and `api_key` before adapter initialization.
- Import `get_model_provider_map` and add the `_normalize_model_lookup_key` helper in the orchestrator file to support approximate matching.
- Add unit tests in `backend/tests/test_orchestrator_workflow_model_provider_switch.py` covering exact match, approximate allowlist match, and truncated-prefix rejection.

### Testing
- Ran `pytest -q backend/tests/test_orchestrator_workflow_model_provider_switch.py backend/tests/test_workflow_llm_provider_switch.py` and all tests passed: `6 passed in 4.36s`.
- The new orchestrator-focused tests validate exact match, approximate allowlist behavior, and rejection of truncated reverse-prefix matches (all succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f379adcd38832191464d51b9c76f73)