### PR TITLE
Block per-org role changes on global admins (BAS-571)

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1402,6 +1402,7 @@ class TeamMemberResponse(BaseModel):
     status: Optional[str] = None  # 'active', 'crm_only', etc.
     is_guest: bool = False
     can_login_as_admin: bool = False  # True when user is org admin for this org, or global_admin
+    is_global_admin: bool = False  # True when user has the global_admin role at the user level
     identities: list[IdentityMappingResponse] = []
 
 
@@ -1524,6 +1525,7 @@ async def get_organization_members(
                         bool(membership and membership.role == "admin")
                         or _is_global_admin(u)
                     ),
+                    is_global_admin=_is_global_admin(u),
                     identities=identities,
                 )
             )
@@ -2372,6 +2374,13 @@ async def update_organization_member_role(
         requester: Optional[User] = await session.get(User, requester_uuid)
         if not await _can_administer_org(session, requester, org_uuid):
             raise HTTPException(status_code=403, detail="Org admin or global_admin required for this organization")
+
+        target_user: Optional[User] = await session.get(User, target_uuid)
+        if _is_global_admin(target_user):
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot change the org-level role of a global admin. Their global role overrides the per-org setting.",
+            )
 
         membership_result = await session.execute(
             select(OrgMember).where(

--- a/backend/tests/test_update_member_role_blocks_global_admin.py
+++ b/backend/tests/test_update_member_role_blocks_global_admin.py
@@ -1,0 +1,73 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes import auth
+
+
+class _FakeSession:
+    def __init__(self, *, users):
+        self._users = users
+        self.committed = False
+
+    async def get(self, _model, model_id):
+        return self._users.get(model_id)
+
+    async def execute(self, _query):
+        raise AssertionError("execute should not run when global admin guard rejects the request")
+
+    async def commit(self):
+        self.committed = True
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_update_role_rejects_demotion_of_global_admin(monkeypatch):
+    """Demoting a global_admin via the per-org role endpoint must 400.
+
+    The global role overrides the org-level role, so silently flipping the
+    org-level membership.role gives the impression of a successful demotion
+    while the user retains admin power everywhere — exactly the BAS-571 case.
+    """
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    requester_id = UUID("22222222-2222-2222-2222-222222222222")
+    target_id = UUID("33333333-3333-3333-3333-333333333333")
+
+    requester = SimpleNamespace(id=requester_id, is_guest=False, role="admin", roles=[])
+    target_user = SimpleNamespace(id=target_id, is_guest=False, role=None, roles=["global_admin"])
+
+    fake_session = _FakeSession(users={requester_id: requester, target_id: target_user})
+    monkeypatch.setattr(auth, "get_admin_session", lambda: _FakeSessionContext(fake_session))
+
+    async def _allow_admin(*_args, **_kwargs):
+        return True
+
+    monkeypatch.setattr(auth, "_can_administer_org", _allow_admin)
+
+    request = auth.UpdateMemberRoleRequest(role="member")
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            auth.update_organization_member_role(
+                org_id=str(org_id),
+                target_user_id=str(target_id),
+                request=request,
+                user_id=str(requester_id),
+            )
+        )
+
+    assert exc.value.status_code == 400
+    assert "global admin" in exc.value.detail.lower()
+    assert not fake_session.committed

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -999,6 +999,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                       const isGuest: boolean = member.isGuest;
                       const isInvited: boolean = member.status === 'invited';
                       const isOrgAdminMember: boolean = member.role === 'admin';
+                      const isGlobalAdmin: boolean = member.isGlobalAdmin;
                       const isAdmin: boolean = member.role === 'admin'
                         || member.role === 'global_admin'
                         || member.canLoginAsAdmin;
@@ -1132,18 +1133,27 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                                       </button>
                                       {canAdministerOrg && (
                                         <>
-                                          <button
-                                            type="button"
-                                            onClick={() => {
-                                              setMenuOpenMemberId(null);
-                                              const nextRole: 'admin' | 'member' = isOrgAdminMember ? 'member' : 'admin';
-                                              void handleUpdateMemberRole(member.id, nextRole);
-                                            }}
-                                            disabled={updateMemberRoleMutation.isPending}
-                                            className="w-full text-left px-3 py-2 text-sm text-surface-200 hover:bg-surface-600/60 transition-colors disabled:opacity-50"
-                                          >
-                                            {isOrgAdminMember ? 'Demote to user' : 'Promote to admin'}
-                                          </button>
+                                          {isGlobalAdmin ? (
+                                            <div
+                                              className="w-full text-left px-3 py-2 text-sm text-surface-400 italic cursor-not-allowed"
+                                              title="Global admin role is managed at the user level and overrides per-org admin status."
+                                            >
+                                              Global admin
+                                            </div>
+                                          ) : (
+                                            <button
+                                              type="button"
+                                              onClick={() => {
+                                                setMenuOpenMemberId(null);
+                                                const nextRole: 'admin' | 'member' = isOrgAdminMember ? 'member' : 'admin';
+                                                void handleUpdateMemberRole(member.id, nextRole);
+                                              }}
+                                              disabled={updateMemberRoleMutation.isPending}
+                                              className="w-full text-left px-3 py-2 text-sm text-surface-200 hover:bg-surface-600/60 transition-colors disabled:opacity-50"
+                                            >
+                                              {isOrgAdminMember ? 'Demote to user' : 'Promote to admin'}
+                                            </button>
+                                          )}
                                           <button
                                             type="button"
                                             onClick={() => {

--- a/frontend/src/hooks/useOrganization.ts
+++ b/frontend/src/hooks/useOrganization.ts
@@ -39,6 +39,7 @@ export interface TeamMember {
   status: string | null;
   isGuest: boolean;
   canLoginAsAdmin: boolean;
+  isGlobalAdmin: boolean;
   identities: IdentityMapping[];
 }
 
@@ -73,6 +74,7 @@ interface TeamMembersApiResponse {
     status: string | null;
     is_guest: boolean;
     can_login_as_admin?: boolean;
+    is_global_admin?: boolean;
     identities: IdentityMappingApiResponse[];
   }>;
   unmapped_identities: IdentityMappingApiResponse[];
@@ -155,6 +157,7 @@ async function fetchTeamMembers(orgId: string, userId: string): Promise<TeamMemb
       status: m.status ?? null,
       isGuest: Boolean(m.is_guest),
       canLoginAsAdmin: Boolean(m.can_login_as_admin),
+      isGlobalAdmin: Boolean(m.is_global_admin),
       identities: (m.identities ?? []).map(mapIdentity),
     })),
     unmappedIdentities: (data.unmapped_identities ?? []).map(mapIdentity),


### PR DESCRIPTION
## Summary
The Promote/Demote menu in the org team list operated on `OrgMember.role`, but `global_admin` lives on `User.roles` and overrides any per-org role. Two visible bugs followed:

1. **Demoting a global admin silently failed** — the per-org `role` flipped to `member`, but the user still had global admin everywhere, so nothing visible changed and no error fired.
2. **Promote-to-admin made no sense for a global admin who wasn't an org admin** — they already showed the "admin" pill (because `canLoginAsAdmin` is true for global admins) but the menu still offered "Promote to admin".

## Changes
- **Backend** (`backend/api/routes/auth.py`): `update_organization_member_role` now returns `400 "Cannot change the org-level role of a global admin..."` when the target is a global admin. The team members response also gains an `is_global_admin` field so the UI can distinguish a true global admin from someone who's just an org admin (both currently report `can_login_as_admin: true`).
- **Frontend** (`OrganizationPanel.tsx`, `useOrganization.ts`): `TeamMember.isGlobalAdmin` is plumbed through. The Promote/Demote menu item is replaced with a non-interactive "Global admin" entry (with a tooltip explaining the override) for global admins.
- **Test** (`backend/tests/test_update_member_role_blocks_global_admin.py`): asserts the 400 + no commit when attempting to demote a global admin.

Linear: BAS-571

## Test plan
- [ ] In Org Panel team list, find a global admin row → open the three-dot menu → confirm it shows a non-clickable "Global admin" entry instead of "Promote/Demote".
- [ ] Find a regular member → confirm Promote/Demote still works as before.
- [ ] Hit the API directly: `PATCH /auth/organizations/{org}/members/{global_admin_user}/role { role: "member" }` → expect 400.
- [ ] `pytest backend/tests/test_update_member_role_blocks_global_admin.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)