### PR TITLE
Land invited existing users in the right org + accurate email copy (BAS-468)

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1922,6 +1922,9 @@ async def invite_to_organization(
             select(User).where(User.email == invite_email)
         )
         target_user: Optional[User] = result.scalar_one_or_none()
+        # Existing == previously logged in. Stub users from a prior invite have
+        # last_login=None, so they still get the "sign up" copy.
+        recipient_is_existing_user: bool = bool(target_user and target_user.last_login)
 
         if not target_user:
             # Create stub user
@@ -1964,6 +1967,8 @@ async def invite_to_organization(
                     inviter_name,
                     org_logo_url=org.logo_url,
                     inviter_avatar_url=inviter.avatar_url,
+                    org_id=str(org_uuid),
+                    recipient_is_existing_user=recipient_is_existing_user,
                 )
                 return InviteToOrgResponse(
                     membership_id=membership_id_str,
@@ -2000,6 +2005,8 @@ async def invite_to_organization(
             inviter_name,
             org_logo_url=org.logo_url,
             inviter_avatar_url=inviter.avatar_url,
+            org_id=str(org_uuid),
+            recipient_is_existing_user=recipient_is_existing_user,
         )
 
         return InviteToOrgResponse(
@@ -2163,6 +2170,8 @@ async def invite_missing_slack_users_to_organization(
 
         inviter_name: str = inviter.name or inviter.email
         for email in invited_emails:
+            existing_user = target_users.get(email)
+            recipient_is_existing_user: bool = bool(existing_user and existing_user.last_login)
             background_tasks.add_task(
                 send_org_invitation_email,
                 email,
@@ -2170,6 +2179,8 @@ async def invite_missing_slack_users_to_organization(
                 inviter_name,
                 org_logo_url=org.logo_url,
                 inviter_avatar_url=inviter.avatar_url,
+                org_id=str(org_uuid),
+                recipient_is_existing_user=recipient_is_existing_user,
             )
 
         return SlackMissingInviteResponse(

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -472,7 +472,7 @@ async def send_org_invitation_email(
         subject = (
             f"{invited_by_name} added you to {org_name} on Basebase"
             if invited_by_name
-            else f"You&apos;ve been added to {org_name} on Basebase"
+            else f"You've been added to {org_name} on Basebase"
         )
         cta_subhead = f"Open Basebase to start collaborating in {org_name}."
         cta_button = "Open Basebase"

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -426,6 +426,8 @@ async def send_org_invitation_email(
     invited_by_name: Optional[str] = None,
     org_logo_url: Optional[str] = None,
     inviter_avatar_url: Optional[str] = None,
+    org_id: Optional[str] = None,
+    recipient_is_existing_user: bool = False,
 ) -> bool:
     """
     Send an invitation email to join an organization.
@@ -436,6 +438,10 @@ async def send_org_invitation_email(
         invited_by_name: Name of the person who sent the invite
         org_logo_url: URL of the organization's logo (passed to frontend via query params)
         inviter_avatar_url: URL of the inviter's avatar (passed to frontend via query params)
+        org_id: Organization UUID, passed to the frontend so existing users land in
+            the invited org instead of their previous active one.
+        recipient_is_existing_user: True when the invitee already has a Basebase
+            account. Switches the copy from "sign up" to "open Basebase".
 
     Returns:
         True if email sent successfully, False otherwise
@@ -447,6 +453,8 @@ async def send_org_invitation_email(
         return False
 
     params: list[str] = [f"invite=1", f"org_name={quote(org_name)}", f"email={quote(to_email)}"]
+    if org_id:
+        params.append(f"org_id={quote(org_id)}")
     if org_logo_url:
         params.append(f"org_logo={quote(org_logo_url)}")
     if invited_by_name:
@@ -455,17 +463,34 @@ async def send_org_invitation_email(
         params.append(f"inviter_avatar={quote(inviter_avatar_url)}")
     invite_url: str = f"{settings.FRONTEND_URL}?{'&'.join(params)}"
 
-    headline: str = (
-        f"{invited_by_name} invited you to use Basebase in {org_name}&apos;s Slack workspace"
-        if invited_by_name
-        else f"You&apos;ve been invited to use Basebase in {org_name}&apos;s Slack workspace"
-    )
-
-    subject: str = (
-        f"{invited_by_name} invited you to use Basebase"
-        if invited_by_name
-        else f"You're invited to use Basebase in {org_name}'s Slack"
-    )
+    if recipient_is_existing_user:
+        headline = (
+            f"{invited_by_name} added you to {org_name} on Basebase"
+            if invited_by_name
+            else f"You&apos;ve been added to {org_name} on Basebase"
+        )
+        subject = (
+            f"{invited_by_name} added you to {org_name} on Basebase"
+            if invited_by_name
+            else f"You&apos;ve been added to {org_name} on Basebase"
+        )
+        cta_subhead = f"Open Basebase to start collaborating in {org_name}."
+        cta_button = "Open Basebase"
+        text_subhead = f"Open Basebase to start collaborating in {org_name}."
+    else:
+        headline = (
+            f"{invited_by_name} invited you to use Basebase in {org_name}&apos;s Slack workspace"
+            if invited_by_name
+            else f"You&apos;ve been invited to use Basebase in {org_name}&apos;s Slack workspace"
+        )
+        subject = (
+            f"{invited_by_name} invited you to use Basebase"
+            if invited_by_name
+            else f"You're invited to use Basebase in {org_name}'s Slack"
+        )
+        cta_subhead = "Sign up for Basebase to accept."
+        cta_button = "Sign Up"
+        text_subhead = "Sign up for Basebase to accept."
 
     html_content: str = f"""
 <!DOCTYPE html>
@@ -494,12 +519,12 @@ async def send_org_invitation_email(
           <tr>
             <td style="padding:24px 36px 0;text-align:center;">
               <h1 style="margin:0 0 12px;font-size:24px;line-height:1.3;color:#111;font-weight:700;">{headline}</h1>
-              <p style="margin:0;color:#6b7280;font-size:15px;line-height:1.6;">Sign up for Basebase to accept.</p>
+              <p style="margin:0;color:#6b7280;font-size:15px;line-height:1.6;">{cta_subhead}</p>
             </td>
           </tr>
           <tr>
             <td style="padding:28px 36px 0;text-align:center;">
-              <a href="{invite_url}" style="display:inline-block;background:#FF9F1C;color:#111111;text-decoration:none;font-size:16px;font-weight:600;padding:14px 32px;border-radius:10px;">Sign Up</a>
+              <a href="{invite_url}" style="display:inline-block;background:#FF9F1C;color:#111111;text-decoration:none;font-size:16px;font-weight:600;padding:14px 32px;border-radius:10px;">{cta_button}</a>
             </td>
           </tr>
           <tr>
@@ -527,16 +552,23 @@ async def send_org_invitation_email(
 </html>
     """
 
-    headline_text: str = (
-        f"{invited_by_name} invited you to use Basebase in {org_name}'s Slack workspace."
-        if invited_by_name
-        else f"You've been invited to use Basebase in {org_name}'s Slack workspace."
-    )
+    if recipient_is_existing_user:
+        headline_text = (
+            f"{invited_by_name} added you to {org_name} on Basebase."
+            if invited_by_name
+            else f"You've been added to {org_name} on Basebase."
+        )
+    else:
+        headline_text = (
+            f"{invited_by_name} invited you to use Basebase in {org_name}'s Slack workspace."
+            if invited_by_name
+            else f"You've been invited to use Basebase in {org_name}'s Slack workspace."
+        )
 
     text_content: str = f"""
 {headline_text}
 
-Sign up for Basebase to accept.
+{text_subhead}
 
 Basebase lives in your Slack workspace. Ask it anything -- cross-tool summaries, data lookups, task automation -- and it answers right in the thread. When one person learns something, the whole team benefits.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -223,6 +223,31 @@ function App(): JSX.Element {
     const domain = getEmailDomain(email);
     setEmailDomain(domain);
 
+    // If the user landed via an invite URL (?invite=1&org_id=...), redirect them
+    // into the invited org instead of falling back to their previous active org.
+    // Auto-acceptance of the pending membership happens server-side during sync.
+    const redirectToInvitedOrg = async (): Promise<void> => {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('invite') !== '1') return;
+      const invitedOrgId = params.get('org_id');
+      if (!invitedOrgId) return;
+      const switched = await switchActiveOrganization(invitedOrgId);
+      if (switched) {
+        const orgs = useAppStore.getState().organizations;
+        const next = orgs.find((o) => o.id === invitedOrgId);
+        if (next) {
+          setOrganization({
+            id: next.id,
+            name: next.name,
+            logoUrl: next.logoUrl ?? null,
+            handle: next.handle ?? null,
+          });
+        }
+        // Strip the invite params so a refresh doesn't re-trigger this branch.
+        window.history.replaceState({}, '', window.location.pathname);
+      }
+    };
+
     // Get avatar from OAuth metadata - try multiple possible field names
     // Google OAuth stores it in user_metadata, but also check identities array
     const identityData = supabaseUser.identities?.[0]?.identity_data as Record<string, unknown> | undefined;
@@ -324,6 +349,7 @@ function App(): JSX.Element {
             setScreen('onboarding-wizard');
             return;
           }
+          await redirectToInvitedOrg();
           setScreen('app');
           return;
         }
@@ -347,6 +373,7 @@ function App(): JSX.Element {
           });
         }
       }
+      await redirectToInvitedOrg();
       setScreen('app');
       return;
     }

--- a/frontend/src/components/Auth.tsx
+++ b/frontend/src/components/Auth.tsx
@@ -11,6 +11,7 @@ import { API_BASE } from '../lib/api';
 import { APP_NAME, LOGO_PATH } from '../lib/brand';
 
 interface InviteContext {
+  orgId: string | null;
   orgName: string;
   orgLogo: string | null;
   inviterName: string | null;
@@ -51,6 +52,7 @@ function parseInviteParams(): InviteContext | null {
   const orgName: string | null = params.get('org_name');
   if (!orgName) return null;
   return {
+    orgId: params.get('org_id') || null,
     orgName,
     orgLogo: params.get('org_logo') || null,
     inviterName: params.get('inviter_name') || null,

--- a/frontend/src/components/Auth.tsx
+++ b/frontend/src/components/Auth.tsx
@@ -169,10 +169,14 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
     setError(null);
 
     try {
+      // Preserve invite params across the OAuth round-trip so the post-auth
+      // redirect can land the user in the invited org (BAS-468).
+      const currentParams = new URLSearchParams(window.location.search);
+      const inviteSearch = currentParams.get('invite') === '1' ? `?${currentParams.toString()}` : '';
       const { error } = await supabase.auth.signInWithOAuth({
         provider,
         options: {
-          redirectTo: `${window.location.origin}/auth/callback`,
+          redirectTo: `${window.location.origin}/auth/callback${inviteSearch}`,
           scopes: provider === 'azure' ? 'email profile openid' : undefined,
           // Force account selection prompt - prevents auto-selecting a previously used account
           queryParams: {

--- a/frontend/src/components/OAuthCallback.tsx
+++ b/frontend/src/components/OAuthCallback.tsx
@@ -55,7 +55,7 @@ export function OAuthCallback(): JSX.Element {
           setState('success');
           // Redirect to home after a brief delay
           setTimeout(() => {
-            window.location.href = '/';
+            window.location.href = `/${preserveInviteSearch()}`;
           }, 1500);
         } else {
           // No session yet - might still be processing

--- a/frontend/src/components/OAuthCallback.tsx
+++ b/frontend/src/components/OAuthCallback.tsx
@@ -12,6 +12,14 @@ import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
 
 type CallbackState = 'processing' | 'success' | 'error';
 
+// Carry invite params through to "/" so the post-auth redirect in App.tsx
+// can land the user in the invited org (BAS-468).
+function preserveInviteSearch(): string {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('invite') !== '1') return '';
+  return `?${params.toString()}`;
+}
+
 export function OAuthCallback(): JSX.Element {
   const [state, setState] = useState<CallbackState>('processing');
   const [error, setError] = useState<string | null>(null);
@@ -57,7 +65,7 @@ export function OAuthCallback(): JSX.Element {
               if (event === 'SIGNED_IN' && session) {
                 setState('success');
                 setTimeout(() => {
-                  window.location.href = '/';
+                  window.location.href = `/${preserveInviteSearch()}`;
                 }, 1500);
                 subscription.unsubscribe();
               }


### PR DESCRIPTION
## Summary
Two fixes for the invite flow when the recipient already has a Basebase account.

### 1. Email copy
`send_org_invitation_email` now takes `recipient_is_existing_user` and renders different headline / button (\"Open Basebase\" instead of \"Sign Up\") so the message doesn't tell an existing user to create an account they already have. The flag is true when `target_user.last_login` is set, so freshly-stubbed invitees still get the \"sign up\" copy. Both the single-invite endpoint and the `slack-missing` bulk path pass it through.

### 2. Land in the invited org
Invite URLs now carry `org_id`. After auth, the `App.tsx` sync flow reads `?invite=1&org_id=...` and calls `switchActiveOrganization(orgId)` + `setOrganization(...)` before showing the app shell — so Cynthia clicking a Mountary invite while logged in to Cro Metrics actually lands in Mountary. Invite params are stripped from the URL after the switch so a refresh is idempotent.

Welcome splash (the third item in the original ticket) is intentionally deferred — it needs new transient state and is independent of this fix.

Linear: BAS-468

## Test plan
- [ ] **New user invite**: Invite an email that has never used Basebase → email body says \"Sign up for Basebase to accept\" with a \"Sign Up\" button (unchanged).
- [ ] **Existing user invite**: Invite a user who has logged in before → email body says \"Open Basebase to start collaborating in {org}\" with an \"Open Basebase\" button.
- [ ] **Existing user clicks invite link while logged in**: They land in the invited org (not their previously active one). Org switcher shows the invited org as active.
- [ ] **Existing user clicks invite link while logged out**: They sign in, then land in the invited org.
- [ ] **Refresh after redirect**: URL no longer contains `?invite=1`, behavior is normal.
- [ ] **Bulk Slack-missing invite**: Each recipient gets the right copy variant based on whether they previously logged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)