### PR TITLE
Log Slack conversation visibility and reason on create

### DIFF
--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -95,11 +95,11 @@ def _merge_participating_user_ids(
     return current
 
 
-def _resolve_conversation_scope(
+def _resolve_conversation_scope_with_reason(
     message: InboundMessage,
     revtops_user_id: str | None,
-) -> str:
-    """Resolve conversation scope for newly created or updated conversations."""
+) -> tuple[str, str]:
+    """Resolve conversation scope plus a short explanation for logging."""
     channel_type: str = (message.messenger_context.get("channel_type") or "").strip().lower()
     channel_id: str = (message.messenger_context.get("channel_id") or "").strip().upper()
 
@@ -113,16 +113,26 @@ def _resolve_conversation_scope(
         )
     )
     if is_private_slack_channel:
-        return "private"
+        return "private", "private_slack_channel_or_group"
 
     if message.message_type != MessageType.DIRECT:
-        return "shared"
+        return "shared", "non_direct_message"
 
     if channel_type in {"mpim", "groupchat"}:
-        return "private"
+        return "private", "group_direct_message"
 
     identity_known: bool = bool(revtops_user_id or message.external_user_id)
-    return "private" if identity_known else "shared"
+    if identity_known:
+        return "private", "direct_message_with_known_identity"
+    return "shared", "direct_message_without_identity"
+
+
+def _resolve_conversation_scope(
+    message: InboundMessage,
+    revtops_user_id: str | None,
+) -> str:
+    """Resolve conversation scope for newly created or updated conversations."""
+    return _resolve_conversation_scope_with_reason(message, revtops_user_id)[0]
 
 
 def _build_workflow_context_for_message(
@@ -702,7 +712,7 @@ class WorkspaceMessenger(BaseMessenger):
 
             if conversation is not None:
                 changed: bool = False
-                target_scope: str = _resolve_conversation_scope(message, revtops_user_id)
+                target_scope, target_scope_reason = _resolve_conversation_scope_with_reason(message, revtops_user_id)
                 if message.external_user_id and conversation.source_user_id != message.external_user_id:
                     conversation.source_user_id = message.external_user_id
                     changed = True
@@ -726,6 +736,15 @@ class WorkspaceMessenger(BaseMessenger):
                 if conversation.scope != target_scope:
                     conversation.scope = target_scope
                     changed = True
+                    if source == "slack":
+                        logger.info(
+                            "[%s] Updated conversation scope for %s scope=%s reason=%s channel=%s",
+                            source,
+                            conversation.id,
+                            target_scope,
+                            target_scope_reason,
+                            source_channel_id,
+                        )
 
                 if changed:
                     await session.commit()
@@ -738,6 +757,8 @@ class WorkspaceMessenger(BaseMessenger):
             }.get(message.message_type.value, self.meta.name)
 
             user_display: str = user.name or message.external_user_id
+            conversation_scope, conversation_scope_reason = _resolve_conversation_scope_with_reason(message, revtops_user_id)
+
             conversation = Conversation(
                 organization_id=UUID(organization_id),
                 user_id=UUID(revtops_user_id) if revtops_user_id else None,
@@ -745,7 +766,7 @@ class WorkspaceMessenger(BaseMessenger):
                 source_channel_id=source_channel_id,
                 source_user_id=message.external_user_id,
                 participating_user_ids=_merge_participating_user_ids([], revtops_user_id),
-                scope=_resolve_conversation_scope(message, revtops_user_id),
+                scope=conversation_scope,
                 type="agent",
                 title=f"{source_label} - {user_display}",
             )
@@ -758,6 +779,18 @@ class WorkspaceMessenger(BaseMessenger):
                 "[%s] Created conversation %s channel=%s user=%s",
                 source, conversation.id, source_channel_id, revtops_user_id,
             )
+            if source == "slack":
+                visibility: str = "public" if conversation_scope == "shared" else "private"
+                logger.info(
+                    "[%s] Slack conversation visibility on create conversation_id=%s visibility=%s reason=%s channel=%s channel_type=%s message_type=%s",
+                    source,
+                    conversation.id,
+                    visibility,
+                    conversation_scope_reason,
+                    channel_id,
+                    ctx.get("channel_type"),
+                    message.message_type.value,
+                )
             return str(conversation.id)
 
     # ------------------------------------------------------------------

--- a/backend/tests/test_workspace_conversation_scope.py
+++ b/backend/tests/test_workspace_conversation_scope.py
@@ -1,4 +1,4 @@
-from messengers._workspace import _resolve_conversation_scope
+from messengers._workspace import _resolve_conversation_scope, _resolve_conversation_scope_with_reason
 from messengers.base import InboundMessage, MessageType
 
 
@@ -52,3 +52,25 @@ def test_resolve_conversation_scope_private_for_mentions_in_private_slack_channe
 def test_resolve_conversation_scope_private_for_teams_groupchat_direct_message() -> None:
     message = _build_message(MessageType.DIRECT, channel_type="groupChat", external_user_id="U123")
     assert _resolve_conversation_scope(message, revtops_user_id="11111111-1111-1111-1111-111111111111") == "private"
+
+
+def test_resolve_conversation_scope_with_reason_for_private_slack_channel() -> None:
+    message = InboundMessage(
+        external_user_id="U123",
+        text="hello",
+        message_type=MessageType.MENTION,
+        messenger_context={"channel_type": "private_channel", "channel_id": "C123"},
+        message_id="mid-1",
+    )
+    assert _resolve_conversation_scope_with_reason(
+        message,
+        revtops_user_id="11111111-1111-1111-1111-111111111111",
+    ) == ("private", "private_slack_channel_or_group")
+
+
+def test_resolve_conversation_scope_with_reason_for_shared_mention() -> None:
+    message = _build_message(MessageType.MENTION, channel_type="channel", external_user_id="U123")
+    assert _resolve_conversation_scope_with_reason(
+        message,
+        revtops_user_id="11111111-1111-1111-1111-111111111111",
+    ) == ("shared", "non_direct_message")


### PR DESCRIPTION
### Motivation
- Improve observability around Slack-driven conversation creation so we can audit whether a conversation was created as public or private and why.
- Provide richer debug info when conversation scope changes for existing Slack conversations.

### Description
- Added `_resolve_conversation_scope_with_reason` to return `(scope, reason)` with concise reason codes such as `private_slack_channel_or_group`, `non_direct_message`, `group_direct_message`, `direct_message_with_known_identity`, and `direct_message_without_identity` in `backend/messengers/_workspace.py`.
- Kept `_resolve_conversation_scope` as a wrapper for compatibility so existing callers continue to work.
- Logged scope-change events for existing Slack conversations when the resolved scope differs from the stored scope, including the reason and channel id.
- Logged visibility at creation time for new Slack conversations as `public` or `private` along with the reason, channel id, channel type, and message type.
- Updated unit tests in `backend/tests/test_workspace_conversation_scope.py` to validate the new reason-bearing resolver behavior.

### Testing
- Ran `pytest -q backend/tests/test_workspace_conversation_scope.py` and all tests passed (8 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3f59f908483219a5c167901b9a773)