### PR TITLE
Validate OAuth callback 'state' and redirect to frontend login when missing; add tests

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -3647,6 +3647,18 @@ async def nango_oauth_callback_redirect(request: Request) -> RedirectResponse:
     This route can be used as the callback URL for any Nango integration.
     It preserves all query parameters and redirects to Nango's callback endpoint.
     """
+    frontend_url = settings.FRONTEND_URL.rstrip("/")
+    if "state" not in request.query_params:
+        logger.warning(
+            "OAuth callback missing state key; redirecting to login. path=%s query_keys=%s",
+            request.url.path,
+            sorted(request.query_params.keys()),
+        )
+        return RedirectResponse(
+            url=f"{frontend_url}/login?reason=missing_state",
+            status_code=302,
+        )
+
     nango_callback_url = "https://api.nango.dev/oauth/callback"
     
     # Preserve all query parameters from the incoming request

--- a/backend/tests/test_auth_oauth_callback_redirect.py
+++ b/backend/tests/test_auth_oauth_callback_redirect.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+client = TestClient(app)
+
+
+def test_oauth_callback_missing_state_redirects_to_login() -> None:
+    response = client.get("/api/auth/oauth/callback", params={"code": "abc"}, follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.headers["location"].endswith("/login?reason=missing_state")
+
+
+def test_oauth_callback_with_state_redirects_to_nango_and_preserves_query() -> None:
+    response = client.get(
+        "/api/auth/oauth/callback",
+        params={"state": "s1", "code": "abc", "scope": "read"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    location = response.headers["location"]
+    assert location.startswith("https://api.nango.dev/oauth/callback?")
+    assert "state=s1" in location
+    assert "code=abc" in location
+    assert "scope=read" in location
+
+
+def test_oauth_callback_no_query_string_redirects_to_login() -> None:
+    response = client.get("/api/auth/oauth/callback", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.headers["location"].endswith("/login?reason=missing_state")


### PR DESCRIPTION
### Motivation
- Ensure the OAuth callback route only forwards requests to Nango when the required `state` parameter is present to avoid incomplete or malicious redirects.
- Provide a clear fallback redirect to the frontend login when the `state` key is missing to improve error handling.

### Description
- Update the `/api/auth/oauth/callback` route to check for `state` in `request.query_params` and log a warning when missing, then redirect to the frontend login with `?reason=missing_state` using `settings.FRONTEND_URL`.
- Preserve existing behavior to forward all query parameters to `https://api.nango.dev/oauth/callback` when `state` is present.
- Add unit tests in `backend/tests/test_auth_oauth_callback_redirect.py` covering missing `state`, present `state` with preserved query string, and no query string cases.

### Testing
- Ran the new test module with `pytest backend/tests/test_auth_oauth_callback_redirect.py` and all tests passed.
- Verified the three tests assert the redirect status `302` and the expected `Location` header for each scenario and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f422e568d883218102f53a358cf733)