### PR TITLE
Rename temp_data → knowledge_base, add collections and RLS migrations

### DIFF
--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -136,7 +136,7 @@ Available tables (use these exact column names):
 - tracker_projects: Issue tracker projects (source_system, source_id, name, description, state, progress, target_date, start_date, lead_name, team_ids JSONB). Filter by source_system.
 - tracker_issues: Issue tracker issues/tasks (source_system, source_id, team_id, identifier e.g. "ENG-123", title, description, state_name, state_type, priority 0-4, priority_label, issue_type, assignee_name, assignee_email, creator_name, project_id, labels JSONB, estimate, url, due_date, created_date, updated_date, completed_date, cancelled_date, user_id). Filter by source_system.
 - shared_files: Synced file metadata from cloud sources like Google Drive (external_id, source, name, mime_type, folder_path, web_view_link, file_size, source_modified_at). Filter by source (e.g. 'google_drive'). Use query_on_connector(connector='google_drive', query='search:...') for name-based searches.
-- temp_data: Agent-generated results and computed metrics. Flexible JSONB storage linked to entities. Columns: entity_type, entity_id, namespace, key, value (JSONB), metadata (JSONB), created_by_user_id, created_at, expires_at. Example: SELECT td.value->>'score' as confidence, d.name FROM temp_data td JOIN deals d ON d.id = td.entity_id WHERE td.namespace = 'deal_confidence'
+- knowledge_base: Agent-generated results and computed metrics. Flexible JSONB storage linked to entities. Columns: entity_type, entity_id, namespace, key, value (JSONB), metadata (JSONB), created_by_user_id, created_at, expires_at. Example: SELECT td.value->>'score' as confidence, d.name FROM knowledge_base td JOIN deals d ON d.id = td.entity_id WHERE td.namespace = 'deal_confidence'
 - daily_digests: Per-member daily activity digest. Columns: id, user_id, digest_date (DATE), summary (JSONB with keys: narrative, highlights, categories), raw_data (JSONB, nullable), generated_at. One row per user per date. Join to users via user_id. All org members' digests are visible.
 - daily_team_summaries: Org-wide daily team summary. Columns: id, digest_date (DATE), summary_text (TEXT), generated_at. One row per date. Read-only.
 
@@ -364,7 +364,7 @@ Writable tables:
 - users: (phone_number) → immediate. Phone numbers MUST be E.164 format with country code, e.g. +14155551234 for US numbers. If the user gives a 10-digit number like 4159028648, prepend +1.
 - workflows: See workflow format below → immediate
 - artifacts: (type, title, description, data) → immediate
-- temp_data: (entity_type, entity_id, namespace, key, value, metadata, expires_at) → immediate. Flexible JSONB store for computed results. Use namespace to group (e.g. 'deal_confidence'). value is JSONB, any shape.
+- knowledge_base: (entity_type, entity_id, namespace, key, value, metadata, expires_at) → immediate. Flexible JSONB store for computed results. Use namespace to group (e.g. 'deal_confidence'). value is JSONB, any shape.
 - daily_digests: (summary) → immediate, user can only update their own digest. summary is JSONB with keys: narrative (string), highlights (array), categories (array). user_id is auto-set to the current user on INSERT.
 
 **WORKFLOW FORMAT (Important!):**

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -196,7 +196,7 @@ ALLOWED_TABLES: set[str] = {
     "shared_files",
     "tracker_teams", "tracker_projects", "tracker_issues",
     "bulk_operations", "bulk_operation_results",
-    "temp_data",
+    "knowledge_base",
     "daily_digests", "daily_team_summaries",
 }
 
@@ -1330,7 +1330,7 @@ WRITABLE_TABLES: set[str] = {
     "deals",
     "accounts",
     "org_members",
-    "temp_data",
+    "knowledge_base",
     "daily_digests",
 }
 

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -2691,7 +2691,7 @@ async def delete_organization(
             "apps",
             "artifacts",
             "memories",
-            "temp_data",
+            "knowledge_base",
             "org_members",
         )
         for table_name in org_scoped_tables:

--- a/backend/db/migrations/versions/137_kb_docs.py
+++ b/backend/db/migrations/versions/137_kb_docs.py
@@ -1,0 +1,159 @@
+"""Rename temp_data to knowledge_base_docs and add doc collections.
+
+Revision ID: 137_kb_docs
+Revises: 58726d896351
+Create Date: 2026-04-30
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "137_kb_docs"
+down_revision = "58726d896351"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE temp_data DISABLE ROW LEVEL SECURITY")
+    op.execute("DROP POLICY IF EXISTS temp_data_org_isolation ON temp_data")
+
+    op.rename_table("temp_data", "knowledge_base_docs")
+    op.execute(
+        "ALTER INDEX IF EXISTS ix_temp_data_ns_entity RENAME TO ix_kb_docs_ns_entity"
+    )
+    op.execute(
+        "ALTER INDEX IF EXISTS ix_temp_data_entity RENAME TO ix_kb_docs_entity"
+    )
+    op.execute(
+        "ALTER INDEX IF EXISTS ix_temp_data_expires RENAME TO ix_kb_docs_expires"
+    )
+
+    op.execute("ALTER TABLE knowledge_base_docs ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY knowledge_base_docs_org_isolation ON knowledge_base_docs
+        FOR ALL
+        USING (organization_id = current_setting('app.current_org_id')::uuid)
+        WITH CHECK (organization_id = current_setting('app.current_org_id')::uuid)
+        """
+    )
+
+    op.create_table(
+        "knowledge_base_collections",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "organization_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("organization_id", "name", name="uq_kb_collections_org_name"),
+    )
+    op.create_index(
+        "ix_kb_collections_org_name",
+        "knowledge_base_collections",
+        ["organization_id", "name"],
+    )
+
+    op.create_table(
+        "knowledge_base_collection_items",
+        sa.Column(
+            "collection_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("knowledge_base_collections.id", ondelete="CASCADE"),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "doc_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("knowledge_base_docs.id", ondelete="CASCADE"),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index(
+        "ix_kb_collection_items_doc",
+        "knowledge_base_collection_items",
+        ["doc_id"],
+    )
+
+    op.execute("ALTER TABLE knowledge_base_collections ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY knowledge_base_collections_org_isolation ON knowledge_base_collections
+        FOR ALL
+        USING (organization_id = current_setting('app.current_org_id')::uuid)
+        WITH CHECK (organization_id = current_setting('app.current_org_id')::uuid)
+        """
+    )
+
+    op.execute("ALTER TABLE knowledge_base_collection_items ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY knowledge_base_collection_items_org_isolation ON knowledge_base_collection_items
+        FOR ALL
+        USING (
+            EXISTS (
+                SELECT 1
+                FROM knowledge_base_collections c
+                WHERE c.id = collection_id
+                  AND c.organization_id = current_setting('app.current_org_id')::uuid
+            )
+        )
+        WITH CHECK (
+            EXISTS (
+                SELECT 1
+                FROM knowledge_base_collections c
+                WHERE c.id = collection_id
+                  AND c.organization_id = current_setting('app.current_org_id')::uuid
+            )
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP POLICY IF EXISTS knowledge_base_collection_items_org_isolation ON knowledge_base_collection_items"
+    )
+    op.execute(
+        "DROP POLICY IF EXISTS knowledge_base_collections_org_isolation ON knowledge_base_collections"
+    )
+    op.execute(
+        "DROP POLICY IF EXISTS knowledge_base_docs_org_isolation ON knowledge_base_docs"
+    )
+
+    op.drop_index("ix_kb_collection_items_doc", table_name="knowledge_base_collection_items")
+    op.drop_table("knowledge_base_collection_items")
+
+    op.drop_index("ix_kb_collections_org_name", table_name="knowledge_base_collections")
+    op.drop_table("knowledge_base_collections")
+
+    op.execute("ALTER TABLE knowledge_base_docs DISABLE ROW LEVEL SECURITY")
+    op.rename_table("knowledge_base_docs", "temp_data")
+
+    op.execute("ALTER INDEX IF EXISTS ix_kb_docs_ns_entity RENAME TO ix_temp_data_ns_entity")
+    op.execute("ALTER INDEX IF EXISTS ix_kb_docs_entity RENAME TO ix_temp_data_entity")
+    op.execute("ALTER INDEX IF EXISTS ix_kb_docs_expires RENAME TO ix_temp_data_expires")
+
+    op.execute("ALTER TABLE temp_data ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY temp_data_org_isolation ON temp_data
+        FOR ALL
+        USING (organization_id = current_setting('app.current_org_id')::uuid)
+        """
+    )

--- a/backend/db/migrations/versions/138_kb_rename.py
+++ b/backend/db/migrations/versions/138_kb_rename.py
@@ -1,0 +1,56 @@
+"""Rename knowledge_base_docs to knowledge_base.
+
+Revision ID: 138_kb_rename
+Revises: 137_kb_docs
+Create Date: 2026-04-30
+"""
+
+from alembic import op
+
+
+revision = "138_kb_rename"
+down_revision = "137_kb_docs"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE knowledge_base_docs DISABLE ROW LEVEL SECURITY")
+    op.execute(
+        "DROP POLICY IF EXISTS knowledge_base_docs_org_isolation ON knowledge_base_docs"
+    )
+
+    op.rename_table("knowledge_base_docs", "knowledge_base")
+    op.execute("ALTER INDEX IF EXISTS ix_kb_docs_ns_entity RENAME TO ix_kb_ns_entity")
+    op.execute("ALTER INDEX IF EXISTS ix_kb_docs_entity RENAME TO ix_kb_entity")
+    op.execute("ALTER INDEX IF EXISTS ix_kb_docs_expires RENAME TO ix_kb_expires")
+
+    op.execute("ALTER TABLE knowledge_base ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY knowledge_base_org_isolation ON knowledge_base
+        FOR ALL
+        USING (organization_id = current_setting('app.current_org_id')::uuid)
+        WITH CHECK (organization_id = current_setting('app.current_org_id')::uuid)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS knowledge_base_org_isolation ON knowledge_base")
+    op.execute("ALTER TABLE knowledge_base DISABLE ROW LEVEL SECURITY")
+
+    op.rename_table("knowledge_base", "knowledge_base_docs")
+    op.execute("ALTER INDEX IF EXISTS ix_kb_ns_entity RENAME TO ix_kb_docs_ns_entity")
+    op.execute("ALTER INDEX IF EXISTS ix_kb_entity RENAME TO ix_kb_docs_entity")
+    op.execute("ALTER INDEX IF EXISTS ix_kb_expires RENAME TO ix_kb_docs_expires")
+
+    op.execute("ALTER TABLE knowledge_base_docs ENABLE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        CREATE POLICY knowledge_base_docs_org_isolation ON knowledge_base_docs
+        FOR ALL
+        USING (organization_id = current_setting('app.current_org_id')::uuid)
+        WITH CHECK (organization_id = current_setting('app.current_org_id')::uuid)
+        """
+    )

--- a/backend/models/temp_data.py
+++ b/backend/models/temp_data.py
@@ -1,5 +1,5 @@
 """
-TempData model – flexible JSONB storage for agent-computed results.
+KnowledgeBaseEntry model – flexible JSONB document storage for agents/workflows.
 
 Agents and workflows write interim / computed outputs here (deal confidence
 scores, churn risk, engagement grades, etc.).  Rows are optionally linked
@@ -18,10 +18,10 @@ from sqlalchemy.orm import Mapped, mapped_column
 from models.database import Base
 
 
-class TempData(Base):
-    """Flexible key/value store for agent-generated results."""
+class KnowledgeBaseEntry(Base):
+    """Flexible JSON document store for agent-generated knowledge."""
 
-    __tablename__ = "temp_data"
+    __tablename__ = "knowledge_base"
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4

--- a/backend/services/user_merge.py
+++ b/backend/services/user_merge.py
@@ -151,7 +151,7 @@ async def merge_users(
             ("apps.user_id", "UPDATE apps SET user_id = :target_id WHERE user_id = :source_id"),
             ("artifacts.user_id", "UPDATE artifacts SET user_id = :target_id WHERE user_id = :source_id"),
             ("bulk_operations.user_id", "UPDATE bulk_operations SET user_id = :target_id WHERE user_id = :source_id"),
-            ("temp_data.created_by_user_id", "UPDATE temp_data SET created_by_user_id = :target_id WHERE created_by_user_id = :source_id"),
+            ("knowledge_base.created_by_user_id", "UPDATE knowledge_base SET created_by_user_id = :target_id WHERE created_by_user_id = :source_id"),
             ("sheet_imports.user_id", "UPDATE sheet_imports SET user_id = :target_id WHERE user_id = :source_id"),
             ("user_tool_settings.user_id", "UPDATE user_tool_settings SET user_id = :target_id WHERE user_id = :source_id"),
             ("pending_operations.user_id", "UPDATE pending_operations SET user_id = :target_id WHERE user_id = :source_id"),

--- a/backend/tests/test_knowledge_base_docs_tables.py
+++ b/backend/tests/test_knowledge_base_docs_tables.py
@@ -1,0 +1,11 @@
+from agents import tools
+
+
+def test_knowledge_base_is_sql_accessible() -> None:
+    assert "knowledge_base" in tools.ALLOWED_TABLES
+    assert "knowledge_base" in tools.WRITABLE_TABLES
+
+
+def test_temp_data_removed_from_sql_tables() -> None:
+    assert "temp_data" not in tools.ALLOWED_TABLES
+    assert "temp_data" not in tools.WRITABLE_TABLES

--- a/backend/tests/test_knowledge_base_rls_migrations.py
+++ b/backend/tests/test_knowledge_base_rls_migrations.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import importlib
+from unittest.mock import patch
+
+
+def _sql_for_upgrade(module_name: str) -> str:
+    mig = importlib.import_module(module_name)
+    executed_sql: list[str] = []
+    with (
+        patch.object(mig.op, "execute", side_effect=lambda sql: executed_sql.append(str(sql))),
+        patch.object(mig.op, "rename_table", side_effect=lambda old, new: executed_sql.append(f"RENAME TABLE {old} TO {new}")),
+        patch.object(mig.op, "create_table", side_effect=lambda name, *args, **kwargs: executed_sql.append(f"CREATE TABLE {name}")),
+        patch.object(mig.op, "create_index", side_effect=lambda name, table_name, columns, *args, **kwargs: executed_sql.append(f"CREATE INDEX {name} ON {table_name}({','.join(columns)})")),
+    ):
+        mig.upgrade()
+    return "\n".join(executed_sql)
+
+
+def test_137_revision_metadata_and_length_guards() -> None:
+    mig = importlib.import_module("db.migrations.versions.137_kb_docs")
+    assert mig.revision == "137_kb_docs"
+    assert mig.down_revision == "58726d896351"
+    assert len(mig.revision) <= 32
+    assert len(mig.down_revision) <= 32
+
+
+def test_138_revision_metadata_and_length_guards() -> None:
+    mig = importlib.import_module("db.migrations.versions.138_kb_rename")
+    assert mig.revision == "138_kb_rename"
+    assert mig.down_revision == "137_kb_docs"
+    assert len(mig.revision) <= 32
+    assert len(mig.down_revision) <= 32
+
+
+def test_137_upgrade_enables_rls_and_blocks_cross_org_access() -> None:
+    sql = _sql_for_upgrade("db.migrations.versions.137_kb_docs")
+
+    assert "ALTER TABLE knowledge_base_docs ENABLE ROW LEVEL SECURITY" in sql
+    assert "CREATE POLICY knowledge_base_docs_org_isolation ON knowledge_base_docs" in sql
+    assert "WITH CHECK (organization_id = current_setting('app.current_org_id')::uuid)" in sql
+
+    assert "ALTER TABLE knowledge_base_collections ENABLE ROW LEVEL SECURITY" in sql
+    assert "CREATE POLICY knowledge_base_collections_org_isolation ON knowledge_base_collections" in sql
+    assert "WITH CHECK (organization_id = current_setting('app.current_org_id')::uuid)" in sql
+
+    assert "ALTER TABLE knowledge_base_collection_items ENABLE ROW LEVEL SECURITY" in sql
+    assert "CREATE POLICY knowledge_base_collection_items_org_isolation ON knowledge_base_collection_items" in sql
+    # Cross-org inserts/selects fail because policy requires an in-org collection owner row.
+    assert "FROM knowledge_base_collections c" in sql
+    assert "c.organization_id = current_setting('app.current_org_id')::uuid" in sql
+
+
+def test_138_upgrade_enables_rls_and_org_scoping_on_renamed_table() -> None:
+    sql = _sql_for_upgrade("db.migrations.versions.138_kb_rename")
+
+    assert "ALTER TABLE knowledge_base ENABLE ROW LEVEL SECURITY" in sql
+    assert "CREATE POLICY knowledge_base_org_isolation ON knowledge_base" in sql
+    assert "USING (organization_id = current_setting('app.current_org_id')::uuid)" in sql
+    assert "WITH CHECK (organization_id = current_setting('app.current_org_id')::uuid)" in sql


### PR DESCRIPTION
### Motivation

- Centralize agent-generated documents under a clearer `knowledge_base` concept instead of the vague `temp_data` table to better support collections and querying semantics. 
- Enforce organization-level row-level security (RLS) for the new KB objects and provide a collection abstraction for grouping docs.

### Description

- Add two Alembic migrations: `137_kb_docs` which renames `temp_data` → `knowledge_base_docs`, enables RLS and creates `knowledge_base_collections` and `knowledge_base_collection_items`, and `138_kb_rename` which renames `knowledge_base_docs` → `knowledge_base` and updates indexes and policies. 
- Rename the model in `models/temp_data.py` from `TempData` to `KnowledgeBaseEntry` and update the `__tablename__` to `knowledge_base` to match the DB rename. 
- Replace references to `temp_data` with `knowledge_base` across code including `backend/agents/registry.py`, `backend/agents/tools.py`, `backend/api/routes/auth.py`, and `backend/services/user_merge.py`. 
- Update allowed and writable table sets in `tools.py` to include `knowledge_base` and remove `temp_data`, and add tests to assert those changes.

### Testing

- Added unit tests `test_knowledge_base_docs_tables.py` and `test_knowledge_base_rls_migrations.py` which validate table-name updates and that the migrations enable RLS and create org-scoped policies; these tests were executed and passed. 
- Ran the repository unit test suite focusing on the agents/db migration checks and table-access assertions, and they completed successfully. 
- Smoke-checked that code references compile after renames by running static imports for the modified modules, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3befd2cac832191950555a538fa9a)