### PR TITLE
feat(ui): Sidebar workspace nav + less chrome

### DIFF
--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -14,6 +14,7 @@ from api.routes.public import (
     _public_preview_title,
     share_router,
 )
+from config import settings
 from api.routes.artifacts import _generate_chart_html, get_artifact
 from starlette.routing import Match
 from services.public_previews import build_preview_html, decode_data_url_image, render_card_png
@@ -136,7 +137,8 @@ def test_public_preview_title_falls_back_when_artifact_title_missing() -> None:
     assert title == "Shared Document · Basebase"
 
 
-def test_public_origin_prefers_forwarded_proxy_headers() -> None:
+def test_public_origin_prefers_forwarded_proxy_headers(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "BACKEND_PUBLIC_URL", "")
     request = SimpleNamespace(
         headers={"x-forwarded-proto": "https", "x-forwarded-host": "app.basebase.com"},
         url=SimpleNamespace(scheme="http", netloc="internal:8000"),

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1812,7 +1812,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
     <div className="h-full flex flex-col bg-surface-950 overflow-hidden">
       {/* Masquerade Banner */}
       {masquerade && (
-        <div className="bg-amber-500/20 dark:bg-amber-500/20 border-b border-amber-500/30 px-4 py-2 flex items-center justify-between flex-shrink-0">
+        <div className="bg-amber-500/20 dark:bg-amber-500/20 px-4 py-2 flex items-center justify-between flex-shrink-0">
           <div className="flex items-center gap-2 text-amber-700 dark:text-amber-400">
             <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -1838,7 +1838,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       <div className="flex-1 flex flex-col md:flex-row min-h-0 overflow-hidden">
       {/* Mobile Header */}
       {isMobile && (
-        <header className="h-14 bg-surface-900 border-b border-surface-800 flex items-center justify-between px-4 flex-shrink-0">
+        <header className="h-14 bg-surface-900 flex items-center justify-between px-4 flex-shrink-0">
           <button
             onClick={() => setMobileSidebarOpen(true)}
             className="p-2 -ml-2 rounded-lg text-surface-400 hover:text-surface-200 hover:bg-surface-800 transition-colors"
@@ -1914,7 +1914,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       <main className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden">
         {orgAccessError ? (
           <div className="flex-1 flex flex-col items-center justify-center p-6 text-center">
-            <div className="max-w-md rounded-lg border border-surface-600 bg-surface-900/80 p-6 shadow-lg">
+            <div className="max-w-md rounded-lg bg-surface-900/80 p-6 shadow-2xl ring-1 ring-white/10">
               <h2 className="text-lg font-semibold text-surface-100">
                 You don&apos;t have access to this organization
               </h2>
@@ -1938,7 +1938,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
           <>
         {/* Release Stage Banner */}
         {RELEASE_STAGE.stage && showReleaseBanner && (
-          <div className="flex-shrink-0 px-4 md:px-6 py-3 bg-primary-500/10 border-b border-primary-500/20">
+          <div className="flex-shrink-0 px-4 md:px-6 py-3 bg-primary-500/10">
             <div className="flex items-center justify-between gap-3 max-w-7xl mx-auto">
               <p className="text-sm text-surface-300 min-w-0 flex-1 leading-relaxed">
                 <span className="text-primary-400 font-semibold mr-2">

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1809,7 +1809,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
   };
 
   return (
-    <div className="h-full flex flex-col bg-surface-950 overflow-hidden">
+    <div className="h-full flex flex-col bg-surface-900 overflow-hidden">
       {/* Masquerade Banner */}
       {masquerade && (
         <div className="bg-amber-500/20 dark:bg-amber-500/20 px-4 py-2 flex items-center justify-between flex-shrink-0">
@@ -1838,7 +1838,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       <div className="flex-1 flex flex-col md:flex-row min-h-0 overflow-hidden">
       {/* Mobile Header */}
       {isMobile && (
-        <header className="h-14 bg-surface-900 flex items-center justify-between px-4 flex-shrink-0">
+        <header className="h-14 bg-surface-950 flex items-center justify-between px-4 flex-shrink-0">
           <button
             onClick={() => setMobileSidebarOpen(true)}
             className="p-2 -ml-2 rounded-lg text-surface-400 hover:text-surface-200 hover:bg-surface-800 transition-colors"

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -5,8 +5,8 @@
  * - Collapsible left sidebar (icons when collapsed)
  * - Slide-out drawer on mobile
  * - New Chat button
- * - Connectors tab with badge
- * - Chats tab with recent conversations
+ * - Org switcher dropdown includes workspace links (Connectors, Apps, etc.)
+ * - Recent conversations in sidebar
  * - Organization & Profile sections at bottom
  * 
  * Also manages global WebSocket connection for background task updates.
@@ -41,7 +41,7 @@ const DocumentsGallery = lazy(() => import('./documents/DocumentsGallery').then(
 import { APP_NAME, LOGO_PATH, RELEASE_STAGE } from '../lib/brand';
 import { ProfilePanel } from './ProfilePanel';
 import { useAppStore, useChatStore, useUIStore, useMasquerade, useIntegrations, useIsSwitchingOrg, useIsGlobalAdmin, useIsOrgAdmin, type ActiveTask, type AdminPanelTab, type ToolCallData, type ChatMessage, type ContentBlock, type View, type Participant } from '../store';
-import { useTeamMembers, useWebSocket } from '../hooks';
+import { useWebSocket } from '../hooks';
 import { apiRequest } from '../lib/api';
 
 // Re-export types from store for backwards compatibility
@@ -267,7 +267,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
   });
   const workflowCount = workflows.length;
 
-  // Billing status for credits display in sidebar
+  // Billing status (OrganizationPanel credits tab + masquerade banner)
   const { data: billingStatus } = useQuery({
     queryKey: ['billing', organization?.id],
     queryFn: async () => {
@@ -303,12 +303,6 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
     window.addEventListener('pending-changes-updated', handle);
     return () => window.removeEventListener('pending-changes-updated', handle);
   }, [fetchPendingCount, orgId]);
-
-  // React Query: Get team members for member count (single source of truth)
-  const { data: teamData } = useTeamMembers(
-    organization?.id ?? null,
-    user?.id ?? null
-  );
 
   // Get actions separately (they're stable and don't need shallow comparison)
   const setSidebarCollapsed = useAppStore((state) => state.setSidebarCollapsed);
@@ -1900,10 +1894,6 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
           currentChatId={currentChatId}
           onNewChat={startNewChat}
           organization={organization}
-          members={teamData?.members ?? []}
-          creditsDisplay={billingStatus ? { balance: billingStatus.credits_balance, included: billingStatus.credits_included } : null}
-          onOpenOrgPanel={() => { setOrgPanelTab('team'); setShowOrgPanel(true); }}
-          onOpenBilling={() => { setOrgPanelTab('billing'); setShowOrgPanel(true); }}
           onCreateNewOrg={onCreateNewOrg}
           onOpenProfilePanel={() => setShowProfilePanel(true)}
           isMobile={isMobile}

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -113,7 +113,7 @@ interface ToolApprovalState {
 const AGENT_AVATAR_PATH: string = '/basebase_logo_reverse-256.png';
 const CHAT_MSG_ROW: string =
   'group/msg flex items-start gap-3 px-5 -mx-5 hover:bg-black/[0.035] dark:hover:bg-surface-800/40 transition-colors';
-const CHAT_MSG_AVATAR: string = 'flex-shrink-0 !w-9 !h-9 !rounded-lg mt-px';
+const CHAT_MSG_AVATAR: string = 'flex-shrink-0 !w-9 !h-9 !rounded-full mt-px';
 const CHAT_MSG_AVATAR_SPACER: string = 'w-9 flex-shrink-0 mt-px';
 const CHAT_MSG_NAME: string =
   'text-[15px] font-bold leading-tight text-surface-50 dark:text-surface-50 tracking-[-0.015em]';

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2873,7 +2873,7 @@ export function Chat({
                       autoFocus={chatId === null}
                     />
 
-                    <div className="flex items-center justify-between gap-2 border-t border-surface-700/40 px-1.5 py-1 min-w-0">
+                    <div className="flex items-center justify-between gap-2 px-1.5 pt-0 pb-1 min-w-0">
                       <div className="flex min-w-0 items-center gap-1.5">
                         {attachButton}
                         {modelLabel}

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1974,17 +1974,17 @@ export function Chat({
           <div className="h-5 w-48 rounded bg-surface-800 animate-pulse" />
         </header>
 
-        <div className="flex-1 overflow-hidden p-3 md:p-6">
+        <div className="flex-1 overflow-hidden px-4 py-3 md:p-5">
           <div className="space-y-6">
-            <div className="flex gap-3">
-              <div className="w-7 h-7 rounded-full bg-surface-700 animate-pulse flex-shrink-0 mt-0.5" />
+            <div className="flex items-start gap-3">
+              <div className="w-9 h-9 rounded-full bg-surface-700 animate-pulse flex-shrink-0 mt-px" />
               <div className="space-y-2 flex-1 max-w-[65%]">
                 <div className="h-3 rounded-full bg-surface-800 animate-pulse w-4/5" />
                 <div className="h-3 rounded-full bg-surface-800 animate-pulse w-3/5" />
               </div>
             </div>
-            <div className="flex gap-3">
-              <div className="w-7 h-7 rounded-full bg-surface-700 animate-pulse flex-shrink-0 mt-0.5" />
+            <div className="flex items-start gap-3">
+              <div className="w-9 h-9 rounded-full bg-surface-700 animate-pulse flex-shrink-0 mt-px" />
               <div className="space-y-2 flex-1 max-w-[80%]">
                 <div className="h-3 rounded-full bg-surface-800 animate-pulse w-full" style={{ animationDelay: '75ms' }} />
                 <div className="h-3 rounded-full bg-surface-800 animate-pulse w-11/12" style={{ animationDelay: '150ms' }} />
@@ -1992,14 +1992,14 @@ export function Chat({
                 <div className="h-3 rounded-full bg-surface-800 animate-pulse w-5/6" style={{ animationDelay: '300ms' }} />
               </div>
             </div>
-            <div className="flex gap-3">
-              <div className="w-7 h-7 rounded-full bg-surface-700 animate-pulse flex-shrink-0 mt-0.5" />
+            <div className="flex items-start gap-3">
+              <div className="w-9 h-9 rounded-full bg-surface-700 animate-pulse flex-shrink-0 mt-px" />
               <div className="space-y-2 flex-1 max-w-[55%]">
                 <div className="h-3 rounded-full bg-surface-800 animate-pulse w-full" style={{ animationDelay: '375ms' }} />
               </div>
             </div>
-            <div className="flex gap-3">
-              <div className="w-7 h-7 rounded-full bg-surface-700 animate-pulse flex-shrink-0 mt-0.5" />
+            <div className="flex items-start gap-3">
+              <div className="w-9 h-9 rounded-full bg-surface-700 animate-pulse flex-shrink-0 mt-px" />
               <div className="space-y-2 flex-1 max-w-[75%]">
                 <div className="h-3 rounded-full bg-surface-800 animate-pulse w-full" style={{ animationDelay: '450ms' }} />
                 <div className="h-3 rounded-full bg-surface-800 animate-pulse w-5/6" style={{ animationDelay: '525ms' }} />
@@ -2009,7 +2009,7 @@ export function Chat({
           </div>
         </div>
 
-        <div className="flex-shrink-0 border-t border-surface-800 p-3 md:p-4">
+        <div className="flex-shrink-0 border-t border-surface-800 px-4 md:px-5 pb-4 pt-1">
           <div>
             <div className="h-11 rounded-xl bg-surface-800 animate-pulse" />
           </div>

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2504,7 +2504,7 @@ export function Chat({
                 />
               </div>
             )}
-            <div ref={messagesContainerRef} className="absolute inset-0 overflow-y-auto overflow-x-hidden p-3 md:p-5">
+            <div ref={messagesContainerRef} className="absolute inset-0 overflow-y-auto overflow-x-hidden px-4 py-3 md:p-5">
             {!userId && (
               <div className="mb-3 rounded-lg border border-amber-600/50 bg-amber-900/20 px-3 py-2 text-sm text-amber-200">
                 User context is missing — artifacts and apps may not save correctly. Please refresh or re-sign in.
@@ -2650,7 +2650,7 @@ export function Chat({
       </div>
 
       {/* Composer */}
-      <div className="px-3 md:px-5 pb-4 pt-1">
+      <div className="px-4 md:px-5 pb-4 pt-1">
         <div className="relative">
           <div
             className={`absolute left-0 bottom-full mb-1 min-w-[14rem] max-w-sm max-h-44 overflow-y-auto rounded-lg border border-surface-700 bg-surface-900 shadow-lg z-50 ${

--- a/frontend/src/components/DailyDigestGrid.tsx
+++ b/frontend/src/components/DailyDigestGrid.tsx
@@ -516,7 +516,7 @@ export function DailyDigestGrid({ digestDate, onDigestDateChange }: DailyDigestG
       ) : null}
 
       {error ? (
-        <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-4 text-red-300 text-sm">{error}</div>
+        <div className="px-1 py-2 text-sm text-red-500">{error}</div>
       ) : null}
 
       {loading ? (

--- a/frontend/src/components/HelpButton.tsx
+++ b/frontend/src/components/HelpButton.tsx
@@ -1,0 +1,142 @@
+/**
+ * Get help / contact support trigger.
+ *
+ * Renders an inline row trigger (icon + label) and a modal that posts a
+ * message to /support/request. Designed to live in account/profile menus
+ * where users expect to find help (Linear / Notion / Slack pattern).
+ */
+
+import { useCallback, useState } from 'react';
+import { apiRequest } from '../lib/api';
+
+interface HelpButtonProps {
+  /** Optional className applied to the trigger row. */
+  triggerClassName?: string;
+  /** Override the label shown in the trigger row (default: "Get help"). */
+  label?: string;
+}
+
+export function HelpButton({ triggerClassName, label = 'Get help' }: HelpButtonProps): JSX.Element {
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const [message, setMessage] = useState<string>('');
+  const [submitting, setSubmitting] = useState<boolean>(false);
+  const [success, setSuccess] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = useCallback(async (): Promise<void> => {
+    const trimmed: string = message.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    const { error: err } = await apiRequest<{ status: string; detail: string }>('/support/request', {
+      method: 'POST',
+      body: JSON.stringify({ message: trimmed }),
+    });
+    setSubmitting(false);
+    if (err) {
+      setError(err);
+      return;
+    }
+    setSuccess(true);
+    setMessage('');
+  }, [message, submitting]);
+
+  const handleClose = useCallback((): void => {
+    setShowModal(false);
+    setSuccess(false);
+    setError(null);
+    setMessage('');
+  }, []);
+
+  const defaultTriggerClass: string =
+    'w-full flex items-center justify-center gap-2 px-4 py-3 text-surface-300 hover:text-surface-100 hover:bg-surface-800 rounded-lg transition-colors font-medium';
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setShowModal(true)}
+        className={triggerClassName ?? defaultTriggerClass}
+      >
+        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093M12 17h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        {label}
+      </button>
+      {showModal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
+        >
+          <div
+            className="bg-surface-900 rounded-xl shadow-2xl ring-1 ring-white/10 max-w-md w-full p-6"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-surface-100">Get help</h2>
+              <button
+                type="button"
+                onClick={handleClose}
+                className="p-1 text-surface-400 hover:text-surface-200 rounded transition-colors"
+                aria-label="Close"
+              >
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            {success ? (
+              <p className="text-sm text-surface-300 mb-4">
+                Your message has been sent. A team member will be notified immediately and will respond within a few minutes during business hours.
+              </p>
+            ) : (
+              <>
+                <p className="text-sm text-surface-300 mb-4">
+                  You&apos;re our partner in building this product. Share questions, feedback, feature requests, or suggestions of any kind—we read every message and respond within a few minutes during business hours.
+                </p>
+                <textarea
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  placeholder="Questions, feedback, feature requests, or suggestions..."
+                  rows={4}
+                  className="w-full px-3 py-2 rounded-lg bg-surface-800 border border-surface-700 text-surface-100 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none mb-4"
+                  maxLength={4000}
+                />
+                {error && <p className="text-sm text-red-400 mb-2">{error}</p>}
+              </>
+            )}
+            <div className="flex justify-end gap-2">
+              {success ? (
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  className="px-4 py-2 rounded-lg bg-primary-600 hover:bg-primary-700 text-white font-medium transition-colors"
+                >
+                  Done
+                </button>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    onClick={handleClose}
+                    className="px-4 py-2 rounded-lg text-surface-400 hover:text-surface-200 hover:bg-surface-800 transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleSubmit()}
+                    disabled={!message.trim() || submitting}
+                    className="px-4 py-2 rounded-lg bg-primary-600 hover:bg-primary-700 text-white font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {submitting ? 'Sending...' : 'Send'}
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -277,10 +277,10 @@ export function Home(): JSX.Element {
         <div className="pt-4 pl-2 md:pl-4 flex flex-col min-h-full">
         {/* Connect data sources banner */}
         {!hasConnectedSources && (
-          <div className="mb-4 md:mb-6 mr-2 md:mr-4 bg-gradient-to-r from-primary-500/20 to-primary-600/10 border border-primary-500/30 rounded-xl p-4 md:p-5">
+          <div className="mb-4 md:mb-6 mr-2 md:mr-4 px-1">
             <div className="flex flex-col sm:flex-row items-start gap-3 md:gap-4">
-              <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-primary-500/20 flex items-center justify-center">
-                <svg className="w-5 h-5 text-primary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <div className="flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center text-primary-500">
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                 </svg>
               </div>

--- a/frontend/src/components/ProfilePanel.tsx
+++ b/frontend/src/components/ProfilePanel.tsx
@@ -13,6 +13,7 @@ import type { UserProfile } from './AppLayout';
 import { API_BASE, getAuthenticatedRequestHeaders } from '../lib/api';
 import { useUIStore, type UITheme } from '../store/uiStore';
 import { Memories } from './Memories';
+import { HelpButton } from './HelpButton';
 
 // ---------------------------------------------------------------------------
 // Phone verification modal
@@ -546,6 +547,7 @@ export function ProfilePanel({ user, onClose, onLogout, onUpdateUser }: ProfileP
               {isSaving ? 'Saving...' : 'Save changes'}
             </button>
           )}
+          <HelpButton />
           <button
             onClick={handleLogout}
             className="w-full flex items-center justify-center gap-2 px-4 py-3 text-red-400 hover:text-red-300 hover:bg-red-500/10 rounded-lg transition-colors font-medium"

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -9,8 +9,7 @@
  * - Profile section
  */
 
-import { useMemo, useState, useRef, useEffect } from 'react';
-import { createPortal } from 'react-dom';
+import { useMemo, useState, useRef, useEffect, useCallback } from 'react';
 import type { View, ChatSummary, OrganizationInfo } from './AppLayout';
 import { useAppStore, useAuthStore, useChatStore, useIsGlobalAdmin, useIsOrgAdmin, useActiveTasksByConversation, type UserOrganization, type AdminPanelTab } from '../store';
 import { apiRequest } from '../lib/api';
@@ -78,24 +77,96 @@ function OrgDropdownWorkspaceRow({
 }
 
 /** Organization switcher — displayed prominently at the top of the sidebar. */
+/** Org identity row — toggles the in-sidebar org panel below it. */
 function OrgSwitcherSection({
   organization,
-  onCreateNewOrg,
   isMobile,
   currentView,
+  panelOpen,
+  onTogglePanel,
+}: {
+  organization: OrganizationInfo;
+  isMobile: boolean;
+  currentView: View;
+  panelOpen: boolean;
+  onTogglePanel: () => void;
+}): JSX.Element {
+  const isAdminConsole: boolean = currentView === 'admin';
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={onTogglePanel}
+        aria-expanded={panelOpen}
+        aria-label={panelOpen ? 'Hide workspace menu' : 'Show workspace menu'}
+        className="w-full flex items-center gap-3 px-4 pt-3 pb-1 hover:bg-surface-800/50 transition-colors"
+      >
+        {isAdminConsole ? (
+          <>
+            <div className="w-9 h-9 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0 self-start mt-0.5 text-amber-400">
+              <GlobalAdminShieldIcon className="w-6 h-6" />
+            </div>
+            <div className="flex-1 min-w-0 text-left">
+              <div className="text-lg font-semibold text-surface-100 truncate leading-tight">
+                Global Admin
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            {organization.logoUrl ? (
+              <img
+                src={organization.logoUrl}
+                alt={organization.name}
+                className="w-9 h-9 rounded-lg object-cover flex-shrink-0 self-start mt-0.5"
+              />
+            ) : (
+              <div className="w-9 h-9 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0 self-start mt-0.5">
+                <img src={LOGO_PATH} alt={APP_NAME} className="w-6 h-6" />
+              </div>
+            )}
+            <div className="flex-1 min-w-0 text-left">
+              <div className="text-lg font-semibold text-surface-100 truncate leading-tight">
+                {organization.name}
+              </div>
+            </div>
+          </>
+        )}
+        <svg
+          className={`w-4 h-4 text-surface-400 flex-shrink-0 transition-transform duration-200 ${panelOpen ? 'rotate-180' : ''}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div className="pb-1" />
+      {/* keep isMobile referenced (mobile-specific behavior may live here later) */}
+      {isMobile ? null : null}
+    </div>
+  );
+}
+
+/** Org switcher + workspace nav, rendered in-place inside the sidebar body. */
+function OrgPanel({
+  currentView,
   onViewChange,
+  onCreateNewOrg,
   connectedSourcesCount,
   workflowCount,
   pendingChangesCount,
+  onClosePanel,
 }: {
-  organization: OrganizationInfo;
-  onCreateNewOrg: () => void;
-  isMobile: boolean;
   currentView: View;
   onViewChange: (view: View) => void;
+  onCreateNewOrg: () => void;
   connectedSourcesCount: number;
   workflowCount: number;
   pendingChangesCount: number;
+  onClosePanel: () => void;
 }): JSX.Element {
   const isGlobalAdmin: boolean = useIsGlobalAdmin();
   const isOrgAdmin: boolean = useIsOrgAdmin();
@@ -104,44 +175,9 @@ function OrgSwitcherSection({
   const switchActiveOrganization = useAppStore((state) => state.switchActiveOrganization);
   const fetchConversations = useAppStore((state) => state.fetchConversations);
   const fetchIntegrations = useAppStore((state) => state.fetchIntegrations);
-  const [showDropdown, setShowDropdown] = useState(false);
-  const [dropdownRect, setDropdownRect] = useState<{ top: number; left: number; width: number } | null>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const dropdownContentRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent): void => {
-      const target = e.target as Node;
-      if (
-        triggerRef.current?.contains(target) ||
-        dropdownContentRef.current?.contains(target)
-      ) {
-        return;
-      }
-      setShowDropdown(false);
-    };
-    if (showDropdown) {
-      document.addEventListener('mousedown', handleClickOutside);
-    }
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [showDropdown]);
-
-  useEffect(() => {
-    if (showDropdown && triggerRef.current) {
-      const rect = triggerRef.current.getBoundingClientRect();
-      const inset = 8; // matches original mx-2
-      setDropdownRect({
-        top: rect.bottom + 4,
-        left: rect.left + inset,
-        width: Math.max(240, rect.width - inset * 2),
-      });
-    } else {
-      setDropdownRect(null);
-    }
-  }, [showDropdown]);
-
-  const handleSwitchOrg = async (orgId: string): Promise<void> => {
-    setShowDropdown(false);
+  const handleSwitchOrg = useCallback(async (orgId: string): Promise<void> => {
+    onClosePanel();
     useAuthStore.setState({ isSwitchingOrg: true });
     try {
       const switched: boolean = await switchActiveOrganization(orgId);
@@ -153,292 +189,205 @@ function OrgSwitcherSection({
     } finally {
       useAuthStore.setState({ isSwitchingOrg: false });
     }
-  };
+  }, [onClosePanel, switchActiveOrganization, fetchConversations, fetchIntegrations]);
 
-  const handleEnterGlobalAdmin = (): void => {
-    setShowDropdown(false);
+  const handleEnterGlobalAdmin = useCallback((): void => {
+    onClosePanel();
     useAuthStore.setState({
       organizations: organizations.map((o) => ({ ...o, isActive: false })),
     });
     onViewChange('admin');
-  };
+  }, [onClosePanel, organizations, onViewChange]);
+
+  const goTo = useCallback((view: View): void => {
+    onClosePanel();
+    onViewChange(view);
+  }, [onClosePanel, onViewChange]);
 
   return (
-    <div className="relative">
-      {/* Org identity row */}
-      <div className="relative">
-        <button
-          ref={triggerRef}
-          onClick={() => setShowDropdown((prev) => !prev)}
-          className="w-full flex items-center gap-3 px-4 pt-3 pb-1 hover:bg-surface-800/50 transition-colors"
-        >
-          {isAdminConsole ? (
-            <>
-              <div className="w-9 h-9 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0 self-start mt-0.5 text-amber-400">
-                <GlobalAdminShieldIcon className="w-6 h-6" />
-              </div>
-              <div className="flex-1 min-w-0 text-left">
-                <div className="text-lg font-semibold text-surface-100 truncate leading-tight">
-                  Global Admin
-                </div>
-              </div>
-            </>
-          ) : (
-            <>
-              {organization.logoUrl ? (
-                <img
-                  src={organization.logoUrl}
-                  alt={organization.name}
-                  className="w-9 h-9 rounded-lg object-cover flex-shrink-0 self-start mt-0.5"
-                />
-              ) : (
-                <div className="w-9 h-9 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0 self-start mt-0.5">
-                  <img src={LOGO_PATH} alt={APP_NAME} className="w-6 h-6" />
-                </div>
-              )}
-              <div className="flex-1 min-w-0 text-left">
-                <div className="text-lg font-semibold text-surface-100 truncate leading-tight">
-                  {organization.name}
-                </div>
-              </div>
-            </>
-          )}
-          {!isMobile && (
-            <svg className="w-4 h-4 text-surface-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-            </svg>
-          )}
-        </button>
-
-        {/* Org switcher dropdown — rendered in portal to escape overflow clipping */}
-        {showDropdown && dropdownRect != null && createPortal(
-          <div
-            ref={dropdownContentRef}
-            role="menu"
-            className="fixed bg-surface-800 rounded-lg shadow-2xl ring-1 ring-white/10 max-h-[min(85vh,640px)] overflow-y-auto z-[9999]"
-            style={{ top: dropdownRect.top, left: dropdownRect.left, width: dropdownRect.width }}
+    <div className="h-full overflow-y-auto scrollbar-thin px-2 pb-2" role="menu" aria-label="Workspace menu">
+      <div className="text-[11px] uppercase tracking-wider text-surface-500 px-2 pt-1 pb-1 font-medium">
+        Workspaces
+      </div>
+      <div className="space-y-0.5">
+        {organizations.map((org) => (
+          <button
+            key={org.id}
+            type="button"
+            onClick={() => void handleSwitchOrg(org.id)}
+            className={`w-full flex items-center gap-3 px-2 py-2 rounded-md text-left transition-colors ${
+              org.isActive
+                ? 'bg-primary-500/10 text-primary-400'
+                : 'text-surface-300 hover:bg-surface-800/60'
+            }`}
           >
-            <div className="py-1">
-              {organizations.map((org) => (
-                <div
-                  key={org.id}
-                  className={`flex items-center transition-colors ${
-                    org.isActive
-                      ? 'bg-primary-500/10 text-primary-400'
-                      : 'text-surface-300 hover:bg-surface-700'
-                  }`}
-                >
-                  <button
-                    onClick={() => void handleSwitchOrg(org.id)}
-                    className="flex-1 min-w-0 flex items-center gap-3 px-3 py-2.5 text-left"
-                  >
-                    {org.logoUrl ? (
-                      <img src={org.logoUrl} alt={org.name} className="w-6 h-6 rounded object-cover flex-shrink-0" />
-                    ) : (
-                      <div className="w-6 h-6 rounded bg-surface-700 flex items-center justify-center flex-shrink-0">
-                        <img src={LOGO_PATH} alt={APP_NAME} className="w-4 h-4" />
-                      </div>
-                    )}
-                    <span className="text-sm truncate flex-1">{org.name}</span>
-                    {org.isActive && (
-                      <svg className="w-4 h-4 text-primary-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                      </svg>
-                    )}
-                  </button>
-                </div>
-              ))}
-              <div className="h-2 shrink-0" aria-hidden />
-              <div className="flex items-center justify-between px-3 py-2.5">
-                <span className="text-sm text-surface-400">New Team</span>
-                <button
-                  type="button"
-                  onClick={() => { setShowDropdown(false); onCreateNewOrg(); }}
-                  className="shrink-0 px-2.5 py-1 rounded-md bg-primary-600 hover:bg-primary-500 text-white text-xs font-medium transition-colors"
-                >
-                  + Create
-                </button>
+            {org.logoUrl ? (
+              <img src={org.logoUrl} alt={org.name} className="w-6 h-6 rounded object-cover flex-shrink-0" />
+            ) : (
+              <div className="w-6 h-6 rounded bg-surface-800 flex items-center justify-center flex-shrink-0">
+                <img src={LOGO_PATH} alt={APP_NAME} className="w-4 h-4" />
               </div>
-              {isGlobalAdmin && (
-                <>
-                  <div className="h-2 shrink-0" aria-hidden />
-                  <button
-                    type="button"
-                    onClick={handleEnterGlobalAdmin}
-                    className={`w-full flex items-center gap-3 px-3 py-2.5 text-left transition-colors ${
-                      isAdminConsole
-                        ? 'bg-primary-500/10 text-primary-400'
-                        : 'text-surface-300 hover:bg-surface-700'
-                    }`}
-                  >
-                    <div className="w-6 h-6 rounded bg-surface-700 flex items-center justify-center flex-shrink-0 text-amber-400">
-                      <GlobalAdminShieldIcon className="w-4 h-4" />
-                    </div>
-                    <span className="text-sm truncate flex-1">Global Admin</span>
-                    {isAdminConsole && (
-                      <svg className="w-4 h-4 text-primary-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                      </svg>
-                    )}
-                  </button>
-                </>
-              )}
-              {!isAdminConsole && (
-                <>
-                  <div className="h-2 shrink-0" aria-hidden />
-                  <div className="py-1" role="group" aria-label="Workspace">
-                    <OrgDropdownWorkspaceRow
-                      label="Home"
-                      isActive={currentView === 'home'}
-                      onSelect={() => {
-                        setShowDropdown(false);
-                        onViewChange('home');
-                      }}
-                      icon={
-                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-                        </svg>
-                      }
-                    />
-                    <OrgDropdownWorkspaceRow
-                      label="All chats"
-                      isActive={currentView === 'chats'}
-                      onSelect={() => {
-                        setShowDropdown(false);
-                        onViewChange('chats');
-                      }}
-                      icon={
-                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-                        </svg>
-                      }
-                    />
-                    <OrgDropdownWorkspaceRow
-                      label="Connectors"
-                      badge={connectedSourcesCount}
-                      isActive={currentView === 'data-sources'}
-                      onSelect={() => {
-                        setShowDropdown(false);
-                        onViewChange('data-sources');
-                      }}
-                      icon={
-                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
-                        </svg>
-                      }
-                    />
-                    <OrgDropdownWorkspaceRow
-                      label="Search Data"
-                      isActive={currentView === 'data'}
-                      onSelect={() => {
-                        setShowDropdown(false);
-                        onViewChange('data');
-                      }}
-                      icon={
-                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                        </svg>
-                      }
-                    />
-                    <OrgDropdownWorkspaceRow
-                      label="Workflows"
-                      badge={workflowCount}
-                      isActive={currentView === 'workflows'}
-                      onSelect={() => {
-                        setShowDropdown(false);
-                        onViewChange('workflows');
-                      }}
-                      icon={
-                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                        </svg>
-                      }
-                    />
-                    <OrgDropdownWorkspaceRow
-                      label="Apps"
-                      isActive={currentView === 'apps' || currentView === 'app-view'}
-                      onSelect={() => {
-                        setShowDropdown(false);
-                        onViewChange('apps');
-                      }}
-                      icon={
-                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                        </svg>
-                      }
-                    />
-                    <OrgDropdownWorkspaceRow
-                      label="Documents"
-                      isActive={currentView === 'documents' || currentView === 'artifact-view'}
-                      onSelect={() => {
-                        setShowDropdown(false);
-                        onViewChange('documents');
-                      }}
-                      icon={
-                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                        </svg>
-                      }
-                    />
-                    <div className="h-2 shrink-0" aria-hidden />
-                    {isOrgAdmin && (
-                      <OrgDropdownWorkspaceRow
-                        label="Activity"
-                        isActive={currentView === 'activity-log'}
-                        onSelect={() => {
-                          setShowDropdown(false);
-                          onViewChange('activity-log');
-                        }}
-                        icon={
-                          <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
-                          </svg>
-                        }
-                      />
-                    )}
-                    <OrgDropdownWorkspaceRow
-                      label="Settings"
-                      isActive={currentView === 'org-settings'}
-                      onSelect={() => {
-                        setShowDropdown(false);
-                        onViewChange('org-settings');
-                      }}
-                      icon={
-                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                        </svg>
-                      }
-                    />
-                    {pendingChangesCount > 0 && (
-                      <OrgDropdownWorkspaceRow
-                        label="Changes"
-                        badge={pendingChangesCount}
-                        badgeColor="amber"
-                        colorTheme="amber"
-                        isActive={currentView === 'pending-changes'}
-                        onSelect={() => {
-                          setShowDropdown(false);
-                          onViewChange('pending-changes');
-                        }}
-                        icon={
-                          <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-                          </svg>
-                        }
-                      />
-                    )}
-                  </div>
-                </>
-              )}
+            )}
+            <span className="text-sm truncate flex-1">{org.name}</span>
+            {org.isActive && (
+              <svg className="w-4 h-4 text-primary-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            )}
+          </button>
+        ))}
+        <div className="flex items-center justify-between px-2 py-2">
+          <span className="text-sm text-surface-400">New team</span>
+          <button
+            type="button"
+            onClick={() => { onClosePanel(); onCreateNewOrg(); }}
+            className="shrink-0 px-2.5 py-1 rounded-md bg-primary-600 hover:bg-primary-500 text-white text-xs font-medium transition-colors"
+          >
+            + Create
+          </button>
+        </div>
+        {isGlobalAdmin && (
+          <button
+            type="button"
+            onClick={handleEnterGlobalAdmin}
+            className={`w-full flex items-center gap-3 px-2 py-2 rounded-md text-left transition-colors ${
+              isAdminConsole
+                ? 'bg-primary-500/10 text-primary-400'
+                : 'text-surface-300 hover:bg-surface-800/60'
+            }`}
+          >
+            <div className="w-6 h-6 rounded bg-surface-800 flex items-center justify-center flex-shrink-0 text-amber-400">
+              <GlobalAdminShieldIcon className="w-4 h-4" />
             </div>
-          </div>,
-          document.body
+            <span className="text-sm truncate flex-1">Global Admin</span>
+            {isAdminConsole && (
+              <svg className="w-4 h-4 text-primary-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            )}
+          </button>
         )}
       </div>
 
-      {/* Bottom padding for the header block */}
-      <div className="pb-1" />
+      {!isAdminConsole && (
+        <>
+          <div className="text-[11px] uppercase tracking-wider text-surface-500 px-2 pt-4 pb-1 font-medium">
+            Workspace
+          </div>
+          <div className="space-y-0.5" role="group" aria-label="Workspace navigation">
+            <OrgDropdownWorkspaceRow
+              label="Home"
+              isActive={currentView === 'home'}
+              onSelect={() => goTo('home')}
+              icon={
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+                </svg>
+              }
+            />
+            <OrgDropdownWorkspaceRow
+              label="All chats"
+              isActive={currentView === 'chats'}
+              onSelect={() => goTo('chats')}
+              icon={
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                </svg>
+              }
+            />
+            <OrgDropdownWorkspaceRow
+              label="Connectors"
+              badge={connectedSourcesCount}
+              isActive={currentView === 'data-sources'}
+              onSelect={() => goTo('data-sources')}
+              icon={
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
+                </svg>
+              }
+            />
+            <OrgDropdownWorkspaceRow
+              label="Search Data"
+              isActive={currentView === 'data'}
+              onSelect={() => goTo('data')}
+              icon={
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+              }
+            />
+            <OrgDropdownWorkspaceRow
+              label="Workflows"
+              badge={workflowCount}
+              isActive={currentView === 'workflows'}
+              onSelect={() => goTo('workflows')}
+              icon={
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+              }
+            />
+            <OrgDropdownWorkspaceRow
+              label="Apps"
+              isActive={currentView === 'apps' || currentView === 'app-view'}
+              onSelect={() => goTo('apps')}
+              icon={
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                </svg>
+              }
+            />
+            <OrgDropdownWorkspaceRow
+              label="Documents"
+              isActive={currentView === 'documents' || currentView === 'artifact-view'}
+              onSelect={() => goTo('documents')}
+              icon={
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+              }
+            />
+            {isOrgAdmin && (
+              <OrgDropdownWorkspaceRow
+                label="Activity"
+                isActive={currentView === 'activity-log'}
+                onSelect={() => goTo('activity-log')}
+                icon={
+                  <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
+                  </svg>
+                }
+              />
+            )}
+            <OrgDropdownWorkspaceRow
+              label="Settings"
+              isActive={currentView === 'org-settings'}
+              onSelect={() => goTo('org-settings')}
+              icon={
+                <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+              }
+            />
+            {pendingChangesCount > 0 && (
+              <OrgDropdownWorkspaceRow
+                label="Changes"
+                badge={pendingChangesCount}
+                badgeColor="amber"
+                colorTheme="amber"
+                isActive={currentView === 'pending-changes'}
+                onSelect={() => goTo('pending-changes')}
+                icon={
+                  <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                  </svg>
+                }
+              />
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }
@@ -588,6 +537,14 @@ export function Sidebar({
   const storedWidth = useAppStore((state) => state.sidebarWidth);
   const widthPx = collapsed ? 64 : storedWidth;
 
+  const [panelMode, setPanelMode] = useState<'chats' | 'org'>('chats');
+  const togglePanel = useCallback((): void => {
+    setPanelMode((prev) => (prev === 'chats' ? 'org' : 'chats'));
+  }, []);
+  const closePanel = useCallback((): void => {
+    setPanelMode('chats');
+  }, []);
+
   const orderedChats = useMemo(() => {
     if (pinnedChatIds.length === 0) {
       return recentChats;
@@ -618,53 +575,77 @@ export function Sidebar({
         )}
         <OrgSwitcherSection
           organization={organization}
-          onCreateNewOrg={onCreateNewOrg}
           isMobile={isMobile}
           currentView={currentView}
-          onViewChange={onViewChange}
-          connectedSourcesCount={connectedSourcesCount}
-          workflowCount={workflowCount}
-          pendingChangesCount={pendingChangesCount}
+          panelOpen={panelMode === 'org'}
+          onTogglePanel={togglePanel}
         />
       </div>
 
       {currentView !== 'admin' && (
-      <>
-      <div className={`px-3 py-2 flex-shrink-0 flex items-center gap-1.5 ${collapsed ? 'flex-col' : ''}`}>
-        <button
-          type="button"
-          onClick={onNewChat}
-          className={`flex-1 flex items-center gap-2 px-3 py-[5px] rounded-lg bg-primary-600 hover:bg-primary-700 text-white font-medium text-sm transition-colors ${collapsed ? 'w-full justify-center' : ''}`}
-        >
-          <svg className="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-          {!collapsed && <span>New Chat</span>}
-        </button>
-        <button
-          type="button"
-          onClick={() => onViewChange('chats')}
-          title="Search all chats"
-          aria-label="Search all chats"
-          className={`flex items-center justify-center rounded-lg text-surface-400 hover:text-surface-100 hover:bg-surface-800/60 transition-colors ${collapsed ? 'w-full py-[5px]' : 'h-8 w-8'}`}
-        >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-          </svg>
-        </button>
-      </div>
+        <div className="relative flex-1 min-h-0">
+          {/* Chats layer */}
+          <div
+            className={`absolute inset-0 flex flex-col transition-opacity duration-150 ${
+              panelMode === 'chats' ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+            }`}
+            aria-hidden={panelMode !== 'chats'}
+          >
+            <div className={`px-3 py-2 flex-shrink-0 flex items-center gap-1.5 ${collapsed ? 'flex-col' : ''}`}>
+              <button
+                type="button"
+                onClick={onNewChat}
+                className={`flex-1 flex items-center gap-2 px-3 py-[5px] rounded-lg bg-primary-600 hover:bg-primary-700 text-white font-medium text-sm transition-colors ${collapsed ? 'w-full justify-center' : ''}`}
+              >
+                <svg className="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                {!collapsed && <span>New Chat</span>}
+              </button>
+              <button
+                type="button"
+                onClick={() => onViewChange('chats')}
+                title="Search all chats"
+                aria-label="Search all chats"
+                className={`flex items-center justify-center rounded-lg text-surface-400 hover:text-surface-100 hover:bg-surface-800/60 transition-colors ${collapsed ? 'w-full py-[5px]' : 'h-8 w-8'}`}
+              >
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+              </button>
+            </div>
 
-      {/* Recent chats (single list) */}
-      <ChatAccordion
-        collapsed={collapsed}
-        orderedChats={orderedChats}
-        currentChatId={currentChatId}
-        activeTasksByConversation={activeTasksByConversation}
-        onSelectChat={onSelectChat}
-      />
+            <ChatAccordion
+              collapsed={collapsed}
+              orderedChats={orderedChats}
+              currentChatId={currentChatId}
+              activeTasksByConversation={activeTasksByConversation}
+              onSelectChat={onSelectChat}
+            />
 
-      {collapsed && <div className="flex-1" />}
-      </>
+            {collapsed && <div className="flex-1" />}
+          </div>
+
+          {/* Org / workspace layer */}
+          {!collapsed && (
+            <div
+              className={`absolute inset-0 transition-opacity duration-150 ${
+                panelMode === 'org' ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+              }`}
+              aria-hidden={panelMode !== 'org'}
+            >
+              <OrgPanel
+                currentView={currentView}
+                onViewChange={onViewChange}
+                onCreateNewOrg={onCreateNewOrg}
+                connectedSourcesCount={connectedSourcesCount}
+                workflowCount={workflowCount}
+                pendingChangesCount={pendingChangesCount}
+                onClosePanel={closePanel}
+              />
+            </div>
+          )}
+        </div>
       )}
 
       {currentView === 'admin' && isGlobalAdmin && (

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,13 +1,11 @@
 /**
  * Collapsible sidebar navigation.
- * 
+ *
  * Features:
- * - Expand/collapse toggle
+ * - Org switcher with workspace links (Connectors, Apps, Workflows, etc.)
  * - New Chat button
- * - Connectors tab with badge
- * - Chats tab
  * - Recent chats list
- * - Organization section
+ * - Organization identity (org switcher)
  * - Profile section
  */
 
@@ -17,7 +15,7 @@ import type { View, ChatSummary, OrganizationInfo } from './AppLayout';
 import { useAppStore, useAuthStore, useChatStore, useIsGlobalAdmin, useIsOrgAdmin, useActiveTasksByConversation, type UserOrganization, type AdminPanelTab } from '../store';
 import { apiRequest } from '../lib/api';
 import { FaLifeRing } from 'react-icons/fa';
-import { Avatar, type AvatarUser } from './Avatar';
+import { Avatar } from './Avatar';
 import { ScopeLockIcon } from './ScopeVisibilityIcons';
 import { APP_NAME, LOGO_PATH, RELEASE_STAGE } from '../lib/brand';
 
@@ -142,38 +140,6 @@ function HelpButton(): JSX.Element {
   );
 }
 
-/** Small SVG donut chart showing remaining credits as a ring. */
-function CreditDonut({ balance, total }: { balance: number; total: number }): JSX.Element {
-  const size = 22;
-  const strokeWidth = 2.5;
-  const radius: number = (size - strokeWidth) / 2;
-  const circumference: number = 2 * Math.PI * radius;
-  const pct: number = total > 0 ? Math.max(0, Math.min(1, balance / total)) : 0;
-  const dashOffset: number = circumference * (1 - pct);
-
-  const strokeColor = '#9ca3af';
-
-  return (
-    <svg width={size} height={size} className="flex-shrink-0">
-      <circle
-        cx={size / 2} cy={size / 2} r={radius}
-        fill="none" stroke="currentColor" strokeWidth={strokeWidth}
-        className="text-surface-700"
-      />
-      {pct > 0 && (
-        <circle
-          cx={size / 2} cy={size / 2} r={radius}
-          fill="none" stroke={strokeColor} strokeWidth={strokeWidth}
-          strokeDasharray={circumference}
-          strokeDashoffset={dashOffset}
-          strokeLinecap="round"
-          transform={`rotate(-90 ${size / 2} ${size / 2})`}
-        />
-      )}
-    </svg>
-  );
-}
-
 /** Shield icon for global admin console identity in the org switcher. */
 function GlobalAdminShieldIcon({ className }: { className?: string }): JSX.Element {
   return (
@@ -183,29 +149,74 @@ function GlobalAdminShieldIcon({ className }: { className?: string }): JSX.Eleme
   );
 }
 
+/** Single row in org dropdown for workspace (team) navigation. */
+function OrgDropdownWorkspaceRow({
+  label,
+  icon,
+  isActive,
+  onSelect,
+  badge,
+  badgeColor = 'primary',
+  colorTheme = 'surface',
+}: {
+  label: string;
+  icon: JSX.Element;
+  isActive: boolean;
+  onSelect: () => void;
+  badge?: number;
+  badgeColor?: 'primary' | 'amber';
+  colorTheme?: 'surface' | 'amber';
+}): JSX.Element {
+  const activeClass: string =
+    colorTheme === 'amber'
+      ? 'bg-amber-500/15 text-amber-300'
+      : 'bg-surface-700 text-surface-100';
+  const inactiveClass: string =
+    colorTheme === 'amber'
+      ? 'text-amber-400 hover:bg-amber-500/10 hover:text-amber-300'
+      : 'text-surface-300 hover:bg-surface-700 hover:text-surface-100';
+  const badgeBg: string = badgeColor === 'amber' ? 'bg-amber-500' : 'bg-primary-500';
+
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onSelect}
+      className={`w-full flex items-center gap-3 px-3 py-2 text-left text-sm transition-colors ${isActive ? activeClass : inactiveClass}`}
+    >
+      <span className="flex-shrink-0 w-5 h-5 flex items-center justify-center [&>svg]:w-4 [&>svg]:h-4">{icon}</span>
+      <span className="truncate flex-1 min-w-0">{label}</span>
+      {badge != null && badge > 0 ? (
+        <span className={`shrink-0 min-w-[18px] h-[18px] px-1 rounded-full text-[10px] font-bold text-white flex items-center justify-center ${badgeBg}`}>
+          {badge}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
 /** Organization switcher — displayed prominently at the top of the sidebar. */
 function OrgSwitcherSection({
   organization,
-  members,
-  creditsDisplay,
-  onOpenOrgPanel,
-  onOpenBilling,
   onCreateNewOrg,
   isMobile,
   currentView,
   onViewChange,
+  connectedSourcesCount,
+  workflowCount,
+  pendingChangesCount,
 }: {
   organization: OrganizationInfo;
-  members: AvatarUser[];
-  creditsDisplay: { balance: number; included: number } | null;
-  onOpenOrgPanel: () => void;
-  onOpenBilling: () => void;
   onCreateNewOrg: () => void;
   isMobile: boolean;
   currentView: View;
   onViewChange: (view: View) => void;
+  connectedSourcesCount: number;
+  workflowCount: number;
+  pendingChangesCount: number;
 }): JSX.Element {
   const isGlobalAdmin: boolean = useIsGlobalAdmin();
+  const isOrgAdmin: boolean = useIsOrgAdmin();
   const isAdminConsole: boolean = currentView === 'admin';
   const organizations: UserOrganization[] = useAppStore((state) => state.organizations);
   const switchActiveOrganization = useAppStore((state) => state.switchActiveOrganization);
@@ -240,7 +251,7 @@ function OrgSwitcherSection({
       setDropdownRect({
         top: rect.bottom + 4,
         left: rect.left + inset,
-        width: Math.max(200, rect.width - inset * 2),
+        width: Math.max(240, rect.width - inset * 2),
       });
     } else {
       setDropdownRect(null);
@@ -329,7 +340,7 @@ function OrgSwitcherSection({
           <div
             ref={dropdownContentRef}
             role="menu"
-            className="fixed bg-surface-800 border border-surface-700 rounded-lg shadow-xl overflow-hidden z-[9999]"
+            className="fixed bg-surface-800 border border-surface-700 rounded-lg shadow-xl max-h-[min(85vh,640px)] overflow-y-auto z-[9999]"
             style={{ top: dropdownRect.top, left: dropdownRect.left, width: dropdownRect.width }}
           >
             <div className="py-1">
@@ -397,70 +408,146 @@ function OrgSwitcherSection({
                   </button>
                 </>
               )}
+              {!isAdminConsole && (
+                <>
+                  <div className="border-t border-surface-700 my-1" />
+                  <div className="py-1" role="group" aria-label="Workspace">
+                    <OrgDropdownWorkspaceRow
+                      label="Home"
+                      isActive={currentView === 'home'}
+                      onSelect={() => {
+                        setShowDropdown(false);
+                        onViewChange('home');
+                      }}
+                      icon={
+                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+                        </svg>
+                      }
+                    />
+                    <OrgDropdownWorkspaceRow
+                      label="Connectors"
+                      badge={connectedSourcesCount}
+                      isActive={currentView === 'data-sources'}
+                      onSelect={() => {
+                        setShowDropdown(false);
+                        onViewChange('data-sources');
+                      }}
+                      icon={
+                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
+                        </svg>
+                      }
+                    />
+                    <OrgDropdownWorkspaceRow
+                      label="Search Data"
+                      isActive={currentView === 'data'}
+                      onSelect={() => {
+                        setShowDropdown(false);
+                        onViewChange('data');
+                      }}
+                      icon={
+                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                        </svg>
+                      }
+                    />
+                    <OrgDropdownWorkspaceRow
+                      label="Workflows"
+                      badge={workflowCount}
+                      isActive={currentView === 'workflows'}
+                      onSelect={() => {
+                        setShowDropdown(false);
+                        onViewChange('workflows');
+                      }}
+                      icon={
+                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                        </svg>
+                      }
+                    />
+                    <OrgDropdownWorkspaceRow
+                      label="Apps"
+                      isActive={currentView === 'apps' || currentView === 'app-view'}
+                      onSelect={() => {
+                        setShowDropdown(false);
+                        onViewChange('apps');
+                      }}
+                      icon={
+                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                        </svg>
+                      }
+                    />
+                    <OrgDropdownWorkspaceRow
+                      label="Documents"
+                      isActive={currentView === 'documents' || currentView === 'artifact-view'}
+                      onSelect={() => {
+                        setShowDropdown(false);
+                        onViewChange('documents');
+                      }}
+                      icon={
+                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                        </svg>
+                      }
+                    />
+                    <div className="border-t border-surface-700 my-1" />
+                    {isOrgAdmin && (
+                      <OrgDropdownWorkspaceRow
+                        label="Activity"
+                        isActive={currentView === 'activity-log'}
+                        onSelect={() => {
+                          setShowDropdown(false);
+                          onViewChange('activity-log');
+                        }}
+                        icon={
+                          <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
+                          </svg>
+                        }
+                      />
+                    )}
+                    <OrgDropdownWorkspaceRow
+                      label="Settings"
+                      isActive={currentView === 'org-settings'}
+                      onSelect={() => {
+                        setShowDropdown(false);
+                        onViewChange('org-settings');
+                      }}
+                      icon={
+                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                        </svg>
+                      }
+                    />
+                    {pendingChangesCount > 0 && (
+                      <OrgDropdownWorkspaceRow
+                        label="Changes"
+                        badge={pendingChangesCount}
+                        badgeColor="amber"
+                        colorTheme="amber"
+                        isActive={currentView === 'pending-changes'}
+                        onSelect={() => {
+                          setShowDropdown(false);
+                          onViewChange('pending-changes');
+                        }}
+                        icon={
+                          <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                          </svg>
+                        }
+                      />
+                    )}
+                  </div>
+                </>
+              )}
             </div>
           </div>,
           document.body
         )}
       </div>
-
-      {/* Team members row */}
-      {!isAdminConsole && members.length > 0 && (
-        <div className="flex items-center gap-2 px-3 py-1.5">
-          <button
-            onClick={onOpenOrgPanel}
-            className="flex-1 min-w-0 flex items-center gap-2 hover:bg-surface-800/50 transition-colors rounded -mx-1 px-1 py-0.5"
-          >
-            <span className="text-xs text-surface-500 shrink-0">
-              {members.length} {members.length !== 1 ? 'members' : 'member'}
-            </span>
-            <div className="flex -space-x-1.5 ml-auto">
-              {members.filter((m) => m.avatarUrl && !m.isGuest).slice(0, 3).map((m, idx) => (
-                <img
-                  key={m.id}
-                  src={m.avatarUrl!}
-                  alt={m.name ?? m.email ?? ''}
-                  referrerPolicy="no-referrer"
-                  className="w-6 h-6 rounded-full object-cover border border-surface-700 dark:border-surface-600"
-                  style={{ zIndex: 3 - idx }}
-                />
-              ))}
-            </div>
-          </button>
-          <button
-            onClick={onOpenOrgPanel}
-            className="shrink-0 px-2.5 py-1 rounded-md bg-primary-600 hover:bg-primary-500 text-white text-xs font-medium transition-colors"
-          >
-            + Invite
-          </button>
-        </div>
-      )}
-
-      {/* Credits row */}
-      {!isAdminConsole && creditsDisplay != null && (() => {
-        const balance: number = creditsDisplay.balance;
-        const isOut: boolean = balance <= 0;
-        const pct: number = creditsDisplay.included > 0 ? balance / creditsDisplay.included : 1;
-        const isDanger: boolean = !isOut && pct <= 0.05;
-        const isWarning: boolean = !isOut && pct <= 0.25 && pct > 0.05;
-        const textClass: string = isOut || isDanger ? 'text-red-400' : isWarning ? 'text-amber-400' : 'text-surface-500';
-        return (
-          <button
-            onClick={onOpenBilling}
-            className="w-full flex items-center px-3 py-1.5 hover:bg-surface-800/50 transition-colors"
-          >
-            <span className={`text-xs ${textClass}`}>
-              {isOut ? (
-                <span className="font-semibold animate-pulse">No credits remaining</span>
-              ) : (
-                <>{balance} / {creditsDisplay.included} credits</>
-              )}
-            </span>
-            <div className="ml-auto">
-              <CreditDonut balance={balance} total={creditsDisplay.included} />
-            </div>
-          </button>
-        );
-      })()}
 
       {/* Bottom padding for the header block */}
       <div className="pb-1" />
@@ -481,70 +568,10 @@ interface SidebarProps {
   currentChatId: string | null;
   onNewChat: () => void;
   organization: OrganizationInfo;
-  members: AvatarUser[];
-  creditsDisplay: { balance: number; included: number } | null;
-  onOpenOrgPanel: () => void;
-  onOpenBilling: () => void;
   onCreateNewOrg: () => void;
   onOpenProfilePanel: () => void;
   isMobile?: boolean;
   onCloseMobile?: () => void;
-}
-
-/** Shared nav item used by the sidebar navigation. */
-function NavItem({
-  view,
-  activeViews,
-  label,
-  icon,
-  badge,
-  badgeColor = 'primary',
-  colorTheme = 'surface',
-  fontWeight,
-  collapsed,
-  currentView,
-  onViewChange,
-}: {
-  view: View;
-  activeViews?: View[];
-  label: string;
-  icon: JSX.Element;
-  badge?: number;
-  badgeColor?: 'primary' | 'amber';
-  colorTheme?: 'surface' | 'amber';
-  fontWeight?: 'medium';
-  collapsed: boolean;
-  currentView: View;
-  onViewChange: (view: View) => void;
-}): JSX.Element {
-  const isActive = (activeViews ?? [view]).includes(currentView);
-  const activeClass = colorTheme === 'amber'
-    ? 'bg-amber-500/20 text-amber-300'
-    : 'bg-surface-800 text-surface-100';
-  const inactiveClass = colorTheme === 'amber'
-    ? 'text-amber-400 hover:text-amber-300 hover:bg-amber-500/10'
-    : 'text-surface-300 hover:text-surface-200 hover:bg-surface-800/50';
-  const badgeBg = badgeColor === 'amber' ? 'bg-amber-500' : 'bg-primary-500';
-
-  return (
-    <button
-      onClick={() => onViewChange(view)}
-      title={collapsed ? label : undefined}
-      className={`w-full flex items-center gap-2 px-3 py-[5px] rounded-lg transition-colors ${isActive ? activeClass : inactiveClass} ${collapsed ? 'justify-center' : ''}`}
-    >
-      {badge != null && badge > 0 ? (
-        <div className="relative">
-          {icon}
-          <span className={`absolute -top-1.5 -right-1.5 min-w-[16px] h-4 px-1 ${badgeBg} rounded-full text-[10px] font-bold text-white flex items-center justify-center`}>
-            {badge}
-          </span>
-        </div>
-      ) : icon}
-      {!collapsed && (
-        <span className={fontWeight === 'medium' ? 'text-sm font-medium' : 'text-sm'}>{label}</span>
-      )}
-    </button>
-  );
 }
 
 function GlobalAdminSidebarNavItem({
@@ -658,10 +685,6 @@ export function Sidebar({
   currentChatId,
   onNewChat,
   organization,
-  members,
-  creditsDisplay,
-  onOpenOrgPanel,
-  onOpenBilling,
   onCreateNewOrg,
   onOpenProfilePanel,
   isMobile = false,
@@ -673,42 +696,9 @@ export function Sidebar({
   const adminPanelTab = useAppStore((state) => state.adminPanelTab);
   const setAdminPanelTab = useAppStore((state) => state.setAdminPanelTab);
   const isGlobalAdmin = useIsGlobalAdmin();
-  const isOrgAdmin = useIsOrgAdmin();
   const activeTasksByConversation = useActiveTasksByConversation();
   const storedWidth = useAppStore((state) => state.sidebarWidth);
   const widthPx = collapsed ? 64 : storedWidth;
-
-  // Draggable divider between nav and chat history
-  const [navHeight, setNavHeight] = useState<number | null>(null);
-  const isDraggingDividerRef = useRef(false);
-  const startYRef = useRef(0);
-  const startNavHeightRef = useRef(0);
-  const navRef = useRef<HTMLDivElement>(null);
-
-  const handleNavDividerMouseDown = useCallback((e: React.MouseEvent): void => {
-    e.preventDefault();
-    isDraggingDividerRef.current = true;
-    startYRef.current = e.clientY;
-    startNavHeightRef.current = navRef.current?.getBoundingClientRect().height ?? 200;
-    document.body.style.cursor = 'ns-resize';
-    document.body.style.userSelect = 'none';
-
-    const onMouseMove = (ev: MouseEvent): void => {
-      if (!isDraggingDividerRef.current) return;
-      const delta = ev.clientY - startYRef.current;
-      const newHeight = Math.min(500, Math.max(80, startNavHeightRef.current + delta));
-      setNavHeight(newHeight);
-    };
-    const onMouseUp = (): void => {
-      isDraggingDividerRef.current = false;
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-    };
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
-  }, []);
 
   const orderedChats = useMemo(() => {
     if (pinnedChatIds.length === 0) {
@@ -740,85 +730,29 @@ export function Sidebar({
         )}
         <OrgSwitcherSection
           organization={organization}
-          members={members}
-          creditsDisplay={creditsDisplay}
-          onOpenOrgPanel={onOpenOrgPanel}
-          onOpenBilling={onOpenBilling}
           onCreateNewOrg={onCreateNewOrg}
           isMobile={isMobile}
           currentView={currentView}
           onViewChange={onViewChange}
+          connectedSourcesCount={connectedSourcesCount}
+          workflowCount={workflowCount}
+          pendingChangesCount={pendingChangesCount}
         />
       </div>
 
       {currentView !== 'admin' && (
       <>
-      {/* Navigation Tabs — scrollable pane */}
-      <div
-        ref={navRef}
-        className="overflow-y-auto scrollbar-thin flex-shrink-0"
-        style={navHeight != null ? { height: navHeight } : undefined}
-      >
-        <nav className="px-2 space-y-0.5">
-          <NavItem view="home" label="Home" collapsed={collapsed} currentView={currentView} onViewChange={onViewChange} icon={
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-            </svg>
-          } />
-          <NavItem view="data-sources" label="Connectors" badge={connectedSourcesCount} collapsed={collapsed} currentView={currentView} onViewChange={onViewChange} icon={
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
-            </svg>
-          } />
-          <NavItem view="data" label="Search Data" collapsed={collapsed} currentView={currentView} onViewChange={onViewChange} icon={
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
-            </svg>
-          } />
-          <NavItem view="workflows" label="Workflows" badge={workflowCount} collapsed={collapsed} currentView={currentView} onViewChange={onViewChange} icon={
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-            </svg>
-          } />
-          <NavItem view="apps" label="Apps" activeViews={['apps', 'app-view']} collapsed={collapsed} currentView={currentView} onViewChange={onViewChange} icon={
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-            </svg>
-          } />
-          <NavItem view="documents" label="Documents" activeViews={['documents', 'artifact-view']} collapsed={collapsed} currentView={currentView} onViewChange={onViewChange} icon={
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-            </svg>
-          } />
-          {pendingChangesCount > 0 && (
-            <NavItem view="pending-changes" label="Changes" badge={pendingChangesCount} badgeColor="amber" colorTheme="amber" fontWeight="medium" collapsed={collapsed} currentView={currentView} onViewChange={onViewChange} icon={
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-              </svg>
-            } />
-          )}
-          {isOrgAdmin && (
-            <NavItem view="activity-log" label="Activity" collapsed={collapsed} currentView={currentView} onViewChange={onViewChange} icon={
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01" />
-              </svg>
-            } />
-          )}
-          <NavItem view="org-settings" label="Settings" collapsed={collapsed} currentView={currentView} onViewChange={onViewChange} icon={
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-            </svg>
-          } />
-        </nav>
-      </div>
-
-      {/* Draggable divider between nav and chat history */}
-      <div
-        onMouseDown={handleNavDividerMouseDown}
-        className="mx-3 h-1.5 cursor-ns-resize flex-shrink-0 group flex items-center justify-center"
-      >
-        <div className="w-full border-t border-surface-800 group-hover:border-surface-600 group-active:border-primary-500 transition-colors" />
+      <div className="px-2 py-2 flex-shrink-0 border-b border-surface-800">
+        <button
+          type="button"
+          onClick={onNewChat}
+          className={`w-full flex items-center gap-2 px-3 py-[5px] rounded-lg bg-primary-600 hover:bg-primary-700 text-white font-medium text-sm transition-colors ${collapsed ? 'justify-center' : ''}`}
+        >
+          <svg className="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+          </svg>
+          {!collapsed && <span>New Chat</span>}
+        </button>
       </div>
 
       {/* Recent chats (single list) */}
@@ -855,20 +789,6 @@ export function Sidebar({
       )}
 
       {/* New Chat Button */}
-      {currentView !== 'admin' && (
-        <div className="px-2 py-1">
-          <button
-            onClick={onNewChat}
-            className={`w-full flex items-center gap-2 px-3 py-[5px] rounded-lg bg-primary-600 hover:bg-primary-700 text-white font-medium text-sm transition-colors ${collapsed ? 'justify-center' : ''}`}
-          >
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-            </svg>
-            {!collapsed && <span>New Chat</span>}
-          </button>
-        </div>
-      )}
-
       {/* Bottom Section */}
       <div className="mt-auto border-t border-surface-800">
         {/* User Profile + Help */}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -911,21 +911,22 @@ function ChatAccordion({
             </svg>
           )}
         </div>
-        <div className="flex items-center gap-1 mt-0 leading-none">
+        <div className="flex items-center gap-1.5 mt-1.5 leading-none">
           {chat.scope === 'shared' && chat.participants && chat.participants.length > 0 && (
-            <div className="flex -space-x-1.5">
+            <div className="flex -space-x-1">
               {chat.participants.slice(0, 3).map((p, idx) => (
                 <Avatar
                   key={p.id}
                   user={p}
                   size="xs"
                   bordered
+                  className="!w-4 !h-4 !text-[8px]"
                   style={{ zIndex: 3 - idx }}
                 />
               ))}
               {chat.participants.length > 3 && (
                 <div
-                  className="w-5 h-5 rounded-full border border-surface-700 dark:border-surface-600 bg-surface-700 flex items-center justify-center text-[10px] font-medium text-surface-300"
+                  className="w-4 h-4 rounded-full border border-surface-700 dark:border-surface-600 bg-surface-700 flex items-center justify-center text-[8px] font-medium text-surface-300"
                   title={`${chat.participants.length - 3} more`}
                 >
                   +{chat.participants.length - 3}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -719,7 +719,7 @@ export function Sidebar({
   return (
     <aside
       style={{ width: widthPx }}
-      className="h-full bg-surface-900 flex flex-col transition-all duration-200 ease-in-out flex-shrink-0 overflow-hidden"
+      className="h-full bg-surface-950 flex flex-col transition-all duration-200 ease-in-out flex-shrink-0 overflow-hidden"
     >
       {/* Header: Organization identity */}
       <div className="relative min-w-0 overflow-hidden flex-shrink-0">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -426,6 +426,19 @@ function OrgSwitcherSection({
                       }
                     />
                     <OrgDropdownWorkspaceRow
+                      label="All chats"
+                      isActive={currentView === 'chats'}
+                      onSelect={() => {
+                        setShowDropdown(false);
+                        onViewChange('chats');
+                      }}
+                      icon={
+                        <svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                        </svg>
+                      }
+                    />
+                    <OrgDropdownWorkspaceRow
                       label="Connectors"
                       badge={connectedSourcesCount}
                       isActive={currentView === 'data-sources'}
@@ -762,7 +775,6 @@ export function Sidebar({
         currentChatId={currentChatId}
         activeTasksByConversation={activeTasksByConversation}
         onSelectChat={onSelectChat}
-        onViewAll={() => onViewChange('chats')}
       />
 
       {collapsed && <div className="flex-1" />}
@@ -849,14 +861,12 @@ function ChatAccordion({
   currentChatId,
   activeTasksByConversation,
   onSelectChat,
-  onViewAll,
 }: {
   collapsed: boolean;
   orderedChats: ChatSummary[];
   currentChatId: string | null;
   activeTasksByConversation: Record<string, string>;
   onSelectChat: (id: string) => void;
-  onViewAll: () => void;
 }): JSX.Element | null {
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>({});
@@ -1050,22 +1060,7 @@ function ChatAccordion({
   };
   
   return (
-    <div className="flex-1 flex flex-col min-h-0 px-1.5 py-px">
-      {/* Chat History header — whole row is clickable to open All Chats (with search) */}
-      <button
-        type="button"
-        onClick={onViewAll}
-        className="flex-shrink-0 flex items-center justify-between w-full px-2 py-1.5 rounded-md hover:bg-surface-800 transition-colors group"
-      >
-        <span className="text-xs font-semibold text-surface-200 uppercase tracking-wider group-hover:text-surface-100">Chat History</span>
-        <span className="flex items-center gap-1 text-xs font-medium text-primary-400 group-hover:text-primary-300">
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-          </svg>
-          View All
-        </span>
-      </button>
-
+    <div className="flex-1 flex flex-col min-h-0 px-1.5 pt-1 pb-px">
       <div className="flex-1 overflow-y-auto scrollbar-thin space-y-0 min-h-0">
         {groupedSidebarChats.flattenCount > 0 ? (
           <>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -72,7 +72,7 @@ function HelpButton(): JSX.Element {
           onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
         >
           <div
-            className="bg-surface-900 border border-surface-700 rounded-xl shadow-xl max-w-md w-full p-6"
+            className="bg-surface-900 rounded-xl shadow-2xl ring-1 ring-white/10 max-w-md w-full p-6"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between mb-4">
@@ -340,7 +340,7 @@ function OrgSwitcherSection({
           <div
             ref={dropdownContentRef}
             role="menu"
-            className="fixed bg-surface-800 border border-surface-700 rounded-lg shadow-xl max-h-[min(85vh,640px)] overflow-y-auto z-[9999]"
+            className="fixed bg-surface-800 rounded-lg shadow-2xl ring-1 ring-white/10 max-h-[min(85vh,640px)] overflow-y-auto z-[9999]"
             style={{ top: dropdownRect.top, left: dropdownRect.left, width: dropdownRect.width }}
           >
             <div className="py-1">
@@ -373,7 +373,7 @@ function OrgSwitcherSection({
                   </button>
                 </div>
               ))}
-              <div className="border-t border-surface-700 my-1" />
+              <div className="h-2 shrink-0" aria-hidden />
               <div className="flex items-center justify-between px-3 py-2.5">
                 <span className="text-sm text-surface-400">New Team</span>
                 <button
@@ -386,7 +386,7 @@ function OrgSwitcherSection({
               </div>
               {isGlobalAdmin && (
                 <>
-                  <div className="border-t border-surface-700 my-1" />
+                  <div className="h-2 shrink-0" aria-hidden />
                   <button
                     type="button"
                     onClick={handleEnterGlobalAdmin}
@@ -410,7 +410,7 @@ function OrgSwitcherSection({
               )}
               {!isAdminConsole && (
                 <>
-                  <div className="border-t border-surface-700 my-1" />
+                  <div className="h-2 shrink-0" aria-hidden />
                   <div className="py-1" role="group" aria-label="Workspace">
                     <OrgDropdownWorkspaceRow
                       label="Home"
@@ -492,7 +492,7 @@ function OrgSwitcherSection({
                         </svg>
                       }
                     />
-                    <div className="border-t border-surface-700 my-1" />
+                    <div className="h-2 shrink-0" aria-hidden />
                     {isOrgAdmin && (
                       <OrgDropdownWorkspaceRow
                         label="Activity"
@@ -713,10 +713,10 @@ export function Sidebar({
   return (
     <aside
       style={{ width: widthPx }}
-      className="h-full bg-surface-900 border-r border-surface-800 flex flex-col transition-all duration-200 ease-in-out flex-shrink-0 overflow-hidden"
+      className="h-full bg-surface-900 flex flex-col transition-all duration-200 ease-in-out flex-shrink-0 overflow-hidden"
     >
       {/* Header: Organization identity */}
-      <div className="border-b border-surface-800 relative min-w-0 overflow-hidden flex-shrink-0">
+      <div className="relative min-w-0 overflow-hidden flex-shrink-0">
         {isMobile && (
           <button
             onClick={onCloseMobile}
@@ -742,7 +742,7 @@ export function Sidebar({
 
       {currentView !== 'admin' && (
       <>
-      <div className="px-2 py-2 flex-shrink-0 border-b border-surface-800">
+      <div className="px-2 py-2 flex-shrink-0">
         <button
           type="button"
           onClick={onNewChat}
@@ -788,12 +788,10 @@ export function Sidebar({
         </div>
       )}
 
-      {/* New Chat Button */}
       {/* Bottom Section */}
-      <div className="mt-auto border-t border-surface-800">
-        {/* User Profile + Help */}
+      <div className="mt-auto">
         {user && (
-          <div className="flex items-center border-t border-surface-800">
+          <div className="flex items-center">
             <button
               onClick={onOpenProfilePanel}
               className={`flex-1 min-w-0 flex items-center gap-3 px-3 py-3 hover:bg-surface-800/50 transition-colors ${collapsed ? 'justify-center' : ''}`}
@@ -1307,8 +1305,8 @@ function ChannelPersonalityPanel({
   return (
     <>
       <div className="fixed inset-0 bg-black/50 z-40" onClick={onClose} />
-      <div className="fixed right-0 top-0 bottom-0 w-full max-w-md bg-surface-900 border-l border-surface-800 z-50 flex flex-col shadow-2xl">
-        <header className="flex items-center justify-between px-6 py-4 border-b border-surface-800">
+      <div className="fixed right-0 top-0 bottom-0 w-full max-w-md bg-surface-900 z-50 flex flex-col shadow-2xl">
+        <header className="flex items-center justify-between px-6 py-4">
           <h2 className="font-semibold text-surface-100 truncate">{channelName}</h2>
           <button
             onClick={onClose}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -17,7 +17,7 @@ import { apiRequest } from '../lib/api';
 import { FaLifeRing } from 'react-icons/fa';
 import { Avatar } from './Avatar';
 import { ScopeLockIcon } from './ScopeVisibilityIcons';
-import { APP_NAME, LOGO_PATH, RELEASE_STAGE } from '../lib/brand';
+import { APP_NAME, LOGO_PATH } from '../lib/brand';
 
 const CHANNEL_PERSONALITY_MAX_LENGTH = 1000;
 const CHANNEL_PERSONALITY_TEXTAREA_BASE_HEIGHT_PX = 160;
@@ -318,13 +318,6 @@ function OrgSwitcherSection({
                 <div className="text-lg font-semibold text-surface-100 truncate leading-tight">
                   {organization.name}
                 </div>
-                {RELEASE_STAGE.stage && (
-                  <div className="">
-                    <span className="px-1.5 py-0.5 rounded bg-primary-500/15 text-primary-400/80 font-medium text-[10px] uppercase tracking-wide" title={RELEASE_STAGE.description}>
-                      {RELEASE_STAGE.message}
-                    </span>
-                  </div>
-                )}
               </div>
             </>
           )}
@@ -755,16 +748,27 @@ export function Sidebar({
 
       {currentView !== 'admin' && (
       <>
-      <div className="px-2 py-2 flex-shrink-0">
+      <div className={`px-2 py-2 flex-shrink-0 flex items-center gap-1.5 ${collapsed ? 'flex-col' : ''}`}>
         <button
           type="button"
           onClick={onNewChat}
-          className={`w-full flex items-center gap-2 px-3 py-[5px] rounded-lg bg-primary-600 hover:bg-primary-700 text-white font-medium text-sm transition-colors ${collapsed ? 'justify-center' : ''}`}
+          className={`flex-1 flex items-center gap-2 px-3 py-[5px] rounded-lg bg-primary-600 hover:bg-primary-700 text-white font-medium text-sm transition-colors ${collapsed ? 'w-full justify-center' : ''}`}
         >
           <svg className="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
           </svg>
           {!collapsed && <span>New Chat</span>}
+        </button>
+        <button
+          type="button"
+          onClick={() => onViewChange('chats')}
+          title="Search all chats"
+          aria-label="Search all chats"
+          className={`flex items-center justify-center rounded-lg text-surface-400 hover:text-surface-100 hover:bg-surface-800/60 transition-colors ${collapsed ? 'w-full py-[5px]' : 'h-8 w-8'}`}
+        >
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
         </button>
       </div>
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -9,12 +9,11 @@
  * - Profile section
  */
 
-import { useMemo, useState, useRef, useEffect, useCallback } from 'react';
+import { useMemo, useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import type { View, ChatSummary, OrganizationInfo } from './AppLayout';
 import { useAppStore, useAuthStore, useChatStore, useIsGlobalAdmin, useIsOrgAdmin, useActiveTasksByConversation, type UserOrganization, type AdminPanelTab } from '../store';
 import { apiRequest } from '../lib/api';
-import { FaLifeRing } from 'react-icons/fa';
 import { Avatar } from './Avatar';
 import { ScopeLockIcon } from './ScopeVisibilityIcons';
 import { APP_NAME, LOGO_PATH } from '../lib/brand';
@@ -22,123 +21,6 @@ import { APP_NAME, LOGO_PATH } from '../lib/brand';
 const CHANNEL_PERSONALITY_MAX_LENGTH = 1000;
 const CHANNEL_PERSONALITY_TEXTAREA_BASE_HEIGHT_PX = 160;
 const CHANNEL_PERSONALITY_TEXTAREA_MAX_HEIGHT_PX = Math.round(CHANNEL_PERSONALITY_TEXTAREA_BASE_HEIGHT_PX * 1.5);
-
-/** Help button and modal for support requests. */
-function HelpButton(): JSX.Element {
-  const [showModal, setShowModal] = useState(false);
-  const [message, setMessage] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-  const [success, setSuccess] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const handleSubmit = useCallback(async (): Promise<void> => {
-    const trimmed = message.trim();
-    if (!trimmed || submitting) return;
-    setSubmitting(true);
-    setError(null);
-    const { error: err } = await apiRequest<{ status: string; detail: string }>('/support/request', {
-      method: 'POST',
-      body: JSON.stringify({ message: trimmed }),
-    });
-    setSubmitting(false);
-    if (err) {
-      setError(err);
-      return;
-    }
-    setSuccess(true);
-    setMessage('');
-  }, [message, submitting]);
-
-  const handleClose = useCallback((): void => {
-    setShowModal(false);
-    setSuccess(false);
-    setError(null);
-    setMessage('');
-  }, []);
-
-  return (
-    <>
-      <button
-        onClick={() => setShowModal(true)}
-        title="Get Immediate Help"
-        className="mr-0.5 p-2 rounded-lg text-amber-400 hover:text-amber-300 hover:bg-amber-500/15 transition-colors"
-        aria-label="Get Immediate Help"
-      >
-        <FaLifeRing className="w-[18px] h-[18px]" />
-      </button>
-      {showModal && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
-          onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
-        >
-          <div
-            className="bg-surface-900 rounded-xl shadow-2xl ring-1 ring-white/10 max-w-md w-full p-6"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-surface-100">Get Help</h2>
-              <button
-                onClick={handleClose}
-                className="p-1 text-surface-400 hover:text-surface-200 rounded transition-colors"
-                aria-label="Close"
-              >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            {success ? (
-              <p className="text-sm text-surface-300 mb-4">
-                Your message has been sent. A team member will be notified immediately and will respond within a few minutes during business hours.
-              </p>
-            ) : (
-              <>
-                <p className="text-sm text-surface-300 mb-4">
-                  You&apos;re our partner in building this product. Share questions, feedback, feature requests, or suggestions of any kind—we read every message and respond within a few minutes during business hours.
-                </p>
-                <textarea
-                  value={message}
-                  onChange={(e) => setMessage(e.target.value)}
-                  placeholder="Questions, feedback, feature requests, or suggestions..."
-                  rows={4}
-                  className="w-full px-3 py-2 rounded-lg bg-surface-800 border border-surface-700 text-surface-100 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none mb-4"
-                  maxLength={4000}
-                />
-                {error && <p className="text-sm text-red-400 mb-2">{error}</p>}
-              </>
-            )}
-            <div className="flex justify-end gap-2">
-              {success ? (
-                <button
-                  onClick={handleClose}
-                  className="px-4 py-2 rounded-lg bg-primary-600 hover:bg-primary-700 text-white font-medium transition-colors"
-                >
-                  Done
-                </button>
-              ) : (
-                <>
-                  <button
-                    onClick={handleClose}
-                    className="px-4 py-2 rounded-lg text-surface-400 hover:text-surface-200 hover:bg-surface-800 transition-colors"
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    onClick={() => void handleSubmit()}
-                    disabled={!message.trim() || submitting}
-                    className="px-4 py-2 rounded-lg bg-primary-600 hover:bg-primary-700 text-white font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {submitting ? 'Sending...' : 'Send'}
-                  </button>
-                </>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-    </>
-  );
-}
 
 /** Shield icon for global admin console identity in the org switcher. */
 function GlobalAdminShieldIcon({ className }: { className?: string }): JSX.Element {
@@ -288,7 +170,7 @@ function OrgSwitcherSection({
         <button
           ref={triggerRef}
           onClick={() => setShowDropdown((prev) => !prev)}
-          className="w-full flex items-center gap-3 px-3 pt-3 pb-1 hover:bg-surface-800/50 transition-colors"
+          className="w-full flex items-center gap-3 px-4 pt-3 pb-1 hover:bg-surface-800/50 transition-colors"
         >
           {isAdminConsole ? (
             <>
@@ -748,7 +630,7 @@ export function Sidebar({
 
       {currentView !== 'admin' && (
       <>
-      <div className={`px-2 py-2 flex-shrink-0 flex items-center gap-1.5 ${collapsed ? 'flex-col' : ''}`}>
+      <div className={`px-3 py-2 flex-shrink-0 flex items-center gap-1.5 ${collapsed ? 'flex-col' : ''}`}>
         <button
           type="button"
           onClick={onNewChat}
@@ -807,25 +689,21 @@ export function Sidebar({
       {/* Bottom Section */}
       <div className="mt-auto">
         {user && (
-          <div className="flex items-center">
-            <button
-              onClick={onOpenProfilePanel}
-              className={`flex-1 min-w-0 flex items-center gap-3 px-3 py-3 hover:bg-surface-800/50 transition-colors ${collapsed ? 'justify-center' : ''}`}
-            >
-              <Avatar user={user} size="md" />
-              {!collapsed && (
-                <div className="flex-1 min-w-0 text-left">
-                  <div className="text-sm font-medium text-surface-200 truncate">
-                    {user.name ?? 'User'}
-                  </div>
-                  <div className="text-xs text-surface-500 truncate">{user.email}</div>
+          <button
+            onClick={onOpenProfilePanel}
+            className={`w-full flex items-center gap-3 px-4 py-3 hover:bg-surface-800/50 transition-colors ${collapsed ? 'justify-center' : ''}`}
+          >
+            <Avatar user={user} size="md" />
+            {!collapsed && (
+              <div className="flex-1 min-w-0 text-left">
+                <div className="text-sm font-medium text-surface-200 truncate">
+                  {user.name ?? 'User'}
                 </div>
-              )}
-            </button>
-            <HelpButton />
-          </div>
+                <div className="text-xs text-surface-500 truncate">{user.email}</div>
+              </div>
+            )}
+          </button>
         )}
-
       </div>
     </aside>
   );
@@ -1064,7 +942,7 @@ function ChatAccordion({
   };
   
   return (
-    <div className="flex-1 flex flex-col min-h-0 px-1.5 pt-1 pb-px">
+    <div className="flex-1 flex flex-col min-h-0 px-3 pt-1 pb-px">
       <div className="flex-1 overflow-y-auto scrollbar-thin space-y-0 min-h-0">
         {groupedSidebarChats.flattenCount > 0 ? (
           <>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -562,17 +562,6 @@ export function Sidebar({
     >
       {/* Header: Organization identity */}
       <div className="relative min-w-0 overflow-hidden flex-shrink-0">
-        {isMobile && (
-          <button
-            onClick={onCloseMobile}
-            className="absolute right-2 top-3 z-10 p-1.5 rounded-md text-surface-400 hover:text-surface-200 hover:bg-surface-800 transition-colors shrink-0"
-            title="Close menu"
-          >
-            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        )}
         <OrgSwitcherSection
           organization={organization}
           isMobile={isMobile}
@@ -620,7 +609,10 @@ export function Sidebar({
               orderedChats={orderedChats}
               currentChatId={currentChatId}
               activeTasksByConversation={activeTasksByConversation}
-              onSelectChat={onSelectChat}
+              onSelectChat={(id) => {
+                onSelectChat(id);
+                if (isMobile) onCloseMobile?.();
+              }}
             />
 
             {collapsed && <div className="flex-1" />}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,16 +1,19 @@
-/* Surface scale via CSS variables: :root = light (inverted mapping), .dark = dark UI */
+/*
+ * Surface scale via CSS variables: :root = light, .dark = dark UI.
+ * Light theme uses a warm “vellum” ramp (cream paper, brown-gray text) similar to Claude’s calm UI.
+ */
 :root {
-  --surface-50: #09090b;
-  --surface-100: #18181b;
-  --surface-200: #27272a;
-  --surface-300: #3f3f46;
-  --surface-400: #52525b;
-  --surface-500: #71717a;
-  --surface-600: #a1a1aa;
-  --surface-700: #d4d4d8;
-  --surface-800: #e4e4e7;
-  --surface-900: #f4f4f5;
-  --surface-950: #fafafa;
+  --surface-50: #1a1714;
+  --surface-100: #3d3834;
+  --surface-200: #524a44;
+  --surface-300: #6b6159;
+  --surface-400: #857a71;
+  --surface-500: #9e9288;
+  --surface-600: #b8aea4;
+  --surface-700: #d4cbc2;
+  --surface-800: #e8e0d6;
+  --surface-900: #f3ece4;
+  --surface-950: #faf6ef;
   color-scheme: light;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,9 +14,9 @@
   --surface-500: #a39687;
   --surface-600: #bfb4a5;
   --surface-700: #d9d2c2;
-  --surface-800: #efeadf;
-  --surface-900: #fbf8f1;
-  --surface-950: #f6f3ec;
+  --surface-800: #f3eee3;
+  --surface-900: #fefcf6;
+  --surface-950: #faf8f2;
   color-scheme: light;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,9 +14,9 @@
   --surface-500: #a39687;
   --surface-600: #bfb4a5;
   --surface-700: #d9d2c2;
-  --surface-800: #f3eee3;
-  --surface-900: #fefcf6;
-  --surface-950: #faf8f2;
+  --surface-800: #f6f2e8;
+  --surface-900: #ffffff;
+  --surface-950: #fdfcf8;
   color-scheme: light;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,19 +1,22 @@
 /*
  * Surface scale via CSS variables: :root = light, .dark = dark UI.
- * Light theme uses a warm “vellum” ramp (cream paper, brown-gray text) similar to Claude’s calm UI.
+ * Light theme maps design tokens onto Tailwind surface-* usage:
+ *   paper (#f6f3ec) → page (surface-950), paper-2 (#fbf8f1) → cards (surface-900),
+ *   paper-dim (#efeadf) → muted / inline code shells (surface-800),
+ *   rule (#d9d2c2) → hairlines (surface-700). Darker steps are derived for text.
  */
 :root {
-  --surface-50: #1a1714;
-  --surface-100: #3d3834;
-  --surface-200: #524a44;
-  --surface-300: #6b6159;
-  --surface-400: #857a71;
-  --surface-500: #9e9288;
-  --surface-600: #b8aea4;
-  --surface-700: #d4cbc2;
-  --surface-800: #e8e0d6;
-  --surface-900: #f3ece4;
-  --surface-950: #faf6ef;
+  --surface-50: #171513;
+  --surface-100: #3c3832;
+  --surface-200: #554e47;
+  --surface-300: #6e665d;
+  --surface-400: #887e71;
+  --surface-500: #a39687;
+  --surface-600: #bfb4a5;
+  --surface-700: #d9d2c2;
+  --surface-800: #efeadf;
+  --surface-900: #fbf8f1;
+  --surface-950: #f6f3ec;
   color-scheme: light;
 }
 


### PR DESCRIPTION
## Summary
Reduces left-rail noise so chat history is primary.

### Sidebar
- **Workspace navigation** (Home, Connectors, Search Data, Workflows, Apps, Documents, Activity, Settings, Changes) moved into the **org switcher dropdown** so it reads as team/org scope, not personal chrome.
- **New Chat** sits directly under the org header.
- Removed the **members / Invite** row and **credits** donut from the sidebar (same flows live under **Settings → OrganizationPanel** team + billing tabs).
- Dropped the **useTeamMembers** query that existed only to feed the sidebar member strip.

### Tests
- `test_public_origin_prefers_forwarded_proxy_headers` now clears `BACKEND_PUBLIC_URL` so the forwarded-host assertion is deterministic when local `.env` sets a public API URL.

### Verification
- `npm run build` (frontend)
- `pytest -q tests` (backend)

Made with [Cursor](https://cursor.com)