### PR TITLE
Log credit grants to credit_transactions for audit

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1208,6 +1208,15 @@ async def create_organization(
         session.add(new_org)
         await session.flush()
 
+        from services.credits import record_grant
+        await record_grant(
+            session,
+            organization_id=new_org.id,
+            amount=new_org.credits_balance,
+            balance_after=new_org.credits_balance,
+            reason="signup_bonus",
+        )
+
         from models.org_member import OrgMember
 
         guest_user = User(

--- a/backend/api/routes/billing.py
+++ b/backend/api/routes/billing.py
@@ -337,10 +337,19 @@ async def subscribe(
             now = datetime.now(timezone.utc)
             org.subscription_tier = body.tier
             org.subscription_status = "active"
+            old_balance: int = org.credits_balance
             org.credits_included = plan.get("credits_included", 100)
             org.credits_balance = org.credits_included
             org.current_period_start = now
             org.current_period_end = now + timedelta(days=30)
+            from services.credits import record_grant
+            await record_grant(
+                session,
+                organization_id=org.id,
+                amount=org.credits_balance - old_balance,
+                balance_after=org.credits_balance,
+                reason=f"free_tier_signup:{body.tier}",
+            )
             await session.commit()
             return {"status": "ok", "subscription_id": "free"}
 
@@ -421,7 +430,18 @@ async def subscribe(
 
         org.subscription_status = sub.status or "active"
         if sub.status == "active":
+            old_balance: int = org.credits_balance
             org.credits_balance = org.credits_included
+            from services.credits import record_grant
+            await record_grant(
+                session,
+                organization_id=org.id,
+                amount=org.credits_balance - old_balance,
+                balance_after=org.credits_balance,
+                reason=f"paid_subscription:{body.tier}",
+                reference_type="stripe_subscription",
+                reference_id=sub.id,
+            )
             period_end = getattr(sub, "current_period_end", None)
             period_start = getattr(sub, "current_period_start", None)
             if period_end:
@@ -920,6 +940,7 @@ async def _handle_invoice_paid(invoice: Any) -> None:
                 org.credits_balance,
                 credits_included * (cap - 1),
             )
+        old_balance: int = org.credits_balance
         org.credits_balance = credits_included + rollover
         org.credits_included = credits_included
         org.current_period_start = datetime.fromtimestamp(
@@ -927,6 +948,16 @@ async def _handle_invoice_paid(invoice: Any) -> None:
         )
         org.current_period_end = datetime.fromtimestamp(
             invoice.get("period_end", 0), tz=timezone.utc
+        )
+        from services.credits import record_grant
+        await record_grant(
+            session,
+            organization_id=org.id,
+            amount=org.credits_balance - old_balance,
+            balance_after=org.credits_balance,
+            reason=f"subscription_renewal:{effective_tier or 'unknown'}",
+            reference_type="stripe_invoice",
+            reference_id=invoice.get("id"),
         )
         await session.commit()
 

--- a/backend/api/routes/waitlist.py
+++ b/backend/api/routes/waitlist.py
@@ -805,12 +805,23 @@ async def grant_organization_free_credits(
 
         org.subscription_tier = "partner"
         org.subscription_status = "active"
+        old_balance: int = org.credits_balance
         org.credits_balance = body.credits
         org.credits_included = body.credits
         org.current_period_start = now
         org.current_period_end = period_end
         org.stripe_customer_id = None
         org.stripe_subscription_id = None
+
+        from services.credits import record_grant
+        await record_grant(
+            session,
+            organization_id=org.id,
+            amount=org.credits_balance - old_balance,
+            balance_after=org.credits_balance,
+            reason="partner_grant",
+            user_id=auth.user_id,
+        )
 
         await session.commit()
         await session.refresh(org)

--- a/backend/scripts/grant_free_credits.py
+++ b/backend/scripts/grant_free_credits.py
@@ -68,6 +68,12 @@ async def grant_free_credits(
             return False
         org_name: str = row[0]
 
+        old_balance_result = await session.execute(
+            text("SELECT credits_balance FROM organizations WHERE id = :org_id"),
+            {"org_id": str(org_uuid)},
+        )
+        old_balance: int = int(old_balance_result.scalar_one() or 0)
+
         await session.execute(
             text("""
                 UPDATE organizations
@@ -88,6 +94,25 @@ async def grant_free_credits(
                 "period_end": period_end,
             },
         )
+
+        delta: int = credits - old_balance
+        if delta > 0:
+            await session.execute(
+                text("""
+                    INSERT INTO credit_transactions
+                        (id, organization_id, amount, balance_after, reason, created_at)
+                    VALUES
+                        (gen_random_uuid(), :org_id, :amount, :balance_after, :reason, :now)
+                """),
+                {
+                    "org_id": str(org_uuid),
+                    "amount": delta,
+                    "balance_after": credits,
+                    "reason": "partner_grant_script",
+                    "now": now,
+                },
+            )
+
         await session.commit()
 
         print(f"✓ Granted free credits to: {org_name}")

--- a/backend/services/credits.py
+++ b/backend/services/credits.py
@@ -102,6 +102,43 @@ async def check_sufficient(organization_id: str, amount: int) -> bool:
     return balance >= amount
 
 
+async def record_grant(
+    session: AsyncSession,
+    organization_id: UUID,
+    amount: int,
+    balance_after: int,
+    reason: str,
+    *,
+    reference_type: str | None = None,
+    reference_id: str | None = None,
+    user_id: UUID | None = None,
+) -> None:
+    """Append a positive credit_transactions row for audit.
+
+    Caller updates org.credits_balance (and credits_included if relevant)
+    in the same session; this only writes the audit row. amount must be
+    positive — non-positive grants are ignored so callers can blindly call
+    this with a computed delta without guarding.
+    """
+    if amount <= 0:
+        return
+    session.add(
+        CreditTransaction(
+            organization_id=organization_id,
+            user_id=user_id,
+            amount=amount,
+            balance_after=balance_after,
+            reason=reason[:64],
+            reference_type=reference_type,
+            reference_id=reference_id,
+        )
+    )
+    logger.info(
+        "[Credits] grant: org %s +%d (%s), new balance %d",
+        organization_id, amount, reason, balance_after,
+    )
+
+
 async def deduct(
     organization_id: str,
     amount: int,

--- a/backend/tests/test_credits_record_grant.py
+++ b/backend/tests/test_credits_record_grant.py
@@ -1,0 +1,91 @@
+"""Tests for services.credits.record_grant audit-row helper."""
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+from services import credits as credits_service
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.added: list = []
+
+    def add(self, obj) -> None:
+        self.added.append(obj)
+
+
+def test_record_grant_writes_positive_audit_row() -> None:
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    user_id = UUID("22222222-2222-2222-2222-222222222222")
+    session = _FakeSession()
+
+    asyncio.run(
+        credits_service.record_grant(
+            session,
+            organization_id=org_id,
+            amount=950,
+            balance_after=1000,
+            reason="subscription_renewal:pro",
+            reference_type="stripe_invoice",
+            reference_id="in_123",
+            user_id=user_id,
+        )
+    )
+
+    assert len(session.added) == 1
+    tx = session.added[0]
+    assert tx.organization_id == org_id
+    assert tx.user_id == user_id
+    assert tx.amount == 950
+    assert tx.balance_after == 1000
+    assert tx.reason == "subscription_renewal:pro"
+    assert tx.reference_type == "stripe_invoice"
+    assert tx.reference_id == "in_123"
+
+
+def test_record_grant_skips_non_positive_amounts() -> None:
+    """If a caller passes a zero/negative delta (e.g. balance was reset
+    downward), we silently no-op rather than write a misleading audit row."""
+    org_id = UUID("33333333-3333-3333-3333-333333333333")
+    session = _FakeSession()
+
+    asyncio.run(
+        credits_service.record_grant(
+            session,
+            organization_id=org_id,
+            amount=0,
+            balance_after=100,
+            reason="noop",
+        )
+    )
+    asyncio.run(
+        credits_service.record_grant(
+            session,
+            organization_id=org_id,
+            amount=-50,
+            balance_after=50,
+            reason="noop",
+        )
+    )
+
+    assert session.added == []
+
+
+def test_record_grant_truncates_long_reason() -> None:
+    """reason column is varchar(64); helper must truncate to fit."""
+    org_id = UUID("44444444-4444-4444-4444-444444444444")
+    session = _FakeSession()
+    long_reason = "x" * 100
+
+    asyncio.run(
+        credits_service.record_grant(
+            session,
+            organization_id=org_id,
+            amount=10,
+            balance_after=10,
+            reason=long_reason,
+        )
+    )
+
+    assert len(session.added[0].reason) == 64


### PR DESCRIPTION
## Summary
The `credit_transactions` table only had deduction rows — every place that **added** credits (signup bonus, free-tier subscribe, paid-tier subscribe, Stripe renewal webhook, admin partner grant, and the standalone `grant_free_credits.py` script) just bumped `org.credits_balance` with no audit trail. So there was no way to answer \"when was this org last granted credits?\" or to detect a duplicate grant.

## Changes
- **New helper**: `services.credits.record_grant(session, organization_id, amount, balance_after, reason, *, reference_type=None, reference_id=None, user_id=None)` — positive sibling of the existing `deduct`. Writes a `CreditTransaction` row in the caller's session; no-ops on non-positive deltas so callers can blindly pass `new_balance - old_balance`. Truncates `reason` to fit the `varchar(64)` column.
- **Routed every credit-add site through it** with a descriptive reason:
  - `auth.py` org creation → `signup_bonus`
  - `billing.py` free tier subscribe → `free_tier_signup:{tier}`
  - `billing.py` paid tier subscribe → `paid_subscription:{tier}` (+ `reference_type=stripe_subscription`, `reference_id=sub.id`)
  - `billing.py` invoice.paid webhook → `subscription_renewal:{tier}` (+ `reference_type=stripe_invoice`, `reference_id=invoice.id`)
  - `waitlist.py` admin partner grant → `partner_grant` (+ `user_id=admin`)
  - `scripts/grant_free_credits.py` → `partner_grant_script`
- **Test**: `tests/test_credits_record_grant.py` — covers positive write, non-positive no-op, reason truncation.

No change to balance math anywhere. Pure audit addition. Sets us up to add dedupe (e.g. \"don't re-grant on duplicate Stripe webhook\") with a one-line lookup later.

## Test plan
- [ ] `pytest backend/tests/test_credits_record_grant.py` passes.
- [ ] Manually create a new org → check `credit_transactions` has a row with `reason='signup_bonus'`, `amount=100`, `balance_after=100`.
- [ ] Subscribe an existing org to a paid plan → row with `reason='paid_subscription:{tier}'`, `reference_id` set to the Stripe sub id.
- [ ] Trigger a Stripe `invoice.paid` (or wait for next renewal) → row with `reason='subscription_renewal:{tier}'`, `reference_id` set to the invoice id.
- [ ] Run `python scripts/grant_free_credits.py <org>` → row with `reason='partner_grant_script'`.
- [ ] Admin grant via the panel → row with `reason='partner_grant'` and `user_id` set to the granting admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)