### PR TITLE
Skip teammate warning for apps and web connectors

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -703,7 +703,7 @@ def _build_cross_user_connector_warning(
     """Return a user-facing warning when we used a teammate's connector."""
     if not requester_user_id:
         return None
-    if connector_slug in {"slack", "teams"}:
+    if connector_slug in {"slack", "teams", "apps", "web_search"}:
         return None
 
     raw_integration_user_id: Any = getattr(connector_instance, "user_id", None)

--- a/backend/tests/test_action_ledger.py
+++ b/backend/tests/test_action_ledger.py
@@ -615,6 +615,32 @@ class TestChokepoints:
         assert "HubSpot" in str(result["warning"])
         assert "connect to HubSpot as yourself" in str(result["warning"])
 
+
+    @pytest.mark.parametrize("connector_slug", ["apps", "web_search"])
+    def test_write_on_connector_does_not_add_warning_for_apps_or_web(self, connector_slug: str) -> None:
+        """Cross-user Apps/Web connector use should not add teammate connector warning."""
+        from agents import tools
+
+        fake_instance = MagicMock()
+        fake_instance.user_id = "teammate-1"
+        fake_instance.write = AsyncMock(return_value={"id": "99", "status": "ok"})
+
+        with patch.object(tools, "_get_connector_instance", new=AsyncMock(return_value=(fake_instance, None))), \
+             patch.object(tools, "check_connector_call", new=AsyncMock(return_value=MagicMock(allowed=True))), \
+             patch("services.action_ledger.record_intent", new=AsyncMock(return_value=uuid.uuid4())), \
+             patch("services.action_ledger.record_outcome", new=AsyncMock()):
+
+            result = asyncio.run(tools._write_on_connector(
+                params={"connector": connector_slug, "operation": "update_record", "data": {"id": "1"}},
+                organization_id="org-1",
+                user_id="user-1",
+                skip_approval=True,
+                context={"conversation_id": "conv-1"},
+            ))
+
+        assert result.get("id") == "99"
+        assert "warning" not in result
+
     def test_write_on_connector_records_error_on_exception(self) -> None:
         """When instance.write raises, record_outcome should still be called with error."""
         from agents import tools


### PR DESCRIPTION
### Motivation
- The teammate cross-user connector warning should not be shown for the `apps` or `web_search` connectors because those are app-level/web tools rather than teammate-owned personal integrations.

### Description
- Updated `_build_cross_user_connector_warning` in `backend/agents/tools.py` to also suppress warnings for `apps` and `web_search` in addition to the existing `slack`/`teams` exclusions.
- Added a parametrized test in `backend/tests/test_action_ledger.py` (`test_write_on_connector_does_not_add_warning_for_apps_or_web`) to assert that cross-user calls to `apps` and `web_search` do not attach a `warning` field.

### Testing
- Ran the targeted tests with `pytest -q backend/tests/test_action_ledger.py -k "cross_user or apps_or_web"`, which completed with `3 passed, 36 deselected`.
- The new regression test passed and confirms no teammate warning is emitted for `apps` and `web_search`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7624887c88321ad2b5b49de31a27b)