### PR TITLE
Introduce Knowledge Base (kb_*) schema, models, migrations and replace temp_data usage

### DIFF
--- a/backend/agents/registry.py
+++ b/backend/agents/registry.py
@@ -136,7 +136,7 @@ Available tables (use these exact column names):
 - tracker_projects: Issue tracker projects (source_system, source_id, name, description, state, progress, target_date, start_date, lead_name, team_ids JSONB). Filter by source_system.
 - tracker_issues: Issue tracker issues/tasks (source_system, source_id, team_id, identifier e.g. "ENG-123", title, description, state_name, state_type, priority 0-4, priority_label, issue_type, assignee_name, assignee_email, creator_name, project_id, labels JSONB, estimate, url, due_date, created_date, updated_date, completed_date, cancelled_date, user_id). Filter by source_system.
 - shared_files: Synced file metadata from cloud sources like Google Drive (external_id, source, name, mime_type, folder_path, web_view_link, file_size, source_modified_at). Filter by source (e.g. 'google_drive'). Use query_on_connector(connector='google_drive', query='search:...') for name-based searches.
-- temp_data: Agent-generated results and computed metrics. Flexible JSONB storage linked to entities. Columns: entity_type, entity_id, namespace, key, value (JSONB), metadata (JSONB), created_by_user_id, created_at, expires_at. Example: SELECT td.value->>'score' as confidence, d.name FROM temp_data td JOIN deals d ON d.id = td.entity_id WHERE td.namespace = 'deal_confidence'
+- kb_entries: Knowledge base entries. Columns: entry_kind, namespace, key, title, content (JSONB), metadata (JSONB), conversation_id, visibility, created_by_user_id, created_at, expires_at. Example: SELECT namespace, key, content FROM kb_entries WHERE namespace = 'deal_confidence'
 - daily_digests: Per-member daily activity digest. Columns: id, user_id, digest_date (DATE), summary (JSONB with keys: narrative, highlights, categories), raw_data (JSONB, nullable), generated_at. One row per user per date. Join to users via user_id. All org members' digests are visible.
 - daily_team_summaries: Org-wide daily team summary. Columns: id, digest_date (DATE), summary_text (TEXT), generated_at. One row per date. Read-only.
 
@@ -364,7 +364,7 @@ Writable tables:
 - users: (phone_number) → immediate. Phone numbers MUST be E.164 format with country code, e.g. +14155551234 for US numbers. If the user gives a 10-digit number like 4159028648, prepend +1.
 - workflows: See workflow format below → immediate
 - artifacts: (type, title, description, data) → immediate
-- temp_data: (entity_type, entity_id, namespace, key, value, metadata, expires_at) → immediate. Flexible JSONB store for computed results. Use namespace to group (e.g. 'deal_confidence'). value is JSONB, any shape.
+- kb_entries: (entry_kind, namespace, key, title, content, metadata, conversation_id, visibility, expires_at) → immediate. Canonical knowledge base row store.
 - daily_digests: (summary) → immediate, user can only update their own digest. summary is JSONB with keys: narrative (string), highlights (array), categories (array). user_id is auto-set to the current user on INSERT.
 
 **WORKFLOW FORMAT (Important!):**

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -198,7 +198,11 @@ ALLOWED_TABLES: set[str] = {
     "shared_files",
     "tracker_teams", "tracker_projects", "tracker_issues",
     "bulk_operations", "bulk_operation_results",
-    "temp_data",
+    "kb_entries",
+    "kb_entry_sources",
+    "kb_cluster_types",
+    "kb_clusters",
+    "kb_entry_cluster_links",
     "daily_digests", "daily_team_summaries",
 }
 
@@ -1369,7 +1373,11 @@ WRITABLE_TABLES: set[str] = {
     "deals",
     "accounts",
     "org_members",
-    "temp_data",
+    "kb_entries",
+    "kb_entry_sources",
+    "kb_cluster_types",
+    "kb_clusters",
+    "kb_entry_cluster_links",
     "daily_digests",
 }
 

--- a/backend/db/migrations/env.py
+++ b/backend/db/migrations/env.py
@@ -79,3 +79,11 @@ if context.is_offline_mode():
     run_migrations_offline()
 else:
     run_migrations_online()
+
+from models.knowledge_base import (
+    KnowledgeBaseEntry,
+    KnowledgeBaseEntrySource,
+    KnowledgeBaseClusterType,
+    KnowledgeBaseCluster,
+    KnowledgeBaseEntryClusterLink,
+)

--- a/backend/db/migrations/versions/133_kb_schema.py
+++ b/backend/db/migrations/versions/133_kb_schema.py
@@ -1,0 +1,103 @@
+"""create knowledge base schema
+
+Revision ID: 133_kb_schema
+Revises: 132_wf_llm_model
+Create Date: 2026-05-03
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "133_kb_schema"
+down_revision = "132_wf_llm_model"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "kb_entries",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("entry_kind", sa.Text(), nullable=False, server_default="fact"),
+        sa.Column("namespace", sa.Text(), nullable=False),
+        sa.Column("key", sa.Text(), nullable=True),
+        sa.Column("title", sa.Text(), nullable=True),
+        sa.Column("content", postgresql.JSONB(), nullable=False),
+        sa.Column("metadata", postgresql.JSONB(), nullable=True),
+        sa.Column("conversation_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("conversations.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("source_scope", sa.Text(), nullable=True),
+        sa.Column("visibility", sa.Text(), nullable=False, server_default="org"),
+        sa.Column("owner_user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("created_by_user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("legacy_temp_data_id", postgresql.UUID(as_uuid=True), nullable=True, unique=True),
+    )
+    op.create_index("ix_kb_entries_org_ns_created", "kb_entries", ["organization_id", "namespace", "created_at"])
+
+    op.create_table(
+        "kb_entry_sources",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("kb_entry_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("kb_entries.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("source_type", sa.Text(), nullable=False),
+        sa.Column("source_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("source_ref", sa.Text(), nullable=True),
+        sa.Column("captured_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("kb_entry_id", "source_type", "source_id", "source_ref", name="uq_kb_entry_source"),
+    )
+
+    op.create_table(
+        "kb_cluster_types",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("key", sa.Text(), nullable=False),
+        sa.Column("label", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+
+    op.create_table(
+        "kb_clusters",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("cluster_type_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("kb_cluster_types.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("key", sa.Text(), nullable=False),
+        sa.Column("label", sa.Text(), nullable=False),
+        sa.Column("metadata", postgresql.JSONB(), nullable=True),
+    )
+
+    op.create_table(
+        "kb_entry_cluster_links",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("kb_entry_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("kb_entries.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("cluster_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("kb_clusters.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("score", sa.Numeric(5, 4), nullable=True),
+        sa.Column("assigned_by", sa.Text(), nullable=False, server_default="rule"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint("kb_entry_id", "cluster_id", name="uq_kb_entry_cluster"),
+    )
+
+    for table in ["kb_entries", "kb_entry_sources", "kb_cluster_types", "kb_clusters", "kb_entry_cluster_links"]:
+        op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+        op.execute(
+            f"""
+            CREATE POLICY org_isolation ON {table}
+            FOR ALL
+            USING (organization_id::text = COALESCE(NULLIF(current_setting('app.current_org_id', true), ''), '00000000-0000-0000-0000-000000000000'))
+            WITH CHECK (organization_id::text = COALESCE(NULLIF(current_setting('app.current_org_id', true), ''), '00000000-0000-0000-0000-000000000000'))
+            """
+        )
+
+
+def downgrade() -> None:
+    for table in ["kb_entry_cluster_links", "kb_clusters", "kb_cluster_types", "kb_entry_sources", "kb_entries"]:
+        op.execute(f"DROP POLICY IF EXISTS org_isolation ON {table}")
+    op.drop_table("kb_entry_cluster_links")
+    op.drop_table("kb_clusters")
+    op.drop_table("kb_cluster_types")
+    op.drop_table("kb_entry_sources")
+    op.drop_index("ix_kb_entries_org_ns_created", table_name="kb_entries")
+    op.drop_table("kb_entries")

--- a/backend/db/migrations/versions/134_kb_backfill.py
+++ b/backend/db/migrations/versions/134_kb_backfill.py
@@ -1,0 +1,48 @@
+"""backfill knowledge base from temp_data
+
+Revision ID: 134_kb_backfill
+Revises: 133_kb_schema
+Create Date: 2026-05-03
+"""
+from alembic import op
+
+revision = "134_kb_backfill"
+down_revision = "133_kb_schema"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("""
+    INSERT INTO kb_entries (
+      organization_id, entry_kind, namespace, key, content, metadata,
+      created_by_user_id, created_at, expires_at, legacy_temp_data_id, visibility
+    )
+    SELECT
+      organization_id,
+      'fact',
+      namespace,
+      key,
+      value,
+      metadata,
+      created_by_user_id,
+      created_at,
+      expires_at,
+      id,
+      'org'
+    FROM temp_data
+    ON CONFLICT (legacy_temp_data_id) DO NOTHING
+    """)
+
+    op.execute("""
+    INSERT INTO kb_entry_sources (organization_id, kb_entry_id, source_type, source_id)
+    SELECT e.organization_id, e.id, 'temp_data_migration', t.id
+    FROM kb_entries e
+    JOIN temp_data t ON t.id = e.legacy_temp_data_id
+    ON CONFLICT DO NOTHING
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM kb_entry_sources WHERE source_type = 'temp_data_migration'")
+    op.execute("DELETE FROM kb_entries WHERE legacy_temp_data_id IS NOT NULL")

--- a/backend/db/migrations/versions/135_kb_cutover.py
+++ b/backend/db/migrations/versions/135_kb_cutover.py
@@ -1,0 +1,38 @@
+"""cut over temp_data to knowledge base
+
+Revision ID: 135_kb_cutover
+Revises: 134_kb_backfill
+Create Date: 2026-05-03
+"""
+from alembic import op
+
+revision = "135_kb_cutover"
+down_revision = "134_kb_backfill"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE temp_data RENAME TO temp_data_legacy")
+    op.execute("""
+    CREATE VIEW temp_data AS
+    SELECT
+      legacy_temp_data_id AS id,
+      organization_id,
+      NULL::text AS entity_type,
+      NULL::uuid AS entity_id,
+      namespace,
+      key,
+      content AS value,
+      metadata,
+      created_by_user_id,
+      created_at,
+      expires_at
+    FROM kb_entries
+    WHERE legacy_temp_data_id IS NOT NULL
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS temp_data")
+    op.execute("ALTER TABLE temp_data_legacy RENAME TO temp_data")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -35,6 +35,13 @@ from models.notification import Notification
 from models.action_ledger import ActionLedgerEntry
 from models.daily_digest import DailyDigest
 from models.topic_graph_snapshot import TopicGraphSnapshot
+from models.knowledge_base import (
+    KnowledgeBaseEntry,
+    KnowledgeBaseEntrySource,
+    KnowledgeBaseClusterType,
+    KnowledgeBaseCluster,
+    KnowledgeBaseEntryClusterLink,
+)
 
 __all__ = [
     "Base",
@@ -78,4 +85,9 @@ __all__ = [
     "ActionLedgerEntry",
     "DailyDigest",
     "TopicGraphSnapshot",
+    "KnowledgeBaseEntry",
+    "KnowledgeBaseEntrySource",
+    "KnowledgeBaseClusterType",
+    "KnowledgeBaseCluster",
+    "KnowledgeBaseEntryClusterLink",
 ]

--- a/backend/models/knowledge_base.py
+++ b/backend/models/knowledge_base.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import DateTime, ForeignKey, Numeric, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.database import Base
+
+
+class KnowledgeBaseEntry(Base):
+    __tablename__ = "kb_entries"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    entry_kind: Mapped[str] = mapped_column(Text, nullable=False, server_default="fact")
+    namespace: Mapped[str] = mapped_column(Text, nullable=False)
+    key: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    title: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    content: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    metadata_json: Mapped[Optional[dict[str, Any]]] = mapped_column("metadata", JSONB, nullable=True)
+    conversation_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("conversations.id", ondelete="SET NULL"), nullable=True
+    )
+    source_scope: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    visibility: Mapped[str] = mapped_column(Text, nullable=False, server_default="org")
+    owner_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    created_by_user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default="now()")
+    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    legacy_temp_data_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True, unique=True)
+
+
+class KnowledgeBaseEntrySource(Base):
+    __tablename__ = "kb_entry_sources"
+    __table_args__ = (
+        UniqueConstraint("kb_entry_id", "source_type", "source_id", "source_ref", name="uq_kb_entry_source"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    kb_entry_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("kb_entries.id", ondelete="CASCADE"), nullable=False
+    )
+    source_type: Mapped[str] = mapped_column(Text, nullable=False)
+    source_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUID(as_uuid=True), nullable=True)
+    source_ref: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    captured_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default="now()")
+
+
+class KnowledgeBaseClusterType(Base):
+    __tablename__ = "kb_cluster_types"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    key: Mapped[str] = mapped_column(Text, nullable=False)
+    label: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(nullable=False, server_default="true")
+
+
+class KnowledgeBaseCluster(Base):
+    __tablename__ = "kb_clusters"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    cluster_type_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("kb_cluster_types.id", ondelete="CASCADE"), nullable=False
+    )
+    key: Mapped[str] = mapped_column(Text, nullable=False)
+    label: Mapped[str] = mapped_column(Text, nullable=False)
+    metadata_json: Mapped[Optional[dict[str, Any]]] = mapped_column("metadata", JSONB, nullable=True)
+
+
+class KnowledgeBaseEntryClusterLink(Base):
+    __tablename__ = "kb_entry_cluster_links"
+    __table_args__ = (UniqueConstraint("kb_entry_id", "cluster_id", name="uq_kb_entry_cluster"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False
+    )
+    kb_entry_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("kb_entries.id", ondelete="CASCADE"), nullable=False
+    )
+    cluster_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("kb_clusters.id", ondelete="CASCADE"), nullable=False
+    )
+    score: Mapped[Optional[float]] = mapped_column(Numeric(5, 4), nullable=True)
+    assigned_by: Mapped[str] = mapped_column(Text, nullable=False, server_default="rule")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default="now()")

--- a/backend/tests/test_kb_cutover_sql_write.py
+++ b/backend/tests/test_kb_cutover_sql_write.py
@@ -1,0 +1,10 @@
+from agents import tools
+
+
+def test_temp_data_removed_from_writable_tables():
+    assert "temp_data" not in tools.WRITABLE_TABLES
+    assert "kb_entries" in tools.WRITABLE_TABLES
+
+
+def test_kb_tables_allowed_for_read_query_table_list():
+    assert "kb_entries" in tools.ALLOWED_TABLES

--- a/backend/tests/test_migration_revision_lengths.py
+++ b/backend/tests/test_migration_revision_lengths.py
@@ -1,0 +1,13 @@
+from importlib import import_module
+
+
+def test_new_migration_revision_lengths():
+    modules = [
+        import_module("db.migrations.versions.133_kb_schema"),
+        import_module("db.migrations.versions.134_kb_backfill"),
+        import_module("db.migrations.versions.135_kb_cutover"),
+    ]
+    for m in modules:
+        assert len(m.revision) <= 32
+        if isinstance(m.down_revision, str):
+            assert len(m.down_revision) <= 32


### PR DESCRIPTION
### Motivation
- Replace the legacy `temp_data` store with a canonical knowledge base to better represent agent-generated facts and computed metrics.
- Ensure the application, tooling and DB are aligned so agents read/write KB rows instead of the ad-hoc `temp_data` table.

### Description
- Add new ORM models in `models/knowledge_base.py` for `KnowledgeBaseEntry`, `KnowledgeBaseEntrySource`, `KnowledgeBaseClusterType`, `KnowledgeBaseCluster`, and `KnowledgeBaseEntryClusterLink` and export them from `models/__init__.py`.
- Introduce three Alembic migrations: `133_kb_schema` to create the `kb_*` tables with RLS policies, `134_kb_backfill` to migrate rows from `temp_data` into `kb_entries` and `kb_entry_sources`, and `135_kb_cutover` to rename `temp_data` to `temp_data_legacy` and present a compatibility view mapping legacy IDs to `kb_entries`.
- Update runtime tooling to remove `temp_data` from `ALLOWED_TABLES`/`WRITABLE_TABLES` and add the new `kb_entries`, `kb_entry_sources`, `kb_cluster_types`, `kb_clusters`, and `kb_entry_cluster_links` tables, and update docs/comments to reference `kb_entries` where appropriate.
- Import the new models into the migration environment via `db/migrations/env.py` so metadata is available during migrations.

### Testing
- Added unit tests `test_kb_cutover_sql_write.py` to assert `temp_data` is no longer writable and `kb_entries` is allowed for reads, and `test_migration_revision_lengths.py` to validate migration revision ID lengths; both tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7875d90748321858d0b15d7d3910f)