### PR TITLE
Add model-aware max token support for conversation context progress UI

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -2590,10 +2590,16 @@ async def update_organization(
 
 
 @router.get("/llm-options")
-async def get_llm_options() -> dict[str, str | dict[str, str]]:
-    """Return model→provider map from ALL_MODEL_STRINGS."""
-    from services.llm_provider import get_model_provider_map
-    return {"models": get_model_provider_map()}
+async def get_llm_options() -> dict[str, str | dict[str, str] | dict[str, int] | int]:
+    """Return LLM model metadata for settings and chat context UI."""
+    from services.llm_provider import get_model_max_tokens_map, get_model_provider_map
+
+    default_max_tokens: int = 200_000
+    return {
+        "models": get_model_provider_map(),
+        "model_max_tokens": get_model_max_tokens_map(default_max_tokens=default_max_tokens),
+        "default_max_tokens": default_max_tokens,
+    }
 
 
 @router.get("/organizations/{org_id}", response_model=OrganizationResponse)

--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -303,6 +303,24 @@ def get_model_provider_map() -> dict[str, str]:
     return _parse_model_map()
 
 
+def get_model_max_tokens_map(default_max_tokens: int = 200_000) -> dict[str, int]:
+    """Return model→context-window map for UI context progress calculations.
+
+    Models not explicitly listed should use ``default_max_tokens`` on the client.
+    """
+    raw_model_map: dict[str, str] = _parse_model_map()
+    explicit_windows: dict[str, int] = {
+        "claude-opus-4-6": 1_000_000,
+        "gpt-5.5": 1_000_000,
+        "gpt5.5": 1_000_000,
+        "qwen3.6-plus": 1_000_000,
+    }
+    return {
+        model_name: explicit_windows.get(model_name, default_max_tokens)
+        for model_name in raw_model_map
+    }
+
+
 def get_allowed_models() -> list[str]:
     """Return the allowlist of model names from ALL_MODEL_STRINGS.
 

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -135,3 +135,20 @@ def test_resolve_llm_config_infers_provider_from_model_prefix_when_allowlist_omi
     assert config.provider == "openai"
     assert config.primary_model == "gpt-5.5"
     assert config.cheap_model == "gpt-5.5-mini"
+
+
+def test_get_model_max_tokens_map_uses_explicit_windows_and_defaults(monkeypatch) -> None:
+    from services import llm_provider
+
+    monkeypatch.setattr(
+        llm_provider.settings,
+        "ALL_MODEL_STRINGS",
+        "claude-opus-4-6:anthropic,gpt-5.5:openai,qwen3.6-plus:alibaba,random-model:openai",
+    )
+
+    max_tokens_map = llm_provider.get_model_max_tokens_map(default_max_tokens=200_000)
+
+    assert max_tokens_map["claude-opus-4-6"] == 1_000_000
+    assert max_tokens_map["gpt-5.5"] == 1_000_000
+    assert max_tokens_map["qwen3.6-plus"] == 1_000_000
+    assert max_tokens_map["random-model"] == 200_000

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -105,6 +105,9 @@ interface ToolApprovalState {
   result: WsToolApprovalResult | null;
 }
 
+const DEFAULT_MODEL_MAX_TOKENS = 200_000;
+const ONE_MILLION_TOKEN_MODELS = new Set<string>(['claude-opus-4-6', 'gpt-5.5', 'gpt5.5', 'qwen3.6-plus']);
+
 /**
  * Slack-like message thread typography & layout.
  * NOTE: :root light mode uses an inverted surface scale (see index.css): low numbers = dark ink,
@@ -492,6 +495,8 @@ export function Chat({
   const [currentAttachmentId, setCurrentAttachmentId] = useState<string | null>(null);
   const [currentAttachmentMeta, setCurrentAttachmentMeta] = useState<{ filename: string; mimeType: string } | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [modelMaxTokensMap, setModelMaxTokensMap] = useState<Record<string, number>>({});
+  const [defaultModelMaxTokens, setDefaultModelMaxTokens] = useState<number>(DEFAULT_MODEL_MAX_TOKENS);
 
   // App preview panel state
   const [previewAppId, setPreviewAppId] = useState<string | null>(null);
@@ -515,6 +520,32 @@ export function Chat({
   const [headerTitleDraft, setHeaderTitleDraft] = useState('');
   const headerTitleInputRef = useRef<HTMLInputElement>(null);
   const scopePatchInFlightRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadModelWindows = async (): Promise<void> => {
+      const { data, error } = await apiRequest<{
+        model_max_tokens?: Record<string, number>;
+        default_max_tokens?: number;
+      }>('/auth/llm-options', { cache: 'no-store' });
+      if (cancelled || error) return;
+      setModelMaxTokensMap(data?.model_max_tokens ?? {});
+      setDefaultModelMaxTokens(data?.default_max_tokens ?? DEFAULT_MODEL_MAX_TOKENS);
+    };
+    void loadModelWindows();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const activeModelMaxTokens: number = useMemo(() => {
+    const modelName = activeModelName?.trim();
+    if (!modelName) return defaultModelMaxTokens;
+    if (modelMaxTokensMap[modelName] != null) return modelMaxTokensMap[modelName];
+    const normalizedModel = modelName.toLowerCase();
+    if (ONE_MILLION_TOKEN_MODELS.has(normalizedModel)) return 1_000_000;
+    return defaultModelMaxTokens;
+  }, [activeModelName, defaultModelMaxTokens, modelMaxTokensMap]);
   const [conversationParticipants, setConversationParticipants] = useState<Array<{
     id: string;
     name: string | null;
@@ -2200,9 +2231,9 @@ export function Chat({
             </span>
           )}
           {(() => {
-            const contextPct = (conversationState?.contextTokens ?? 0) / 200_000;
+            const contextPct = (conversationState?.contextTokens ?? 0) / activeModelMaxTokens;
             return conversationState?.contextTokens != null ? (
-              <div className="flex items-center gap-1.5 ml-2" title={`${Math.round(contextPct * 100)}% context used (${(conversationState.contextTokens / 1000).toFixed(0)}k / 200k tokens)`}>
+              <div className="flex items-center gap-1.5 ml-2" title={`${Math.round(contextPct * 100)}% context used (${(conversationState.contextTokens / 1000).toFixed(0)}k / ${(activeModelMaxTokens / 1000).toFixed(0)}k tokens)`}>
                 <div className="w-16 h-1.5 bg-surface-700 rounded-full overflow-hidden">
                   <div
                     className={`h-full rounded-full transition-all ${


### PR DESCRIPTION
### Motivation
- The conversation progress UI used a hardcoded 200k denominator which is inaccurate for large-context models like Opus 4.6, GPT‑5.5, and QWEN; the UI should fetch model windows and render the progress bar appropriately.
- Clients should have a sane default when a model's max tokens are not configured (use 200,000 for UI/progress calculations).

### Description
- Added `get_model_max_tokens_map()` in `backend/services/llm_provider.py` to expose per-model context windows and include explicit 1,000,000-token entries for `claude-opus-4-6`, `gpt-5.5`/`gpt5.5`, and `qwen3.6-plus`, with a configurable `default_max_tokens` fallback.
- Extended `/auth/llm-options` (`backend/api/routes/auth.py`) to return `models`, `model_max_tokens`, and `default_max_tokens` for the UI to consume.
- Updated `frontend/src/components/Chat.tsx` to fetch the new metadata, compute `activeModelMaxTokens` for the currently running model, and use it as the denominator for the conversation context progress bar and tooltip while keeping a safe fallback to `200000` tokens and a small in-code mapping for common million-token model name variants.
- Added a unit test `test_get_model_max_tokens_map_uses_explicit_windows_and_defaults` to `backend/tests/test_llm_provider.py` to validate explicit and default window behavior.

### Testing
- Ran `pytest -q backend/tests/test_llm_provider.py` and observed all tests passing (`9 passed`).
- Manual compile-level checks applied to updated frontend component to ensure the progress denominator and tooltip strings use `activeModelMaxTokens` and preserve existing styling and thresholds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7cbf3dff8832187c16af56fca59f3)