### PR TITLE
Add app API workflow trigger using logged-in user context

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -14,9 +14,13 @@ write_on_connector, run_on_connector) which dispatch to the appropriate connecto
 from __future__ import annotations
 
 import asyncio
+import base64
+import hashlib
+import hmac
 import json
 import logging
 import re
+import time
 from collections.abc import Awaitable, Callable
 from datetime import date, datetime, timezone
 from decimal import Decimal
@@ -1046,6 +1050,27 @@ async def _query_on_connector(
         )
 
 
+
+
+def _build_apps_auth_envelope(*, authenticated_user_id: str | None, organization_id: str, delegated_actor_user_id: str | None = None, ttl_seconds: int = 300) -> dict[str, Any] | None:
+    """Build signed auth envelope for apps workflow triggers (server-only internal field)."""
+    if not authenticated_user_id:
+        return None
+    now = int(time.time())
+    exp = now + max(60, min(ttl_seconds, 300))
+    payload: dict[str, Any] = {
+        "sub": authenticated_user_id,
+        "org": organization_id,
+        "iat": now,
+        "exp": exp,
+    }
+    if delegated_actor_user_id and delegated_actor_user_id != authenticated_user_id:
+        payload["delegated_actor"] = delegated_actor_user_id
+    body = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    sig = hmac.new(settings.SECRET_KEY.encode("utf-8"), body, hashlib.sha256).digest()
+    token = base64.urlsafe_b64encode(body).decode("utf-8").rstrip("=")
+    signature = base64.urlsafe_b64encode(sig).decode("utf-8").rstrip("=")
+    return {"v": 1, "token": token, "sig": signature, "alg": "HS256"}
 async def _write_on_connector(
     params: dict[str, Any],
     organization_id: str,
@@ -1078,6 +1103,14 @@ async def _write_on_connector(
             data["conversation_id"] = ctx_apps["conversation_id"]
         if ctx_apps.get("message_id"):
             data["message_id"] = str(ctx_apps["message_id"]) if ctx_apps["message_id"] else None
+        if operation == "trigger_workflow":
+            envelope = _build_apps_auth_envelope(
+                authenticated_user_id=user_id,
+                organization_id=organization_id,
+                delegated_actor_user_id=None,
+            )
+            if envelope is not None:
+                data["_auth_envelope"] = envelope
         if operation == "create" and not data.get(" app created by"):
             conversation_owner_id = await _resolve_conversation_owner_user_id(
                 organization_id=organization_id,

--- a/backend/api/routes/apps.py
+++ b/backend/api/routes/apps.py
@@ -28,6 +28,7 @@ from models.database import get_session, get_admin_session
 from models.organization import Organization
 from models.user import User
 from models.visibility import normalize_visibility
+from models.workflow import Workflow
 from services.app_query_runner import (
     AppQueryResponse as QueryResponse,
     json_serial,
@@ -35,6 +36,7 @@ from services.app_query_runner import (
     validate_sql_is_select,
 )
 from services.org_admin import user_is_org_admin
+from services.workflow_pause import get_workflow_execution_pause_until
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +76,17 @@ class EmbedTokenResponse(BaseModel):
     embed_url: str
     token: str
     expires_at: str
+
+
+class TriggerAppWorkflowRequest(BaseModel):
+    trigger_data: dict[str, Any] | None = None
+
+
+class TriggerAppWorkflowResponse(BaseModel):
+    status: str
+    task_id: str
+    workflow_id: str
+    triggered_by_user_id: str
 
 
 # ---------------------------------------------------------------------------
@@ -226,6 +239,84 @@ async def execute_app_query(
             params=params,
             session=session,
         )
+
+
+@router.post("/{app_id}/workflows/{workflow_id}/trigger", response_model=TriggerAppWorkflowResponse)
+async def trigger_app_workflow(
+    app_id: str,
+    workflow_id: str,
+    body: TriggerAppWorkflowRequest | None = None,
+    auth: AuthContext = Depends(require_organization),
+) -> TriggerAppWorkflowResponse:
+    """Trigger a workflow from an app as the currently logged-in user."""
+    trigger_data: dict[str, Any] | None = (body or TriggerAppWorkflowRequest()).trigger_data
+
+    try:
+        app_uuid = UUID(app_id)
+        workflow_uuid = UUID(workflow_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid ID format") from exc
+
+    assert auth.organization_id_str is not None
+    async with get_session(
+        organization_id=auth.organization_id_str,
+        user_id=auth.user_id_str,
+    ) as session:
+        app_result = await session.execute(select(App).where(App.id == app_uuid))
+        app: App | None = app_result.scalar_one_or_none()
+        if app is None or str(app.organization_id) != auth.organization_id_str:
+            raise HTTPException(status_code=404, detail="App not found")
+
+        workflow_result = await session.execute(
+            select(Workflow).where(
+                Workflow.id == workflow_uuid,
+                Workflow.organization_id == app.organization_id,
+            )
+        )
+        workflow: Workflow | None = workflow_result.scalar_one_or_none()
+        if workflow is None:
+            raise HTTPException(status_code=404, detail="Workflow not found")
+        if workflow.archived_at is not None:
+            raise HTTPException(status_code=400, detail="Archived workflows cannot be triggered")
+        if not workflow.is_enabled:
+            raise HTTPException(status_code=400, detail="Workflow is disabled")
+
+    pause_until = await get_workflow_execution_pause_until()
+    if pause_until is not None:
+        logger.warning(
+            "[Apps API] Workflow trigger blocked by workflow execution pause app_id=%s workflow_id=%s organization_id=%s pause_until=%s",
+            app_id,
+            workflow_id,
+            auth.organization_id_str,
+            pause_until.isoformat(),
+        )
+        raise HTTPException(
+            status_code=503,
+            detail=f"Workflow execution temporarily paused until {pause_until.isoformat()}",
+        )
+
+    from workers.tasks.workflows import execute_workflow
+
+    task = execute_workflow.delay(
+        workflow_id=workflow_id,
+        triggered_by="app",
+        trigger_data=trigger_data,
+        conversation_id=None,
+        organization_id=auth.organization_id_str,
+        triggered_by_user_id=auth.user_id_str,
+    )
+    logger.info(
+        "[Apps API] Queued workflow from app app_id=%s workflow_id=%s user_id=%s",
+        app_id,
+        workflow_id,
+        auth.user_id_str,
+    )
+    return TriggerAppWorkflowResponse(
+        status="queued",
+        task_id=task.id,
+        workflow_id=workflow_id,
+        triggered_by_user_id=auth.user_id_str or "",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -330,10 +330,12 @@ class AppsConnector(BaseConnector):
             triggered_by_user_id=str(request_user_uuid),
         )
         logger.info(
-            "[AppsConnector] Queued workflow trigger via apps connector app_id=%s workflow_id=%s user_id=%s task_id=%s",
+            "[AppsConnector] Queued workflow trigger via apps connector app_id=%s workflow_id=%s triggered_user_id=%s connector_owner_user_id=%s delegated_actor_user_id=%s task_id=%s",
             app_id_raw,
             workflow_id_raw,
             request_user_uuid,
+            self.user_id,
+            delegated_actor,
             task.id,
         )
         return {

--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -42,7 +42,7 @@ USAGE_GUIDE: str = """# Apps Connector Usage Guide
 - **create**: Create a new app. Requires title, queries, frontend_code.
 - **update**: Update an existing app. Requires app_id, plus queries and/or frontend_code to change.
 - **test_query**: Run a query and return sample data to verify correctness. Requires app_id, query_name.
-- **trigger_workflow**: Trigger a workflow from an app as the current user. Requires app_id, workflow_id.
+- **trigger_workflow**: Trigger a workflow from an app as the current user. Requires app_id, workflow_id, user_id.
 
 ## Recommended workflow
 1. Create the app with operation="create"
@@ -169,10 +169,11 @@ class AppsConnector(BaseConnector):
             WriteOperation(
                 name="trigger_workflow",
                 entity_type="workflow",
-                description="Trigger a workflow for an app as the currently logged-in user. Requires app_id and workflow_id.",
+                description="Trigger a workflow for an app as the currently logged-in user. Requires app_id, workflow_id, and user_id.",
                 parameters=[
                     {"name": "app_id", "type": "string", "required": True, "description": "UUID of the app"},
                     {"name": "workflow_id", "type": "string", "required": True, "description": "UUID of the workflow to trigger"},
+                    {"name": "user_id", "type": "string", "required": True, "description": "UUID of the currently authenticated user triggering the workflow"},
                     {"name": "trigger_data", "type": "object", "required": False, "description": "Optional trigger payload passed to the workflow run"},
                 ],
             ),

--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -7,8 +7,13 @@ the agent can query (read) and write (create, update, test_query).
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import hmac
+import json
 import logging
 import re
+import time
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -42,7 +47,7 @@ USAGE_GUIDE: str = """# Apps Connector Usage Guide
 - **create**: Create a new app. Requires title, queries, frontend_code.
 - **update**: Update an existing app. Requires app_id, plus queries and/or frontend_code to change.
 - **test_query**: Run a query and return sample data to verify correctness. Requires app_id, query_name.
-- **trigger_workflow**: Trigger a workflow from an app as the current user. Requires app_id, workflow_id, user_id.
+- **trigger_workflow**: Trigger a workflow from an app as the current user. Requires app_id, workflow_id.
 
 ## Recommended workflow
 1. Create the app with operation="create"
@@ -117,6 +122,48 @@ For Revenue by Region (with params), use useAppQuery('revenue_data', { start_dat
 """
 
 
+
+
+def _decode_apps_auth_envelope(envelope: dict[str, Any] | None, *, expected_org: str) -> tuple[str | None, str | None]:
+    """Validate signed server auth envelope and return (request_user_id, delegated_actor)."""
+    if not isinstance(envelope, dict):
+        return None, "Missing auth envelope"
+    token = envelope.get("token")
+    sig = envelope.get("sig")
+    if not isinstance(token, str) or not isinstance(sig, str):
+        return None, "Invalid auth envelope"
+
+    def _b64decode(v: str) -> bytes:
+        padding = '=' * (-len(v) % 4)
+        return base64.urlsafe_b64decode(v + padding)
+
+    try:
+        body = _b64decode(token)
+        sent_sig = _b64decode(sig)
+    except Exception:
+        return None, "Invalid auth envelope encoding"
+
+    expected_sig = hmac.new(settings.SECRET_KEY.encode("utf-8"), body, hashlib.sha256).digest()
+    if not hmac.compare_digest(sent_sig, expected_sig):
+        return None, "Invalid auth envelope signature"
+
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except Exception:
+        return None, "Invalid auth envelope payload"
+
+    now = int(time.time())
+    exp = payload.get("exp")
+    org = payload.get("org")
+    sub = payload.get("sub")
+    delegated_actor = payload.get("delegated_actor")
+    if not isinstance(exp, int) or exp < now:
+        return None, "Auth envelope expired"
+    if not isinstance(org, str) or org != expected_org:
+        return None, "Auth envelope organization mismatch"
+    if not isinstance(sub, str):
+        return None, "Auth envelope missing subject"
+    return sub, delegated_actor if isinstance(delegated_actor, str) else None
 class AppsConnector(BaseConnector):
     """Create, read, update, and test interactive mini-apps (React + SQL)."""
 
@@ -169,12 +216,11 @@ class AppsConnector(BaseConnector):
             WriteOperation(
                 name="trigger_workflow",
                 entity_type="workflow",
-                description="Trigger a workflow for an app as the currently logged-in user. Requires app_id, workflow_id, and user_id.",
+                description="Trigger a workflow for an app as the currently logged-in user. Requires app_id and workflow_id; user context is attached by server auth envelope.",
                 parameters=[
                     {"name": "app_id", "type": "string", "required": True, "description": "UUID of the app"},
                     {"name": "workflow_id", "type": "string", "required": True, "description": "UUID of the workflow to trigger"},
-                    {"name": "user_id", "type": "string", "required": True, "description": "UUID of the currently authenticated user triggering the workflow"},
-                    {"name": "trigger_data", "type": "object", "required": False, "description": "Optional trigger payload passed to the workflow run"},
+                                        {"name": "trigger_data", "type": "object", "required": False, "description": "Optional trigger payload passed to the workflow run"},
                 ],
             ),
         ],
@@ -227,7 +273,7 @@ class AppsConnector(BaseConnector):
     async def _trigger_workflow(self, data: dict[str, Any]) -> dict[str, Any]:
         app_id_raw: str | None = data.get("app_id")
         workflow_id_raw: str | None = data.get("workflow_id")
-        request_user_id_raw: str | None = data.get("user_id")
+        auth_envelope: dict[str, Any] | None = data.get("_auth_envelope")
         trigger_data: dict[str, Any] | None = data.get("trigger_data")
 
         if not app_id_raw:
@@ -235,15 +281,16 @@ class AppsConnector(BaseConnector):
         if not workflow_id_raw:
             return {"error": "workflow_id is required for trigger_workflow operation"}
 
+        request_user_id_raw, delegated_actor = _decode_apps_auth_envelope(auth_envelope, expected_org=self.organization_id)
         if not request_user_id_raw:
-            return {"error": "user_id is required for trigger_workflow operation"}
+            return {"error": "Missing or invalid authenticated user context for trigger_workflow"}
 
         try:
             app_uuid = UUID(app_id_raw)
             workflow_uuid = UUID(workflow_id_raw)
             request_user_uuid = UUID(request_user_id_raw)
         except (TypeError, ValueError):
-            return {"error": "Invalid app_id, workflow_id, or user_id format (must be valid UUIDs)"}
+            return {"error": "Invalid app_id or workflow_id format (must be valid UUIDs)"}
 
         async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
             app_result = await session.execute(select(App).where(App.id == app_uuid))
@@ -295,6 +342,7 @@ class AppsConnector(BaseConnector):
             "app_id": app_id_raw,
             "workflow_id": workflow_id_raw,
             "triggered_by_user_id": str(request_user_uuid),
+            "delegated_actor_user_id": delegated_actor,
         }
 
     @staticmethod

--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -226,6 +226,7 @@ class AppsConnector(BaseConnector):
     async def _trigger_workflow(self, data: dict[str, Any]) -> dict[str, Any]:
         app_id_raw: str | None = data.get("app_id")
         workflow_id_raw: str | None = data.get("workflow_id")
+        request_user_id_raw: str | None = data.get("user_id")
         trigger_data: dict[str, Any] | None = data.get("trigger_data")
 
         if not app_id_raw:
@@ -233,11 +234,15 @@ class AppsConnector(BaseConnector):
         if not workflow_id_raw:
             return {"error": "workflow_id is required for trigger_workflow operation"}
 
+        if not request_user_id_raw:
+            return {"error": "user_id is required for trigger_workflow operation"}
+
         try:
             app_uuid = UUID(app_id_raw)
             workflow_uuid = UUID(workflow_id_raw)
-        except ValueError:
-            return {"error": "Invalid app_id or workflow_id format (must be valid UUIDs)"}
+            request_user_uuid = UUID(request_user_id_raw)
+        except (TypeError, ValueError):
+            return {"error": "Invalid app_id, workflow_id, or user_id format (must be valid UUIDs)"}
 
         async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
             app_result = await session.execute(select(App).where(App.id == app_uuid))
@@ -274,13 +279,13 @@ class AppsConnector(BaseConnector):
             trigger_data=trigger_data if isinstance(trigger_data, dict) else None,
             conversation_id=None,
             organization_id=self.organization_id,
-            triggered_by_user_id=self.user_id,
+            triggered_by_user_id=str(request_user_uuid),
         )
         logger.info(
             "[AppsConnector] Queued workflow trigger via apps connector app_id=%s workflow_id=%s user_id=%s task_id=%s",
             app_id_raw,
             workflow_id_raw,
-            self.user_id,
+            request_user_uuid,
             task.id,
         )
         return {
@@ -288,7 +293,7 @@ class AppsConnector(BaseConnector):
             "task_id": task.id,
             "app_id": app_id_raw,
             "workflow_id": workflow_id_raw,
-            "triggered_by_user_id": self.user_id,
+            "triggered_by_user_id": str(request_user_uuid),
         }
 
     @staticmethod

--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -292,7 +292,7 @@ class AppsConnector(BaseConnector):
         except (TypeError, ValueError):
             return {"error": "Invalid app_id or workflow_id format (must be valid UUIDs)"}
 
-        async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
+        async with get_session(organization_id=self.organization_id, user_id=str(request_user_uuid)) as session:
             app_result = await session.execute(select(App).where(App.id == app_uuid))
             app = app_result.scalar_one_or_none()
             if app is None:

--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -29,6 +29,8 @@ from models.conversation import Conversation
 from models.database import get_session
 from models.external_identity_mapping import ExternalIdentityMapping
 from models.organization import Organization
+from models.workflow import Workflow
+from services.workflow_pause import get_workflow_execution_pause_until
 from services.public_preview_warmup import warm_public_preview_cache
 from services.slack_identity import get_alternate_slack_user_ids_for_identity
 
@@ -40,6 +42,7 @@ USAGE_GUIDE: str = """# Apps Connector Usage Guide
 - **create**: Create a new app. Requires title, queries, frontend_code.
 - **update**: Update an existing app. Requires app_id, plus queries and/or frontend_code to change.
 - **test_query**: Run a query and return sample data to verify correctness. Requires app_id, query_name.
+- **trigger_workflow**: Trigger a workflow from an app as the current user. Requires app_id, workflow_id.
 
 ## Recommended workflow
 1. Create the app with operation="create"
@@ -163,6 +166,16 @@ class AppsConnector(BaseConnector):
                     {"name": "limit", "type": "integer", "required": False, "description": "Max rows to return (default 5, max 50)"},
                 ],
             ),
+            WriteOperation(
+                name="trigger_workflow",
+                entity_type="workflow",
+                description="Trigger a workflow for an app as the currently logged-in user. Requires app_id and workflow_id.",
+                parameters=[
+                    {"name": "app_id", "type": "string", "required": True, "description": "UUID of the app"},
+                    {"name": "workflow_id", "type": "string", "required": True, "description": "UUID of the workflow to trigger"},
+                    {"name": "trigger_data", "type": "object", "required": False, "description": "Optional trigger payload passed to the workflow run"},
+                ],
+            ),
         ],
         description="Create and update interactive mini-apps with React + SQL queries.",
         usage_guide=USAGE_GUIDE,
@@ -206,7 +219,77 @@ class AppsConnector(BaseConnector):
             return await self._update(data)
         if operation == "test_query":
             return await self._test_query(data)
-        return {"error": f"Unknown operation: {operation}. Use 'create', 'update', or 'test_query'."}
+        if operation == "trigger_workflow":
+            return await self._trigger_workflow(data)
+        return {"error": f"Unknown operation: {operation}. Use 'create', 'update', 'test_query', or 'trigger_workflow'."}
+
+    async def _trigger_workflow(self, data: dict[str, Any]) -> dict[str, Any]:
+        app_id_raw: str | None = data.get("app_id")
+        workflow_id_raw: str | None = data.get("workflow_id")
+        trigger_data: dict[str, Any] | None = data.get("trigger_data")
+
+        if not app_id_raw:
+            return {"error": "app_id is required for trigger_workflow operation"}
+        if not workflow_id_raw:
+            return {"error": "workflow_id is required for trigger_workflow operation"}
+
+        try:
+            app_uuid = UUID(app_id_raw)
+            workflow_uuid = UUID(workflow_id_raw)
+        except ValueError:
+            return {"error": "Invalid app_id or workflow_id format (must be valid UUIDs)"}
+
+        async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
+            app_result = await session.execute(select(App).where(App.id == app_uuid))
+            app = app_result.scalar_one_or_none()
+            if app is None:
+                return {"error": f"App not found: {app_id_raw}"}
+
+            workflow_result = await session.execute(
+                select(Workflow).where(
+                    Workflow.id == workflow_uuid,
+                    Workflow.organization_id == app.organization_id,
+                )
+            )
+            workflow = workflow_result.scalar_one_or_none()
+            if workflow is None:
+                return {"error": f"Workflow not found: {workflow_id_raw}"}
+            if workflow.archived_at is not None:
+                return {"error": "Archived workflows cannot be triggered"}
+            if not workflow.is_enabled:
+                return {"error": "Workflow is disabled"}
+
+        pause_until = await get_workflow_execution_pause_until()
+        if pause_until is not None:
+            return {
+                "error": f"Workflow execution temporarily paused until {pause_until.isoformat()}",
+                "status": "paused",
+            }
+
+        from workers.tasks.workflows import execute_workflow
+
+        task = execute_workflow.delay(
+            workflow_id=workflow_id_raw,
+            triggered_by="app",
+            trigger_data=trigger_data if isinstance(trigger_data, dict) else None,
+            conversation_id=None,
+            organization_id=self.organization_id,
+            triggered_by_user_id=self.user_id,
+        )
+        logger.info(
+            "[AppsConnector] Queued workflow trigger via apps connector app_id=%s workflow_id=%s user_id=%s task_id=%s",
+            app_id_raw,
+            workflow_id_raw,
+            self.user_id,
+            task.id,
+        )
+        return {
+            "status": "queued",
+            "task_id": task.id,
+            "app_id": app_id_raw,
+            "workflow_id": workflow_id_raw,
+            "triggered_by_user_id": self.user_id,
+        }
 
     @staticmethod
     def _validate_queries(queries: dict[str, Any]) -> str | None:

--- a/backend/tests/test_apps_connector_workflow_trigger.py
+++ b/backend/tests/test_apps_connector_workflow_trigger.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 import pytest
 
-from connectors.apps import AppsConnector
+from connectors.apps import AppsConnector, _decode_apps_auth_envelope
 
 
 class _ScalarResult:
@@ -58,6 +58,7 @@ async def test_apps_connector_trigger_workflow_queues_with_current_user(monkeypa
     monkeypatch.setattr("connectors.apps.get_session", _fake_session)
     monkeypatch.setattr("connectors.apps.get_workflow_execution_pause_until", _no_pause)
     monkeypatch.setitem(__import__("sys").modules, "workers.tasks.workflows", SimpleNamespace(execute_workflow=_FakeExecuteWorkflow))
+    monkeypatch.setattr("connectors.apps._decode_apps_auth_envelope", lambda _env, expected_org: ("00000000-0000-0000-0000-000000000005", None))
 
     connector = AppsConnector(organization_id=org_id, user_id=user_id)
     result = await connector.write(
@@ -65,7 +66,7 @@ async def test_apps_connector_trigger_workflow_queues_with_current_user(monkeypa
         {
             "app_id": app_id,
             "workflow_id": workflow_id,
-            "user_id": "00000000-0000-0000-0000-000000000005",
+            "_auth_envelope": {"token": "", "sig": ""},
             "trigger_data": {"from": "test"},
         },
     )
@@ -78,7 +79,7 @@ async def test_apps_connector_trigger_workflow_queues_with_current_user(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_apps_connector_trigger_workflow_requires_request_user_id(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_apps_connector_trigger_workflow_requires_auth_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
     org_id = "00000000-0000-0000-0000-000000000001"
     connector = AppsConnector(organization_id=org_id, user_id="00000000-0000-0000-0000-000000000002")
 
@@ -90,4 +91,10 @@ async def test_apps_connector_trigger_workflow_requires_request_user_id(monkeypa
         },
     )
 
-    assert result == {"error": "user_id is required for trigger_workflow operation"}
+    assert result == {"error": "Missing or invalid authenticated user context for trigger_workflow"}
+
+
+def test_decode_apps_auth_envelope_rejects_missing() -> None:
+    user_id, delegated = _decode_apps_auth_envelope(None, expected_org="00000000-0000-0000-0000-000000000001")
+    assert user_id is None
+    assert delegated == "Missing auth envelope"

--- a/backend/tests/test_apps_connector_workflow_trigger.py
+++ b/backend/tests/test_apps_connector_workflow_trigger.py
@@ -62,11 +62,32 @@ async def test_apps_connector_trigger_workflow_queues_with_current_user(monkeypa
     connector = AppsConnector(organization_id=org_id, user_id=user_id)
     result = await connector.write(
         "trigger_workflow",
-        {"app_id": app_id, "workflow_id": workflow_id, "trigger_data": {"from": "test"}},
+        {
+            "app_id": app_id,
+            "workflow_id": workflow_id,
+            "user_id": "00000000-0000-0000-0000-000000000005",
+            "trigger_data": {"from": "test"},
+        },
     )
 
     assert result["status"] == "queued"
     assert result["task_id"] == "task-xyz"
-    assert result["triggered_by_user_id"] == user_id
+    assert result["triggered_by_user_id"] == "00000000-0000-0000-0000-000000000005"
     assert captured["triggered_by"] == "app"
-    assert captured["triggered_by_user_id"] == user_id
+    assert captured["triggered_by_user_id"] == "00000000-0000-0000-0000-000000000005"
+
+
+@pytest.mark.asyncio
+async def test_apps_connector_trigger_workflow_requires_request_user_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    org_id = "00000000-0000-0000-0000-000000000001"
+    connector = AppsConnector(organization_id=org_id, user_id="00000000-0000-0000-0000-000000000002")
+
+    result = await connector.write(
+        "trigger_workflow",
+        {
+            "app_id": "00000000-0000-0000-0000-000000000003",
+            "workflow_id": "00000000-0000-0000-0000-000000000004",
+        },
+    )
+
+    assert result == {"error": "user_id is required for trigger_workflow operation"}

--- a/backend/tests/test_apps_connector_workflow_trigger.py
+++ b/backend/tests/test_apps_connector_workflow_trigger.py
@@ -40,8 +40,11 @@ async def test_apps_connector_trigger_workflow_uses_envelope_user_not_connector_
     app_obj = SimpleNamespace(id=UUID(app_id), organization_id=UUID(org_id))
     workflow_obj = SimpleNamespace(id=UUID(workflow_id), organization_id=UUID(org_id), archived_at=None, is_enabled=True)
 
+    session_kwargs: dict[str, str] = {}
+
     @asynccontextmanager
     async def _fake_session(**_kwargs):
+        session_kwargs.update(_kwargs)
         yield _FakeSession(app_obj, workflow_obj)
 
     async def _no_pause():
@@ -77,6 +80,7 @@ async def test_apps_connector_trigger_workflow_uses_envelope_user_not_connector_
     assert captured["triggered_by"] == "app"
     assert captured["triggered_by_user_id"] == "00000000-0000-0000-0000-000000000005"
     assert captured["triggered_by_user_id"] != user_id
+    assert session_kwargs["user_id"] == "00000000-0000-0000-0000-000000000005"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_apps_connector_workflow_trigger.py
+++ b/backend/tests/test_apps_connector_workflow_trigger.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+from connectors.apps import AppsConnector
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _FakeSession:
+    def __init__(self, app_obj, workflow_obj) -> None:
+        self._responses = [app_obj, workflow_obj]
+
+    async def execute(self, _query):
+        return _ScalarResult(self._responses.pop(0))
+
+
+class _FakeTask:
+    def __init__(self, task_id: str) -> None:
+        self.id = task_id
+
+
+@pytest.mark.asyncio
+async def test_apps_connector_trigger_workflow_queues_with_current_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    org_id = "00000000-0000-0000-0000-000000000001"
+    user_id = "00000000-0000-0000-0000-000000000002"
+    app_id = "00000000-0000-0000-0000-000000000003"
+    workflow_id = "00000000-0000-0000-0000-000000000004"
+
+    app_obj = SimpleNamespace(id=UUID(app_id), organization_id=UUID(org_id))
+    workflow_obj = SimpleNamespace(id=UUID(workflow_id), organization_id=UUID(org_id), archived_at=None, is_enabled=True)
+
+    @asynccontextmanager
+    async def _fake_session(**_kwargs):
+        yield _FakeSession(app_obj, workflow_obj)
+
+    async def _no_pause():
+        return None
+
+    captured: dict[str, str | None] = {}
+
+    class _FakeExecuteWorkflow:
+        @staticmethod
+        def delay(**kwargs):
+            captured.update(kwargs)
+            return _FakeTask("task-xyz")
+
+    monkeypatch.setattr("connectors.apps.get_session", _fake_session)
+    monkeypatch.setattr("connectors.apps.get_workflow_execution_pause_until", _no_pause)
+    monkeypatch.setitem(__import__("sys").modules, "workers.tasks.workflows", SimpleNamespace(execute_workflow=_FakeExecuteWorkflow))
+
+    connector = AppsConnector(organization_id=org_id, user_id=user_id)
+    result = await connector.write(
+        "trigger_workflow",
+        {"app_id": app_id, "workflow_id": workflow_id, "trigger_data": {"from": "test"}},
+    )
+
+    assert result["status"] == "queued"
+    assert result["task_id"] == "task-xyz"
+    assert result["triggered_by_user_id"] == user_id
+    assert captured["triggered_by"] == "app"
+    assert captured["triggered_by_user_id"] == user_id

--- a/backend/tests/test_apps_connector_workflow_trigger.py
+++ b/backend/tests/test_apps_connector_workflow_trigger.py
@@ -31,7 +31,7 @@ class _FakeTask:
 
 
 @pytest.mark.asyncio
-async def test_apps_connector_trigger_workflow_queues_with_current_user(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_apps_connector_trigger_workflow_uses_envelope_user_not_connector_owner(monkeypatch: pytest.MonkeyPatch) -> None:
     org_id = "00000000-0000-0000-0000-000000000001"
     user_id = "00000000-0000-0000-0000-000000000002"
     app_id = "00000000-0000-0000-0000-000000000003"
@@ -76,6 +76,7 @@ async def test_apps_connector_trigger_workflow_queues_with_current_user(monkeypa
     assert result["triggered_by_user_id"] == "00000000-0000-0000-0000-000000000005"
     assert captured["triggered_by"] == "app"
     assert captured["triggered_by_user_id"] == "00000000-0000-0000-0000-000000000005"
+    assert captured["triggered_by_user_id"] != user_id
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_apps_workflow_trigger.py
+++ b/backend/tests/test_apps_workflow_trigger.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+from api.auth_middleware import AuthContext
+from api.routes import apps as apps_routes
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _FakeSession:
+    def __init__(self, app_obj, workflow_obj) -> None:
+        self._responses = [app_obj, workflow_obj]
+
+    async def execute(self, _query):
+        return _ScalarResult(self._responses.pop(0))
+
+
+class _FakeTask:
+    def __init__(self, task_id: str) -> None:
+        self.id = task_id
+
+
+@pytest.mark.asyncio
+async def test_trigger_app_workflow_runs_as_logged_in_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    org_id = UUID("00000000-0000-0000-0000-000000000001")
+    user_id = UUID("00000000-0000-0000-0000-000000000002")
+    app_id = UUID("00000000-0000-0000-0000-000000000003")
+    workflow_id = UUID("00000000-0000-0000-0000-000000000004")
+
+    app_obj = SimpleNamespace(id=app_id, organization_id=org_id)
+    workflow_obj = SimpleNamespace(id=workflow_id, organization_id=org_id, archived_at=None, is_enabled=True)
+
+    @asynccontextmanager
+    async def _fake_session(**_kwargs):
+        yield _FakeSession(app_obj, workflow_obj)
+
+    captured: dict[str, str | None] = {}
+
+    class _FakeExecuteWorkflow:
+        @staticmethod
+        def delay(**kwargs):
+            captured.update(kwargs)
+            return _FakeTask("task-123")
+
+    async def _no_pause():
+        return None
+
+    monkeypatch.setattr(apps_routes, "get_session", _fake_session)
+    monkeypatch.setattr(apps_routes, "get_workflow_execution_pause_until", _no_pause)
+    monkeypatch.setitem(__import__("sys").modules, "workers.tasks.workflows", SimpleNamespace(execute_workflow=_FakeExecuteWorkflow))
+
+    auth = AuthContext(
+        user_id=user_id,
+        organization_id=org_id,
+        email="user@example.com",
+        role="member",
+        is_global_admin=False,
+    )
+
+    response = await apps_routes.trigger_app_workflow(
+        app_id=str(app_id),
+        workflow_id=str(workflow_id),
+        body=apps_routes.TriggerAppWorkflowRequest(trigger_data={"source": "app"}),
+        auth=auth,
+    )
+
+    assert response.status == "queued"
+    assert response.triggered_by_user_id == str(user_id)
+    assert captured["triggered_by_user_id"] == str(user_id)
+    assert captured["triggered_by"] == "app"


### PR DESCRIPTION
### Motivation
- Enable apps to trigger workflows on behalf of the currently authenticated user so app-initiated actions run with the logged-in user's identity while preserving org scoping and workflow safety checks.

### Description
- Add `POST /api/apps/{app_id}/workflows/{workflow_id}/trigger` in `backend/api/routes/apps.py` with request/response models `TriggerAppWorkflowRequest` and `TriggerAppWorkflowResponse` to accept `trigger_data` and return the queued task id.
- Validate `app_id` and `workflow_id` as UUIDs, ensure the app and workflow belong to the same organization, and reject archived or disabled workflows before queueing execution.
- Respect global workflow pause state by calling `get_workflow_execution_pause_until` and return `503` when paused, and queue the workflow via Celery with `triggered_by=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c6dccd9c8321a0669ddf0ac91a03)