### PR TITLE
Refactor sidebar: add 'Hub' collapsible nav and restore chat pin button

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2310,6 +2310,23 @@ export function Chat({
             </div>
           )}
           <ConnectionStatus state={connectionState} />
+          {chatId ? (
+            <button
+              type="button"
+              onClick={handleMenuTogglePin}
+              className={`p-1.5 rounded-md transition-colors ${
+                isCurrentChatPinned
+                  ? 'text-amber-300 bg-amber-500/10 hover:bg-amber-500/20'
+                  : 'text-surface-400 hover:text-surface-200 hover:bg-surface-800'
+              }`}
+              title={isCurrentChatPinned ? 'Unpin chat' : 'Pin chat'}
+              aria-label={isCurrentChatPinned ? 'Unpin chat' : 'Pin chat'}
+            >
+              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3l14 14M9 7l8 8m-2-10l3 3-4 4 3 7-7-3-4 4-3-3 4-4-3-7 7 3 4-4z" />
+              </svg>
+            </button>
+          ) : null}
           <div className="relative flex-shrink-0" ref={chatHeaderMenuRef}>
             <button
               type="button"

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -272,7 +272,7 @@ function OrgPanel({
       {!isAdminConsole && (
         <>
           <div className="text-[11px] uppercase tracking-wider text-surface-500 px-2 pt-4 pb-1 font-medium">
-            Workspace
+            Hub
           </div>
           <div className="space-y-0.5" role="group" aria-label="Workspace navigation">
             <OrgDropdownWorkspaceRow
@@ -606,9 +606,11 @@ export function Sidebar({
 
             <ChatAccordion
               collapsed={collapsed}
+              currentView={currentView}
               orderedChats={orderedChats}
               currentChatId={currentChatId}
               activeTasksByConversation={activeTasksByConversation}
+              onViewChange={onViewChange}
               onSelectChat={(id) => {
                 onSelectChat(id);
                 if (isMobile) onCloseMobile?.();
@@ -712,15 +714,19 @@ function normalizeChannelIdForMemory(source: string | null | undefined, channelK
 /** Recent chats: shared + private in one list (recency), pinned first; lock marks private. Row actions live in the chat ⋮ menu. */
 function ChatAccordion({
   collapsed,
+  currentView,
   orderedChats,
   currentChatId,
   activeTasksByConversation,
+  onViewChange,
   onSelectChat,
 }: {
   collapsed: boolean;
+  currentView: View;
   orderedChats: ChatSummary[];
   currentChatId: string | null;
   activeTasksByConversation: Record<string, string>;
+  onViewChange: (view: View) => void;
   onSelectChat: (id: string) => void;
 }): JSX.Element | null {
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -924,6 +930,35 @@ function ChatAccordion({
   return (
     <div className="flex-1 flex flex-col min-h-0 px-3 pt-1 pb-px">
       <div className="flex-1 overflow-y-auto scrollbar-thin space-y-0 min-h-0">
+        <div className="mb-1">
+          <SidebarSectionHeader
+            title="Hub"
+            collapsed={isSectionCollapsed('hub')}
+            onToggle={() => toggleSection('hub')}
+          />
+          {!isSectionCollapsed('hub') && (
+            <div className="space-y-0.5 mb-1">
+              {[
+                { label: 'Settings', view: 'org-settings' as View },
+                { label: 'Workflows', view: 'workflows' as View },
+                { label: 'Apps', view: 'apps' as View },
+              ].map((item) => (
+                <button
+                  key={item.label}
+                  type="button"
+                  onClick={() => onViewChange(item.view)}
+                  className={`w-full text-left px-2 py-1.5 rounded-md text-sm transition-colors ${
+                    currentView === item.view
+                      ? 'bg-surface-800 text-surface-100'
+                      : 'text-surface-300 hover:text-surface-100 hover:bg-surface-800/70'
+                  }`}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
         {groupedSidebarChats.flattenCount > 0 ? (
           <>
             {groupedSidebarChats.pinned.length > 0 && (


### PR DESCRIPTION
### Motivation
- Surface workspace-level navigation higher in the UI so quick links (Settings, Workflows, Apps) appear above conversation lists and are easier to access.
- Give the workspace section the same collapsible chrome as other sidebar sections and rename it to a clearer label `Hub`.
- Restore a dedicated, visible pin/unpin control in the conversation header to improve discoverability for pinning chats.

### Description
- Moved workspace quick links into the primary left navigation by adding a collapsible `Hub` section at the top of the chat accordion and wired it to `currentView`/`onViewChange` so buttons navigate views directly (`frontend/src/components/Sidebar.tsx`).
- Renamed the org/workspace panel heading from `Workspace` to `Hub` to match the new label (`frontend/src/components/Sidebar.tsx`).
- Restored a dedicated pin/unpin icon button in the conversation top bar that calls the existing pin toggle handler while leaving the ellipsis menu action intact (`frontend/src/components/Chat.tsx`).
- Updated `ChatAccordion` component signature to accept `currentView` and `onViewChange` so the new Hub buttons can change the app view (`frontend/src/components/Sidebar.tsx`).

### Testing
- Ran `npm run -s lint` in the `frontend/` directory and it completed successfully.
- No additional automated unit or integration tests were added for this UI-only change.
- Manual smoke-checks of the sidebar and chat header were performed during development (no failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f2bde3c08321bb24b1cfae972352)