### PR TITLE
Remove scope toggles from chat header ellipsis menu

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2394,35 +2394,6 @@ export function Chat({
                     ) : null}
                   </>
                 ) : null}
-                {canToggleChatScope ? (
-                  <>
-                    <div className="my-1 border-t border-surface-800" role="separator" />
-                    <button
-                      type="button"
-                      role="menuitem"
-                      disabled={scopeToggleSaving || conversationScope === 'shared'}
-                      className="flex w-full items-center px-3 py-2 text-left text-sm text-surface-200 hover:bg-surface-800 disabled:opacity-40 disabled:cursor-not-allowed"
-                      onClick={() => {
-                        setChatHeaderMenuOpen(false);
-                        void handleMakeShared();
-                      }}
-                    >
-                      Make shared
-                    </button>
-                    <button
-                      type="button"
-                      role="menuitem"
-                      disabled={scopeToggleSaving || conversationScope === 'private'}
-                      className="flex w-full items-center px-3 py-2 text-left text-sm text-surface-200 hover:bg-surface-800 disabled:opacity-40 disabled:cursor-not-allowed"
-                      onClick={() => {
-                        setChatHeaderMenuOpen(false);
-                        void handleMakePrivate();
-                      }}
-                    >
-                      Make private
-                    </button>
-                  </>
-                ) : null}
                 <div className="my-1 border-t border-surface-800" role="separator" />
                 <button
                   type="button"


### PR DESCRIPTION
### Motivation
- Remove the redundant scope toggle actions from the chat header ellipsis menu so scope changes are performed only via the dedicated scope pill control in the header.

### Description
- Deleted the `Make shared` and `Make private` menu items from the ellipsis dropdown in `frontend/src/components/Chat.tsx`.
- Kept all other ellipsis menu options and behavior (rename, pin/unpin, mark as read, share, delete) unchanged.
- Scope can still be changed via the existing header scope pill control; no backend/API changes were required.

### Testing
- Ran `rg -n "Make shared|Make private" frontend/src/components/Chat.tsx` to confirm the strings are no longer present, and the search returned no matches (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f4070bac83219e05bded76f69304)