### PR TITLE
Change conversation pin icon to pushpin style

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2288,7 +2288,7 @@ export function Chat({
               aria-label={isCurrentChatPinned ? 'Unpin chat' : 'Pin chat'}
             >
               <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 3l14 14M9 7l8 8m-2-10l3 3-4 4 3 7-7-3-4 4-3-3 4-4-3-7 7 3 4-4z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 3a3 3 0 00-6 0v3H6.5A1.5 1.5 0 005 7.5V9h14V7.5A1.5 1.5 0 0017.5 6H16V3zm-1 9.5V21l-2-3-2 3v-8.5l-2.2-2.2a1 1 0 011.4-1.4L10 10.7l1.8-1.8a1 1 0 011.4 1.4L11 12.5z" />
               </svg>
             </button>
           ) : null}

--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -511,7 +511,7 @@ function ChatRow({
                 title={isPinned ? 'Unpin conversation' : 'Pin conversation'}
               >
                 <svg className={`w-4 h-4 ${isPinned ? 'text-primary-400' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 3a3 3 0 00-6 0v3H6.5A1.5 1.5 0 005 7.5V9h14V7.5A1.5 1.5 0 0017.5 6H16V3zm-1 9.5V21l-2-3-2 3v-8.5l-2.2-2.2a1 1 0 011.4-1.4L10 10.7l1.8-1.8a1 1 0 011.4 1.4L11 12.5z" />
                 </svg>
               </button>
             </div>


### PR DESCRIPTION
### Motivation
- Make the conversation pin icon look like a pushpin (Pinterest-style) for clearer visual affordance and consistency across the app.

### Description
- Replaced the SVG path used for the pin action in the chat header in `frontend/src/components/Chat.tsx` with a pushpin-style glyph.
- Replaced the SVG path used for the pin action in the chat row in `frontend/src/components/ChatsList.tsx` with the same pushpin-style glyph for consistency.
- This is a visual-only change and does not modify any pin/unpin behavior or application logic.

### Testing
- No automated test files were added or changed because this is a UI-only update.
- Performed an automated file-diff inspection to verify that only the two SVG path strings in `Chat.tsx` and `ChatsList.tsx` were modified and no other lines were affected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f94a1cec8321917d18497028ac21)