### PR TITLE
Use bookmark icon for conversation pin controls

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2288,7 +2288,7 @@ export function Chat({
               aria-label={isCurrentChatPinned ? 'Unpin chat' : 'Pin chat'}
             >
               <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 3a3 3 0 00-6 0v3H6.5A1.5 1.5 0 005 7.5V9h14V7.5A1.5 1.5 0 0017.5 6H16V3zm-1 9.5V21l-2-3-2 3v-8.5l-2.2-2.2a1 1 0 011.4-1.4L10 10.7l1.8-1.8a1 1 0 011.4 1.4L11 12.5z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 21l-5-3-5 3V5a2 2 0 012-2h6a2 2 0 012 2v16z" />
               </svg>
             </button>
           ) : null}

--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -511,7 +511,7 @@ function ChatRow({
                 title={isPinned ? 'Unpin conversation' : 'Pin conversation'}
               >
                 <svg className={`w-4 h-4 ${isPinned ? 'text-primary-400' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 3a3 3 0 00-6 0v3H6.5A1.5 1.5 0 005 7.5V9h14V7.5A1.5 1.5 0 0017.5 6H16V3zm-1 9.5V21l-2-3-2 3v-8.5l-2.2-2.2a1 1 0 011.4-1.4L10 10.7l1.8-1.8a1 1 0 011.4 1.4L11 12.5z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 21l-5-3-5 3V5a2 2 0 012-2h6a2 2 0 012 2v16z" />
                 </svg>
               </button>
             </div>


### PR DESCRIPTION
### Motivation
- Make the conversation pin affordance visually consistent by using a bookmark glyph for pin actions in both the chat header and the chats list.

### Description
- Replaced the pin SVG path with a bookmark glyph in `frontend/src/components/Chat.tsx` for the header pin button.
- Replaced the pin SVG path with the same bookmark glyph in `frontend/src/components/ChatsList.tsx` for per-row pin buttons.
- No behavior or state logic was changed; this is a purely presentational swap of the SVG path.

### Testing
- Ran `cd frontend && npm run -s lint` and it passed.
- Ran `cd frontend && npm run -s typecheck` which exited non-zero because the `typecheck` script is not defined (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7fb4fda7c8321a22c039794f4af5c)