### PR TITLE
Fix Sidebar TypeScript prop mismatches and missing org-admin hook

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -11,7 +11,7 @@
 
 import { useMemo, useState, useRef, useEffect, useCallback } from 'react';
 import type { View, ChatSummary, OrganizationInfo } from './AppLayout';
-import { useAppStore, useAuthStore, useChatStore, useIsGlobalAdmin, useActiveTasksByConversation, type UserOrganization, type AdminPanelTab } from '../store';
+import { useAppStore, useAuthStore, useChatStore, useIsGlobalAdmin, useIsOrgAdmin, useActiveTasksByConversation, type UserOrganization, type AdminPanelTab } from '../store';
 import { apiRequest } from '../lib/api';
 import { Avatar } from './Avatar';
 import { ScopeLockIcon } from './ScopeVisibilityIcons';
@@ -155,12 +155,16 @@ function OrgPanel({
   currentView,
   onViewChange,
   onCreateNewOrg,
+  connectedSourcesCount,
+  workflowCount,
   pendingChangesCount,
   onClosePanel,
 }: {
   currentView: View;
   onViewChange: (view: View) => void;
   onCreateNewOrg: () => void;
+  connectedSourcesCount: number;
+  workflowCount: number;
   pendingChangesCount: number;
   onClosePanel: () => void;
 }): JSX.Element {
@@ -198,6 +202,9 @@ function OrgPanel({
     onClosePanel();
     onViewChange(view);
   }, [onClosePanel, onViewChange]);
+
+  void connectedSourcesCount;
+  void workflowCount;
 
   return (
     <div className="h-full overflow-y-auto scrollbar-thin px-2 pb-2" role="menu" aria-label="Workspace menu">
@@ -290,6 +297,8 @@ interface SidebarProps {
   onToggleCollapse: () => void;
   currentView: View;
   onViewChange: (view: View) => void;
+  connectedSourcesCount: number;
+  workflowCount: number;
   pendingChangesCount: number;
   recentChats: ChatSummary[];
   onSelectChat: (id: string) => void;
@@ -405,6 +414,8 @@ export function Sidebar({
   // onToggleCollapse — kept in SidebarProps for future re-introduction
   currentView,
   onViewChange,
+  connectedSourcesCount,
+  workflowCount,
   pendingChangesCount,
   recentChats,
   onSelectChat,
@@ -618,6 +629,7 @@ function ChatAccordion({
   onViewChange: (view: View) => void;
   onSelectChat: (id: string) => void;
 }): JSX.Element | null {
+  const isOrgAdmin: boolean = useIsOrgAdmin();
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>({});
   const [channelPersonalityTarget, setChannelPersonalityTarget] = useState<{


### PR DESCRIPTION
### Motivation
- Resolve TypeScript build errors where `Sidebar` was passed `connectedSourcesCount` and `workflowCount` but did not declare those props.  
- Fix missing identifier errors for `isOrgAdmin` used in conditional nav rendering.  
- Keep component API consistent with `AppLayout` usage so the frontend TypeScript build succeeds.

### Description
- Added `useIsOrgAdmin` to the imports and used it in `ChatAccordion` as `const isOrgAdmin: boolean = useIsOrgAdmin();` to restore the Activity nav conditional.  
- Added `connectedSourcesCount` and `workflowCount` parameters to `OrgPanel` props and its type signature, and threaded those props into `SidebarProps` and the `Sidebar` destructuring so `AppLayout` calls type-check.  
- Inserted `void connectedSourcesCount;` and `void workflowCount;` in `OrgPanel` to acknowledge the values and avoid unused-variable issues while preserving the prop surface.  
- Changes applied to `frontend/src/components/Sidebar.tsx` to align runtime usage and type declarations.

### Testing
- Ran `cd frontend && npm run build` and the TypeScript + Vite production build completed successfully (no TypeScript errors).  
- The build shows existing Vite warnings about large chunks and mixed dynamic/static imports but these are unrelated to the fix and did not block the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7fbe7b8b48321a77cb9b9c6ab628c)