### PR TITLE
Collapse Hub by default and persist left-nav section toggles

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -20,6 +20,7 @@ import { APP_NAME, LOGO_PATH } from '../lib/brand';
 const CHANNEL_PERSONALITY_MAX_LENGTH = 1000;
 const CHANNEL_PERSONALITY_TEXTAREA_BASE_HEIGHT_PX = 160;
 const CHANNEL_PERSONALITY_TEXTAREA_MAX_HEIGHT_PX = Math.round(CHANNEL_PERSONALITY_TEXTAREA_BASE_HEIGHT_PX * 1.5);
+const SIDEBAR_COLLAPSED_SECTIONS_STORAGE_KEY = 'sidebar_collapsed_sections_v1';
 
 /** Shield icon for global admin console identity in the org switcher. */
 function GlobalAdminShieldIcon({ className }: { className?: string }): JSX.Element {
@@ -631,7 +632,7 @@ function ChatAccordion({
 }): JSX.Element | null {
   const isOrgAdmin: boolean = useIsOrgAdmin();
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>({});
+  const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>({ hub: true });
   const [channelPersonalityTarget, setChannelPersonalityTarget] = useState<{
     key: string;
     label: string;
@@ -646,6 +647,33 @@ function ChatAccordion({
   useEffect(() => {
     return () => { if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current); };
   }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const raw = window.localStorage.getItem(SIDEBAR_COLLAPSED_SECTIONS_STORAGE_KEY);
+      if (!raw) return;
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const normalized: Record<string, boolean> = { hub: true };
+        for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+          if (typeof value === 'boolean') normalized[key] = value;
+        }
+        setCollapsedSections(normalized);
+      }
+    } catch (error) {
+      console.warn('[Sidebar] Failed to load collapsed section preferences', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(SIDEBAR_COLLAPSED_SECTIONS_STORAGE_KEY, JSON.stringify(collapsedSections));
+    } catch (error) {
+      console.warn('[Sidebar] Failed to persist collapsed section preferences', error);
+    }
+  }, [collapsedSections]);
 
   const groupedSidebarChats = useMemo(() => {
     const pinnedSet = new Set(pinnedChatIds);


### PR DESCRIPTION
### Motivation
- Default the left-nav `Hub` section to collapsed and remember users' expand/collapse choices across sessions so the sidebar respects user preferences.

### Description
- Set initial `collapsedSections` state to `{ hub: true }` so the Hub section is collapsed by default in `frontend/src/components/Sidebar.tsx`.
- Add `SIDEBAR_COLLAPSED_SECTIONS_STORAGE_KEY = 'sidebar_collapsed_sections_v1'` and persist `collapsedSections` to `localStorage` on change.
- Load and normalize persisted preferences from `localStorage` on mount with defensive parsing and `console.warn` logging for failures.

### Testing
- Ran `cd frontend && npm run -s lint`, which completed successfully.
- Attempted `cd frontend && npm run -s eslint src/components/Sidebar.tsx`, which exited non-zero in this environment, so full lint was used instead and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7fe1410f483218c931c7dbaf0003a)