### PR TITLE
Fix Chat.tsx build error by wiring currentUserId prop

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -3246,6 +3246,7 @@ function MessageWithBlocks({
   onToolCancel,
   onToolClick,
   onRetry,
+  currentUserId,
 }: {
   message: ChatMessage;
   isGroupedWithPrevious?: boolean;


### PR DESCRIPTION
### Motivation
- Resolve a TypeScript build error caused by `currentUserId` being referenced inside `MessageWithBlocks` but not included in the function's destructured parameters.

### Description
- Add `currentUserId` to the parameter destructuring of `MessageWithBlocks` in `frontend/src/components/Chat.tsx` so the runtime usage matches the declared prop type and avoids the undefined identifier.

### Testing
- Ran `npm run build` in `frontend/` and the build completed successfully; only pre-existing Vite chunking warnings remain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f81627d46883218f34b4f18be2edd5)