### PR TITLE
Add iframe postMessage bridge for app workflow triggers

### DIFF
--- a/frontend/src/components/apps/SandpackAppRenderer.tsx
+++ b/frontend/src/components/apps/SandpackAppRenderer.tsx
@@ -267,6 +267,16 @@ export function SandpackAppRenderer({
         const requestId = data.requestId;
         const workflowId = data.workflowId;
         const payloadAppId = data.appId;
+        const expectedSource = iframeRef.current?.contentWindow ?? null;
+        const expectedOrigin = window.location.origin;
+
+        if (event.source !== expectedSource || event.origin !== expectedOrigin) {
+          console.warn("[Apps iframe bridge] Rejected workflow trigger from unexpected sender", {
+            origin: event.origin,
+            hasExpectedSource: event.source === expectedSource,
+          });
+          return;
+        }
 
         if (!requestId || !workflowId || !payloadAppId || payloadAppId !== appId) {
           (event.source as Window | null)?.postMessage({

--- a/frontend/src/components/apps/SandpackAppRenderer.tsx
+++ b/frontend/src/components/apps/SandpackAppRenderer.tsx
@@ -246,7 +246,14 @@ export function SandpackAppRenderer({
   // Listen for error / token-expired messages from the iframe
   useEffect(() => {
     const handler = (event: MessageEvent): void => {
-      const data = event.data as { type?: string; error?: string } | null;
+      const data = event.data as {
+        type?: string;
+        error?: string;
+        requestId?: string;
+        appId?: string;
+        workflowId?: string;
+        triggerData?: Record<string, unknown>;
+      } | null;
       if (data?.type === "app-error" && data.error && onError) {
         onError(data.error);
       }
@@ -255,6 +262,61 @@ export function SandpackAppRenderer({
         try { sessionStorage.removeItem(`app_token_${appId}`); } catch { /* ignore */ }
         setTokenData(null);
         setTokenRetry((n: number) => n + 1);
+      }
+      if (data?.type === "app-trigger-workflow") {
+        const requestId = data.requestId;
+        const workflowId = data.workflowId;
+        const payloadAppId = data.appId;
+
+        if (!requestId || !workflowId || !payloadAppId || payloadAppId !== appId) {
+          (event.source as Window | null)?.postMessage({
+            type: "app-trigger-workflow-result",
+            requestId,
+            ok: false,
+            error: "Invalid workflow trigger payload",
+          }, "*");
+          return;
+        }
+
+        void (async () => {
+          try {
+            console.info("[Apps iframe bridge] Trigger workflow request", { appId: payloadAppId, workflowId, requestId });
+            const response = await apiRequest<{
+              status: string;
+              task_id: string;
+              workflow_id: string;
+              triggered_by_user_id: string;
+            }>(`/apps/${payloadAppId}/workflows/${workflowId}/trigger`, {
+              method: "POST",
+              body: JSON.stringify({
+                trigger_data: data.triggerData && typeof data.triggerData === "object" ? data.triggerData : undefined,
+              }),
+            });
+            if (response.error || !response.data) {
+              (event.source as Window | null)?.postMessage({
+                type: "app-trigger-workflow-result",
+                requestId,
+                ok: false,
+                error: response.error ?? "Failed to queue workflow",
+              }, "*");
+              return;
+            }
+            (event.source as Window | null)?.postMessage({
+              type: "app-trigger-workflow-result",
+              requestId,
+              ok: true,
+              result: response.data,
+            }, "*");
+          } catch (err) {
+            console.error("[Apps iframe bridge] Trigger workflow failed", err);
+            (event.source as Window | null)?.postMessage({
+              type: "app-trigger-workflow-result",
+              requestId,
+              ok: false,
+              error: err instanceof Error ? err.message : "Failed to trigger workflow",
+            }, "*");
+          }
+        })();
       }
     };
     window.addEventListener("message", handler);

--- a/frontend/src/components/apps/appSdkSource.ts
+++ b/frontend/src/components/apps/appSdkSource.ts
@@ -98,6 +98,53 @@ export function useAppQuery(queryName, params, options) {
   return { data, columns, loading, error, refetch };
 }
 
+
+
+// ---------------------------------------------------------------------------
+// triggerWorkflow – request host window to enqueue a workflow from this app
+// ---------------------------------------------------------------------------
+export function triggerWorkflow(workflowId, triggerData) {
+  const requestId = (globalThis.crypto && globalThis.crypto.randomUUID)
+    ? globalThis.crypto.randomUUID()
+    : (Date.now().toString(36) + Math.random().toString(36).slice(2));
+
+  return new Promise((resolve, reject) => {
+    let timeoutId = null;
+
+    const cleanup = () => {
+      window.removeEventListener("message", onMessage);
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+
+    const onMessage = (event) => {
+      const payload = event && event.data ? event.data : null;
+      if (!payload || payload.type !== "app-trigger-workflow-result" || payload.requestId !== requestId) return;
+      cleanup();
+      if (payload.ok) resolve(payload.result || { status: "queued" });
+      else reject(new Error(payload.error || "Failed to trigger workflow"));
+    };
+
+    window.addEventListener("message", onMessage);
+    timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for workflow trigger response"));
+    }, 15000);
+
+    try {
+      window.parent.postMessage({
+        type: "app-trigger-workflow",
+        requestId,
+        appId: APP_ID,
+        workflowId,
+        triggerData: triggerData && typeof triggerData === "object" ? triggerData : undefined,
+      }, "*");
+    } catch (err) {
+      cleanup();
+      reject(err instanceof Error ? err : new Error("Failed to post message to parent"));
+    }
+  });
+}
+
 // ---------------------------------------------------------------------------
 // useDateRange – convert named periods to { start, end } ISO date strings
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Allow sandboxed app code to request server-side workflow execution without embedding credentials or calling the API directly from the iframe. 
- Provide a safe, correlated async RPC from iframe → parent → API so apps can trigger workflows and receive success/failure responses.

### Description
- Added `triggerWorkflow(workflowId, triggerData)` to the inlined app SDK (`frontend/src/components/apps/appSdkSource.ts`) which sends a `postMessage` to the parent, correlates messages with a `requestId`, and exposes a Promise with a 15s timeout.
- Extended the parent-side iframe bridge in `SandpackAppRenderer` (`frontend/src/components/apps/SandpackAppRenderer.tsx`) to handle `app-trigger-workflow` messages, validate the payload and `appId`, call the existing `/apps/{appId}/workflows/{workflowId}/trigger` API endpoint, and return structured `app-trigger-workflow-result` messages back to the iframe.
- Added logging and error handling around the bridge (validation failures, API errors, exceptions) and ensured responses are posted back to the original event source for safety.
- Reused existing apps connector / API behavior for permission and workflow state checks; no new backend endpoints were added.

### Testing
- Ran frontend linter: `npm --prefix frontend run lint` and it completed successfully.
- Attempted to run a frontend typecheck script (`npm --prefix frontend run typecheck`) but the project has no `typecheck` script; the attempt failed because the script is missing.  
- No unit tests were added; manual integration exercised via console logging in the bridge during development and API route flow was reused and exercised by the bridge code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b236d2188321a317433251f95230)