### PR TITLE
Harden Slack read_file URL handling to prevent token exfiltration

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -16,7 +16,7 @@ import re
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
 from sqlalchemy import func, select
@@ -31,6 +31,7 @@ _SLACK_MESSAGE_PERMALINK_RE: re.Pattern[str] = re.compile(
 )
 _MARKDOWN_TABLE_CODE_BLOCK_TEMPLATE: str = "```\n{table}\n```"
 _markdown_logger = logging.getLogger(__name__)
+_SLACK_ALLOWED_FILE_HOST_SUFFIXES: tuple[str, ...] = ("slack.com",)
 
 
 def _clean_table_lines(raw: str) -> str:
@@ -1333,6 +1334,13 @@ Returns normalized messages for one channel since a cutoff (does not write to th
                     message_ts=message_ts,
                     permalink=normalized_ref,
                 )
+            if not self._is_allowed_slack_file_url(normalized_ref):
+                return {
+                    "error": (
+                        "read_file only supports Slack-hosted https URLs "
+                        "(for example, files.slack.com url_private links)."
+                    )
+                }
             download_url = normalized_ref
         else:
             file_data = await self._make_request("GET", "files.info", params={"file": normalized_ref})
@@ -1395,6 +1403,22 @@ Returns normalized messages for one channel since a cutoff (does not write to th
                 "note": "Binary file returned as base64 because text extraction is not supported for this mime type.",
             },
         }
+
+    def _is_allowed_slack_file_url(self, file_url: str) -> bool:
+        """Return True when URL is https and hosted on an allowed Slack domain."""
+        try:
+            parsed = urlparse(file_url.strip())
+        except Exception:
+            return False
+
+        if parsed.scheme.lower() != "https":
+            return False
+
+        hostname = (parsed.hostname or "").lower().rstrip(".")
+        return any(
+            hostname == suffix or hostname.endswith(f".{suffix}")
+            for suffix in _SLACK_ALLOWED_FILE_HOST_SUFFIXES
+        )
 
     def _parse_slack_message_permalink(self, url: str) -> tuple[str, str] | None:
         """Return ``(channel_id, message_ts)`` when URL is a Slack message permalink."""
@@ -1773,15 +1797,39 @@ Returns normalized messages for one channel since a cutoff (does not write to th
             httpx.HTTPStatusError: If the download request fails.
             ValueError: If the response body is empty.
         """
+        if not self._is_allowed_slack_file_url(url_private):
+            raise ValueError("Refusing to download non-Slack URL for file content")
+
         headers: dict[str, str] = await self._get_headers()
         # Remove Content-Type for raw file download
         headers.pop("Content-Type", None)
 
-        async with httpx.AsyncClient(follow_redirects=True) as client:
-            response: httpx.Response = await client.get(
-                url_private, headers=headers, timeout=60.0,
-            )
-            response.raise_for_status()
+        current_url: str = url_private
+        max_redirects: int = 5
+        async with httpx.AsyncClient(follow_redirects=False) as client:
+            for _ in range(max_redirects + 1):
+                response: httpx.Response = await client.get(
+                    current_url, headers=headers, timeout=60.0,
+                )
+                if response.is_redirect:
+                    location: str | None = response.headers.get("location")
+                    if not location:
+                        raise ValueError(
+                            f"Redirect without location while downloading Slack file: {current_url}"
+                        )
+                    next_url: str = urljoin(str(response.url), location)
+                    if not self._is_allowed_slack_file_url(next_url):
+                        raise ValueError(
+                            "Refusing redirect to non-Slack host while downloading file"
+                        )
+                    current_url = next_url
+                    continue
+                response.raise_for_status()
+                break
+            else:
+                raise ValueError(
+                    f"Too many redirects while downloading Slack file: {url_private}"
+                )
 
         data: bytes = response.content
         if not data:

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -124,6 +124,28 @@ def test_query_read_file_by_url_returns_base64_for_binary(monkeypatch) -> None:
     assert "Binary file returned as base64" in result["file"]["note"]
 
 
+def test_query_read_file_rejects_non_slack_url(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+    called = {"download": False}
+
+    async def _fake_download_file(url_private: str) -> bytes:
+        called["download"] = True
+        return b"should_not_download"
+
+    monkeypatch.setattr(connector, "download_file", _fake_download_file)
+
+    result = asyncio.run(connector.query("read_file:https://evil.example.com/steal"))
+    assert "only supports Slack-hosted https URLs" in result["error"]
+    assert called["download"] is False
+
+
+def test_download_file_rejects_non_slack_url() -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+
+    with pytest.raises(ValueError, match="non-Slack URL"):
+        asyncio.run(connector.download_file("https://evil.example.com/steal"))
+
+
 def test_query_read_file_from_message_permalink_downloads_attached_files(monkeypatch) -> None:
     connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
 


### PR DESCRIPTION
### Motivation
- Close an SSRF/token exfiltration vector where `read_file:<url>` accepted arbitrary http(s) URLs and the connector attached the Slack `Authorization` header to fetched URLs.
- Restrict file downloads to Slack-hosted URLs and add defense-in-depth to avoid leaking bot tokens via redirects or attacker-controlled hosts.

### Description
- Add `_SLACK_ALLOWED_FILE_HOST_SUFFIXES` and a helper `def _is_allowed_slack_file_url(file_url: str) -> bool` to validate that URLs are `https` and hosted on allowed Slack domains (e.g., `slack.com`).
- Enforce URL validation in `_read_file_for_query` so `read_file:<url>` returns an error when the URL is not a Slack-hosted `https` URL.
- Harden `download_file` by refusing non-Slack URLs, disabling automatic redirect following, manually handling redirects up to a limit, and rejecting redirects that point to non-Slack hosts.
- Add unit tests (`backend/tests/test_slack_connector_actions.py`) that assert non-Slack URLs are rejected both at the `query` entrypoint and the `download_file` path, while preserving existing behavior for Slack-hosted URLs.

### Testing
- Ran `pytest -q backend/tests/test_slack_connector_actions.py` and all tests passed: `18 passed`.
- The new tests verify rejection of non-Slack URLs and the existing tests verify Slack-hosted file handling still works as before.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecea20c5cc8321b7d05002cb47a685)