### PR TITLE
Secure channel memory endpoints with org-scoped auth checks

### DIFF
--- a/backend/api/routes/memories.py
+++ b/backend/api/routes/memories.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 import logging
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy import and_, select
 
+from api.auth_middleware import AuthContext, require_organization
 from models.database import get_session
 from models.memory import Memory
 
@@ -101,6 +102,18 @@ def _build_memory_response(memory: Memory) -> MemoryResponse:
         created_at=f"{memory.created_at.isoformat()}Z" if memory.created_at else None,
         updated_at=f"{memory.updated_at.isoformat()}Z" if memory.updated_at else None,
     )
+
+
+def _require_path_org_access(organization_id: str, auth: AuthContext) -> UUID:
+    """Validate the path organization_id matches authenticated organization scope."""
+    try:
+        path_org_uuid = UUID(organization_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid ID format")
+
+    if auth.organization_id != path_org_uuid:
+        raise HTTPException(status_code=403, detail="Organization access denied")
+    return path_org_uuid
 
 
 @router.get("/{organization_id}", response_model=MemoryDashboardResponse)
@@ -239,16 +252,18 @@ async def delete_user_memory(organization_id: str, memory_id: str, user_id: str)
 
 
 @router.get("/{organization_id}/channel", response_model=MemoryResponse | None)
-async def get_channel_memory(organization_id: str, source: str, channel_id: str) -> MemoryResponse | None:
+async def get_channel_memory(
+    organization_id: str,
+    source: str,
+    channel_id: str,
+    auth: AuthContext = Depends(require_organization),
+) -> MemoryResponse | None:
     """Get channel personality memory by source + normalized channel identifier."""
-    try:
-        org_uuid = UUID(organization_id)
-        normalized_channel_id = normalize_channel_scope_channel_id(source, channel_id)
-        normalized_source = source.strip().lower()
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid ID format")
+    org_uuid = _require_path_org_access(organization_id, auth)
+    normalized_channel_id = normalize_channel_scope_channel_id(source, channel_id)
+    normalized_source = source.strip().lower()
 
-    async with get_session(organization_id=organization_id) as session:
+    async with get_session(organization_id=str(auth.organization_id), user_id=str(auth.user_id)) as session:
         result = await session.execute(
             select(Memory)
             .where(
@@ -287,6 +302,7 @@ async def upsert_channel_memory(
     source: str,
     channel_id: str,
     request: UpdateMemoryRequest,
+    auth: AuthContext = Depends(require_organization),
 ) -> MemoryResponse:
     """Create/update channel personality memory by source + channel identifier."""
     content = request.content.strip()
@@ -294,14 +310,11 @@ async def upsert_channel_memory(
         raise HTTPException(status_code=400, detail="content is required")
     validate_memory_content(content, CHANNEL_PERSONALITY_CATEGORY)
 
-    try:
-        org_uuid = UUID(organization_id)
-        normalized_source = source.strip().lower()
-        normalized_channel_id = normalize_channel_scope_channel_id(source, channel_id)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid ID format")
+    org_uuid = _require_path_org_access(organization_id, auth)
+    normalized_source = source.strip().lower()
+    normalized_channel_id = normalize_channel_scope_channel_id(source, channel_id)
 
-    async with get_session(organization_id=organization_id) as session:
+    async with get_session(organization_id=str(auth.organization_id), user_id=str(auth.user_id)) as session:
         result = await session.execute(
             select(Memory).where(
                 Memory.organization_id == org_uuid,
@@ -325,7 +338,7 @@ async def upsert_channel_memory(
                 scope_type="channel",
                 scope_source=normalized_source,
                 scope_channel_id=normalized_channel_id,
-                created_by_user_id=None,
+                created_by_user_id=auth.user_id,
             )
             session.add(memory)
             action = "created"
@@ -344,16 +357,18 @@ async def upsert_channel_memory(
 
 
 @router.delete("/{organization_id}/channel")
-async def delete_channel_memory(organization_id: str, source: str, channel_id: str) -> dict[str, str]:
+async def delete_channel_memory(
+    organization_id: str,
+    source: str,
+    channel_id: str,
+    auth: AuthContext = Depends(require_organization),
+) -> dict[str, str]:
     """Delete channel personality memory by source + channel identifier."""
-    try:
-        org_uuid = UUID(organization_id)
-        normalized_source = source.strip().lower()
-        normalized_channel_id = normalize_channel_scope_channel_id(source, channel_id)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid ID format")
+    org_uuid = _require_path_org_access(organization_id, auth)
+    normalized_source = source.strip().lower()
+    normalized_channel_id = normalize_channel_scope_channel_id(source, channel_id)
 
-    async with get_session(organization_id=organization_id) as session:
+    async with get_session(organization_id=str(auth.organization_id), user_id=str(auth.user_id)) as session:
         result = await session.execute(
             select(Memory).where(
                 Memory.organization_id == org_uuid,

--- a/backend/tests/test_memory_policy.py
+++ b/backend/tests/test_memory_policy.py
@@ -4,6 +4,9 @@ import types
 from datetime import datetime
 from uuid import UUID
 
+from fastapi import HTTPException
+
+from api.auth_middleware import AuthContext
 from api.routes import memories as memories_api
 
 fake_websockets = types.ModuleType("api.websockets")
@@ -44,6 +47,14 @@ class _FakeSession:
             obj.created_at = datetime(2026, 1, 1, 0, 0, 0)
         if getattr(obj, "updated_at", None) is None:
             obj.updated_at = datetime(2026, 1, 1, 0, 0, 0)
+
+    async def execute(self, *_args: object, **_kwargs: object):
+        class _FakeResult:
+            @staticmethod
+            def scalar_one_or_none() -> None:
+                return None
+
+        return _FakeResult()
 
 
 class _TrackedSessionContext:
@@ -163,3 +174,54 @@ def test_global_command_limit_allows_1000_chars() -> None:
 def test_channel_scope_normalization_for_slack_thread_id() -> None:
     normalized = memories_api.normalize_channel_scope_channel_id("slack", "C12345678:1714691329.001200")
     assert normalized == "C12345678"
+
+
+def test_channel_path_org_mismatch_is_forbidden() -> None:
+    auth = AuthContext(
+        user_id=UUID("00000000-0000-0000-0000-000000000001"),
+        organization_id=UUID("00000000-0000-0000-0000-000000000010"),
+        email="user@example.com",
+        role="user",
+        is_global_admin=False,
+    )
+
+    try:
+        memories_api._require_path_org_access("00000000-0000-0000-0000-000000000099", auth)
+        assert False, "Expected HTTPException"
+    except HTTPException as exc:
+        assert exc.status_code == 403
+
+
+def test_upsert_channel_memory_sets_created_by_user_id(monkeypatch) -> None:
+    fake_session = _FakeSession()
+    tracker = {"entered": 0, "exited": 0}
+
+    def _fake_get_session(*_args: object, **_kwargs: object) -> _TrackedSessionContext:
+        return _TrackedSessionContext(fake_session, tracker)
+
+    monkeypatch.setattr(memories_api, "get_session", _fake_get_session)
+
+    auth = AuthContext(
+        user_id=UUID("00000000-0000-0000-0000-000000000001"),
+        organization_id=UUID("00000000-0000-0000-0000-000000000010"),
+        email="user@example.com",
+        role="user",
+        is_global_admin=False,
+    )
+
+    response = asyncio.run(
+        memories_api.upsert_channel_memory(
+            organization_id="00000000-0000-0000-0000-000000000010",
+            source="slack",
+            channel_id="C12345678",
+            request=memories_api.UpdateMemoryRequest(content="Be concise"),
+            auth=auth,
+        )
+    )
+
+    assert tracker == {"entered": 1, "exited": 1}
+    assert fake_session.commit_count == 1
+    assert len(fake_session.added) == 1
+    saved_memory = fake_session.added[0]
+    assert saved_memory.created_by_user_id == auth.user_id
+    assert response.created_by_user_id == str(auth.user_id)


### PR DESCRIPTION
### Motivation
- The new channel-memory GET/PUT/DELETE endpoints previously trusted a path `organization_id` and allowed unauthenticated read/write/delete, enabling persistent prompt-tampering and unauthorized access.

### Description
- Added `AuthContext` and route-level dependency `Depends(require_organization)` to channel memory endpoints in `backend/api/routes/memories.py` to require authenticated org context.
- Introduced `_require_path_org_access` to validate that the `/{organization_id}` path value matches the authenticated organization and return `403` on mismatch.
- Scoped DB sessions with the authenticated `organization_id` and `user_id` and set `created_by_user_id=auth.user_id` when creating channel memories to preserve ownership attribution.
- Updated tests in `backend/tests/test_memory_policy.py` to cover org-mismatch rejection and that `upsert_channel_memory` attributes new channel memories to the authenticated user, plus a small fake-session `execute` stub for those tests.

### Testing
- Ran `pytest -q backend/tests/test_memory_policy.py` and the suite completed successfully with `9 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0227e3cfc8321b12f6c8734111ee1)