### PR TITLE
Harden public snapshot image decoding against SVG XSS

### DIFF
--- a/backend/services/public_previews.py
+++ b/backend/services/public_previews.py
@@ -8,13 +8,18 @@ from io import BytesIO
 from PIL import Image, ImageDraw, ImageFont
 
 
+SAFE_IMAGE_MIME_TYPES = {"image/png", "image/jpeg", "image/webp", "image/gif"}
+
+
 def decode_data_url_image(data_url: str | None) -> tuple[bytes, str] | None:
     if not data_url or not data_url.startswith("data:image/"):
         return None
     marker = ";base64,"
     if marker not in data_url:
         return None
-    mime_type = data_url[5:data_url.index(marker)]
+    mime_type = data_url[5:data_url.index(marker)].lower()
+    if mime_type not in SAFE_IMAGE_MIME_TYPES:
+        return None
     encoded = data_url[data_url.index(marker) + len(marker):]
     try:
         return base64.b64decode(encoded, validate=True), mime_type

--- a/backend/tests/test_public_previews.py
+++ b/backend/tests/test_public_previews.py
@@ -28,6 +28,22 @@ def test_decode_data_url_image_valid_png() -> None:
     assert mime == "image/png"
 
 
+
+
+def test_decode_data_url_image_rejects_svg() -> None:
+    payload = base64.b64encode(b"<svg><script>alert(1)</script></svg>").decode("ascii")
+    decoded = decode_data_url_image(f"data:image/svg+xml;base64,{payload}")
+    assert decoded is None
+
+
+def test_decode_data_url_image_accepts_case_insensitive_jpeg_mime() -> None:
+    payload = base64.b64encode(b"jpeg-bytes").decode("ascii")
+    decoded = decode_data_url_image(f"data:image/JPEG;base64,{payload}")
+    assert decoded is not None
+    content, mime = decoded
+    assert content == b"jpeg-bytes"
+    assert mime == "image/jpeg"
+
 def test_build_preview_html_includes_og_and_twitter_tags() -> None:
     html = build_preview_html(
         page_title="Example",


### PR DESCRIPTION
### Motivation
- The public snapshot endpoint decoded stored `data:image/...` URLs and returned the user-controlled MIME type, which allowed `image/svg+xml` payloads with embedded scripts to be served from the application origin and caused stored XSS risk.

### Description
- Add a safe raster-image allowlist `SAFE_IMAGE_MIME_TYPES` and enforce it in `decode_data_url_image` in `backend/services/public_previews.py` so only `image/png`, `image/jpeg`, `image/webp`, and `image/gif` are accepted.
- Normalize parsed MIME types to lowercase before validation and return `None` for unsupported types (causing the public preview to fall back to the generated PNG card instead of serving the raw bytes).
- Add regression tests in `backend/tests/test_public_previews.py` to ensure SVG data URLs are rejected and mixed-case MIME types like `image/JPEG` are accepted and normalized.

### Testing
- Ran `pytest -q backend/tests/test_public_previews.py` and all tests passed (`22 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf07663188321a7650f092df16aac)