### PR TITLE
Require verified auth context for identity link/unlink endpoints

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1602,6 +1602,7 @@ async def get_organization_members(
 async def link_identity(
     org_id: str,
     request: LinkIdentityRequest,
+    auth: AuthContext = Depends(get_current_auth),
     user_id: Optional[str] = None,
 ) -> dict[str, str]:
     """Manually link an unmatched identity mapping to a user.
@@ -1610,8 +1611,11 @@ async def link_identity(
     """
     from models.external_identity_mapping import ExternalIdentityMapping
 
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Not authenticated")
+    if user_id is not None and user_id != auth.user_id_str:
+        raise HTTPException(
+            status_code=403, detail="user_id does not match authenticated user"
+        )
+    requester_uuid = auth.user_id
 
     try:
         org_uuid = UUID(org_id)
@@ -1621,6 +1625,10 @@ async def link_identity(
         raise HTTPException(status_code=400, detail="Invalid ID format")
 
     async with get_session(organization_id=str(org_uuid)) as session:
+        requester: User | None = await session.get(User, requester_uuid)
+        if not requester or await _get_org_membership(session, requester_uuid, org_uuid) is None:
+            raise HTTPException(status_code=403, detail="Not authorized to modify this organization")
+
         # Verify target user belongs to this org (membership or guest home org)
         target_user: User | None = await session.get(User, target_uuid)
         if not target_user:
@@ -1641,7 +1649,7 @@ async def link_identity(
                 org_uuid,
                 target_uuid,
                 mapping_uuid,
-                user_id,
+                requester_uuid,
             )
             raise HTTPException(status_code=403, detail="Guest user identities cannot be manually linked")
 
@@ -1760,6 +1768,7 @@ async def link_identity(
 async def unlink_identity(
     org_id: str,
     request: UnlinkIdentityRequest,
+    auth: AuthContext = Depends(get_current_auth),
     user_id: Optional[str] = None,
 ) -> dict[str, str]:
     """Unlink an identity mapping from a user in the org.
@@ -1770,12 +1779,14 @@ async def unlink_identity(
     """
     from models.external_identity_mapping import ExternalIdentityMapping
 
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Not authenticated")
+    if user_id is not None and user_id != auth.user_id_str:
+        raise HTTPException(
+            status_code=403, detail="user_id does not match authenticated user"
+        )
+    requester_uuid = auth.user_id
 
     try:
         org_uuid = UUID(org_id)
-        requester_uuid = UUID(user_id)
         mapping_uuid = UUID(request.mapping_id)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ID format")

--- a/backend/tests/test_auth_guest_identity_guards.py
+++ b/backend/tests/test_auth_guest_identity_guards.py
@@ -8,6 +8,16 @@ from fastapi import HTTPException
 from api.routes import auth
 
 
+def _auth_ctx(user_id: UUID, org_id: UUID):
+    return auth.AuthContext(
+        user_id=user_id,
+        organization_id=org_id,
+        email="requester@example.com",
+        role="member",
+        is_global_admin=False,
+    )
+
+
 class _FakeMembershipResult:
     def scalar_one_or_none(self) -> object:
         return True  # Simulate active org membership
@@ -67,6 +77,7 @@ def test_link_identity_rejects_guest_target(monkeypatch):
             auth.link_identity(
                 org_id=str(org_id),
                 request=auth.LinkIdentityRequest(target_user_id=str(target_user_id), mapping_id=str(mapping_id)),
+                auth=_auth_ctx(requester_id, org_id),
                 user_id=str(requester_id),
             )
         )
@@ -99,6 +110,7 @@ def test_unlink_identity_rejects_guest_mapping(monkeypatch):
             auth.unlink_identity(
                 org_id=str(org_id),
                 request=auth.UnlinkIdentityRequest(mapping_id=str(mapping_id)),
+                auth=_auth_ctx(requester_id, org_id),
                 user_id=str(requester_id),
             )
         )

--- a/backend/tests/test_link_identity_slack.py
+++ b/backend/tests/test_link_identity_slack.py
@@ -5,6 +5,16 @@ from uuid import UUID
 from api.routes import auth
 
 
+def _auth_ctx(user_id: UUID, org_id: UUID):
+    return auth.AuthContext(
+        user_id=user_id,
+        organization_id=org_id,
+        email="requester@example.com",
+        role="member",
+        is_global_admin=False,
+    )
+
+
 class _FakeScalars:
     def __init__(self, rows):
         self._rows = rows
@@ -27,9 +37,13 @@ class _FakeExecuteResult:
     def scalars(self):
         return _FakeScalars(self._rows)
 
+    def scalar_one_or_none(self):
+        return True
+
 
 class _FakeSession:
-    def __init__(self, target_user, mapping, related_rows):
+    def __init__(self, requester_user, target_user, mapping, related_rows):
+        self.requester_user = requester_user
         self.target_user = target_user
         self.mapping = mapping
         self.related_rows = related_rows
@@ -37,6 +51,8 @@ class _FakeSession:
         self.committed = False
 
     async def get(self, _model, model_id):
+        if model_id == self.requester_user.id:
+            return self.requester_user
         if model_id == self.target_user.id:
             return self.target_user
         if model_id == self.mapping.id:
@@ -45,7 +61,7 @@ class _FakeSession:
 
     async def execute(self, _query):
         self.execute_calls += 1
-        if self.execute_calls == 1:
+        if self.execute_calls <= 2:
             return _FakeMembershipResult()
         return _FakeExecuteResult(self.related_rows)
 
@@ -93,7 +109,8 @@ def test_link_identity_links_related_slack_mappings(monkeypatch):
         match_source="unmatched",
     )
 
-    fake_session = _FakeSession(target_user, selected_mapping, [related_mapping])
+    requester_user = SimpleNamespace(id=requester_id, organization_id=org_id, email="requester@example.com")
+    fake_session = _FakeSession(requester_user, target_user, selected_mapping, [related_mapping])
     monkeypatch.setattr(auth, "get_session", lambda **kwargs: _FakeSessionContext(fake_session))
 
     result = asyncio.run(
@@ -103,6 +120,7 @@ def test_link_identity_links_related_slack_mappings(monkeypatch):
                 target_user_id=str(target_user_id),
                 mapping_id=str(selected_mapping_id),
             ),
+            auth=_auth_ctx(requester_id, org_id),
             user_id=str(requester_id),
         )
     )
@@ -116,7 +134,7 @@ def test_link_identity_links_related_slack_mappings(monkeypatch):
     assert related_mapping.user_id == target_user_id
     assert related_mapping.revtops_email == "owner@acme.com"
     assert related_mapping.match_source == "admin_manual_link"
-    assert fake_session.execute_calls == 2  # 1 membership check + 1 related-mapping query
+    assert fake_session.execute_calls == 3  # requester membership + target membership + related-mapping query
     assert fake_session.committed
 
 
@@ -138,7 +156,8 @@ def test_link_identity_non_slack_does_not_attempt_related_linking(monkeypatch):
         match_source="unmatched",
     )
 
-    fake_session = _FakeSession(target_user, selected_mapping, [])
+    requester_user = SimpleNamespace(id=requester_id, organization_id=org_id, email="requester@example.com")
+    fake_session = _FakeSession(requester_user, target_user, selected_mapping, [])
     monkeypatch.setattr(auth, "get_session", lambda **kwargs: _FakeSessionContext(fake_session))
 
     result = asyncio.run(
@@ -148,6 +167,7 @@ def test_link_identity_non_slack_does_not_attempt_related_linking(monkeypatch):
                 target_user_id=str(target_user_id),
                 mapping_id=str(selected_mapping_id),
             ),
+            auth=_auth_ctx(requester_id, org_id),
             user_id=str(requester_id),
         )
     )
@@ -155,5 +175,5 @@ def test_link_identity_non_slack_does_not_attempt_related_linking(monkeypatch):
     assert result == {"status": "linked"}
     assert selected_mapping.user_id == target_user_id
     assert selected_mapping.match_source == "admin_manual_link"
-    assert fake_session.execute_calls == 1  # only the membership check
+    assert fake_session.execute_calls == 2  # requester membership + target membership
     assert fake_session.committed


### PR DESCRIPTION
### Motivation
- Close an authorization bypass where `link_identity` and `unlink_identity` could be invoked using a caller-controlled `user_id` parameter and an RLS-scoped session without JWT verification.
- Prevent attackers from reassigning `ExternalIdentityMapping` rows or creating `MessengerUserMapping` entries for organizations they don't belong to.

### Description
- Add an `AuthContext` dependency (`Depends(get_current_auth)`) to the `link_identity` and `unlink_identity` route handlers.
- Reject requests where an optional `user_id` query parameter does not match the verified `auth.user_id_str`, and derive the requester identity from `auth.user_id` instead of trusting client input.
- Enforce requester org membership by loading the requester via the scoped session and checking `_get_org_membership(session, requester_uuid, org_uuid)` before allowing mapping changes.
- Update tests in `backend/tests/test_auth_guest_identity_guards.py` and `backend/tests/test_link_identity_slack.py` to pass a constructed `AuthContext` and to adapt fake sessions to the requester-membership checks.

### Testing
- Ran `pytest -q backend/tests/test_auth_guest_identity_guards.py backend/tests/test_link_identity_slack.py` and observed all tests pass (`5 passed`).
- Tests cover guest-target rejection, Slack-related related-mapping linking behavior, and unlink restrictions; no regressions observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eceb57107c83218db69e7bbc17ea9a)