### PR TITLE
Preserve first 250k chars for PDF/PPTX extraction and fix PPTX slide ordering

### DIFF
--- a/backend/services/file_handler.py
+++ b/backend/services/file_handler.py
@@ -77,6 +77,8 @@ DOCX_MIME: str = "application/vnd.openxmlformats-officedocument.wordprocessingml
 
 PPTX_MIME: str = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 
+PDF_PPTX_TEXT_TRUNCATION_CHARS: int = 250_000
+
 
 @dataclass
 class StoredFile:
@@ -327,7 +329,7 @@ def pdf_to_text_block(sf: StoredFile) -> dict[str, Any]:
         logger.warning("PDF text extraction failed for %s: %s", sf.filename, exc)
         text = f"[Attached PDF '{sf.filename}' could not be extracted — {exc}]"
 
-    max_chars: int = 200_000
+    max_chars: int = PDF_PPTX_TEXT_TRUNCATION_CHARS
     if len(text) > max_chars:
         text = text[:max_chars] + f"\n\n[Truncated — showing first {max_chars:,} characters of {len(text):,} total]"
 
@@ -418,14 +420,15 @@ def _pptx_to_text_block(sf: StoredFile) -> dict[str, Any]:
         parts: list[str] = []
         with zipfile.ZipFile(io.BytesIO(sf.data)) as zf:
             slide_names: list[str] = sorted(
-                name for name in zf.namelist() if name.startswith("ppt/slides/slide") and name.endswith(".xml")
+                (name for name in zf.namelist() if name.startswith("ppt/slides/slide") and name.endswith(".xml")),
+                key=_pptx_slide_sort_key,
             )
             for name in slide_names:
                 parts.append(zf.read(name).decode("utf-8"))
 
         xml: str = "\n\n".join(parts)
 
-        max_chars: int = 200_000
+        max_chars: int = PDF_PPTX_TEXT_TRUNCATION_CHARS
         if len(xml) > max_chars:
             xml = xml[:max_chars] + f"\n\n[Truncated — showing first {max_chars:,} characters of {len(xml):,} total]"
 
@@ -480,3 +483,13 @@ def _best_effort_text_block(sf: StoredFile) -> dict[str, Any]:
 def _is_text_mime(mime: str) -> bool:
     """Check if a MIME type is text-like."""
     return mime in TEXT_MIMES or mime.startswith("text/")
+
+
+def _pptx_slide_sort_key(name: str) -> tuple[int, str]:
+    """Sort PowerPoint slide XML names in numeric slide order."""
+    stem: str = name.rsplit("/", 1)[-1]
+    numeric_part: str = stem[len("slide"):].split(".", 1)[0]
+    try:
+        return (int(numeric_part), name)
+    except ValueError:
+        return (10**9, name)

--- a/backend/tests/test_file_handler_truncation.py
+++ b/backend/tests/test_file_handler_truncation.py
@@ -1,0 +1,67 @@
+import io
+import sys
+import types
+import zipfile
+
+from services.file_handler import StoredFile, _pptx_to_text_block, _pptx_slide_sort_key, pdf_to_text_block
+
+
+def test_pdf_to_text_block_truncates_to_first_250k_chars(monkeypatch):
+    class _FakePage:
+        def __init__(self, text: str):
+            self._text = text
+
+        def get_text(self) -> str:
+            return self._text
+
+    class _FakeDoc:
+        def __init__(self, text: str):
+            self._text = text
+
+        def __len__(self) -> int:
+            return 1
+
+        def __getitem__(self, _idx: int):
+            return _FakePage(self._text)
+
+        def close(self) -> None:
+            return None
+
+    long_text = "A" * 260_000
+
+    fake_module = types.SimpleNamespace(open=lambda *_args, **_kwargs: _FakeDoc(long_text))
+    monkeypatch.setitem(sys.modules, "pymupdf", fake_module)
+
+    sf = StoredFile("1", "deck.pdf", "application/pdf", 10, b"x")
+    block = pdf_to_text_block(sf)
+    text = block["text"]
+
+    assert "showing first 250,000 characters" in text
+    marker = "--- Page 1 ---\n"
+    preserved = text.split(marker, 1)[1].split("\n\n[Truncated", 1)[0]
+    assert len(preserved) == 250_000 - len(marker)
+    assert preserved.startswith("A" * 1000)
+
+
+def test_pptx_to_text_block_uses_numeric_slide_order_and_250k_truncation():
+    payload = io.BytesIO()
+    with zipfile.ZipFile(payload, "w") as zf:
+        zf.writestr("ppt/slides/slide1.xml", "<s1>")
+        zf.writestr("ppt/slides/slide10.xml", "<s10>")
+        zf.writestr("ppt/slides/slide2.xml", "<s2>" + ("Z" * 260_000))
+
+    sf = StoredFile("2", "deck.pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation", len(payload.getvalue()), payload.getvalue())
+    block = _pptx_to_text_block(sf)
+    text = block["text"]
+
+    assert text.index("<s1>") < text.index("<s2>")
+    assert "showing first 250,000 characters" in text
+
+
+def test_pptx_slide_sort_key_is_numeric():
+    names = ["ppt/slides/slide10.xml", "ppt/slides/slide2.xml", "ppt/slides/slide1.xml"]
+    assert sorted(names, key=_pptx_slide_sort_key) == [
+        "ppt/slides/slide1.xml",
+        "ppt/slides/slide2.xml",
+        "ppt/slides/slide10.xml",
+    ]


### PR DESCRIPTION
### Motivation
- Ensure when large PDFs or PPTX decks are truncated we preserve the start of the deck (first 250k characters) rather than an arbitrary slice. 
- Avoid losing the deck "beginning" by guaranteeing slides are concatenated in true numeric order before truncation. 
- Provide deterministic behavior and coverage via unit tests for the extraction/truncation logic.

### Description
- Introduced `PDF_PPTX_TEXT_TRUNCATION_CHARS = 250_000` and applied it to PDF fallback extraction (`pdf_to_text_block`) and PPTX XML extraction (`_pptx_to_text_block`) in `backend/services/file_handler.py` so truncation now preserves the initial characters. 
- Implemented numeric slide ordering by adding `_pptx_slide_sort_key` and using it when enumerating slide XML names to ensure slide1, slide2, ..., slide10 order before concatenation. 
- Added unit tests in `backend/tests/test_file_handler_truncation.py` to validate: PDF truncation preserves the first 250k characters and reports truncation, PPTX numeric slide ordering, and PPTX truncation messaging/behavior. 
- Kept other text-extraction truncation thresholds unchanged (spreadsheet/plain-text paths remain at their prior limits).

### Testing
- Ran the new targeted test file with `pytest -q backend/tests/test_file_handler_truncation.py`, which returned `3 passed`.
- The added tests exercise `pdf_to_text_block` and `_pptx_to_text_block` and asserted truncation messaging and ordering behavior, and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90d0405848321aedd2f8103a42e13)