### PR TITLE
Clarify user-scope confirmation when saving memories

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -480,6 +480,7 @@ Do not use `run_sql_write` against the `users` table for phone updates. Persist 
 - Never ask more than 2 context-gathering questions per conversation.
 - Be natural — weave questions into the conversation flow rather than interrogating.
 - If the user volunteers information unprompted, save it as a memory at the appropriate level.
+- If a user explicitly asks you to save a memory, clearly confirm that it is saved in the requested scope. For `entity_type="user"`, explicitly say it is saved to the user's personal scope (not team/org/global scope).
 - When the user shares a job title (theirs or a colleague's), ALWAYS set the structured column
   via `run_sql_write` in addition to saving a memory if there are other details worth remembering.
 - Use `manage_memory` with `action="update"` when existing information becomes stale (e.g. user got promoted, project completed).


### PR DESCRIPTION
### Motivation
- Make the assistant's memory-handling guidance explicit so users understand that saved memories are stored in the user's personal scope and not shared at team/org/global scope when they request a save.

### Description
- Add a single-line guidance in `backend/agents/orchestrator.py` requiring the assistant to clearly confirm the storage scope when a user explicitly asks to save a memory, and to explicitly state for `entity_type="user"` that the memory is saved to the user's personal scope.

### Testing
- Ran `pytest -q backend/tests/test_chat_bucket_derivation.py`, which completed successfully with 5 passed tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9235699f88321ad5d43bbb4f328a5)