### PR TITLE
Restore Slack file links in persisted bot DM messages

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -227,6 +227,23 @@ async def _log_bot_dm_message_without_processing(
             return False
 
         content_text: str = text_body.strip() or "(bot message with attachments)"
+        if files:
+            persisted_file_links: str = _format_slack_file_links_for_storage(files)
+            if persisted_file_links:
+                content_text = f"{content_text}\n\nFiles: {persisted_file_links}"
+                logger.info(
+                    "[slack_events] Appended %d Slack file link(s) into persisted bot DM content channel=%s thread=%s",
+                    len(files),
+                    channel_id,
+                    thread_ts,
+                )
+            else:
+                logger.info(
+                    "[slack_events] Slack bot DM had %d attachment(s) but none had storable links channel=%s thread=%s",
+                    len(files),
+                    channel_id,
+                    thread_ts,
+                )
         content_blocks: list[dict[str, Any]] = [
             {
                 "type": "text",
@@ -791,6 +808,23 @@ def _extract_mentions_from_slack_text(
         else:
             mentions.append({"type": "user", "external_user_id": slack_uid})
     return mentions
+
+
+def _format_slack_file_links_for_storage(files: list[dict[str, Any]]) -> str:
+    """Build a compact human-readable list of Slack file links for persisted message text."""
+    rendered_links: list[str] = []
+    for file_data in files:
+        file_name: str = str(file_data.get("name") or file_data.get("title") or "attachment").strip() or "attachment"
+        file_url: str = str(
+            file_data.get("url_private_download")
+            or file_data.get("url_private")
+            or file_data.get("permalink")
+            or ""
+        ).strip()
+        if not file_url:
+            continue
+        rendered_links.append(f"{file_name}: {file_url}")
+    return "; ".join(rendered_links)
 
 
 def _extract_bot_user_ids(payload: dict[str, Any]) -> set[str]:

--- a/backend/tests/test_slack_events_thread_locking.py
+++ b/backend/tests/test_slack_events_thread_locking.py
@@ -304,10 +304,13 @@ def test_log_bot_dm_message_uses_admin_session_for_private_conversations(monkeyp
             return conversation_id
 
     class _FakeSession:
+        added_rows = []
+
         async def execute(self, *_args, **_kwargs):
             return _FakeResult()
 
-        def add(self, _row) -> None:
+        def add(self, row) -> None:
+            self.added_rows.append(row)
             return None
 
         async def commit(self) -> None:
@@ -331,6 +334,13 @@ def test_log_bot_dm_message_uses_admin_session_for_private_conversations(monkeyp
         "channel": "D0AA3KFETUY",
         "text": "bot reply in private convo",
         "bot_id": "B123",
+        "files": [
+            {
+                "id": "F1",
+                "name": "brief.txt",
+                "url_private_download": "https://files.slack.com/files-pri/T1-F1/download/brief.txt",
+            }
+        ],
     }
     persisted = asyncio.run(
         slack_events._log_bot_dm_message_without_processing(
@@ -343,3 +353,6 @@ def test_log_bot_dm_message_uses_admin_session_for_private_conversations(monkeyp
 
     assert persisted is True
     assert used_admin_session["value"] is True
+    assert _FakeSession.added_rows
+    stored_message = _FakeSession.added_rows[0]
+    assert "Files: brief.txt: https://files.slack.com/files-pri/T1-F1/download/brief.txt" in stored_message.content


### PR DESCRIPTION
### Motivation
- Bot-authored DM/group-DM messages were being persisted with file metadata only in `content_blocks`, leaving `ChatMessage.content` without clickable Slack file links and causing regressions in stored message history and searchability. 
- The change restores visible, storable links in persisted message text so downstream tools and UI can surface attachments even when only stored history is available.

### Description
- Add `_format_slack_file_links_for_storage(files)` in `backend/api/routes/slack_events.py` to extract a compact "name: url" list preferring `url_private_download` with fallbacks to `url_private` and `permalink`.
- Append rendered Slack file links to the persisted `content_text` when `files` are present before creating the `ChatMessage`, while preserving the existing `slack_files` `content_blocks` payload. (`backend/api/routes/slack_events.py`)
- Add structured logging for when links are appended and when attachments exist but contain no storable links. (`backend/api/routes/slack_events.py`)
- Extend the regression test in `backend/tests/test_slack_events_thread_locking.py` to include a file in the fake event and assert the stored `ChatMessage.content` contains the expected `Files: name: url` string.

### Testing
- Ran `pytest -q backend/tests/test_slack_events_thread_locking.py -k bot_dm_message -q` and the test passed (with a `DeprecationWarning` about `datetime.utcnow()` but no failures).
- Added unit coverage in `backend/tests/test_slack_events_thread_locking.py` to prevent future regressions; the new assertion verifying stored message content succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f941a924ec8321a4c48638cdc92c17)