### PR TITLE
Persist Slack activity for file-only public channel messages

### DIFF
--- a/backend/api/routes/slack_events.py
+++ b/backend/api/routes/slack_events.py
@@ -550,7 +550,9 @@ async def _process_event_callback_impl(payload: dict[str, Any]) -> None:
         # Persist only public channel messages as Activity rows.
         # Treat private channels and group messages like DMs and skip activity persistence.
         should_persist_activity: bool = channel_type == "channel"
-        if should_persist_activity and event.get("text", "").strip():
+        has_persistable_text: bool = bool(str(event.get("text") or "").strip())
+        has_persistable_files: bool = bool([f for f in (event.get("files") or []) if isinstance(f, dict)])
+        if should_persist_activity and (has_persistable_text or has_persistable_files):
             activity_msg: InboundMessage = _build_inbound_message(
                 event, team_id, MessageType.MENTION,
             )

--- a/backend/tests/test_slack_events_direct_messages.py
+++ b/backend/tests/test_slack_events_direct_messages.py
@@ -162,6 +162,54 @@ def test_process_event_callback_persists_activity_for_public_channels(monkeypatc
     assert persisted == [("channel", "C123")]
 
 
+
+
+def test_process_event_callback_persists_activity_for_public_channel_file_only_messages(monkeypatch) -> None:
+    persisted: list[tuple[str, str]] = []
+
+    async def _fake_is_duplicate_event(_event_id: str) -> bool:
+        return False
+
+    async def _fake_process_inbound(self, _message: InboundMessage):
+        return {"status": "success"}
+
+    async def _fake_persist_activity(_messenger, message: InboundMessage, _team_id: str) -> None:
+        persisted.append(
+            (
+                message.messenger_context.get("channel_type"),
+                message.messenger_context.get("channel_id"),
+            )
+        )
+
+    monkeypatch.setattr(slack_events, "is_duplicate_event", _fake_is_duplicate_event)
+    monkeypatch.setattr(slack_events, "_persist_activity", _fake_persist_activity)
+    monkeypatch.setattr(SlackMessenger, "process_inbound", _fake_process_inbound)
+
+    payload = {
+        "type": "event_callback",
+        "event_id": "EvPublicChannelFilesOnly1",
+        "team_id": "T123",
+        "event": {
+            "type": "message",
+            "channel_type": "channel",
+            "channel": "C123",
+            "user": "U123",
+            "text": "",
+            "files": [
+                {
+                    "id": "F123",
+                    "name": "report.pdf",
+                    "url_private_download": "https://files.slack.com/files-pri/T1-F123/download/report.pdf",
+                }
+            ],
+            "ts": "1700000000.125",
+        },
+    }
+
+    asyncio.run(slack_events._process_event_callback_impl(payload))
+
+    assert persisted == [("channel", "C123")]
+
 def test_process_event_callback_records_failure_when_background_processing_raises(monkeypatch) -> None:
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
### Motivation

- Public Slack channel messages that contained only file attachments but no text were previously skipped during activity persistence, causing attachment metadata to be lost from the activity cache and breaking downstream file-link rendering. 
- The change ensures message attachments are considered when deciding to persist activity so cached channel context includes `custom_fields.files` for file-only events.

### Description

- In `backend/api/routes/slack_events.py` updated the activity-persistence guard in `_process_event_callback_impl` to compute `has_persistable_text` and `has_persistable_files` and persist when either is true. 
- The handler now treats messages with valid `event["files"]` entries as persistable for public channels and still skips private/group messages. 
- Added a regression test `test_process_event_callback_persists_activity_for_public_channel_file_only_messages` in `backend/tests/test_slack_events_direct_messages.py` that verifies file-only public-channel events trigger `_persist_activity`.

### Testing

- Ran `pytest -q backend/tests/test_slack_events_direct_messages.py -q` and the test suite passed (all tests in that file succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f941a924ec8321a4c48638cdc92c17)