### PR TITLE
Fix admin topnav workspace menu to show all teams

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -472,15 +472,16 @@ export function Sidebar({
         />
       </div>
 
-      {currentView !== 'admin' && (
-        <div className="relative flex-1 min-h-0">
-          {/* Chats layer */}
-          <div
-            className={`absolute inset-0 flex flex-col transition-opacity duration-150 ${
-              panelMode === 'chats' ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
-            }`}
-            aria-hidden={panelMode !== 'chats'}
-          >
+      <div className="relative flex-1 min-h-0">
+          {currentView !== 'admin' && (
+            <>
+              {/* Chats layer */}
+              <div
+                className={`absolute inset-0 flex flex-col transition-opacity duration-150 ${
+                  panelMode === 'chats' ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+                }`}
+                aria-hidden={panelMode !== 'chats'}
+              >
             <div className={`px-3 py-2 flex-shrink-0 flex items-center gap-1.5 ${collapsed ? 'flex-col' : ''}`}>
               <button
                 type="button"
@@ -518,8 +519,10 @@ export function Sidebar({
               }}
             />
 
-            {collapsed && <div className="flex-1" />}
-          </div>
+              {collapsed && <div className="flex-1" />}
+            </div>
+            </>
+          )}
 
           {/* Org / workspace layer */}
           {!collapsed && (
@@ -541,7 +544,6 @@ export function Sidebar({
             </div>
           )}
         </div>
-      )}
 
       {currentView === 'admin' && isGlobalAdmin && (
         <div className="flex-1 min-h-0 flex flex-col overflow-hidden">


### PR DESCRIPTION
### Motivation
- The Global Admin topnav (e.g. `/admin/dashboard`) should expose the full list of teams the current user belongs to when expanded so admins can switch into any team. 

### Description
- Kept the org/workspace panel mountable in the sidebar so the workspace menu can be expanded while viewing admin pages by changing the JSX structure in `frontend/src/components/Sidebar.tsx`. 
- Made the chats layer conditional (rendered only when `currentView !== 'admin'`) while ensuring the org panel is still present and usable in admin mode. 
- Preserved existing chat behavior and visual layering so chat controls remain gated to non-admin views and the org switcher overlay functions correctly.

### Testing
- Built the frontend with `cd frontend && npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9458d5e988321ab6bd3b46988d836)