### PR TITLE
Ensure app-triggered workflows create WorkflowRun and propagate run_id

### DIFF
--- a/backend/api/routes/apps.py
+++ b/backend/api/routes/apps.py
@@ -28,7 +28,7 @@ from models.database import get_session, get_admin_session
 from models.organization import Organization
 from models.user import User
 from models.visibility import normalize_visibility
-from models.workflow import Workflow
+from models.workflow import Workflow, WorkflowRun
 from services.app_query_runner import (
     AppQueryResponse as QueryResponse,
     json_serial,
@@ -86,6 +86,7 @@ class TriggerAppWorkflowResponse(BaseModel):
     status: str
     task_id: str
     workflow_id: str
+    run_id: str
     triggered_by_user_id: str
 
 
@@ -281,18 +282,38 @@ async def trigger_app_workflow(
         if not workflow.is_enabled:
             raise HTTPException(status_code=400, detail="Workflow is disabled")
 
-    pause_until = await get_workflow_execution_pause_until()
-    if pause_until is not None:
-        logger.warning(
-            "[Apps API] Workflow trigger blocked by workflow execution pause app_id=%s workflow_id=%s organization_id=%s pause_until=%s",
+        pause_until = await get_workflow_execution_pause_until()
+        if pause_until is not None:
+            logger.warning(
+                "[Apps API] Workflow trigger blocked by workflow execution pause app_id=%s workflow_id=%s organization_id=%s pause_until=%s",
+                app_id,
+                workflow_id,
+                auth.organization_id_str,
+                pause_until.isoformat(),
+            )
+            raise HTTPException(
+                status_code=503,
+                detail=f"Workflow execution temporarily paused until {pause_until.isoformat()}",
+            )
+
+        run = WorkflowRun(
+            workflow_id=workflow.id,
+            organization_id=workflow.organization_id,
+            triggered_by="app",
+            trigger_data=trigger_data,
+            status="pending",
+            started_at=datetime.utcnow(),
+        )
+        session.add(run)
+        await session.commit()
+        await session.refresh(run)
+        run_id = str(run.id)
+        logger.info(
+            "[Apps API] Created pending workflow run from app app_id=%s workflow_id=%s run_id=%s user_id=%s",
             app_id,
             workflow_id,
-            auth.organization_id_str,
-            pause_until.isoformat(),
-        )
-        raise HTTPException(
-            status_code=503,
-            detail=f"Workflow execution temporarily paused until {pause_until.isoformat()}",
+            run_id,
+            auth.user_id_str,
         )
 
     from workers.tasks.workflows import execute_workflow
@@ -304,17 +325,20 @@ async def trigger_app_workflow(
         conversation_id=None,
         organization_id=auth.organization_id_str,
         triggered_by_user_id=auth.user_id_str,
+        workflow_run_id=run_id,
     )
     logger.info(
-        "[Apps API] Queued workflow from app app_id=%s workflow_id=%s user_id=%s",
+        "[Apps API] Queued workflow from app app_id=%s workflow_id=%s run_id=%s user_id=%s",
         app_id,
         workflow_id,
+        run_id,
         auth.user_id_str,
     )
     return TriggerAppWorkflowResponse(
         status="queued",
         task_id=task.id,
         workflow_id=workflow_id,
+        run_id=run_id,
         triggered_by_user_id=auth.user_id_str or "",
     )
 

--- a/backend/tests/test_apps_workflow_trigger.py
+++ b/backend/tests/test_apps_workflow_trigger.py
@@ -21,9 +21,21 @@ class _ScalarResult:
 class _FakeSession:
     def __init__(self, app_obj, workflow_obj) -> None:
         self._responses = [app_obj, workflow_obj]
+        self.added = []
 
     async def execute(self, _query):
         return _ScalarResult(self._responses.pop(0))
+
+    def add(self, value):
+        if getattr(value, "id", None) is None:
+            value.id = UUID("00000000-0000-0000-0000-000000000005")
+        self.added.append(value)
+
+    async def commit(self):
+        return None
+
+    async def refresh(self, value):
+        return None
 
 
 class _FakeTask:
@@ -41,9 +53,13 @@ async def test_trigger_app_workflow_runs_as_logged_in_user(monkeypatch: pytest.M
     app_obj = SimpleNamespace(id=app_id, organization_id=org_id)
     workflow_obj = SimpleNamespace(id=workflow_id, organization_id=org_id, archived_at=None, is_enabled=True)
 
+    fake_sessions: list[_FakeSession] = []
+
     @asynccontextmanager
     async def _fake_session(**_kwargs):
-        yield _FakeSession(app_obj, workflow_obj)
+        fake_session = _FakeSession(app_obj, workflow_obj)
+        fake_sessions.append(fake_session)
+        yield fake_session
 
     captured: dict[str, str | None] = {}
 
@@ -58,7 +74,11 @@ async def test_trigger_app_workflow_runs_as_logged_in_user(monkeypatch: pytest.M
 
     monkeypatch.setattr(apps_routes, "get_session", _fake_session)
     monkeypatch.setattr(apps_routes, "get_workflow_execution_pause_until", _no_pause)
-    monkeypatch.setitem(__import__("sys").modules, "workers.tasks.workflows", SimpleNamespace(execute_workflow=_FakeExecuteWorkflow))
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "workers.tasks.workflows",
+        SimpleNamespace(execute_workflow=_FakeExecuteWorkflow),
+    )
 
     auth = AuthContext(
         user_id=user_id,
@@ -77,5 +97,12 @@ async def test_trigger_app_workflow_runs_as_logged_in_user(monkeypatch: pytest.M
 
     assert response.status == "queued"
     assert response.triggered_by_user_id == str(user_id)
+    assert response.run_id == "00000000-0000-0000-0000-000000000005"
+    assert len(fake_sessions) == 1
+    assert len(fake_sessions[0].added) == 1
+    assert fake_sessions[0].added[0].status == "pending"
+    assert fake_sessions[0].added[0].triggered_by == "app"
+    assert fake_sessions[0].added[0].trigger_data == {"source": "app"}
     assert captured["triggered_by_user_id"] == str(user_id)
     assert captured["triggered_by"] == "app"
+    assert captured["workflow_run_id"] == response.run_id

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -997,6 +997,7 @@ async def _execute_workflow(
     conversation_id: str | None = None,
     organization_id: str | None = None,
     triggered_by_user_id: str | None = None,
+    workflow_run_id: str | None = None,
 ) -> dict[str, Any]:
     """
     Execute a workflow by creating a conversation and sending the prompt to the agent.
@@ -1091,22 +1092,71 @@ async def _execute_workflow(
             )
             return result_payload
 
-        existing_run_count_result = await session.execute(
-            select(WorkflowRun.id).where(WorkflowRun.workflow_id == workflow.id).limit(1)
+        run: WorkflowRun | None = None
+        if workflow_run_id:
+            try:
+                workflow_run_uuid = UUID(workflow_run_id)
+            except ValueError:
+                logger.warning(
+                    "[Workflow] Ignoring invalid pre-created workflow_run_id=%s workflow_id=%s",
+                    workflow_run_id,
+                    workflow_id,
+                )
+            else:
+                run_result = await session.execute(
+                    select(WorkflowRun).where(
+                        WorkflowRun.id == workflow_run_uuid,
+                        WorkflowRun.workflow_id == workflow.id,
+                        WorkflowRun.organization_id == workflow.organization_id,
+                    )
+                )
+                run = run_result.scalar_one_or_none()
+                if run is None:
+                    logger.warning(
+                        "[Workflow] Pre-created run not found; creating a new run workflow_id=%s workflow_run_id=%s",
+                        workflow_id,
+                        workflow_run_id,
+                    )
+
+        existing_run_count_query = select(WorkflowRun.id).where(
+            WorkflowRun.workflow_id == workflow.id
         )
+        if run is not None:
+            existing_run_count_query = existing_run_count_query.where(WorkflowRun.id != run.id)
+        existing_run_count_result = await session.execute(existing_run_count_query.limit(1))
         is_first_run_attempt = existing_run_count_result.scalar_one_or_none() is None
-        
-        # Create run record
-        run = WorkflowRun(
-            workflow_id=workflow.id,
-            organization_id=workflow.organization_id,
-            triggered_by=triggered_by,
-            trigger_data=trigger_data,
-            status="running",
-            started_at=started_at,
-        )
-        session.add(run)
-        await session.flush()
+
+        if run is None:
+            run = WorkflowRun(
+                workflow_id=workflow.id,
+                organization_id=workflow.organization_id,
+                triggered_by=triggered_by,
+                trigger_data=trigger_data,
+                status="running",
+                started_at=started_at,
+            )
+            session.add(run)
+            await session.flush()
+            logger.info(
+                "[Workflow] Created workflow run workflow_id=%s run_id=%s triggered_by=%s",
+                workflow_id,
+                run.id,
+                triggered_by,
+            )
+        else:
+            run.triggered_by = triggered_by
+            run.trigger_data = trigger_data
+            run.status = "running"
+            run.started_at = started_at
+            run.completed_at = None
+            run.error_message = None
+            await session.flush()
+            logger.info(
+                "[Workflow] Claimed pre-created workflow run workflow_id=%s run_id=%s triggered_by=%s",
+                workflow_id,
+                run.id,
+                triggered_by,
+            )
         run_id = run.id
         
         # Check if this workflow uses the new prompt-based execution
@@ -2431,6 +2481,7 @@ def execute_workflow(
     conversation_id: str | None = None,
     organization_id: str | None = None,
     triggered_by_user_id: str | None = None,
+    workflow_run_id: str | None = None,
 ) -> dict[str, Any]:
     """
     Celery task to execute a workflow.
@@ -2441,6 +2492,7 @@ def execute_workflow(
         trigger_data: Optional data from the trigger event
         conversation_id: Optional pre-created conversation ID (for immediate navigation)
         organization_id: Organization ID for RLS context (required for proper security)
+        workflow_run_id: Optional ID of a pending run created by the caller
     
     Returns:
         Execution result with status and any errors
@@ -2454,5 +2506,6 @@ def execute_workflow(
             conversation_id,
             organization_id,
             triggered_by_user_id,
+            workflow_run_id,
         )
     )

--- a/frontend/src/components/apps/SandpackAppRenderer.tsx
+++ b/frontend/src/components/apps/SandpackAppRenderer.tsx
@@ -333,6 +333,7 @@ export function SandpackAppRenderer({
               status: string;
               task_id: string;
               workflow_id: string;
+              run_id: string;
               triggered_by_user_id: string;
             }>(`/apps/${payloadAppId}/workflows/${workflowId}/trigger`, {
               method: "POST",


### PR DESCRIPTION
### Motivation
- Triggering a workflow from an app should create a database-backed run immediately so callers can reference and monitor the run before Celery processes it. 
- Worker execution should be able to claim a pre-created run to avoid creating duplicate or out-of-band run records and to preserve observability. 

### Description
- The Apps API (`backend/api/routes/apps.py`) now creates a pending `WorkflowRun` synchronously, returns `run_id` in the trigger response, and passes `workflow_run_id` into the Celery `execute_workflow` task. 
- The workflow execution path (`backend/workers/tasks/workflows.py`) accepts an optional `workflow_run_id`, validates and claims the pre-created run when present, and only creates a run if none was supplied or found. 
- Frontend app iframe bridge typing (`frontend/src/components/apps/SandpackAppRenderer.tsx`) was updated to include the new `run_id` field in the trigger response type. 
- Tests were expanded (`backend/tests/test_apps_workflow_trigger.py`) to assert a pending run is created, the returned `run_id` is populated, and the Celery task receives that run ID. 

### Testing
- `pytest tests/test_apps_workflow_trigger.py -q` — passed (1 passed, 1 warning). 
- `python -m py_compile api/routes/apps.py workers/tasks/workflows.py tests/test_apps_workflow_trigger.py` — passed (compiled without errors). 
- `npm run build` (frontend build) — passed (production build completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f946b889c88321a00c61aeebc29f36)