### PR TITLE
Top-align Global Admin sidebar navigation

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -473,15 +473,44 @@ export function Sidebar({
       </div>
 
       <div className="relative flex-1 min-h-0">
-          {currentView !== 'admin' && (
-            <>
-              {/* Chats layer */}
-              <div
-                className={`absolute inset-0 flex flex-col transition-opacity duration-150 ${
-                  panelMode === 'chats' ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
-                }`}
-                aria-hidden={panelMode !== 'chats'}
-              >
+        {currentView === 'admin' && isGlobalAdmin ? (
+          <div className="absolute inset-0 flex flex-col overflow-hidden">
+            {!collapsed && panelMode === 'org' ? (
+              <OrgPanel
+                currentView={currentView}
+                onViewChange={onViewChange}
+                onCreateNewOrg={onCreateNewOrg}
+                connectedSourcesCount={connectedSourcesCount}
+                workflowCount={workflowCount}
+                pendingChangesCount={pendingChangesCount}
+                onClosePanel={closePanel}
+              />
+            ) : (
+              <div className="px-2 py-2 overflow-y-auto scrollbar-thin flex-1">
+                <nav className="space-y-0.5" aria-label="Global Admin sections">
+                  {GLOBAL_ADMIN_NAV_ITEMS.map((item) => (
+                    <GlobalAdminSidebarNavItem
+                      key={item.id}
+                      label={item.label}
+                      collapsed={collapsed}
+                      active={adminPanelTab === item.id}
+                      onClick={() => setAdminPanelTab(item.id)}
+                      icon={item.icon}
+                    />
+                  ))}
+                </nav>
+              </div>
+            )}
+          </div>
+        ) : (
+          <>
+            {/* Chats layer */}
+            <div
+              className={`absolute inset-0 flex flex-col transition-opacity duration-150 ${
+                panelMode === 'chats' ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+              }`}
+              aria-hidden={panelMode !== 'chats'}
+            >
             <div className={`px-3 py-2 flex-shrink-0 flex items-center gap-1.5 ${collapsed ? 'flex-col' : ''}`}>
               <button
                 type="button"
@@ -521,48 +550,29 @@ export function Sidebar({
 
               {collapsed && <div className="flex-1" />}
             </div>
-            </>
-          )}
 
-          {/* Org / workspace layer */}
-          {!collapsed && (
-            <div
-              className={`absolute inset-0 transition-opacity duration-150 ${
-                panelMode === 'org' ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
-              }`}
-              aria-hidden={panelMode !== 'org'}
-            >
-              <OrgPanel
-                currentView={currentView}
-                onViewChange={onViewChange}
-                onCreateNewOrg={onCreateNewOrg}
-                connectedSourcesCount={connectedSourcesCount}
-                workflowCount={workflowCount}
-                pendingChangesCount={pendingChangesCount}
-                onClosePanel={closePanel}
-              />
-            </div>
-          )}
-        </div>
-
-      {currentView === 'admin' && isGlobalAdmin && (
-        <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-          <div className="px-2 py-2 overflow-y-auto scrollbar-thin flex-1">
-            <nav className="space-y-0.5" aria-label="Global Admin sections">
-              {GLOBAL_ADMIN_NAV_ITEMS.map((item) => (
-                <GlobalAdminSidebarNavItem
-                  key={item.id}
-                  label={item.label}
-                  collapsed={collapsed}
-                  active={adminPanelTab === item.id}
-                  onClick={() => setAdminPanelTab(item.id)}
-                  icon={item.icon}
+            {/* Org / workspace layer */}
+            {!collapsed && (
+              <div
+                className={`absolute inset-0 transition-opacity duration-150 ${
+                  panelMode === 'org' ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+                }`}
+                aria-hidden={panelMode !== 'org'}
+              >
+                <OrgPanel
+                  currentView={currentView}
+                  onViewChange={onViewChange}
+                  onCreateNewOrg={onCreateNewOrg}
+                  connectedSourcesCount={connectedSourcesCount}
+                  workflowCount={workflowCount}
+                  pendingChangesCount={pendingChangesCount}
+                  onClosePanel={closePanel}
                 />
-              ))}
-            </nav>
-          </div>
-        </div>
-      )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
 
       {/* Bottom Section */}
       <div className="mt-auto bg-surface-900/40">


### PR DESCRIPTION
### Motivation
- Admin navigation items were rendered in the middle of the left sidebar on admin pages instead of being top-aligned, making the admin UI feel awkward and less discoverable.

### Description
- Render the Global Admin navigation inside the sidebar's main flex region so admin nav items are top-aligned for the admin view.
- Preserve access to the workspace/org panel from the admin sidebar header by rendering `OrgPanel` in the same top-aligned admin area when opened.
- Adjust conditional rendering and panel toggling in `frontend/src/components/Sidebar.tsx` to switch between the admin nav and the chats/org layers depending on `currentView`, `isGlobalAdmin`, `panelMode`, and `collapsed` state.
- Run automatic formatting/cleanup across the modified file while making the functional changes.

### Testing
- Ran `npm run lint` in `frontend` which completed successfully with no lint errors.
- Ran `npm run build` in `frontend` which completed successfully (Vite build passed, with existing chunk-size warnings reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94833bd2c8321a3512f1553559128)