### PR TITLE
Add app workflow trigger diagnostics and request_id propagation

### DIFF
--- a/backend/api/routes/apps.py
+++ b/backend/api/routes/apps.py
@@ -80,6 +80,7 @@ class EmbedTokenResponse(BaseModel):
 
 class TriggerAppWorkflowRequest(BaseModel):
     trigger_data: dict[str, Any] | None = None
+    request_id: str | None = None
 
 
 class TriggerAppWorkflowResponse(BaseModel):
@@ -88,6 +89,7 @@ class TriggerAppWorkflowResponse(BaseModel):
     workflow_id: str
     run_id: str
     triggered_by_user_id: str
+    request_id: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -250,12 +252,30 @@ async def trigger_app_workflow(
     auth: AuthContext = Depends(require_organization),
 ) -> TriggerAppWorkflowResponse:
     """Trigger a workflow from an app as the currently logged-in user."""
-    trigger_data: dict[str, Any] | None = (body or TriggerAppWorkflowRequest()).trigger_data
+    request_body = body or TriggerAppWorkflowRequest()
+    trigger_data: dict[str, Any] | None = request_body.trigger_data
+    request_id: str | None = request_body.request_id
+    trigger_data_keys = sorted(trigger_data.keys()) if isinstance(trigger_data, dict) else []
+    logger.info(
+        "[Apps API] Received app workflow trigger request app_id=%s workflow_id=%s organization_id=%s user_id=%s request_id=%s trigger_data_keys=%s",
+        app_id,
+        workflow_id,
+        auth.organization_id_str,
+        auth.user_id_str,
+        request_id,
+        trigger_data_keys,
+    )
 
     try:
         app_uuid = UUID(app_id)
         workflow_uuid = UUID(workflow_id)
     except ValueError as exc:
+        logger.warning(
+            "[Apps API] Rejected app workflow trigger with invalid ID app_id=%s workflow_id=%s request_id=%s",
+            app_id,
+            workflow_id,
+            request_id,
+        )
         raise HTTPException(status_code=400, detail="Invalid ID format") from exc
 
     assert auth.organization_id_str is not None
@@ -266,6 +286,13 @@ async def trigger_app_workflow(
         app_result = await session.execute(select(App).where(App.id == app_uuid))
         app: App | None = app_result.scalar_one_or_none()
         if app is None or str(app.organization_id) != auth.organization_id_str:
+            logger.warning(
+                "[Apps API] App workflow trigger app not found app_id=%s workflow_id=%s organization_id=%s request_id=%s",
+                app_id,
+                workflow_id,
+                auth.organization_id_str,
+                request_id,
+            )
             raise HTTPException(status_code=404, detail="App not found")
 
         workflow_result = await session.execute(
@@ -276,20 +303,40 @@ async def trigger_app_workflow(
         )
         workflow: Workflow | None = workflow_result.scalar_one_or_none()
         if workflow is None:
+            logger.warning(
+                "[Apps API] App workflow trigger workflow not found app_id=%s workflow_id=%s organization_id=%s request_id=%s",
+                app_id,
+                workflow_id,
+                auth.organization_id_str,
+                request_id,
+            )
             raise HTTPException(status_code=404, detail="Workflow not found")
         if workflow.archived_at is not None:
+            logger.warning(
+                "[Apps API] App workflow trigger rejected archived workflow app_id=%s workflow_id=%s request_id=%s",
+                app_id,
+                workflow_id,
+                request_id,
+            )
             raise HTTPException(status_code=400, detail="Archived workflows cannot be triggered")
         if not workflow.is_enabled:
+            logger.warning(
+                "[Apps API] App workflow trigger rejected disabled workflow app_id=%s workflow_id=%s request_id=%s",
+                app_id,
+                workflow_id,
+                request_id,
+            )
             raise HTTPException(status_code=400, detail="Workflow is disabled")
 
         pause_until = await get_workflow_execution_pause_until()
         if pause_until is not None:
             logger.warning(
-                "[Apps API] Workflow trigger blocked by workflow execution pause app_id=%s workflow_id=%s organization_id=%s pause_until=%s",
+                "[Apps API] Workflow trigger blocked by workflow execution pause app_id=%s workflow_id=%s organization_id=%s pause_until=%s request_id=%s",
                 app_id,
                 workflow_id,
                 auth.organization_id_str,
                 pause_until.isoformat(),
+                request_id,
             )
             raise HTTPException(
                 status_code=503,
@@ -309,11 +356,12 @@ async def trigger_app_workflow(
         await session.refresh(run)
         run_id = str(run.id)
         logger.info(
-            "[Apps API] Created pending workflow run from app app_id=%s workflow_id=%s run_id=%s user_id=%s",
+            "[Apps API] Created pending workflow run from app app_id=%s workflow_id=%s run_id=%s user_id=%s request_id=%s",
             app_id,
             workflow_id,
             run_id,
             auth.user_id_str,
+            request_id,
         )
 
     from workers.tasks.workflows import execute_workflow
@@ -328,11 +376,13 @@ async def trigger_app_workflow(
         workflow_run_id=run_id,
     )
     logger.info(
-        "[Apps API] Queued workflow from app app_id=%s workflow_id=%s run_id=%s user_id=%s",
+        "[Apps API] Queued workflow from app app_id=%s workflow_id=%s run_id=%s task_id=%s user_id=%s request_id=%s",
         app_id,
         workflow_id,
         run_id,
+        task.id,
         auth.user_id_str,
+        request_id,
     )
     return TriggerAppWorkflowResponse(
         status="queued",
@@ -340,6 +390,7 @@ async def trigger_app_workflow(
         workflow_id=workflow_id,
         run_id=run_id,
         triggered_by_user_id=auth.user_id_str or "",
+        request_id=request_id,
     )
 
 

--- a/backend/tests/test_apps_workflow_trigger.py
+++ b/backend/tests/test_apps_workflow_trigger.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from uuid import UUID
@@ -44,7 +45,7 @@ class _FakeTask:
 
 
 @pytest.mark.asyncio
-async def test_trigger_app_workflow_runs_as_logged_in_user(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_trigger_app_workflow_runs_as_logged_in_user(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
     org_id = UUID("00000000-0000-0000-0000-000000000001")
     user_id = UUID("00000000-0000-0000-0000-000000000002")
     app_id = UUID("00000000-0000-0000-0000-000000000003")
@@ -88,16 +89,19 @@ async def test_trigger_app_workflow_runs_as_logged_in_user(monkeypatch: pytest.M
         is_global_admin=False,
     )
 
+    caplog.set_level(logging.INFO, logger=apps_routes.logger.name)
+
     response = await apps_routes.trigger_app_workflow(
         app_id=str(app_id),
         workflow_id=str(workflow_id),
-        body=apps_routes.TriggerAppWorkflowRequest(trigger_data={"source": "app"}),
+        body=apps_routes.TriggerAppWorkflowRequest(trigger_data={"source": "app"}, request_id="req-test-123"),
         auth=auth,
     )
 
     assert response.status == "queued"
     assert response.triggered_by_user_id == str(user_id)
     assert response.run_id == "00000000-0000-0000-0000-000000000005"
+    assert response.request_id == "req-test-123"
     assert len(fake_sessions) == 1
     assert len(fake_sessions[0].added) == 1
     assert fake_sessions[0].added[0].status == "pending"
@@ -106,3 +110,6 @@ async def test_trigger_app_workflow_runs_as_logged_in_user(monkeypatch: pytest.M
     assert captured["triggered_by_user_id"] == str(user_id)
     assert captured["triggered_by"] == "app"
     assert captured["workflow_run_id"] == response.run_id
+    assert "Received app workflow trigger request" in caplog.text
+    assert "request_id=req-test-123" in caplog.text
+    assert "task_id=task-123" in caplog.text

--- a/frontend/src/components/apps/SandpackAppRenderer.tsx
+++ b/frontend/src/components/apps/SandpackAppRenderer.tsx
@@ -291,7 +291,19 @@ export function SandpackAppRenderer({
     const handler = (event: MessageEvent): void => {
       const expectedSource = iframeRef.current?.contentWindow ?? null;
       const expectedOrigin = window.location.origin;
+      const maybeData = event.data as { type?: string; requestId?: string; appId?: string; workflowId?: string } | null;
       if (event.source !== expectedSource || event.origin !== expectedOrigin) {
+        if (maybeData?.type?.startsWith("app-")) {
+          console.warn("[Apps iframe bridge] Ignored app message from unexpected source or origin", {
+            type: maybeData.type,
+            requestId: maybeData.requestId,
+            appId: maybeData.appId,
+            workflowId: maybeData.workflowId,
+            actualOrigin: event.origin,
+            expectedOrigin,
+            sourceMatches: event.source === expectedSource,
+          });
+        }
         return;
       }
 
@@ -317,6 +329,12 @@ export function SandpackAppRenderer({
         const workflowId = data.workflowId;
         const payloadAppId = data.appId;
         if (!requestId || !workflowId || !payloadAppId || payloadAppId !== appId) {
+          console.warn("[Apps iframe bridge] Invalid workflow trigger payload", {
+            requestId,
+            workflowId,
+            payloadAppId,
+            expectedAppId: appId,
+          });
           (event.source as Window | null)?.postMessage({
             type: "app-trigger-workflow-result",
             requestId,
@@ -328,20 +346,36 @@ export function SandpackAppRenderer({
 
         void (async () => {
           try {
-            console.info("[Apps iframe bridge] Trigger workflow request", { appId: payloadAppId, workflowId, requestId });
+            const triggerDataKeys = data.triggerData && typeof data.triggerData === "object"
+              ? Object.keys(data.triggerData).sort()
+              : [];
+            console.info("[Apps iframe bridge] Trigger workflow request", {
+              appId: payloadAppId,
+              workflowId,
+              requestId,
+              triggerDataKeys,
+            });
             const response = await apiRequest<{
               status: string;
               task_id: string;
               workflow_id: string;
               run_id: string;
               triggered_by_user_id: string;
+              request_id?: string | null;
             }>(`/apps/${payloadAppId}/workflows/${workflowId}/trigger`, {
               method: "POST",
               body: JSON.stringify({
                 trigger_data: data.triggerData && typeof data.triggerData === "object" ? data.triggerData : undefined,
+                request_id: requestId,
               }),
             });
             if (response.error || !response.data) {
+              console.error("[Apps iframe bridge] Workflow trigger API rejected request", {
+                appId: payloadAppId,
+                workflowId,
+                requestId,
+                error: response.error,
+              });
               (event.source as Window | null)?.postMessage({
                 type: "app-trigger-workflow-result",
                 requestId,
@@ -350,6 +384,13 @@ export function SandpackAppRenderer({
               }, "*");
               return;
             }
+            console.info("[Apps iframe bridge] Workflow trigger queued", {
+              appId: payloadAppId,
+              workflowId,
+              requestId,
+              taskId: response.data.task_id,
+              runId: response.data.run_id,
+            });
             (event.source as Window | null)?.postMessage({
               type: "app-trigger-workflow-result",
               requestId,

--- a/frontend/src/components/apps/appSdkSource.ts
+++ b/frontend/src/components/apps/appSdkSource.ts
@@ -120,23 +120,36 @@ export function triggerWorkflow(workflowId, triggerData) {
       const payload = event && event.data ? event.data : null;
       if (!payload || payload.type !== "app-trigger-workflow-result" || payload.requestId !== requestId) return;
       cleanup();
-      if (payload.ok) resolve(payload.result || { status: "queued" });
-      else reject(new Error(payload.error || "Failed to trigger workflow"));
+      if (payload.ok) {
+        console.info("[App SDK] Workflow trigger queued", { requestId, workflowId, result: payload.result });
+        resolve(payload.result || { status: "queued" });
+      } else {
+        console.error("[App SDK] Workflow trigger failed", { requestId, workflowId, error: payload.error });
+        reject(new Error(payload.error || "Failed to trigger workflow"));
+      }
     };
 
     window.addEventListener("message", onMessage);
     timeoutId = setTimeout(() => {
       cleanup();
+      console.error("[App SDK] Workflow trigger timed out", { requestId, workflowId });
       reject(new Error("Timed out waiting for workflow trigger response"));
     }, 15000);
 
     try {
+      const sanitizedTriggerData = triggerData && typeof triggerData === "object" ? triggerData : undefined;
+      console.info("[App SDK] Requesting workflow trigger", {
+        requestId,
+        appId: APP_ID,
+        workflowId,
+        triggerDataKeys: sanitizedTriggerData ? Object.keys(sanitizedTriggerData).sort() : [],
+      });
       window.parent.postMessage({
         type: "app-trigger-workflow",
         requestId,
         appId: APP_ID,
         workflowId,
-        triggerData: triggerData && typeof triggerData === "object" ? triggerData : undefined,
+        triggerData: sanitizedTriggerData,
       }, "*");
     } catch (err) {
       cleanup();


### PR DESCRIPTION
### Motivation
- App-triggered workflows were hard to trace across iframe → frontend → backend → worker queue, so correlated diagnostics and a stable request identifier were needed to make failures and queueing visible. 

### Description
- Add a `request_id` field to the app trigger request/response models so the browser, API, and queued Celery task logs can be correlated (`backend/api/routes/apps.py`).
- Add structured INFO/WARNING logs in the Apps API for request receipt, invalid IDs, missing app/workflow, archived/disabled workflow rejects, global pause blocking, `WorkflowRun` creation, and Celery queueing (`backend/api/routes/apps.py`).
- Add browser-console diagnostics in the in-app SDK `triggerWorkflow` for request, queued success, failure, and timeout paths (`frontend/src/components/apps/appSdkSource.ts`).
- Add iframe-bridge diagnostics in the host (`SandpackAppRenderer`) for origin/source mismatches, invalid payloads, API rejections, and successful queueing (includes `task_id` and `run_id`) and propagate `request_id` in the API body (`frontend/src/components/apps/SandpackAppRenderer.tsx`).
- Extend the unit test to assert `request_id` propagation and presence of key backend log breadcrumbs (`backend/tests/test_apps_workflow_trigger.py`).

### Testing
- Ran `pytest backend/tests/test_apps_workflow_trigger.py`, which passed (1 passed, 0 failed). 
- Ran `npm run build` for the frontend, which completed successfully (production build generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f94d87e53c832199f3c9df93e5309b)