### PR TITLE
Harden /auth/users/sync against forged identity data

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -732,7 +732,10 @@ class SyncUserResponse(BaseModel):
 
 
 @router.post("/users/sync", response_model=SyncUserResponse)
-async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
+async def sync_user(
+    request: SyncUserRequest,
+    auth: AuthContext = Depends(get_current_auth),
+) -> SyncUserResponse:
     """Sync a user from Supabase auth to our database.
     
     Called when a user authenticates via Supabase OAuth.
@@ -742,6 +745,14 @@ async def sync_user(request: SyncUserRequest) -> SyncUserResponse:
         user_uuid = UUID(request.id)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid user ID")
+
+    if auth.user_id != user_uuid:
+        raise HTTPException(status_code=403, detail="User ID does not match authenticated user")
+
+    request_email = request.email.strip().lower()
+    auth_email = (auth.email or "").strip().lower()
+    if auth_email and request_email != auth_email:
+        raise HTTPException(status_code=403, detail="Email does not match authenticated user")
 
     org_uuid: Optional[UUID] = None
     if request.organization_id:


### PR DESCRIPTION
### Motivation
- The `POST /auth/users/sync` endpoint previously accepted caller-supplied `id`/`email`/`organization_id` without ensuring the request was authenticated or bound to the JWT subject, enabling unauthorized self-enrollment into an organization when an `org_id` was exposed in invite links.
- The change prevents attacker-controlled payloads from creating or activating `OrgMember` rows for arbitrary organizations by requiring a trusted authentication context.

### Description
- Require an authenticated context for `sync_user` by adding `auth: AuthContext = Depends(get_current_auth)` to the endpoint signature so the route is no longer callable anonymously.
- Enforce that `request.id` (the Supabase user ID) matches `auth.user_id`, returning HTTP 403 if they differ to prevent ID spoofing.
- Enforce that the request `email` matches the authenticated claim `auth.email` when an authenticated email is present, returning HTTP 403 on mismatch to prevent forged email-based correlation.
- The remainder of the existing `sync_user` logic (migration, membership activation, pending membership handling) is preserved and runs only after the identity checks.

### Testing
- Ran `python -m compileall backend/api/routes/auth.py` and the file compiled successfully. 
- Performed a code review of the patched `sync_user` path to confirm the identity gate is applied before any membership creation logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f43d947d8c8321b40130a39c4d39a0)