### PR TITLE
Increase warning-level diagnostics for app workflow triggers

### DIFF
--- a/backend/api/routes/apps.py
+++ b/backend/api/routes/apps.py
@@ -256,7 +256,7 @@ async def trigger_app_workflow(
     trigger_data: dict[str, Any] | None = request_body.trigger_data
     request_id: str | None = request_body.request_id
     trigger_data_keys = sorted(trigger_data.keys()) if isinstance(trigger_data, dict) else []
-    logger.info(
+    logger.warning(
         "[Apps API] Received app workflow trigger request app_id=%s workflow_id=%s organization_id=%s user_id=%s request_id=%s trigger_data_keys=%s",
         app_id,
         workflow_id,
@@ -355,7 +355,7 @@ async def trigger_app_workflow(
         await session.commit()
         await session.refresh(run)
         run_id = str(run.id)
-        logger.info(
+        logger.warning(
             "[Apps API] Created pending workflow run from app app_id=%s workflow_id=%s run_id=%s user_id=%s request_id=%s",
             app_id,
             workflow_id,
@@ -375,7 +375,7 @@ async def trigger_app_workflow(
         triggered_by_user_id=auth.user_id_str,
         workflow_run_id=run_id,
     )
-    logger.info(
+    logger.warning(
         "[Apps API] Queued workflow from app app_id=%s workflow_id=%s run_id=%s task_id=%s user_id=%s request_id=%s",
         app_id,
         workflow_id,

--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -275,6 +275,7 @@ class AppsConnector(BaseConnector):
         workflow_id_raw: str | None = data.get("workflow_id")
         auth_envelope: dict[str, Any] | None = data.get("_auth_envelope")
         trigger_data: dict[str, Any] | None = data.get("trigger_data")
+        request_id: str | None = data.get("request_id") if isinstance(data.get("request_id"), str) else None
 
         if not app_id_raw:
             return {"error": "app_id is required for trigger_workflow operation"}
@@ -284,6 +285,15 @@ class AppsConnector(BaseConnector):
         request_user_id_raw, delegated_actor = _decode_apps_auth_envelope(auth_envelope, expected_org=self.organization_id)
         if not request_user_id_raw:
             return {"error": "Missing or invalid authenticated user context for trigger_workflow"}
+        logger.warning(
+            "[AppsConnector] Received trigger_workflow request app_id=%s workflow_id=%s request_id=%s connector_owner_user_id=%s delegated_actor_user_id=%s trigger_data_keys=%s",
+            app_id_raw,
+            workflow_id_raw,
+            request_id,
+            self.user_id,
+            delegated_actor,
+            sorted(trigger_data.keys()) if isinstance(trigger_data, dict) else [],
+        )
 
         try:
             app_uuid = UUID(app_id_raw)
@@ -329,10 +339,11 @@ class AppsConnector(BaseConnector):
             organization_id=self.organization_id,
             triggered_by_user_id=str(request_user_uuid),
         )
-        logger.info(
-            "[AppsConnector] Queued workflow trigger via apps connector app_id=%s workflow_id=%s triggered_user_id=%s connector_owner_user_id=%s delegated_actor_user_id=%s task_id=%s",
+        logger.warning(
+            "[AppsConnector] Queued workflow trigger via apps connector app_id=%s workflow_id=%s request_id=%s triggered_user_id=%s connector_owner_user_id=%s delegated_actor_user_id=%s task_id=%s",
             app_id_raw,
             workflow_id_raw,
+            request_id,
             request_user_uuid,
             self.user_id,
             delegated_actor,
@@ -345,6 +356,7 @@ class AppsConnector(BaseConnector):
             "workflow_id": workflow_id_raw,
             "triggered_by_user_id": str(request_user_uuid),
             "delegated_actor_user_id": delegated_actor,
+            "request_id": request_id,
         }
 
     @staticmethod

--- a/backend/tests/test_apps_connector_workflow_trigger.py
+++ b/backend/tests/test_apps_connector_workflow_trigger.py
@@ -71,6 +71,7 @@ async def test_apps_connector_trigger_workflow_uses_envelope_user_not_connector_
             "workflow_id": workflow_id,
             "_auth_envelope": {"token": "", "sig": ""},
             "trigger_data": {"from": "test"},
+            "request_id": "req-123",
         },
     )
 
@@ -81,6 +82,7 @@ async def test_apps_connector_trigger_workflow_uses_envelope_user_not_connector_
     assert captured["triggered_by_user_id"] == "00000000-0000-0000-0000-000000000005"
     assert captured["triggered_by_user_id"] != user_id
     assert session_kwargs["user_id"] == "00000000-0000-0000-0000-000000000005"
+    assert result["request_id"] == "req-123"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/apps/SandpackAppRenderer.tsx
+++ b/frontend/src/components/apps/SandpackAppRenderer.tsx
@@ -477,7 +477,7 @@ export function SandpackAppRenderer({
             const triggerDataKeys = data.triggerData && typeof data.triggerData === "object"
               ? Object.keys(data.triggerData).sort()
               : [];
-            console.info("[Apps iframe bridge] Trigger workflow request", {
+            console.warn("[Apps iframe bridge] Trigger workflow request", {
               appId: payloadAppId,
               workflowId,
               requestId,
@@ -498,7 +498,7 @@ export function SandpackAppRenderer({
               }),
             });
             if (response.error || !response.data) {
-              console.error("[Apps iframe bridge] Workflow trigger API rejected request", {
+              console.warn("[Apps iframe bridge] Workflow trigger API rejected request", {
                 appId: payloadAppId,
                 workflowId,
                 requestId,
@@ -512,7 +512,7 @@ export function SandpackAppRenderer({
               }, "*");
               return;
             }
-            console.info("[Apps iframe bridge] Workflow trigger queued", {
+            console.warn("[Apps iframe bridge] Workflow trigger queued", {
               appId: payloadAppId,
               workflowId,
               requestId,
@@ -526,7 +526,7 @@ export function SandpackAppRenderer({
               result: response.data,
             }, "*");
           } catch (err) {
-            console.error("[Apps iframe bridge] Trigger workflow failed", err);
+            console.warn("[Apps iframe bridge] Trigger workflow failed", err);
             (event.source as Window | null)?.postMessage({
               type: "app-trigger-workflow-result",
               requestId,


### PR DESCRIPTION
### Motivation
- Make browser-side app workflow trigger breadcrumbs more visible under strict production log filters so host integrators can diagnose failures. 
- Surface and persist a `request_id` through connector and API paths to enable end-to-end correlation of trigger attempts. 
- Ensure server-side connector logs report trigger receipt and queueing at warning level so they are not hidden by INFO-level production filters.

### Description
- Switched host iframe bridge breadcrumbs in `SandpackAppRenderer` from `console.info`/`console.error` to `console.warn` for workflow trigger request, API reject, queued, and exception cases. 
- Extended `AppsConnector._trigger_workflow` to accept a `request_id`, emit a `logger.warning` on request receipt (including trigger-data keys and delegated actor context), include `request_id` in queue logging, and return `request_id` in the connector response. 
- Promoted Apps API lifecycle breadcrumbs in `backend/api/routes/apps.py` (request received, run created, queued) from `logger.info` to `logger.warning`. 
- Updated connector test `backend/tests/test_apps_connector_workflow_trigger.py` to supply a `request_id` and assert it is propagated in the connector response. 

### Testing
- Ran `pytest -q backend/tests/test_apps_connector_workflow_trigger.py backend/tests/test_apps_workflow_trigger.py`, which completed with `4 passed, 1 warning` (the warning is a pre-existing `datetime.utcnow()` deprecation notice).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f95adf28708321bb85fca9fbceeea5)