### PR TITLE
Show invited email in auth invite banner

### DIFF
--- a/frontend/src/components/Auth.tsx
+++ b/frontend/src/components/Auth.tsx
@@ -229,7 +229,19 @@ export function Auth({ onBack, onSuccess }: AuthProps): JSX.Element {
               ) : null}
               <p className="text-surface-300 text-sm leading-relaxed">
                 {inviteContext.inviterName ? (
-                  <><span className="text-surface-100 font-medium">{inviteContext.inviterName}</span> invited you to join</>
+                  <>
+                    <span className="text-surface-100 font-medium">{inviteContext.inviterName}</span>
+                    {' '}
+                    invited
+                    {inviteContext.email ? (
+                      <>
+                        {' '}
+                        <span className="text-surface-100 font-medium">({inviteContext.email})</span>
+                      </>
+                    ) : null}
+                    {' '}
+                    to join
+                  </>
                 ) : (
                   <>You've been invited to join</>
                 )}


### PR DESCRIPTION
### Motivation
- Clarify the invite UX by including the invited email in the banner so recipients can see which address was invited when an inviter name is displayed.

### Description
- Update `frontend/src/components/Auth.tsx` to render the invited email in parentheses after the inviter's name when `inviteContext.email` is present, while keeping the existing fallback copy when inviter details are missing.

### Testing
- Ran `npm -C frontend run -s lint` which succeeded and `npm -C frontend run -s typecheck` which failed (non-zero exit code); no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f95d1b62ec8321906b3d36c70fa152)