### PR TITLE
Add admin-view guard diagnostics in AppLayout

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1764,12 +1764,23 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
 
   useEffect(() => {
     if (currentView === 'admin' && !isGlobalAdmin) {
+      console.warn('[AppLayout] Blocking admin view: missing global_admin role', {
+        currentPath: window.location.pathname,
+        userId: user?.id ?? null,
+        userRoles: user?.roles ?? [],
+        masqueradeOriginalRoles: masquerade?.originalUser.roles ?? [],
+      });
       setCurrentView('home');
     }
     if (currentView === 'activity-log' && !isOrgAdmin) {
+      console.warn('[AppLayout] Blocking activity-log view: missing org admin access', {
+        currentPath: window.location.pathname,
+        userId: user?.id ?? null,
+        userRoles: user?.roles ?? [],
+      });
       setCurrentView('home');
     }
-  }, [currentView, isGlobalAdmin, isOrgAdmin, setCurrentView]);
+  }, [currentView, isGlobalAdmin, isOrgAdmin, masquerade, setCurrentView, user?.id, user?.roles]);
 
   // Guard against missing user/org (shouldn't happen, but be safe)
   if (!user || !organization || isSwitchingOrg) {


### PR DESCRIPTION
### Motivation
- Make the silent redirect from admin/activity-log views observable so we can diagnose cases where `/admin/*` appears blocked even when a user has the `global_admin` role. 

### Description
- Add structured `console.warn` diagnostics and include `currentPath`, `userId`, `user.roles`, and `masquerade.originalUser.roles` before redirecting to home in `frontend/src/components/AppLayout.tsx`, and update the `useEffect` dependency list to include `masquerade` and `user` values. 

### Testing
- Ran frontend lint for the modified file with `npm run -s lint -- src/components/AppLayout.tsx`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f961c76c088321b0b21838d4acddd7)