### PR TITLE
Fix global admin detection for legacy `role` field

### DIFF
--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -164,9 +164,13 @@ export const useCurrentView = () => useUIStore((state) => state.currentView);
 /** True if the signed-in user or the pre-masquerade admin is global_admin (UI access while impersonating). */
 export const useIsGlobalAdmin = (): boolean =>
   useAuthStore((state) => {
+    const currentUserRole = (state.user as { role?: string } | null)?.role;
+    if (currentUserRole === "global_admin") return true;
     if (state.user?.roles?.includes("global_admin")) return true;
-    if (state.masquerade?.originalUser.roles?.includes("global_admin"))
-      return true;
+
+    const originalUserRole = (state.masquerade?.originalUser as { role?: string } | undefined)?.role;
+    if (originalUserRole === "global_admin") return true;
+    if (state.masquerade?.originalUser.roles?.includes("global_admin")) return true;
     return false;
   });
 /** True if the signed-in user is an admin of the current organization. */


### PR DESCRIPTION
### Motivation
- Client-side admin guard could block access to `/admin/*` (including `/admin/graph-magic`) when user payloads used the legacy `role` string instead of the modern `roles[]` array, and the same issue affected masquerading (original user) checks.

### Description
- Update `useIsGlobalAdmin` in `frontend/src/store/index.ts` to check the singular `role` field first and then the `roles[]` array for both the current `user` and `masquerade.originalUser`, preserving admin UI access for legacy payload shapes.

### Testing
- Ran the frontend typecheck with `npm --prefix frontend run -s typecheck`, which exited non-zero in this environment (typecheck could not complete due to local setup), so no further automated test run succeeded here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f961c76c088321b0b21838d4acddd7)