### PR TITLE
Fix unauthorized user sync during app bootstrap

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { supabase } from './lib/supabase';
 import { getEmailDomain } from './lib/email';
-import { API_BASE } from './lib/api';
+import { API_BASE, getAuthenticatedRequestHeaders } from './lib/api';
 import { useAppStore } from './store';
 import { Auth } from './components/Auth';
 import { OnboardingWizard } from './components/OnboardingWizard';
@@ -287,9 +287,10 @@ function App(): JSX.Element {
     // This catches users who signed up via waitlist form
     // Also handles invited users with personal emails (they'll have a pending invitation)
     try {
+      const authHeaders = await getAuthenticatedRequestHeaders();
       const syncResponse = await fetch(`${API_BASE}/auth/users/sync`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
         body: JSON.stringify({
           id: supabaseUser.id,
           email,


### PR DESCRIPTION
### Motivation
- The app bootstrap called `POST /auth/users/sync` without forwarding the Supabase JWT and scoped headers, which caused the backend to return `401 Unauthorized` and left the frontend `roles` empty (breaking global-admin guards). 

### Description
- Import `getAuthenticatedRequestHeaders` into `frontend/src/App.tsx` and merge those headers into the `/auth/users/sync` request so the `Authorization` and scoped headers are sent with the call. 

### Testing
- Built the frontend with `npm run -s build` and the build completed successfully (Vite warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f963bbd0888321a0f081e217c695c6)