### PR TITLE
Improve app SDK workflow trigger console logging

### DIFF
--- a/frontend/src/components/apps/appSdkSource.ts
+++ b/frontend/src/components/apps/appSdkSource.ts
@@ -121,7 +121,7 @@ export function triggerWorkflow(workflowId, triggerData) {
       if (!payload || payload.type !== "app-trigger-workflow-result" || payload.requestId !== requestId) return;
       cleanup();
       if (payload.ok) {
-        console.info("[App SDK] Workflow trigger queued", { requestId, workflowId, result: payload.result });
+        console.log("[App SDK] Workflow trigger queued", { requestId, workflowId, result: payload.result });
         resolve(payload.result || { status: "queued" });
       } else {
         console.error("[App SDK] Workflow trigger failed", { requestId, workflowId, error: payload.error });
@@ -130,6 +130,7 @@ export function triggerWorkflow(workflowId, triggerData) {
     };
 
     window.addEventListener("message", onMessage);
+    console.log("[App SDK] Listening for workflow trigger result", { requestId, workflowId });
     timeoutId = setTimeout(() => {
       cleanup();
       console.error("[App SDK] Workflow trigger timed out", { requestId, workflowId });
@@ -138,7 +139,7 @@ export function triggerWorkflow(workflowId, triggerData) {
 
     try {
       const sanitizedTriggerData = triggerData && typeof triggerData === "object" ? triggerData : undefined;
-      console.info("[App SDK] Requesting workflow trigger", {
+      console.log("[App SDK] Requesting workflow trigger", {
         requestId,
         appId: APP_ID,
         workflowId,


### PR DESCRIPTION
### Motivation
- Browser devtools often hide `console.info`, causing no visible output when apps call `triggerWorkflow`; switching to `console.log` and adding an explicit listener registration log makes debugging the postMessage round-trip easier.

### Description
- Changed `console.info` to `console.log` for the request and queued events and added `console.log("[App SDK] Listening for workflow trigger result", { requestId, workflowId })` immediately after `window.addEventListener("message", onMessage)` in `frontend/src/components/apps/appSdkSource.ts`.

### Testing
- No automated tests were run for this change; the patch was validated by inspecting the `git diff` for `frontend/src/components/apps/appSdkSource.ts` and committing the updated file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9641087748321b8773da37a825bb1)