### PR TITLE
apps: add status callbacks and improved logging/timeouts to triggerWorkflow

### DIFF
--- a/frontend/src/components/apps/appSdkSource.ts
+++ b/frontend/src/components/apps/appSdkSource.ts
@@ -102,13 +102,28 @@ export function useAppQuery(queryName, params, options) {
 
 // ---------------------------------------------------------------------------
 // triggerWorkflow – request host window to enqueue a workflow from this app
+//
+// Usage:
+// await triggerWorkflow("<workflow-id>", { foo: "bar" });
+//
+// Optional status listener:
+// await triggerWorkflow("<workflow-id>", { foo: "bar" }, {
+//   onStatus: ({ stage, requestId, error, result }) => {
+//     console.log("[My App] workflow trigger status", stage, { requestId, error, result });
+//   },
+// });
 // ---------------------------------------------------------------------------
-export function triggerWorkflow(workflowId, triggerData) {
+export function triggerWorkflow(workflowId, triggerData, options) {
   const requestId = (globalThis.crypto && globalThis.crypto.randomUUID)
     ? globalThis.crypto.randomUUID()
     : (Date.now().toString(36) + Math.random().toString(36).slice(2));
 
   return new Promise((resolve, reject) => {
+    const notify = (stage, details) => {
+      try {
+        if (options && typeof options.onStatus === "function") options.onStatus({ stage, ...details });
+      } catch (_) {}
+    };
     let timeoutId = null;
 
     const cleanup = () => {
@@ -121,24 +136,35 @@ export function triggerWorkflow(workflowId, triggerData) {
       if (!payload || payload.type !== "app-trigger-workflow-result" || payload.requestId !== requestId) return;
       cleanup();
       if (payload.ok) {
-        console.info("[App SDK] Workflow trigger queued", { requestId, workflowId, result: payload.result });
+        notify("queued", { requestId, workflowId, result: payload.result });
+        console.log("[App SDK] Workflow trigger queued", { requestId, workflowId, result: payload.result });
         resolve(payload.result || { status: "queued" });
       } else {
+        notify("failed", { requestId, workflowId, error: payload.error });
         console.error("[App SDK] Workflow trigger failed", { requestId, workflowId, error: payload.error });
         reject(new Error(payload.error || "Failed to trigger workflow"));
       }
     };
 
     window.addEventListener("message", onMessage);
+    notify("listening", { requestId, workflowId });
+    console.log("[App SDK] Listening for workflow trigger result", { requestId, workflowId });
     timeoutId = setTimeout(() => {
       cleanup();
       console.error("[App SDK] Workflow trigger timed out", { requestId, workflowId });
+      notify("timeout", { requestId, workflowId });
       reject(new Error("Timed out waiting for workflow trigger response"));
     }, 15000);
 
     try {
       const sanitizedTriggerData = triggerData && typeof triggerData === "object" ? triggerData : undefined;
-      console.info("[App SDK] Requesting workflow trigger", {
+      console.log("[App SDK] Requesting workflow trigger", {
+        requestId,
+        appId: APP_ID,
+        workflowId,
+        triggerDataKeys: sanitizedTriggerData ? Object.keys(sanitizedTriggerData).sort() : [],
+      });
+      notify("posting", {
         requestId,
         appId: APP_ID,
         workflowId,


### PR DESCRIPTION
### Motivation

- Provide observable lifecycle updates for workflow triggers from apps so callers can react to queued/failed/timeout events. 

### Description

- Add an `options` parameter to `triggerWorkflow` with an `onStatus` callback and invoke it at key stages (`listening`, `posting`, `queued`, `failed`, `timeout`).
- Introduce a local `notify` helper to safely call `options.onStatus` and wrap message posting with sanitized `triggerData` and sorted `triggerDataKeys` for logging.
- Improve console output by switching some `console.info` calls to `console.log` and adding explicit logs for listening and request posting, while preserving existing cleanup and timeout behavior.
- Keep existing message handling and promise resolution semantics, and ensure `window.postMessage` errors are caught and rejected.

### Testing

- Ran the frontend unit test suite and TypeScript type checks, and they passed. 
- Ran the linting process, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9641087748321b8773da37a825bb1)