### PR TITLE
Require validated auth for organization member role updates

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -2361,7 +2361,7 @@ async def update_organization_member_role(
     try:
         org_uuid = UUID(org_id)
         target_uuid = UUID(target_user_id)
-        requester_uuid = UUID(auth.user_id)
+        requester_uuid = auth.user_id
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ID format")
 

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -2350,13 +2350,10 @@ async def update_organization_member_role(
     org_id: str,
     target_user_id: str,
     request: UpdateMemberRoleRequest,
-    user_id: Optional[str] = None,
+    auth: AuthContext = Depends(get_current_auth),
 ) -> dict[str, str]:
     """Promote or demote a member. Requires org admin for this org, or global_admin."""
     from models.org_member import OrgMember
-
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Not authenticated")
 
     if request.role not in {"admin", "member"}:
         raise HTTPException(status_code=400, detail="Role must be 'admin' or 'member'")
@@ -2364,7 +2361,7 @@ async def update_organization_member_role(
     try:
         org_uuid = UUID(org_id)
         target_uuid = UUID(target_user_id)
-        requester_uuid = UUID(user_id)
+        requester_uuid = UUID(auth.user_id)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ID format")
 


### PR DESCRIPTION
### Motivation
- The `PATCH /auth/organizations/{org_id}/members/{target_user_id}/role` endpoint previously trusted a caller-provided `user_id` query parameter for authorization, allowing an attacker to spoof an admin identity and escalate privileges.

### Description
- Replaced the untrusted `user_id` query parameter with `auth: AuthContext = Depends(get_current_auth)` and derive the requester as `UUID(auth.user_id)` in `backend/api/routes/auth.py` so identity comes from validated auth middleware rather than a caller-controlled value.

### Testing
- Compiled the modified module with `python -m compileall backend/api/routes/auth.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1408c170832180e845421df5b21b)