### PR TITLE
Secure guest-user toggle with authenticated JWT context

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -2726,17 +2726,15 @@ async def delete_organization(
 async def update_guest_user(
     org_id: str,
     request: UpdateGuestUserRequest,
-    user_id: Optional[str] = None,
+    auth: AuthContext = Depends(get_current_auth),
 ) -> dict[str, bool]:
     """Enable/disable guest user fallback for unmapped Slack identities."""
     try:
         org_uuid = UUID(org_id)
-        user_uuid = UUID(user_id) if user_id else None
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ID format")
 
-    if not user_uuid:
-        raise HTTPException(status_code=401, detail="Not authenticated")
+    user_uuid = auth.user_id
 
     async with get_session(organization_id=org_id) as session:
         requesting_user = await session.get(User, user_uuid)

--- a/backend/tests/test_auth_guest_identity_guards.py
+++ b/backend/tests/test_auth_guest_identity_guards.py
@@ -151,7 +151,13 @@ def test_update_guest_user_scopes_session_to_org(monkeypatch):
         auth.update_guest_user(
             org_id=str(org_id),
             request=auth.UpdateGuestUserRequest(enabled=True),
-            user_id=str(requester_id),
+            auth=auth.AuthContext(
+                user_id=requester_id,
+                organization_id=org_id,
+                email="admin@example.com",
+                role="admin",
+                is_global_admin=False,
+            ),
         )
     )
 


### PR DESCRIPTION
### Motivation
- Prevent unauthorized toggling of the guest-user fallback by removing trust in a client-supplied `user_id` query parameter which allowed low-privilege callers to enable Slack guest mapping.
- Ensure the route uses the verified JWT-backed identity and existing org-admin/global-admin checks to authorize this sensitive operation.

### Description
- Changed the `PATCH /organizations/{org_id}/guest-user` handler to require `AuthContext = Depends(get_current_auth)` and removed the `user_id` query parameter from the route signature.
- The handler now derives the acting user from `auth.user_id` instead of accepting a client-provided UUID, while preserving the `_can_administer_org` authorization check and org-scoped `get_session` behavior.
- Updated the targeted unit test `test_update_guest_user_scopes_session_to_org` to pass an `AuthContext` object to the route function instead of a `user_id` string to match the new signature.

### Testing
- Ran `pytest -q backend/tests/test_auth_guest_identity_guards.py` and all tests passed: `3 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1613a2dc83218e85e55b58488fe9)