### PR TITLE
Normalize app ID comparison in iframe bridge to fix app-triggered workflows

### DIFF
--- a/frontend/src/components/apps/SandpackAppRenderer.tsx
+++ b/frontend/src/components/apps/SandpackAppRenderer.tsx
@@ -456,7 +456,15 @@ export function SandpackAppRenderer({
         const requestId = data.requestId;
         const workflowId = data.workflowId;
         const payloadAppId = data.appId;
-        if (!requestId || !workflowId || !payloadAppId || payloadAppId !== appId) {
+        const payloadAppIdMatchesCurrentApp = (() => {
+          if (!payloadAppId) return false;
+          try {
+            return payloadAppId.toLowerCase() === appId.toLowerCase();
+          } catch {
+            return false;
+          }
+        })();
+        if (!requestId || !workflowId || !payloadAppIdMatchesCurrentApp) {
           console.warn("[Apps iframe bridge] Invalid workflow trigger payload", {
             requestId,
             workflowId,


### PR DESCRIPTION
### Motivation
- App workflow triggers were sometimes rejected because the iframe bridge compared app IDs with strict string equality while UUIDs can differ only by letter casing, preventing valid triggers from apps.

### Description
- Updated `frontend/src/components/apps/SandpackAppRenderer.tsx` to perform a case-insensitive comparison (`toLowerCase()`) when validating the `appId` in `app-trigger-workflow` messages and preserved existing logging/invalid-payload behavior.

### Testing
- Ran frontend typecheck with `pnpm -C frontend exec tsc --noEmit` which completed with no errors. 
- Ran backend tests `pytest -q backend/tests/test_apps_connector_workflow_trigger.py backend/tests/test_workflow_trigger_defaults.py` which passed (4 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f96dd8520c83218046070cb49330c0)