### PR TITLE
Require app SDK triggerWorkflow for app workflow triggers

### DIFF
--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -72,6 +72,25 @@ The App component receives NO props. Data is NOT passed in. You MUST call `useAp
   - period: "last_7d", "last_30d", "last_90d", "last_quarter", "this_quarter", "ytd", "last_year", "this_year"
 - Spinner — loading spinner component
 - ErrorBanner({ message }) — error display component
+- triggerWorkflow(workflowId, triggerData?, options?) → Promise<{ok, runId, taskId, requestId, workflowId}>
+
+## CRITICAL — Triggering workflows from app frontend_code
+- Always call the SDK helper: `triggerWorkflow(...)` from `@revtops/app-sdk`.
+- Do NOT hand-roll `window.parent.postMessage(...)` for workflow triggers.
+- Do NOT invent message types (for example `basebase:trigger_workflow`).
+- The SDK handles the correct host protocol (`app-trigger-workflow`), requestId correlation, and timeout handling.
+
+Example:
+```jsx
+import { triggerWorkflow } from '@revtops/app-sdk';
+
+async function onRunWorkflow() {
+  const result = await triggerWorkflow('00000000-0000-0000-0000-000000000000', { source: 'button_click' });
+  if (!result?.ok) {
+    throw new Error(result?.error || 'Workflow trigger failed');
+  }
+}
+```
 
 ## Rules
 - All SQL must be SELECT-only. No INSERT/UPDATE/DELETE.

--- a/backend/tests/test_apps_connector_usage_guide.py
+++ b/backend/tests/test_apps_connector_usage_guide.py
@@ -1,0 +1,7 @@
+from connectors.apps import USAGE_GUIDE
+
+
+def test_usage_guide_requires_sdk_trigger_workflow_helper() -> None:
+    assert "Always call the SDK helper: `triggerWorkflow(...)`" in USAGE_GUIDE
+    assert "Do NOT hand-roll `window.parent.postMessage(...)`" in USAGE_GUIDE
+    assert "app-trigger-workflow" in USAGE_GUIDE


### PR DESCRIPTION
### Motivation
- Prevent apps from using fragile hand-rolled `window.parent.postMessage(...)` with incorrect message types (e.g. `basebase:trigger_workflow`) when enqueuing workflows. 
- Standardize workflow triggers on the client SDK so message protocol, `requestId` correlation, and timeout behavior are handled reliably.

### Description
- Extended the `USAGE_GUIDE` in `backend/connectors/apps.py` to document `triggerWorkflow(workflowId, triggerData?, options?)` from `@revtops/app-sdk` and add explicit guardrails against manual `postMessage` usage. 
- Added a concrete JSX example showing how to call `triggerWorkflow(...)` from `frontend_code`.
- Added an automated test `backend/tests/test_apps_connector_usage_guide.py` that asserts the new guidance and protocol string are present in `USAGE_GUIDE`.

### Testing
- Ran `pytest -q backend/tests/test_apps_connector_usage_guide.py` and the new test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97053b694832198eceb6fcf56cd50)