### PR TITLE
apps: hint developers to use SDK workflow trigger path

### DIFF
--- a/frontend/src/components/apps/SandpackAppRenderer.tsx
+++ b/frontend/src/components/apps/SandpackAppRenderer.tsx
@@ -464,6 +464,15 @@ export function SandpackAppRenderer({
             return false;
           }
         })();
+        if (data.transport !== "sdk.triggerWorkflow") {
+          console.warn("[Apps iframe bridge] Workflow trigger should use first-class SDK helper triggerWorkflow() instead of a hand-rolled postMessage", {
+            appId: payloadAppId,
+            workflowId,
+            requestId,
+            transport: data.transport,
+          });
+        }
+
         if (!requestId || !workflowId || !payloadAppIdMatchesCurrentApp) {
           console.warn("[Apps iframe bridge] Invalid workflow trigger payload", {
             requestId,

--- a/frontend/src/components/apps/appSdkSource.ts
+++ b/frontend/src/components/apps/appSdkSource.ts
@@ -101,10 +101,14 @@ export function useAppQuery(queryName, params, options) {
 
 
 // ---------------------------------------------------------------------------
-// triggerWorkflow – request host window to enqueue a workflow from this app
+// triggerWorkflow – first-class app SDK API to enqueue a workflow run from this app
 //
 // Usage:
 // await triggerWorkflow("<workflow-id>", { foo: "bar" });
+//
+// Note: Do not hand-roll window.parent.postMessage("app-trigger-workflow").
+// This helper is the supported codepath and handles request IDs, status updates,
+// validation compatibility, and timeout behavior.
 //
 // Optional status listener:
 // await triggerWorkflow("<workflow-id>", { foo: "bar" }, {
@@ -176,6 +180,7 @@ export function triggerWorkflow(workflowId, triggerData, options) {
         appId: APP_ID,
         workflowId,
         triggerData: sanitizedTriggerData,
+        transport: "sdk.triggerWorkflow",
       }, "*");
     } catch (err) {
       cleanup();


### PR DESCRIPTION
### Motivation
- Prevent apps from using ad-hoc `postMessage` wiring to enqueue workflows by promoting the SDK helper `triggerWorkflow()` as the first-class, supported codepath. 
- Make it easier for the host bridge to recognize SDK-originated trigger requests for better validation, logging, and forward-compatibility.

### Description
- Clarify the API comment in `frontend/src/components/apps/appSdkSource.ts` to state that `triggerWorkflow()` is the first-class SDK API and to discourage hand-rolled `window.parent.postMessage("app-trigger-workflow")` usage. 
- Add a `transport: "sdk.triggerWorkflow"` marker to the object posted by the SDK in `frontend/src/components/apps/appSdkSource.ts`. 
- Add a host-side warning in `frontend/src/components/apps/SandpackAppRenderer.tsx` that logs when `app-trigger-workflow` messages arrive without the expected `transport` marker to nudge authors toward the SDK API. 

### Testing
- Ran the frontend linter with `cd frontend && npm run -s lint -- src/components/apps/appSdkSource.ts src/components/apps/SandpackAppRenderer.tsx`, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f973ac8a508321b01c1e43b5156e4e)