### PR TITLE
Suppress teammate warning for org-scoped connectors

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -707,7 +707,7 @@ def _build_cross_user_connector_warning(
     """Return a user-facing warning when we used a teammate's connector."""
     if not requester_user_id:
         return None
-    if connector_slug in {"slack", "teams", "apps", "web_search"}:
+    if connector_slug in {"slack", "teams"}:
         return None
 
     raw_integration_user_id: Any = getattr(connector_instance, "user_id", None)
@@ -719,10 +719,12 @@ def _build_cross_user_connector_warning(
 
     service_name: str = connector_slug.replace("_", " ").title()
     try:
-        from connectors.registry import resolve_connector
+        from connectors.registry import ConnectorScope, resolve_connector
 
         connector_cls = resolve_connector(connector_slug)
         if connector_cls is not None and getattr(connector_cls, "meta", None) is not None:
+            if connector_cls.meta.scope == ConnectorScope.ORGANIZATION:
+                return None
             service_name = connector_cls.meta.name
     except Exception:
         logger.debug(

--- a/backend/tests/test_action_ledger.py
+++ b/backend/tests/test_action_ledger.py
@@ -616,9 +616,9 @@ class TestChokepoints:
         assert "connect to HubSpot as yourself" in str(result["warning"])
 
 
-    @pytest.mark.parametrize("connector_slug", ["apps", "web_search"])
-    def test_write_on_connector_does_not_add_warning_for_apps_or_web(self, connector_slug: str) -> None:
-        """Cross-user Apps/Web connector use should not add teammate connector warning."""
+    @pytest.mark.parametrize("connector_slug", ["apps", "web_search", "twilio", "code_sandbox", "artifacts"])
+    def test_write_on_connector_does_not_add_warning_for_org_scoped_connectors(self, connector_slug: str) -> None:
+        """Cross-user org-scoped connector use should not add teammate connector warning."""
         from agents import tools
 
         fake_instance = MagicMock()


### PR DESCRIPTION
### Motivation
- Team-scoped connectors (e.g. Twilio, Code Sandbox, Artifacts) were incorrectly showing the "used another teammate's connector" warning when used via a team/org connection. 
- The goal is to suppress that warning for any connector that is truly organization-scoped instead of maintaining a brittle hardcoded allowlist.

### Description
- Changed cross-user warning logic in `backend/agents/tools.py` to check connector metadata scope and return no warning when `connector_cls.meta.scope == ConnectorScope.ORGANIZATION`, while preserving explicit suppression for `slack` and `teams`.
- Removed reliance on a partial hardcoded allowlist and kept connector display-name resolution for user-scoped warnings by using `resolve_connector` and `ConnectorScope` from the registry.
- Expanded tests in `backend/tests/test_action_ledger.py` to include `twilio`, `code_sandbox`, and `artifacts` in the no-warning cases for org-scoped connectors and renamed the test accordingly.

### Testing
- Ran `pytest -q backend/tests/test_action_ledger.py -k "cross_user_non_slack or org_scoped_connectors"` and the targeted tests passed (`6 passed, 36 deselected`).
- Unit tests confirm that user-scoped cross-user usage still emits a warning while org-scoped connectors do not.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa08f8748c8321b1e8937b0e66f325)