### PR TITLE
Add optional transport field to Sandpack iframe message type

### DIFF
--- a/frontend/src/components/apps/SandpackAppRenderer.tsx
+++ b/frontend/src/components/apps/SandpackAppRenderer.tsx
@@ -432,6 +432,7 @@ export function SandpackAppRenderer({
         requestId?: string;
         target?: string;
         appId?: string;
+        transport?: string;
         workflowId?: string;
         triggerData?: Record<string, unknown>;
       } | null;


### PR DESCRIPTION
### Motivation
- Fix a TypeScript build error where `data.transport` was accessed in the app workflow trigger handler but not declared on the typed iframe message payload, causing `TS2339` during `tsc`.

### Description
- Add `transport?: string` to the `event.data` payload type in `frontend/src/components/apps/SandpackAppRenderer.tsx` so runtime checks of `data.transport` are properly typed.

### Testing
- Ran `npm run build` from the `frontend` directory and the build (TypeScript + Vite) completed successfully, confirming the TS2339 errors are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa203708608321ba0053d1cddf9b24)