### PR TITLE
Enforce auth consistency and org-admin checks; add users RLS migration and tests

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -465,6 +465,11 @@ async def get_current_user(
 ) -> UserResponse:
     """Get current authenticated user."""
     if user_id is not None and user_id != auth.user_id_str:
+        logger.warning(
+            "Rejected current-user read with mismatched user_id query param auth_user=%s query_user=%s",
+            auth.user_id_str,
+            user_id,
+        )
         raise HTTPException(
             status_code=403, detail="user_id does not match authenticated user"
         )
@@ -521,6 +526,11 @@ async def update_profile(
 ) -> UserResponse:
     """Update current user's profile."""
     if user_id is not None and user_id != auth.user_id_str:
+        logger.warning(
+            "Rejected current-user profile update with mismatched user_id query param auth_user=%s query_user=%s",
+            auth.user_id_str,
+            user_id,
+        )
         raise HTTPException(
             status_code=403, detail="user_id does not match authenticated user"
         )
@@ -1648,8 +1658,18 @@ async def link_identity(
 
     async with get_session(organization_id=str(org_uuid)) as session:
         requester: User | None = await session.get(User, requester_uuid)
-        if not requester or await _get_org_membership(session, requester_uuid, org_uuid) is None:
-            raise HTTPException(status_code=403, detail="Not authorized to modify this organization")
+        if not await _can_administer_org(session, requester, org_uuid):
+            logger.warning(
+                "Blocked identity link by non-admin org=%s target_user=%s mapping=%s by_user=%s",
+                org_uuid,
+                target_uuid,
+                mapping_uuid,
+                requester_uuid,
+            )
+            raise HTTPException(
+                status_code=403,
+                detail="Org admin or global_admin required to link identities",
+            )
 
         # Verify target user belongs to this org (membership or guest home org)
         target_user: User | None = await session.get(User, target_uuid)
@@ -1834,9 +1854,20 @@ async def unlink_identity(
                 raise HTTPException(status_code=403, detail="Guest user identities cannot be unlinked")
 
         is_unlinking_own_identity = mapping.user_id == requester_uuid
-        can_link_identities_in_org = True  # Mirrors current link-identity access for org members.
-        if not is_unlinking_own_identity and not can_link_identities_in_org:
-            raise HTTPException(status_code=403, detail="Not authorized to unlink this identity")
+        if not is_unlinking_own_identity and not await _can_administer_org(
+            session, requester, org_uuid
+        ):
+            logger.warning(
+                "Blocked identity unlink by non-admin org=%s mapping=%s linked_user=%s by_user=%s",
+                org_uuid,
+                mapping_uuid,
+                mapping.user_id,
+                requester_uuid,
+            )
+            raise HTTPException(
+                status_code=403,
+                detail="Org admin or global_admin required to unlink another user's identity",
+            )
 
         mapping.user_id = None
         mapping.revtops_email = None
@@ -1899,6 +1930,7 @@ async def invite_to_organization(
     org_id: str,
     request: InviteToOrgRequest,
     background_tasks: BackgroundTasks,
+    auth: AuthContext = Depends(get_current_auth),
     user_id: Optional[str] = None,
 ) -> InviteToOrgResponse:
     """Invite a user to an organization by email.
@@ -1909,12 +1941,20 @@ async def invite_to_organization(
     from models.org_member import OrgMember
     from services.email import send_org_invitation_email
 
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Not authenticated")
+    if user_id is not None and user_id != auth.user_id_str:
+        logger.warning(
+            "Rejected org invitation with mismatched user_id query param org=%s auth_user=%s query_user=%s",
+            org_id,
+            auth.user_id_str,
+            user_id,
+        )
+        raise HTTPException(
+            status_code=403, detail="user_id does not match authenticated user"
+        )
 
     try:
         org_uuid = UUID(org_id)
-        inviter_uuid = UUID(user_id)
+        inviter_uuid = auth.user_id
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ID format")
 
@@ -1932,21 +1972,20 @@ async def invite_to_organization(
         if not org:
             raise HTTPException(status_code=404, detail="Organization not found")
 
-        # Require inviter to be an active member, or be a global admin (e.g. Admin Panel inviting to any org)
-        is_global_admin: bool = (
-            inviter.role == "global_admin" or bool(inviter.roles and "global_admin" in inviter.roles)
-        )
-        if not is_global_admin:
-            result = await session.execute(
-                select(OrgMember).where(
-                    OrgMember.user_id == inviter_uuid,
-                    OrgMember.organization_id == org_uuid,
-                    OrgMember.status.in_(MEMBER_ACTIVE_STATUSES),
-                )
+        if not await _can_administer_org(session, inviter, org_uuid):
+            logger.warning(
+                "Blocked org invitation by non-admin org=%s invite_email=%s by_user=%s",
+                org_uuid,
+                invite_email,
+                inviter_uuid,
             )
-            inviter_membership: Optional[OrgMember] = result.scalar_one_or_none()
-            if not inviter_membership:
-                raise HTTPException(status_code=403, detail="Not a member of this organization")
+            raise HTTPException(
+                status_code=403,
+                detail="Org admin or global_admin required to invite users",
+            )
+
+        if request.role not in {"admin", "member"}:
+            raise HTTPException(status_code=400, detail="Role must be 'admin' or 'member'")
 
         # Find or create the target user
         result = await session.execute(
@@ -2056,6 +2095,7 @@ async def invite_missing_slack_users_to_organization(
     org_id: str,
     request: SlackMissingInviteRequest,
     background_tasks: BackgroundTasks,
+    auth: AuthContext = Depends(get_current_auth),
     user_id: Optional[str] = None,
 ) -> SlackMissingInviteResponse:
     """Invite Slack users (with email) who are not already present in the org."""
@@ -2063,12 +2103,20 @@ async def invite_missing_slack_users_to_organization(
     from models.external_identity_mapping import ExternalIdentityMapping
     from services.email import send_org_invitation_email
 
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Not authenticated")
+    if user_id is not None and user_id != auth.user_id_str:
+        logger.warning(
+            "Rejected Slack missing-user invitation with mismatched user_id query param org=%s auth_user=%s query_user=%s",
+            org_id,
+            auth.user_id_str,
+            user_id,
+        )
+        raise HTTPException(
+            status_code=403, detail="user_id does not match authenticated user"
+        )
 
     try:
         org_uuid = UUID(org_id)
-        inviter_uuid = UUID(user_id)
+        inviter_uuid = auth.user_id
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ID format")
 
@@ -2081,10 +2129,16 @@ async def invite_missing_slack_users_to_organization(
         if not org:
             raise HTTPException(status_code=404, detail="Organization not found")
 
-        if not _is_global_admin(inviter):
-            inviter_membership = await _get_org_membership(session, inviter_uuid, org_uuid)
-            if not inviter_membership:
-                raise HTTPException(status_code=403, detail="Not a member of this organization")
+        if not await _can_administer_org(session, inviter, org_uuid):
+            logger.warning(
+                "Blocked Slack missing-user invitation by non-admin org=%s by_user=%s",
+                org_uuid,
+                inviter_uuid,
+            )
+            raise HTTPException(
+                status_code=403,
+                detail="Org admin or global_admin required to invite users",
+            )
 
         slack_integration_result = await session.execute(
             select(Integration.id).where(
@@ -2302,18 +2356,28 @@ async def update_organization_member(
     org_id: str,
     target_user_id: str,
     request: UpdateMemberRequest,
+    auth: AuthContext = Depends(get_current_auth),
     user_id: Optional[str] = None,
 ) -> dict[str, Optional[str]]:
     """Update a member row. Users can edit themselves; org/global admins can edit anyone in-org."""
     from models.org_member import OrgMember, ORG_MEMBER_SCOPING_STATUSES
 
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Not authenticated")
+    if user_id is not None and user_id != auth.user_id_str:
+        logger.warning(
+            "Rejected org member update with mismatched user_id query param org=%s target_user=%s auth_user=%s query_user=%s",
+            org_id,
+            target_user_id,
+            auth.user_id_str,
+            user_id,
+        )
+        raise HTTPException(
+            status_code=403, detail="user_id does not match authenticated user"
+        )
 
     try:
         org_uuid = UUID(org_id)
         target_uuid = UUID(target_user_id)
-        requester_uuid = UUID(user_id)
+        requester_uuid = auth.user_id
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ID format")
 
@@ -2451,6 +2515,7 @@ async def update_organization_member_role(
 async def remove_organization_member(
     org_id: str,
     target_user_id: str,
+    auth: AuthContext = Depends(get_current_auth),
     user_id: Optional[str] = None,
 ) -> dict[str, str]:
     """Remove a member from an organization, and unlink all identities.
@@ -2460,13 +2525,22 @@ async def remove_organization_member(
     from models.org_member import OrgMember
     from models.external_identity_mapping import ExternalIdentityMapping
 
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Not authenticated")
+    if user_id is not None and user_id != auth.user_id_str:
+        logger.warning(
+            "Rejected org member removal with mismatched user_id query param org=%s target_user=%s auth_user=%s query_user=%s",
+            org_id,
+            target_user_id,
+            auth.user_id_str,
+            user_id,
+        )
+        raise HTTPException(
+            status_code=403, detail="user_id does not match authenticated user"
+        )
 
     try:
         org_uuid = UUID(org_id)
         target_uuid = UUID(target_user_id)
-        requester_uuid = UUID(user_id)
+        requester_uuid = auth.user_id
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ID format")
 

--- a/backend/db/migrations/versions/137_users_self_edit.py
+++ b/backend/db/migrations/versions/137_users_self_edit.py
@@ -1,0 +1,135 @@
+"""Restrict users writes to self or org admins.
+
+Revision ID: 137_users_self_edit
+Revises: 136_web_search_integration
+Create Date: 2026-05-05
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "137_users_self_edit"
+down_revision: Union[str, Sequence[str], None] = "136_web_search_integration"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_CURRENT_ORG_ID: str = """
+COALESCE(
+    NULLIF(current_setting('app.current_org_id', true), ''),
+    '00000000-0000-0000-0000-000000000000'
+)
+""".strip()
+
+_CURRENT_USER_ID: str = """
+COALESCE(
+    NULLIF(current_setting('app.current_user_id', true), ''),
+    '00000000-0000-0000-0000-000000000000'
+)
+""".strip()
+
+_USER_VISIBLE_IN_ORG: str = f"""
+EXISTS (
+    SELECT 1
+    FROM org_members visible_membership
+    WHERE visible_membership.user_id = users.id
+      AND visible_membership.organization_id::text = {_CURRENT_ORG_ID}
+)
+""".strip()
+
+_GUEST_VISIBLE_IN_ORG: str = f"""
+(
+    users.is_guest IS TRUE
+    AND users.guest_organization_id IS NOT NULL
+    AND users.guest_organization_id::text = {_CURRENT_ORG_ID}
+)
+""".strip()
+
+_USER_VISIBLE: str = f"({_USER_VISIBLE_IN_ORG}) OR ({_GUEST_VISIBLE_IN_ORG})"
+
+_USER_IS_SELF: str = f"users.id::text = {_CURRENT_USER_ID}"
+
+_ADMIN_IN_CURRENT_ORG: str = f"""
+EXISTS (
+    SELECT 1
+    FROM org_members admin_membership
+    WHERE admin_membership.organization_id::text = {_CURRENT_ORG_ID}
+      AND admin_membership.user_id::text = {_CURRENT_USER_ID}
+      AND admin_membership.role = 'admin'
+      AND admin_membership.status IN ('active', 'onboarding')
+)
+""".strip()
+
+_CAN_EDIT_USER: str = f"({_USER_IS_SELF}) OR ({_ADMIN_IN_CURRENT_ORG})"
+
+
+def upgrade() -> None:
+    assert len(revision) <= 32
+    assert isinstance(down_revision, str) and len(down_revision) <= 32
+
+    # Avoid waiting indefinitely behind long-running user table writes.
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.execute("ALTER TABLE users ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE users FORCE ROW LEVEL SECURITY")
+
+    op.execute("DROP POLICY IF EXISTS org_isolation ON users")
+    op.execute("DROP POLICY IF EXISTS users_select ON users")
+    op.execute("DROP POLICY IF EXISTS users_insert ON users")
+    op.execute("DROP POLICY IF EXISTS users_update ON users")
+    op.execute("DROP POLICY IF EXISTS users_delete ON users")
+
+    op.execute(
+        f"""
+        CREATE POLICY users_select ON users
+        FOR SELECT
+        USING ({_USER_VISIBLE})
+        """
+    )
+
+    # User creation is still orchestrated by application code. Existing RLS
+    # table restrictions apply to subsequent edits once the row is part of an org.
+    op.execute(
+        """
+        CREATE POLICY users_insert ON users
+        FOR INSERT
+        WITH CHECK (true)
+        """
+    )
+
+    op.execute(
+        f"""
+        CREATE POLICY users_update ON users
+        FOR UPDATE
+        USING ({_USER_VISIBLE} AND ({_CAN_EDIT_USER}))
+        WITH CHECK ({_USER_VISIBLE} AND ({_CAN_EDIT_USER}))
+        """
+    )
+
+    op.execute(
+        f"""
+        CREATE POLICY users_delete ON users
+        FOR DELETE
+        USING ({_USER_VISIBLE} AND ({_ADMIN_IN_CURRENT_ORG}))
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.execute("ALTER TABLE users NO FORCE ROW LEVEL SECURITY")
+
+    op.execute("DROP POLICY IF EXISTS users_select ON users")
+    op.execute("DROP POLICY IF EXISTS users_insert ON users")
+    op.execute("DROP POLICY IF EXISTS users_update ON users")
+    op.execute("DROP POLICY IF EXISTS users_delete ON users")
+
+    op.execute(
+        f"""
+        CREATE POLICY org_isolation ON users
+        FOR ALL
+        USING ({_USER_VISIBLE})
+        """
+    )

--- a/backend/tests/test_member_edit_auth.py
+++ b/backend/tests/test_member_edit_auth.py
@@ -1,0 +1,238 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes import auth
+
+
+class _FakeSession:
+    def __init__(self, *, users):
+        self._users = users
+        self.executed = False
+        self.committed = False
+
+    async def get(self, _model, model_id):
+        return self._users.get(model_id)
+
+    async def execute(self, _query):
+        self.executed = True
+        raise AssertionError(
+            "execute should not run when authorization rejects the request"
+        )
+
+    async def commit(self):
+        self.committed = True
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _auth_context(user_id: UUID) -> auth.AuthContext:
+    return auth.AuthContext(
+        user_id=user_id,
+        organization_id=UUID("11111111-1111-1111-1111-111111111111"),
+        email="member@example.com",
+        role="member",
+        is_global_admin=False,
+    )
+
+
+def test_member_update_rejects_spoofed_query_user_id_before_self_edit_check(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    authenticated_user_id = UUID("22222222-2222-2222-2222-222222222222")
+    spoofed_admin_id = UUID("33333333-3333-3333-3333-333333333333")
+    target_user_id = UUID("44444444-4444-4444-4444-444444444444")
+
+    fake_session = _FakeSession(
+        users={authenticated_user_id: SimpleNamespace(id=authenticated_user_id)}
+    )
+    monkeypatch.setattr(
+        auth, "get_admin_session", lambda: _FakeSessionContext(fake_session)
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            auth.update_organization_member(
+                org_id=str(org_id),
+                target_user_id=str(target_user_id),
+                request=auth.UpdateMemberRequest(title="VP Sales"),
+                auth=_auth_context(authenticated_user_id),
+                user_id=str(spoofed_admin_id),
+            )
+        )
+
+    assert exc.value.status_code == 403
+    assert "authenticated user" in exc.value.detail
+    assert not fake_session.executed
+    assert not fake_session.committed
+
+
+def test_member_update_rejects_non_admin_editing_another_member(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    requester_id = UUID("22222222-2222-2222-2222-222222222222")
+    target_user_id = UUID("33333333-3333-3333-3333-333333333333")
+
+    fake_session = _FakeSession(users={requester_id: SimpleNamespace(id=requester_id)})
+    monkeypatch.setattr(
+        auth, "get_admin_session", lambda: _FakeSessionContext(fake_session)
+    )
+
+    async def _deny_admin(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr(auth, "_can_administer_org", _deny_admin)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            auth.update_organization_member(
+                org_id=str(org_id),
+                target_user_id=str(target_user_id),
+                request=auth.UpdateMemberRequest(title="VP Sales"),
+                auth=_auth_context(requester_id),
+                user_id=str(requester_id),
+            )
+        )
+
+    assert exc.value.status_code == 403
+    assert "own membership" in exc.value.detail
+    assert not fake_session.executed
+    assert not fake_session.committed
+
+
+def test_member_remove_rejects_spoofed_query_user_id_before_admin_check(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    authenticated_user_id = UUID("22222222-2222-2222-2222-222222222222")
+    spoofed_admin_id = UUID("33333333-3333-3333-3333-333333333333")
+    target_user_id = UUID("44444444-4444-4444-4444-444444444444")
+
+    fake_session = _FakeSession(
+        users={authenticated_user_id: SimpleNamespace(id=authenticated_user_id)}
+    )
+    monkeypatch.setattr(
+        auth, "get_admin_session", lambda: _FakeSessionContext(fake_session)
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            auth.remove_organization_member(
+                org_id=str(org_id),
+                target_user_id=str(target_user_id),
+                auth=_auth_context(authenticated_user_id),
+                user_id=str(spoofed_admin_id),
+            )
+        )
+
+    assert exc.value.status_code == 403
+    assert "authenticated user" in exc.value.detail
+    assert not fake_session.executed
+    assert not fake_session.committed
+
+
+class _FakeBackgroundTasks:
+    def add_task(self, *_args, **_kwargs):
+        raise AssertionError(
+            "background task should not be queued when authorization rejects"
+        )
+
+
+def test_link_identity_rejects_non_admin_member(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    requester_id = UUID("22222222-2222-2222-2222-222222222222")
+    target_user_id = UUID("33333333-3333-3333-3333-333333333333")
+    mapping_id = UUID("44444444-4444-4444-4444-444444444444")
+
+    fake_session = _FakeSession(users={requester_id: SimpleNamespace(id=requester_id)})
+    monkeypatch.setattr(
+        auth, "get_session", lambda **_kwargs: _FakeSessionContext(fake_session)
+    )
+
+    async def _deny_admin(*_args, **_kwargs):
+        return False
+
+    monkeypatch.setattr(auth, "_can_administer_org", _deny_admin)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            auth.link_identity(
+                org_id=str(org_id),
+                request=auth.LinkIdentityRequest(
+                    target_user_id=str(target_user_id),
+                    mapping_id=str(mapping_id),
+                ),
+                auth=_auth_context(requester_id),
+                user_id=str(requester_id),
+            )
+        )
+
+    assert exc.value.status_code == 403
+    assert "admin" in exc.value.detail.lower()
+    assert not fake_session.executed
+    assert not fake_session.committed
+
+
+def test_invite_rejects_spoofed_query_user_id_before_admin_check(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    authenticated_user_id = UUID("22222222-2222-2222-2222-222222222222")
+    spoofed_admin_id = UUID("33333333-3333-3333-3333-333333333333")
+
+    fake_session = _FakeSession(
+        users={authenticated_user_id: SimpleNamespace(id=authenticated_user_id)}
+    )
+    monkeypatch.setattr(
+        auth, "get_admin_session", lambda: _FakeSessionContext(fake_session)
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            auth.invite_to_organization(
+                org_id=str(org_id),
+                request=auth.InviteToOrgRequest(
+                    email="new-user@example.com", role="member"
+                ),
+                background_tasks=_FakeBackgroundTasks(),
+                auth=_auth_context(authenticated_user_id),
+                user_id=str(spoofed_admin_id),
+            )
+        )
+
+    assert exc.value.status_code == 403
+    assert "authenticated user" in exc.value.detail
+    assert not fake_session.executed
+    assert not fake_session.committed
+
+
+def test_update_profile_rejects_spoofed_query_user_id_before_user_edit(monkeypatch):
+    authenticated_user_id = UUID("22222222-2222-2222-2222-222222222222")
+    spoofed_user_id = UUID("33333333-3333-3333-3333-333333333333")
+
+    fake_session = _FakeSession(
+        users={authenticated_user_id: SimpleNamespace(id=authenticated_user_id)}
+    )
+    monkeypatch.setattr(
+        auth, "get_admin_session", lambda: _FakeSessionContext(fake_session)
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            auth.update_profile(
+                request=auth.UpdateProfileRequest(name="Evil Edit"),
+                auth=_auth_context(authenticated_user_id),
+                user_id=str(spoofed_user_id),
+            )
+        )
+
+    assert exc.value.status_code == 403
+    assert "authenticated user" in exc.value.detail
+    assert not fake_session.executed
+    assert not fake_session.committed

--- a/backend/tests/test_update_member_role_blocks_global_admin.py
+++ b/backend/tests/test_update_member_role_blocks_global_admin.py
@@ -64,7 +64,13 @@ def test_update_role_rejects_demotion_of_global_admin(monkeypatch):
                 org_id=str(org_id),
                 target_user_id=str(target_id),
                 request=request,
-                user_id=str(requester_id),
+                auth=auth.AuthContext(
+                    user_id=requester_id,
+                    organization_id=org_id,
+                    email="admin@example.com",
+                    role="admin",
+                    is_global_admin=False,
+                ),
             )
         )
 

--- a/backend/tests/test_users_rls_migration.py
+++ b/backend/tests/test_users_rls_migration.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+def test_users_self_edit_migration_has_safe_revision_ids_and_write_policies():
+    migration_path = Path("backend/db/migrations/versions/137_users_self_edit.py")
+    source = migration_path.read_text()
+
+    namespace: dict[str, object] = {}
+    exec(compile(source, str(migration_path), "exec"), namespace)
+
+    revision = namespace["revision"]
+    down_revision = namespace["down_revision"]
+
+    assert isinstance(revision, str)
+    assert len(revision) <= 32
+    assert isinstance(down_revision, str)
+    assert len(down_revision) <= 32
+    assert "CREATE POLICY users_update ON users" in source
+    assert "users.id::text" in source
+    assert "admin_membership.role = 'admin'" in source
+    assert "CREATE POLICY users_delete ON users" in source
+    assert "ALTER TABLE users FORCE ROW LEVEL SECURITY" in source


### PR DESCRIPTION
### Motivation
- Prevent actions using a spoofed `user_id` query parameter by ensuring the query `user_id` matches the authenticated user and logging mismatches. 
- Restrict org-sensitive operations to org admins or global admins so non-admin members cannot link/unlink identities, invite users, or modify other members. 
- Add database-level protections so user rows can only be modified by the subject user or authorized org admins.

### Description
- Added explicit `user_id` vs `auth.user_id_str` checks that return `403` and write a warning log when the `user_id` query parameter does not match the authenticated user for multiple endpoints such as `get_current_user`, `update_profile`, `invite_to_organization`, `invite_missing_slack_users_to_organization`, `update_organization_member`, and `remove_organization_member`.
- Introduced `auth: AuthContext = Depends(get_current_auth)` to several endpoints and replaced uses of the passed `user_id` string with `auth.user_id` where appropriate. 
- Tightened authorization by requiring `_can_administer_org` (org admin or global_admin) for identity linking/unlinking, organization invitations, Slack bulk-invite, and member removal/update flows, added warning logs for blocked attempts, and added a validation to require invite `role` to be either `admin` or `member`.
- Added a new Alembic migration `137_users_self_edit.py` that enables row-level security on the `users` table and creates policies to allow selects for visible users and to restrict updates/deletes so only the user themself or org admins can edit or delete rows, and added tests `test_member_edit_auth.py`, `test_update_member_role_blocks_global_admin.py`, and `test_users_rls_migration.py` covering the new checks and migration contents.

### Testing
- Ran `backend/tests/test_member_edit_auth.py` which exercises spoofed `user_id` rejection and admin checks, and it passed. 
- Ran `backend/tests/test_update_member_role_blocks_global_admin.py` which verifies global-admin demotion is blocked, and it passed. 
- Ran `backend/tests/test_users_rls_migration.py` which validates migration revision length and presence of expected RLS policies, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa3e07a7148321a301fa6800017e32)