### PR TITLE
Restrict users table writes to self and admins

### DIFF
--- a/backend/db/migrations/versions/137_meeting_scope.py
+++ b/backend/db/migrations/versions/137_meeting_scope.py
@@ -5,7 +5,6 @@ Revises: 136_web_search_integration
 Create Date: 2026-05-06
 
 """
-
 from __future__ import annotations
 
 from typing import Sequence, Union
@@ -13,6 +12,7 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import text
+
 
 revision: str = "137_meeting_scope"
 down_revision: Union[str, None] = "136_web_search_integration"
@@ -52,7 +52,8 @@ def upgrade() -> None:
     # meeting remains team-visible; otherwise keep it private to the owner of the
     # most recently synced linked activity. The grouped CTE keeps the update
     # set-based and avoids broad table locks beyond normal UPDATE row locks.
-    conn.execute(text("""
+    conn.execute(
+        text("""
             WITH scoped AS (
                 SELECT
                     a.meeting_id,
@@ -80,7 +81,8 @@ def upgrade() -> None:
                 visibility = scoped.visibility
             FROM scoped
             WHERE scoped.meeting_id = m.id
-        """))
+        """)
+    )
 
     op.create_index("ix_meetings_integration_id", "meetings", ["integration_id"])
     op.create_index("ix_meetings_owner_user_id", "meetings", ["owner_user_id"])
@@ -92,7 +94,8 @@ def upgrade() -> None:
 
     conn.execute(text("DROP POLICY IF EXISTS org_isolation ON meetings"))
     conn.execute(text("DROP POLICY IF EXISTS org_and_user_isolation ON meetings"))
-    conn.execute(text(f"""
+    conn.execute(
+        text(f"""
             CREATE POLICY org_and_user_isolation ON meetings
             FOR ALL
             USING (
@@ -123,14 +126,16 @@ def upgrade() -> None:
                     )
                 )
             )
-        """))
+        """)
+    )
 
 
 def downgrade() -> None:
     conn = op.get_bind()
 
     conn.execute(text("DROP POLICY IF EXISTS org_and_user_isolation ON meetings"))
-    conn.execute(text(f"""
+    conn.execute(
+        text(f"""
             CREATE POLICY org_isolation ON meetings
             FOR ALL
             USING (
@@ -139,7 +144,8 @@ def downgrade() -> None:
                     '{NULL_UUID}'
                 )
             )
-        """))
+        """)
+    )
 
     op.drop_index("ix_meetings_org_visibility", table_name="meetings")
     op.drop_index("ix_meetings_owner_user_id", table_name="meetings")

--- a/backend/db/migrations/versions/137_meeting_scope.py
+++ b/backend/db/migrations/versions/137_meeting_scope.py
@@ -1,0 +1,149 @@
+"""Scope meetings to ingesting connector.
+
+Revision ID: 137_meeting_scope
+Revises: 136_web_search_integration
+Create Date: 2026-05-06
+
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+revision: str = "137_meeting_scope"
+down_revision: Union[str, None] = "136_web_search_integration"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+NULL_UUID: str = "00000000-0000-0000-0000-000000000000"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    op.add_column(
+        "meetings",
+        sa.Column(
+            "integration_id",
+            sa.UUID(),
+            sa.ForeignKey("integrations.id", ondelete="SET NULL", onupdate="CASCADE"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "meetings",
+        sa.Column(
+            "owner_user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id", ondelete="SET NULL", onupdate="CASCADE"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "meetings",
+        sa.Column("visibility", sa.String(20), nullable=False, server_default="team"),
+    )
+
+    # Backfill from linked activities. If any linked activity is team-visible, the
+    # meeting remains team-visible; otherwise keep it private to the owner of the
+    # most recently synced linked activity. The grouped CTE keeps the update
+    # set-based and avoids broad table locks beyond normal UPDATE row locks.
+    conn.execute(text("""
+            WITH scoped AS (
+                SELECT
+                    a.meeting_id,
+                    CASE
+                        WHEN bool_or(a.visibility = 'team') THEN 'team'::varchar
+                        ELSE 'owner_only'::varchar
+                    END AS visibility,
+                    (
+                        array_agg(a.integration_id ORDER BY a.synced_at DESC NULLS LAST)
+                    )[1] AS integration_id,
+                    CASE
+                        WHEN bool_or(a.visibility = 'team') THEN NULL::uuid
+                        ELSE (
+                            array_agg(a.owner_user_id ORDER BY a.synced_at DESC NULLS LAST)
+                        )[1]
+                    END AS owner_user_id
+                FROM activities a
+                WHERE a.meeting_id IS NOT NULL
+                GROUP BY a.meeting_id
+            )
+            UPDATE meetings m
+            SET
+                integration_id = scoped.integration_id,
+                owner_user_id = scoped.owner_user_id,
+                visibility = scoped.visibility
+            FROM scoped
+            WHERE scoped.meeting_id = m.id
+        """))
+
+    op.create_index("ix_meetings_integration_id", "meetings", ["integration_id"])
+    op.create_index("ix_meetings_owner_user_id", "meetings", ["owner_user_id"])
+    op.create_index(
+        "ix_meetings_org_visibility",
+        "meetings",
+        ["organization_id", "visibility"],
+    )
+
+    conn.execute(text("DROP POLICY IF EXISTS org_isolation ON meetings"))
+    conn.execute(text("DROP POLICY IF EXISTS org_and_user_isolation ON meetings"))
+    conn.execute(text(f"""
+            CREATE POLICY org_and_user_isolation ON meetings
+            FOR ALL
+            USING (
+                organization_id::text = COALESCE(
+                    NULLIF(current_setting('app.current_org_id', true), ''),
+                    '{NULL_UUID}'
+                )
+                AND (
+                    visibility = 'team'
+                    OR owner_user_id IS NULL
+                    OR owner_user_id::text = COALESCE(
+                        NULLIF(current_setting('app.current_user_id', true), ''),
+                        '{NULL_UUID}'
+                    )
+                )
+            )
+            WITH CHECK (
+                organization_id::text = COALESCE(
+                    NULLIF(current_setting('app.current_org_id', true), ''),
+                    '{NULL_UUID}'
+                )
+                AND (
+                    visibility = 'team'
+                    OR owner_user_id IS NULL
+                    OR owner_user_id::text = COALESCE(
+                        NULLIF(current_setting('app.current_user_id', true), ''),
+                        '{NULL_UUID}'
+                    )
+                )
+            )
+        """))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(text("DROP POLICY IF EXISTS org_and_user_isolation ON meetings"))
+    conn.execute(text(f"""
+            CREATE POLICY org_isolation ON meetings
+            FOR ALL
+            USING (
+                organization_id::text = COALESCE(
+                    NULLIF(current_setting('app.current_org_id', true), ''),
+                    '{NULL_UUID}'
+                )
+            )
+        """))
+
+    op.drop_index("ix_meetings_org_visibility", table_name="meetings")
+    op.drop_index("ix_meetings_owner_user_id", table_name="meetings")
+    op.drop_index("ix_meetings_integration_id", table_name="meetings")
+    op.drop_column("meetings", "visibility")
+    op.drop_column("meetings", "owner_user_id")
+    op.drop_column("meetings", "integration_id")

--- a/backend/db/migrations/versions/137_users_self_update.py
+++ b/backend/db/migrations/versions/137_users_self_update.py
@@ -1,0 +1,171 @@
+"""Restrict users writes to self, org admins, or global admins.
+
+Revision ID: 137_users_self_update
+Revises: 136_web_search_integration
+Create Date: 2026-05-06
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "137_users_self_update"
+down_revision: Union[str, None] = "136_web_search_integration"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_EMPTY_UUID: str = "00000000-0000-0000-0000-000000000000"
+
+_CURRENT_ORG_ID: str = f"""
+COALESCE(
+    NULLIF(current_setting('app.current_org_id', true), ''),
+    '{_EMPTY_UUID}'
+)::uuid
+""".strip()
+
+_CURRENT_USER_ID: str = f"""
+COALESCE(
+    NULLIF(current_setting('app.current_user_id', true), ''),
+    '{_EMPTY_UUID}'
+)::uuid
+""".strip()
+
+_USER_VISIBLE_IN_ORG: str = f"""
+EXISTS (
+    SELECT 1
+    FROM org_members m
+    WHERE m.user_id = users.id
+      AND m.organization_id = {_CURRENT_ORG_ID}
+)
+OR (
+    users.is_guest IS TRUE
+    AND users.guest_organization_id IS NOT NULL
+    AND users.guest_organization_id = {_CURRENT_ORG_ID}
+)
+""".strip()
+
+_USER_IS_SELF: str = f"users.id = {_CURRENT_USER_ID}"
+
+_CAN_WRITE_USER: str = f"""
+({_USER_IS_SELF})
+OR current_app_user_is_org_admin({_CURRENT_ORG_ID})
+OR current_app_user_is_global_admin()
+""".strip()
+
+
+_CURRENT_USER_IS_GLOBAL_ADMIN_FUNCTION: str = f"""
+CREATE OR REPLACE FUNCTION current_app_user_is_global_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM users u
+        WHERE u.id = {_CURRENT_USER_ID}
+          AND (
+              u.role = 'global_admin'
+              OR COALESCE(u.roles, '[]'::jsonb) ? 'global_admin'
+          )
+    )
+$$;
+""".strip()
+
+_CURRENT_USER_IS_ORG_ADMIN_FUNCTION: str = f"""
+CREATE OR REPLACE FUNCTION current_app_user_is_org_admin(target_org_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM org_members m
+        WHERE m.organization_id = target_org_id
+          AND m.user_id = {_CURRENT_USER_ID}
+          AND m.role = 'admin'
+          AND m.status IN ('active', 'onboarding')
+    )
+$$;
+""".strip()
+
+
+def upgrade() -> None:
+    assert len(revision) <= 32
+    assert isinstance(down_revision, str) and len(down_revision) <= 32
+
+    op.execute(_CURRENT_USER_IS_GLOBAL_ADMIN_FUNCTION)
+    op.execute(_CURRENT_USER_IS_ORG_ADMIN_FUNCTION)
+    op.execute(
+        "GRANT EXECUTE ON FUNCTION current_app_user_is_global_admin() TO revtops_app"
+    )
+    op.execute(
+        "GRANT EXECUTE ON FUNCTION current_app_user_is_org_admin(uuid) TO revtops_app"
+    )
+
+    op.execute("DROP POLICY IF EXISTS org_isolation ON users")
+    op.execute("DROP POLICY IF EXISTS users_select ON users")
+    op.execute("DROP POLICY IF EXISTS users_insert ON users")
+    op.execute("DROP POLICY IF EXISTS users_update ON users")
+    op.execute("DROP POLICY IF EXISTS users_delete ON users")
+
+    op.execute(
+        f"""
+        CREATE POLICY users_select ON users
+        FOR SELECT
+        USING ({_USER_VISIBLE_IN_ORG})
+        """
+    )
+
+    op.execute(
+        f"""
+        CREATE POLICY users_insert ON users
+        FOR INSERT
+        WITH CHECK (current_app_user_is_global_admin())
+        """
+    )
+
+    op.execute(
+        f"""
+        CREATE POLICY users_update ON users
+        FOR UPDATE
+        USING (({_USER_VISIBLE_IN_ORG}) AND ({_CAN_WRITE_USER}))
+        WITH CHECK (({_USER_VISIBLE_IN_ORG}) AND ({_CAN_WRITE_USER}))
+        """
+    )
+
+    op.execute(
+        f"""
+        CREATE POLICY users_delete ON users
+        FOR DELETE
+        USING (current_app_user_is_global_admin())
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS users_select ON users")
+    op.execute("DROP POLICY IF EXISTS users_insert ON users")
+    op.execute("DROP POLICY IF EXISTS users_update ON users")
+    op.execute("DROP POLICY IF EXISTS users_delete ON users")
+
+    op.execute(
+        f"""
+        CREATE POLICY org_isolation ON users
+        FOR ALL
+        USING ({_USER_VISIBLE_IN_ORG})
+        """
+    )
+
+    op.execute(
+        "REVOKE EXECUTE ON FUNCTION current_app_user_is_org_admin(uuid) FROM revtops_app"
+    )
+    op.execute(
+        "REVOKE EXECUTE ON FUNCTION current_app_user_is_global_admin() FROM revtops_app"
+    )
+    op.execute("DROP FUNCTION IF EXISTS current_app_user_is_org_admin(uuid)")
+    op.execute("DROP FUNCTION IF EXISTS current_app_user_is_global_admin()")

--- a/backend/db/migrations/versions/138_users_self_update.py
+++ b/backend/db/migrations/versions/138_users_self_update.py
@@ -1,17 +1,18 @@
 """Restrict users writes to self, org admins, or global admins.
 
-Revision ID: 137_users_self_update
-Revises: 136_web_search_integration
+Revision ID: 138_users_self_update
+Revises: 137_meeting_scope
 Create Date: 2026-05-06
 """
+
 from __future__ import annotations
 
 from typing import Sequence, Union
 
 from alembic import op
 
-revision: str = "137_users_self_update"
-down_revision: Union[str, None] = "136_web_search_integration"
+revision: str = "138_users_self_update"
+down_revision: Union[str, None] = "137_meeting_scope"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -113,38 +114,30 @@ def upgrade() -> None:
     op.execute("DROP POLICY IF EXISTS users_update ON users")
     op.execute("DROP POLICY IF EXISTS users_delete ON users")
 
-    op.execute(
-        f"""
+    op.execute(f"""
         CREATE POLICY users_select ON users
         FOR SELECT
         USING ({_USER_VISIBLE_IN_ORG})
-        """
-    )
+        """)
 
-    op.execute(
-        f"""
+    op.execute(f"""
         CREATE POLICY users_insert ON users
         FOR INSERT
         WITH CHECK (current_app_user_is_global_admin())
-        """
-    )
+        """)
 
-    op.execute(
-        f"""
+    op.execute(f"""
         CREATE POLICY users_update ON users
         FOR UPDATE
         USING (({_USER_VISIBLE_IN_ORG}) AND ({_CAN_WRITE_USER}))
         WITH CHECK (({_USER_VISIBLE_IN_ORG}) AND ({_CAN_WRITE_USER}))
-        """
-    )
+        """)
 
-    op.execute(
-        f"""
+    op.execute(f"""
         CREATE POLICY users_delete ON users
         FOR DELETE
         USING (current_app_user_is_global_admin())
-        """
-    )
+        """)
 
 
 def downgrade() -> None:
@@ -153,13 +146,11 @@ def downgrade() -> None:
     op.execute("DROP POLICY IF EXISTS users_update ON users")
     op.execute("DROP POLICY IF EXISTS users_delete ON users")
 
-    op.execute(
-        f"""
+    op.execute(f"""
         CREATE POLICY org_isolation ON users
         FOR ALL
         USING ({_USER_VISIBLE_IN_ORG})
-        """
-    )
+        """)
 
     op.execute(
         "REVOKE EXECUTE ON FUNCTION current_app_user_is_org_admin(uuid) FROM revtops_app"

--- a/backend/tests/test_users_self_update_migration.py
+++ b/backend/tests/test_users_self_update_migration.py
@@ -10,14 +10,14 @@ MIGRATION_PATH = (
     / "db"
     / "migrations"
     / "versions"
-    / "137_users_self_update.py"
+    / "138_users_self_update.py"
 )
 
 
 class TestUsersSelfUpdateMigration:
     def _load_migration(self) -> ModuleType:
         spec = importlib.util.spec_from_file_location(
-            "migration_137_users_self_update", MIGRATION_PATH
+            "migration_138_users_self_update", MIGRATION_PATH
         )
         assert spec is not None
         assert spec.loader is not None
@@ -28,6 +28,8 @@ class TestUsersSelfUpdateMigration:
     def test_revision_ids_fit_alembic_limit(self) -> None:
         mig = self._load_migration()
 
+        assert mig.revision == "138_users_self_update"
+        assert mig.down_revision == "137_meeting_scope"
         assert len(mig.revision) <= 32
         assert isinstance(mig.down_revision, str)
         assert len(mig.down_revision) <= 32
@@ -81,5 +83,10 @@ class TestUsersSelfUpdateMigration:
         assert "DROP POLICY IF EXISTS users_delete ON users" in combined_sql
         assert "CREATE POLICY org_isolation ON users" in combined_sql
         assert "FOR ALL" in combined_sql
-        assert "DROP FUNCTION IF EXISTS current_app_user_is_org_admin(uuid)" in combined_sql
-        assert "DROP FUNCTION IF EXISTS current_app_user_is_global_admin()" in combined_sql
+        assert (
+            "DROP FUNCTION IF EXISTS current_app_user_is_org_admin(uuid)"
+            in combined_sql
+        )
+        assert (
+            "DROP FUNCTION IF EXISTS current_app_user_is_global_admin()" in combined_sql
+        )

--- a/backend/tests/test_users_self_update_migration.py
+++ b/backend/tests/test_users_self_update_migration.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "db"
+    / "migrations"
+    / "versions"
+    / "137_users_self_update.py"
+)
+
+
+class TestUsersSelfUpdateMigration:
+    def _load_migration(self) -> ModuleType:
+        spec = importlib.util.spec_from_file_location(
+            "migration_137_users_self_update", MIGRATION_PATH
+        )
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_revision_ids_fit_alembic_limit(self) -> None:
+        mig = self._load_migration()
+
+        assert len(mig.revision) <= 32
+        assert isinstance(mig.down_revision, str)
+        assert len(mig.down_revision) <= 32
+
+    def test_upgrade_replaces_broad_users_policy_with_write_scoped_policies(
+        self,
+    ) -> None:
+        mig = self._load_migration()
+        executed_sql: list[str] = []
+
+        with patch.object(
+            mig.op, "execute", side_effect=lambda sql: executed_sql.append(str(sql))
+        ):
+            mig.upgrade()
+
+        combined_sql = "\n".join(executed_sql)
+
+        assert (
+            "CREATE OR REPLACE FUNCTION current_app_user_is_global_admin()"
+            in combined_sql
+        )
+        assert (
+            "CREATE OR REPLACE FUNCTION current_app_user_is_org_admin(target_org_id uuid)"
+            in combined_sql
+        )
+        assert "SECURITY DEFINER" in combined_sql
+        assert "DROP POLICY IF EXISTS org_isolation ON users" in combined_sql
+        assert "CREATE POLICY users_select ON users" in combined_sql
+        assert "CREATE POLICY users_insert ON users" in combined_sql
+        assert "CREATE POLICY users_update ON users" in combined_sql
+        assert "CREATE POLICY users_delete ON users" in combined_sql
+        assert "users.id = COALESCE" in combined_sql
+        assert "current_app_user_is_org_admin" in combined_sql
+        assert "current_app_user_is_global_admin" in combined_sql
+        assert "WITH CHECK" in combined_sql
+
+    def test_downgrade_restores_historical_users_org_isolation_policy(self) -> None:
+        mig = self._load_migration()
+        executed_sql: list[str] = []
+
+        with patch.object(
+            mig.op, "execute", side_effect=lambda sql: executed_sql.append(str(sql))
+        ):
+            mig.downgrade()
+
+        combined_sql = "\n".join(executed_sql)
+
+        assert "DROP POLICY IF EXISTS users_select ON users" in combined_sql
+        assert "DROP POLICY IF EXISTS users_insert ON users" in combined_sql
+        assert "DROP POLICY IF EXISTS users_update ON users" in combined_sql
+        assert "DROP POLICY IF EXISTS users_delete ON users" in combined_sql
+        assert "CREATE POLICY org_isolation ON users" in combined_sql
+        assert "FOR ALL" in combined_sql
+        assert "DROP FUNCTION IF EXISTS current_app_user_is_org_admin(uuid)" in combined_sql
+        assert "DROP FUNCTION IF EXISTS current_app_user_is_global_admin()" in combined_sql


### PR DESCRIPTION
### Motivation
- Prevent non-admin actors from changing arbitrary rows in the `users` table by narrowing write scope to the row owner, an org admin, or a global admin. 
- Provide safe helper functions to evaluate admin status in RLS policies without causing recursive RLS lookups.

### Description
- Add Alembic migration `137_users_self_update` that replaces the broad `org_isolation` policy on `users` with separate `SELECT`, `INSERT`, `UPDATE`, and `DELETE` policies (`users_select`, `users_insert`, `users_update`, `users_delete`).
- Introduce `SECURITY DEFINER` SQL helper functions `current_app_user_is_global_admin()` and `current_app_user_is_org_admin(target_org_id uuid)` and grant execute to `revtops_app` so RLS checks can safely determine admin rights.
- Scope `UPDATE`/`WITH CHECK` to require the row be visible in the current org and that the actor is either the same user, an org admin for the current org, or a global admin; `INSERT`/`DELETE` remain restricted to global admins where appropriate; `downgrade()` restores the previous `org_isolation` policy and removes the helper functions and grants.

### Testing
- Ran `pytest backend/tests/test_users_self_update_migration.py backend/tests/test_migration_safety.py backend/tests/test_alembic_migration_numbering.py`, all tests passed (5 passed).
- Executed a revision preflight import (`importlib.util`-based check) to assert `revision` and `down_revision` string lengths are <= 32, which succeeded.
- Added `backend/tests/test_users_self_update_migration.py` that asserts the migration emits the expected `CREATE FUNCTION`, `CREATE POLICY`, `WITH CHECK`, and downgrade SQL; this test ran successfully as part of the pytest run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faab41e9d88321960d181ce7d8a98f)