### PR TITLE
Refactor SQL read-safety checks into shared helper and enforce in Apps `test_query`

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -93,6 +93,7 @@ from datetime import datetime as dt
 from typing import TypedDict
 
 from services.automated_agent_footer import ensure_automated_agent_footer
+from services.sql_safety import prepare_safe_sql_query
 
 class PendingOperationData(TypedDict):
     tool_name: str
@@ -189,22 +190,6 @@ class ToolProgressUpdater:
             self.organization_id,
             self.user_id,
         )
-
-
-# Tables that are allowed to be queried (synced data only - no internal admin tables)
-# Note: Row-Level Security (RLS) handles organization filtering at the database level
-ALLOWED_TABLES: set[str] = {
-    "deals", "accounts", "contacts", "activities", "meetings", "integrations", "users", "organizations",
-    "org_members", "apps",
-    "conversations", "chat_messages",
-    "pipelines", "pipeline_stages", "goals", "workflows", "workflow_runs", "user_mappings_for_identity",
-    "github_repositories", "github_commits", "github_pull_requests",
-    "shared_files",
-    "tracker_teams", "tracker_projects", "tracker_issues",
-    "bulk_operations", "bulk_operation_results",
-    "temp_data",
-    "daily_digests", "daily_team_summaries",
-}
 
 
 def get_tools(context: dict[str, Any] | None = None) -> list[dict[str, Any]]:
@@ -405,74 +390,6 @@ def _log_tool_execution_result(
 
     else:
         logger.info("[Tools] %s completed: %s", requested_tool_name, result.get("status", result))
-
-
-def _strip_sql_comments(query: str) -> str:
-    """Remove SQL comments (-- line comments and /* block comments */) from a query."""
-    # Remove block comments /* ... */
-    query = re.sub(r'/\*.*?\*/', '', query, flags=re.DOTALL)
-    # Remove line comments -- ...
-    query = re.sub(r'--[^\n]*', '', query)
-    return query.strip()
-
-
-def _validate_sql_query(query: str) -> tuple[bool, str | None]:
-    """
-    Validate that the SQL query is safe to execute.
-    Returns (is_valid, error_message).
-    """
-    # Strip comments before validation so queries like "-- comment\nSELECT ..." pass
-    query_no_comments: str = _strip_sql_comments(query)
-    query_upper = query_no_comments.upper().strip()
-    
-    # Must start with SELECT (or WITH for CTEs)
-    if not (query_upper.startswith("SELECT") or query_upper.startswith("WITH")):
-        return False, "Only SELECT queries are allowed"
-    
-    # Block dangerous keywords
-    dangerous_keywords: list[str] = [
-        "INSERT", "UPDATE", "DELETE", "DROP", "TRUNCATE", "ALTER", 
-        "CREATE", "GRANT", "REVOKE", "EXECUTE", "EXEC",
-        "INTO OUTFILE", "INTO DUMPFILE", "LOAD_FILE",
-    ]
-    for keyword in dangerous_keywords:
-        # Check for keyword as whole word (not part of column name)
-        if re.search(rf'\b{keyword}\b', query_upper):
-            return False, f"'{keyword}' statements are not allowed"
-    
-    return True, None
-
-
-_SQL_BUILTIN_FUNCTIONS: set[str] = {
-    # Date/time functions that might appear after FROM in expressions
-    "now", "current_date", "current_time", "current_timestamp",
-    "localtime", "localtimestamp", "date", "time", "timestamp",
-    "extract", "date_part", "date_trunc", "age", "interval",
-    # Other common functions that could be mistaken for tables
-    "generate_series", "unnest", "json_each", "json_array_elements",
-    "jsonb_each", "jsonb_array_elements", "regexp_matches",
-    "string_to_array", "lateral", "rows",
-}
-
-
-def _extract_tables_from_query(query: str) -> set[str]:
-    """Extract table names from a SQL query (best effort)."""
-    tables: set[str] = set()
-    
-    # Match FROM and JOIN clauses
-    patterns = [
-        r'\bFROM\s+([a-zA-Z_][a-zA-Z0-9_]*)',
-        r'\bJOIN\s+([a-zA-Z_][a-zA-Z0-9_]*)',
-    ]
-    
-    for pattern in patterns:
-        matches = re.findall(pattern, query, re.IGNORECASE)
-        tables.update(m.lower() for m in matches)
-    
-    # Exclude SQL built-in functions that might be mistaken for tables
-    tables -= _SQL_BUILTIN_FUNCTIONS
-    
-    return tables
 
 
 def _serialize_value(value: Any) -> Any:
@@ -1338,20 +1255,6 @@ async def _run_sql_query(
 
     logger.info("[Tools._run_sql_query] Query: %s", query)
 
-    # Validate query is safe (SELECT only, no dangerous keywords)
-    is_valid, error = _validate_sql_query(query)
-    if not is_valid:
-        logger.warning("[Tools._run_sql_query] Query validation failed: %s", error)
-        return {"error": error}
-
-    # Extract tables and validate they're in the allowed list
-    tables: set[str] = _extract_tables_from_query(query)
-    logger.debug("[Tools._run_sql_query] Detected tables: %s", tables)
-
-    disallowed: set[str] = tables - ALLOWED_TABLES
-    if disallowed:
-        return {"error": f"Access to tables not allowed: {disallowed}"}
-
     # Resolve semantic_embed('...') placeholders into real vectors
     final_query, embed_error = await _resolve_semantic_embeds(query)
     if embed_error is not None:
@@ -1361,24 +1264,20 @@ async def _run_sql_query(
     if not re.search(r'\bLIMIT\b', final_query, re.IGNORECASE):
         final_query = final_query.rstrip(';') + " LIMIT 100"
 
-    rights_ctx = RightsContext(
+    safe_query, safety_error = await prepare_safe_sql_query(
+        query=final_query,
         organization_id=organization_id,
         user_id=user_id,
-        conversation_id=None,
-        is_workflow=False,
+        log_prefix="Tools._run_sql_query",
     )
-    rights_result = await check_sql(rights_ctx, final_query, None)
-    if not rights_result.allowed:
-        return {"error": rights_result.deny_reason or "SQL not allowed"}
-    query_to_run: str = (
-        rights_result.transformed_query if rights_result.transformed_query is not None else final_query
-    )
+    if safety_error is not None or safe_query is None:
+        return {"error": safety_error or "SQL not allowed"}
 
     try:
         async with get_session(
             organization_id=organization_id, user_id=user_id
         ) as session:
-            result = await session.execute(text(query_to_run))
+            result = await session.execute(text(safe_query.query))
             rows = result.fetchall()
             columns: list[str] = list(result.keys())
 

--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -38,6 +38,7 @@ from models.workflow import Workflow
 from services.workflow_pause import get_workflow_execution_pause_until
 from services.public_preview_warmup import warm_public_preview_cache
 from services.slack_identity import get_alternate_slack_user_ids_for_identity
+from services.sql_safety import prepare_safe_sql_query
 
 logger = logging.getLogger(__name__)
 
@@ -908,11 +909,20 @@ class AppsConnector(BaseConnector):
             sql: str = query_spec.get("sql", "")
 
             exec_params: dict[str, Any] = {"org_id": self.organization_id, **query_params}
+            safe_query, safety_error = await prepare_safe_sql_query(
+                query=sql,
+                organization_id=self.organization_id,
+                user_id=self.user_id,
+                params=exec_params,
+                log_prefix="AppsConnector._test_query",
+            )
+            if safety_error is not None or safe_query is None:
+                return {"error": safety_error or "SQL not allowed"}
 
-            limited_sql: str = f"SELECT * FROM ({sql.rstrip().rstrip(';')}) AS _q LIMIT {limit}"
+            limited_sql: str = f"SELECT * FROM ({safe_query.query.rstrip().rstrip(';')}) AS _q LIMIT {limit}"
 
             try:
-                result = await session.execute(text(limited_sql), exec_params)
+                result = await session.execute(text(limited_sql), safe_query.params or {})
                 rows: list[dict[str, Any]] = [dict(row._mapping) for row in result.fetchall()]
 
                 for row in rows:

--- a/backend/services/app_query_runner.py
+++ b/backend/services/app_query_runner.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from datetime import date, datetime
 from decimal import Decimal
 from typing import Any
@@ -14,8 +13,8 @@ from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from access_control import RightsContext, check_sql
 from models.app import App
+from services.sql_safety import prepare_safe_sql_query, validate_sql_query
 
 logger = logging.getLogger(__name__)
 
@@ -25,19 +24,11 @@ class AppQueryResponse(BaseModel):
     columns: list[str]
 
 
-_SELECT_RE = re.compile(r"^\s*SELECT\b", re.IGNORECASE)
-_DANGEROUS_RE = re.compile(
-    r"\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|GRANT|REVOKE|EXEC|EXECUTE)\b",
-    re.IGNORECASE,
-)
-
-
 def validate_sql_is_select(sql: str) -> None:
-    """Raise if the SQL is not a plain SELECT statement."""
-    if not _SELECT_RE.match(sql):
-        raise ValueError("Only SELECT queries are allowed")
-    if _DANGEROUS_RE.search(sql):
-        raise ValueError("Query contains disallowed SQL keywords")
+    """Raise if the SQL is not a safe read query."""
+    is_valid, error = validate_sql_query(sql)
+    if not is_valid:
+        raise ValueError(error or "Only SELECT queries are allowed")
 
 
 def json_serial(obj: Any) -> Any:
@@ -99,28 +90,22 @@ async def run_named_app_query(
         if value is not None:
             bound_params[pname] = value
 
-    sql_upper: str = sql.upper()
-    if "LIMIT" not in sql_upper:
-        sql = f"{sql.rstrip().rstrip(';')} LIMIT 5000"
-
-    rights_ctx = RightsContext(
+    safe_query, safety_error = await prepare_safe_sql_query(
+        query=sql,
         organization_id=organization_id,
         user_id=None,
-        conversation_id=None,
-        is_workflow=False,
+        params=bound_params,
+        log_prefix="AppQueryRunner.run_named_app_query",
     )
-    rights_result = await check_sql(rights_ctx, sql, bound_params)
-    if not rights_result.allowed:
-        raise HTTPException(
-            status_code=403,
-            detail=rights_result.deny_reason or "Query not allowed",
-        )
-    query_to_run: str = (
-        rights_result.transformed_query if rights_result.transformed_query is not None else sql
-    )
-    params_to_use: dict[str, Any] = (
-        rights_result.transformed_params if rights_result.transformed_params is not None else bound_params
-    )
+    if safety_error is not None or safe_query is None:
+        raise HTTPException(status_code=403, detail=safety_error or "Query not allowed")
+
+    query_to_run: str = safe_query.query
+    params_to_use: dict[str, Any] = safe_query.params or {}
+
+    sql_upper: str = query_to_run.upper()
+    if "LIMIT" not in sql_upper:
+        query_to_run = f"{query_to_run.rstrip().rstrip(';')} LIMIT 5000"
 
     try:
         raw_result = await session.execute(text(query_to_run), params_to_use)

--- a/backend/services/sql_safety.py
+++ b/backend/services/sql_safety.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -90,19 +91,116 @@ def _normalize_table_identifier(identifier: str) -> str:
     return table_name.strip('"').lower()
 
 
+_FROM_CLAUSE_BOUNDARY_KEYWORDS: set[str] = {
+    "where",
+    "group",
+    "having",
+    "order",
+    "limit",
+    "offset",
+    "union",
+    "intersect",
+    "except",
+    "qualify",
+    "window",
+}
+
+
+def _iter_from_clause_bodies(query: str) -> Iterator[str]:
+    """Yield text after each FROM keyword up to the next top-level clause boundary."""
+    for match in re.finditer(r'\bFROM\b', query, re.IGNORECASE):
+        start = match.end()
+        index = start
+        depth = 0
+        while index < len(query):
+            char = query[index]
+            if char in {"'", '"'}:
+                quote = char
+                index += 1
+                while index < len(query):
+                    if query[index] == quote:
+                        if index + 1 < len(query) and query[index + 1] == quote:
+                            index += 2
+                            continue
+                        index += 1
+                        break
+                    index += 1
+                continue
+            if char == '(':
+                depth += 1
+                index += 1
+                continue
+            if char == ')':
+                if depth == 0:
+                    break
+                depth -= 1
+                index += 1
+                continue
+            if depth == 0:
+                keyword_match = re.match(r'[a-zA-Z_][a-zA-Z0-9_]*', query[index:])
+                if keyword_match and keyword_match.group(0).lower() in _FROM_CLAUSE_BOUNDARY_KEYWORDS:
+                    break
+            index += 1
+        yield query[start:index]
+
+
+def _split_top_level_commas(clause: str) -> list[str]:
+    """Split a FROM clause body on commas that are not nested or quoted."""
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    index = 0
+    while index < len(clause):
+        char = clause[index]
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            while index < len(clause):
+                if clause[index] == quote:
+                    if index + 1 < len(clause) and clause[index + 1] == quote:
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                index += 1
+            continue
+        if char == '(':
+            depth += 1
+        elif char == ')' and depth > 0:
+            depth -= 1
+        elif char == ',' and depth == 0:
+            parts.append(clause[start:index])
+            start = index + 1
+        index += 1
+    parts.append(clause[start:])
+    return parts
+
+
+def _extract_leading_table_reference(clause_part: str) -> str | None:
+    """Return the first table identifier in a comma-delimited FROM item."""
+    stripped = clause_part.lstrip()
+    if not stripped or stripped.startswith('('):
+        return None
+    match = re.match(rf'({_SQL_QUALIFIED_IDENTIFIER})', stripped, re.IGNORECASE)
+    return match.group(1) if match else None
+
+
 def extract_tables_from_query(query: str) -> set[str]:
     """Extract table names from a SQL query (best effort)."""
     tables: set[str] = set()
 
-    # Match FROM and JOIN clauses, including schema-qualified tables like public.contacts.
-    patterns = [
-        rf'\bFROM\s+({_SQL_QUALIFIED_IDENTIFIER})',
-        rf'\bJOIN\s+({_SQL_QUALIFIED_IDENTIFIER})',
-    ]
+    query = strip_sql_comments(query)
 
-    for pattern in patterns:
-        matches = re.findall(pattern, query, re.IGNORECASE)
-        tables.update(_normalize_table_identifier(match) for match in matches)
+    # Match every explicit JOIN target, including schema-qualified tables like public.contacts.
+    join_matches = re.findall(rf'\bJOIN\s+({_SQL_QUALIFIED_IDENTIFIER})', query, re.IGNORECASE)
+    tables.update(_normalize_table_identifier(match) for match in join_matches)
+
+    # FROM can introduce a comma-delimited table list; each item must be checked.
+    for clause_body in _iter_from_clause_bodies(query):
+        for clause_part in _split_top_level_commas(clause_body):
+            table_reference = _extract_leading_table_reference(clause_part)
+            if table_reference is not None:
+                tables.add(_normalize_table_identifier(table_reference))
 
     # Exclude SQL built-in functions that might be mistaken for tables
     tables -= _SQL_BUILTIN_FUNCTIONS

--- a/backend/services/sql_safety.py
+++ b/backend/services/sql_safety.py
@@ -1,0 +1,140 @@
+"""Shared SQL read-safety checks for agent and app queries."""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from access_control import RightsContext, check_sql
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_TABLES: set[str] = {
+    "deals", "accounts", "contacts", "activities", "meetings", "integrations", "users", "organizations",
+    "org_members", "apps",
+    "conversations", "chat_messages",
+    "pipelines", "pipeline_stages", "goals", "workflows", "workflow_runs", "user_mappings_for_identity",
+    "github_repositories", "github_commits", "github_pull_requests",
+    "shared_files",
+    "tracker_teams", "tracker_projects", "tracker_issues",
+    "bulk_operations", "bulk_operation_results",
+    "temp_data",
+    "daily_digests", "daily_team_summaries",
+}
+
+_SQL_BUILTIN_FUNCTIONS: set[str] = {
+    # Date/time functions that might appear after FROM in expressions
+    "now", "current_date", "current_time", "current_timestamp",
+    "localtime", "localtimestamp", "date", "time", "timestamp",
+    "extract", "date_part", "date_trunc", "age", "interval",
+    # Other common functions that could be mistaken for tables
+    "generate_series", "unnest", "json_each", "json_array_elements",
+    "jsonb_each", "jsonb_array_elements", "regexp_matches",
+    "string_to_array", "lateral", "rows",
+}
+
+
+@dataclass(frozen=True)
+class SafeSqlQuery:
+    """SQL query after shared safety and rights checks."""
+
+    query: str
+    params: dict[str, Any] | None
+    tables: set[str]
+
+
+def strip_sql_comments(query: str) -> str:
+    """Remove SQL comments (-- line comments and /* block comments */) from a query."""
+    # Remove block comments /* ... */
+    query = re.sub(r'/\*.*?\*/', '', query, flags=re.DOTALL)
+    # Remove line comments -- ...
+    query = re.sub(r'--[^\n]*', '', query)
+    return query.strip()
+
+
+def validate_sql_query(query: str) -> tuple[bool, str | None]:
+    """
+    Validate that the SQL query is safe to execute.
+    Returns (is_valid, error_message).
+    """
+    # Strip comments before validation so queries like "-- comment\nSELECT ..." pass
+    query_no_comments: str = strip_sql_comments(query)
+    query_upper = query_no_comments.upper().strip()
+
+    # Must start with SELECT (or WITH for CTEs)
+    if not (query_upper.startswith("SELECT") or query_upper.startswith("WITH")):
+        return False, "Only SELECT queries are allowed"
+
+    # Block dangerous keywords
+    dangerous_keywords: list[str] = [
+        "INSERT", "UPDATE", "DELETE", "DROP", "TRUNCATE", "ALTER",
+        "CREATE", "GRANT", "REVOKE", "EXECUTE", "EXEC",
+        "INTO OUTFILE", "INTO DUMPFILE", "LOAD_FILE",
+    ]
+    for keyword in dangerous_keywords:
+        # Check for keyword as whole word (not part of column name)
+        if re.search(rf'\b{keyword}\b', query_upper):
+            return False, f"'{keyword}' statements are not allowed"
+
+    return True, None
+
+
+def extract_tables_from_query(query: str) -> set[str]:
+    """Extract table names from a SQL query (best effort)."""
+    tables: set[str] = set()
+
+    # Match FROM and JOIN clauses
+    patterns = [
+        r'\bFROM\s+([a-zA-Z_][a-zA-Z0-9_]*)',
+        r'\bJOIN\s+([a-zA-Z_][a-zA-Z0-9_]*)',
+    ]
+
+    for pattern in patterns:
+        matches = re.findall(pattern, query, re.IGNORECASE)
+        tables.update(m.lower() for m in matches)
+
+    # Exclude SQL built-in functions that might be mistaken for tables
+    tables -= _SQL_BUILTIN_FUNCTIONS
+
+    return tables
+
+
+async def prepare_safe_sql_query(
+    *,
+    query: str,
+    organization_id: str,
+    user_id: str | None,
+    params: dict[str, Any] | None = None,
+    conversation_id: str | None = None,
+    is_workflow: bool = False,
+    log_prefix: str = "SQL",
+) -> tuple[SafeSqlQuery | None, str | None]:
+    """Run shared read-query validation, table allowlist, and rights checks."""
+    is_valid, error = validate_sql_query(query)
+    if not is_valid:
+        logger.warning("[%s] Query validation failed: %s", log_prefix, error)
+        return None, error
+
+    tables: set[str] = extract_tables_from_query(query)
+    logger.debug("[%s] Detected tables: %s", log_prefix, tables)
+
+    disallowed: set[str] = tables - ALLOWED_TABLES
+    if disallowed:
+        logger.warning("[%s] Query used disallowed tables: %s", log_prefix, disallowed)
+        return None, f"Access to tables not allowed: {disallowed}"
+
+    rights_ctx = RightsContext(
+        organization_id=organization_id,
+        user_id=user_id,
+        conversation_id=conversation_id,
+        is_workflow=is_workflow,
+    )
+    rights_result = await check_sql(rights_ctx, query, params)
+    if not rights_result.allowed:
+        logger.warning("[%s] Rights check denied SQL: %s", log_prefix, rights_result.deny_reason)
+        return None, rights_result.deny_reason or "SQL not allowed"
+
+    query_to_run: str = rights_result.transformed_query if rights_result.transformed_query is not None else query
+    params_to_use: dict[str, Any] | None = rights_result.transformed_params if rights_result.transformed_params is not None else params
+    return SafeSqlQuery(query=query_to_run, params=params_to_use, tables=tables), None

--- a/backend/services/sql_safety.py
+++ b/backend/services/sql_safety.py
@@ -252,9 +252,38 @@ def _is_unqualified_identifier(identifier: str) -> bool:
     return not re.search(r'\s*\.\s*', identifier)
 
 
-def _extract_table_references_from_from_item(clause_part: str) -> set[str]:
-    """Return leading table identifiers from a comma-delimited FROM item."""
-    stripped = clause_part.lstrip()
+def _iter_sql_keyword_positions(sql: str, keyword: str) -> Iterator[int]:
+    """Yield quote-aware positions of a SQL keyword."""
+    index = 0
+    keyword_len = len(keyword)
+    while index < len(sql):
+        char = sql[index]
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            while index < len(sql):
+                if sql[index] == quote:
+                    if index + 1 < len(sql) and sql[index + 1] == quote:
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                index += 1
+            continue
+        if (
+            sql[index:index + keyword_len].lower() == keyword.lower()
+            and (index == 0 or not (sql[index - 1].isalnum() or sql[index - 1] == '_'))
+            and (index + keyword_len == len(sql) or not (sql[index + keyword_len].isalnum() or sql[index + keyword_len] == '_'))
+        ):
+            yield index
+            index += keyword_len
+            continue
+        index += 1
+
+
+def _extract_leading_table_reference(table_expression: str) -> set[str]:
+    """Return table identifiers from the leading table reference in an expression."""
+    stripped = table_expression.lstrip()
     if not stripped:
         return set()
 
@@ -272,6 +301,16 @@ def _extract_table_references_from_from_item(clause_part: str) -> set[str]:
 
     match = re.match(rf'({_SQL_QUALIFIED_IDENTIFIER})', stripped, re.IGNORECASE)
     return {match.group(1)} if match else set()
+
+
+def _extract_table_references_from_from_item(clause_part: str) -> set[str]:
+    """Return all table identifiers from a comma-delimited FROM item."""
+    references = _extract_leading_table_reference(clause_part)
+
+    for join_index in _iter_sql_keyword_positions(clause_part, "JOIN"):
+        references.update(_extract_leading_table_reference(clause_part[join_index + len("JOIN"):]))
+
+    return references
 
 
 def extract_tables_from_query(query: str) -> set[str]:

--- a/backend/services/sql_safety.py
+++ b/backend/services/sql_safety.py
@@ -204,6 +204,54 @@ def _find_matching_parenthesis(sql: str, open_index: int = 0) -> int | None:
     return None
 
 
+def _iter_cte_names(query: str) -> Iterator[str]:
+    """Yield CTE names declared by a leading WITH clause."""
+    match = re.match(r'\s*WITH\b', query, re.IGNORECASE)
+    if not match:
+        return
+
+    index = match.end()
+    recursive_match = re.match(r'\s*RECURSIVE\b', query[index:], re.IGNORECASE)
+    if recursive_match:
+        index += recursive_match.end()
+
+    while index < len(query):
+        name_match = re.match(rf'\s*({_SQL_IDENTIFIER})', query[index:], re.IGNORECASE)
+        if not name_match:
+            return
+        yield _normalize_table_identifier(name_match.group(1))
+        index += name_match.end()
+
+        # Optional column list after the CTE name: cte_name(col_a, col_b) AS (...).
+        while index < len(query) and query[index].isspace():
+            index += 1
+        if index < len(query) and query[index] == '(':
+            close_index = _find_matching_parenthesis(query, index)
+            if close_index is None:
+                return
+            index = close_index + 1
+
+        as_match = re.match(r'\s*AS\s*\(', query[index:], re.IGNORECASE)
+        if not as_match:
+            return
+        open_index = index + as_match.end() - 1
+        close_index = _find_matching_parenthesis(query, open_index)
+        if close_index is None:
+            return
+        index = close_index + 1
+
+        while index < len(query) and query[index].isspace():
+            index += 1
+        if index >= len(query) or query[index] != ',':
+            return
+        index += 1
+
+
+def _is_unqualified_identifier(identifier: str) -> bool:
+    """Return whether an identifier has no schema/database qualifier."""
+    return not re.search(r'\s*\.\s*', identifier)
+
+
 def _extract_table_references_from_from_item(clause_part: str) -> set[str]:
     """Return leading table identifiers from a comma-delimited FROM item."""
     stripped = clause_part.lstrip()
@@ -231,16 +279,25 @@ def extract_tables_from_query(query: str) -> set[str]:
     tables: set[str] = set()
 
     query = strip_sql_comments(query)
+    cte_names = set(_iter_cte_names(query))
 
     # Match every explicit JOIN target, including schema-qualified tables like public.contacts.
     join_matches = re.findall(rf'\bJOIN\s+({_SQL_QUALIFIED_IDENTIFIER})', query, re.IGNORECASE)
-    tables.update(_normalize_table_identifier(match) for match in join_matches)
+    for match in join_matches:
+        table_name = _normalize_table_identifier(match)
+        if table_name in cte_names and _is_unqualified_identifier(match):
+            continue
+        tables.add(table_name)
 
     # FROM can introduce a comma-delimited table list; each item must be checked.
     for clause_body in _iter_from_clause_bodies(query):
         for clause_part in _split_top_level_commas(clause_body):
             table_references = _extract_table_references_from_from_item(clause_part)
-            tables.update(_normalize_table_identifier(table_reference) for table_reference in table_references)
+            for table_reference in table_references:
+                table_name = _normalize_table_identifier(table_reference)
+                if table_name in cte_names and _is_unqualified_identifier(table_reference):
+                    continue
+                tables.add(table_name)
 
     # Exclude SQL built-in functions that might be mistaken for tables
     tables -= _SQL_BUILTIN_FUNCTIONS

--- a/backend/services/sql_safety.py
+++ b/backend/services/sql_safety.py
@@ -176,13 +176,54 @@ def _split_top_level_commas(clause: str) -> list[str]:
     return parts
 
 
-def _extract_leading_table_reference(clause_part: str) -> str | None:
-    """Return the first table identifier in a comma-delimited FROM item."""
+def _find_matching_parenthesis(sql: str, open_index: int = 0) -> int | None:
+    """Return the index of the parenthesis matching ``open_index``."""
+    depth = 0
+    index = open_index
+    while index < len(sql):
+        char = sql[index]
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            while index < len(sql):
+                if sql[index] == quote:
+                    if index + 1 < len(sql) and sql[index + 1] == quote:
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                index += 1
+            continue
+        if char == '(':
+            depth += 1
+        elif char == ')':
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return None
+
+
+def _extract_table_references_from_from_item(clause_part: str) -> set[str]:
+    """Return leading table identifiers from a comma-delimited FROM item."""
     stripped = clause_part.lstrip()
-    if not stripped or stripped.startswith('('):
-        return None
+    if not stripped:
+        return set()
+
+    if stripped.startswith('('):
+        close_index = _find_matching_parenthesis(stripped)
+        if close_index is None:
+            return set()
+        inner = stripped[1:close_index]
+        if re.match(r'\s*(?:SELECT|WITH|VALUES)\b', inner, re.IGNORECASE):
+            return set()
+        references: set[str] = set()
+        for inner_part in _split_top_level_commas(inner):
+            references.update(_extract_table_references_from_from_item(inner_part))
+        return references
+
     match = re.match(rf'({_SQL_QUALIFIED_IDENTIFIER})', stripped, re.IGNORECASE)
-    return match.group(1) if match else None
+    return {match.group(1)} if match else set()
 
 
 def extract_tables_from_query(query: str) -> set[str]:
@@ -198,9 +239,8 @@ def extract_tables_from_query(query: str) -> set[str]:
     # FROM can introduce a comma-delimited table list; each item must be checked.
     for clause_body in _iter_from_clause_bodies(query):
         for clause_part in _split_top_level_commas(clause_body):
-            table_reference = _extract_leading_table_reference(clause_part)
-            if table_reference is not None:
-                tables.add(_normalize_table_identifier(table_reference))
+            table_references = _extract_table_references_from_from_item(clause_part)
+            tables.update(_normalize_table_identifier(table_reference) for table_reference in table_references)
 
     # Exclude SQL built-in functions that might be mistaken for tables
     tables -= _SQL_BUILTIN_FUNCTIONS

--- a/backend/services/sql_safety.py
+++ b/backend/services/sql_safety.py
@@ -80,19 +80,29 @@ def validate_sql_query(query: str) -> tuple[bool, str | None]:
     return True, None
 
 
+_SQL_IDENTIFIER = r'(?:(?:"[^"]+")|(?:[a-zA-Z_][a-zA-Z0-9_]*))'
+_SQL_QUALIFIED_IDENTIFIER = rf'{_SQL_IDENTIFIER}(?:\s*\.\s*{_SQL_IDENTIFIER})*'
+
+
+def _normalize_table_identifier(identifier: str) -> str:
+    """Return the table/object name from a possibly schema-qualified identifier."""
+    table_name = re.split(r'\s*\.\s*', identifier)[-1]
+    return table_name.strip('"').lower()
+
+
 def extract_tables_from_query(query: str) -> set[str]:
     """Extract table names from a SQL query (best effort)."""
     tables: set[str] = set()
 
-    # Match FROM and JOIN clauses
+    # Match FROM and JOIN clauses, including schema-qualified tables like public.contacts.
     patterns = [
-        r'\bFROM\s+([a-zA-Z_][a-zA-Z0-9_]*)',
-        r'\bJOIN\s+([a-zA-Z_][a-zA-Z0-9_]*)',
+        rf'\bFROM\s+({_SQL_QUALIFIED_IDENTIFIER})',
+        rf'\bJOIN\s+({_SQL_QUALIFIED_IDENTIFIER})',
     ]
 
     for pattern in patterns:
         matches = re.findall(pattern, query, re.IGNORECASE)
-        tables.update(m.lower() for m in matches)
+        tables.update(_normalize_table_identifier(match) for match in matches)
 
     # Exclude SQL built-in functions that might be mistaken for tables
     tables -= _SQL_BUILTIN_FUNCTIONS

--- a/backend/tests/test_apps_connector_test_query_safety.py
+++ b/backend/tests/test_apps_connector_test_query_safety.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+from access_control import RightsResult
+from connectors.apps import AppsConnector
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _RowsResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+
+class _FakeRow:
+    def __init__(self, mapping):
+        self._mapping = mapping
+
+
+class _FakeSession:
+    def __init__(self, app):
+        self._app = app
+        self.executed_sql = []
+
+    async def execute(self, query, params=None):
+        query_text = str(query)
+        self.executed_sql.append((query_text, params))
+        if len(self.executed_sql) == 1:
+            return _ScalarResult(self._app)
+        return _RowsResult([_FakeRow({"name": "Ada"})])
+
+
+@pytest.mark.asyncio
+async def test_apps_test_query_rejects_disallowed_tables(monkeypatch: pytest.MonkeyPatch) -> None:
+    org_id = "00000000-0000-0000-0000-000000000001"
+    app_id = "00000000-0000-0000-0000-000000000002"
+    app = SimpleNamespace(
+        id=UUID(app_id),
+        organization_id=UUID(org_id),
+        queries={"unsafe": {"sql": "SELECT * FROM pending_operations", "params": {}}},
+    )
+    fake_session = _FakeSession(app)
+
+    @asynccontextmanager
+    async def _fake_get_session(**_kwargs):
+        yield fake_session
+
+    monkeypatch.setattr("connectors.apps.get_session", _fake_get_session)
+
+    connector = AppsConnector(organization_id=org_id, user_id="00000000-0000-0000-0000-000000000003")
+    result = await connector.write("test_query", {"app_id": app_id, "query_name": "unsafe"})
+
+    assert result == {"error": "Access to tables not allowed: {'pending_operations'}"}
+    assert len(fake_session.executed_sql) == 1
+
+
+@pytest.mark.asyncio
+async def test_apps_test_query_applies_rights_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+    org_id = "00000000-0000-0000-0000-000000000001"
+    user_id = "00000000-0000-0000-0000-000000000003"
+    app_id = "00000000-0000-0000-0000-000000000002"
+    app = SimpleNamespace(
+        id=UUID(app_id),
+        organization_id=UUID(org_id),
+        queries={"contacts": {"sql": "SELECT name FROM contacts WHERE status = :status", "params": {}}},
+    )
+    fake_session = _FakeSession(app)
+
+    @asynccontextmanager
+    async def _fake_get_session(**_kwargs):
+        yield fake_session
+
+    async def _deny_sql(context, query, params):
+        assert context.organization_id == org_id
+        assert context.user_id == user_id
+        assert query == "SELECT name FROM contacts WHERE status = :status"
+        assert params == {"org_id": org_id, "status": "active"}
+        return RightsResult(allowed=False, deny_reason="No contact access")
+
+    monkeypatch.setattr("connectors.apps.get_session", _fake_get_session)
+    monkeypatch.setattr("services.sql_safety.check_sql", _deny_sql)
+
+    connector = AppsConnector(organization_id=org_id, user_id=user_id)
+    result = await connector.write(
+        "test_query",
+        {"app_id": app_id, "query_name": "contacts", "params": {"status": "active"}},
+    )
+
+    assert result == {"error": "No contact access"}
+    assert len(fake_session.executed_sql) == 1

--- a/backend/tests/test_sql_safety.py
+++ b/backend/tests/test_sql_safety.py
@@ -45,3 +45,36 @@ async def test_prepare_safe_sql_query_applies_rights_transform(monkeypatch: pyte
     assert safe_query.query == "SELECT * FROM contacts LIMIT :limit"
     assert safe_query.params == {"limit": 5}
     assert safe_query.tables == {"contacts"}
+
+
+@pytest.mark.asyncio
+async def test_prepare_safe_sql_query_allows_schema_qualified_allowed_tables(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_check_sql(context, query, params):
+        assert query == "SELECT * FROM public.contacts"
+        return RightsResult(allowed=True)
+
+    monkeypatch.setattr(sql_safety, "check_sql", _fake_check_sql)
+
+    safe_query, error = await sql_safety.prepare_safe_sql_query(
+        query="SELECT * FROM public.contacts",
+        organization_id="org-1",
+        user_id="user-1",
+    )
+
+    assert error is None
+    assert safe_query is not None
+    assert safe_query.tables == {"contacts"}
+
+
+def test_extract_tables_from_query_uses_table_name_from_qualified_identifiers() -> None:
+    tables = sql_safety.extract_tables_from_query(
+        'SELECT * FROM public.contacts c JOIN "custom_schema"."accounts" a ON a.id = c.account_id'
+    )
+
+    assert tables == {"contacts", "accounts"}
+
+
+def test_extract_tables_from_query_rejects_qualified_disallowed_table_not_schema() -> None:
+    tables = sql_safety.extract_tables_from_query("SELECT * FROM public.pending_operations")
+
+    assert tables == {"pending_operations"}

--- a/backend/tests/test_sql_safety.py
+++ b/backend/tests/test_sql_safety.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from access_control import RightsResult
+from services import sql_safety
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_prepare_safe_sql_query_rejects_disallowed_tables() -> None:
+    safe_query, error = await sql_safety.prepare_safe_sql_query(
+        query="SELECT * FROM pending_operations",
+        organization_id="00000000-0000-0000-0000-000000000001",
+        user_id="00000000-0000-0000-0000-000000000002",
+    )
+
+    assert safe_query is None
+    assert error == "Access to tables not allowed: {'pending_operations'}"
+
+
+@pytest.mark.asyncio
+async def test_prepare_safe_sql_query_applies_rights_transform(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake_check_sql(context, query, params):
+        assert context.organization_id == "org-1"
+        assert context.user_id == "user-1"
+        assert query == "SELECT * FROM contacts"
+        assert params == {"limit": 10}
+        return RightsResult(
+            allowed=True,
+            transformed_query="SELECT * FROM contacts LIMIT :limit",
+            transformed_params={"limit": 5},
+        )
+
+    monkeypatch.setattr(sql_safety, "check_sql", _fake_check_sql)
+
+    safe_query, error = await sql_safety.prepare_safe_sql_query(
+        query="SELECT * FROM contacts",
+        organization_id="org-1",
+        user_id="user-1",
+        params={"limit": 10},
+    )
+
+    assert error is None
+    assert safe_query is not None
+    assert safe_query.query == "SELECT * FROM contacts LIMIT :limit"
+    assert safe_query.params == {"limit": 5}
+    assert safe_query.tables == {"contacts"}

--- a/backend/tests/test_sql_safety.py
+++ b/backend/tests/test_sql_safety.py
@@ -185,3 +185,35 @@ def test_extract_tables_from_query_keeps_schema_qualified_table_matching_cte_nam
     )
 
     assert tables == {"contacts", "pending_operations"}
+
+
+def test_extract_tables_from_query_reads_parenthesized_join_target_tables() -> None:
+    tables = sql_safety.extract_tables_from_query(
+        "SELECT * FROM contacts c JOIN (pending_operations p JOIN contacts c2 ON true) x ON true"
+    )
+
+    assert tables == {"contacts", "pending_operations"}
+
+
+@pytest.mark.asyncio
+async def test_prepare_safe_sql_query_rejects_disallowed_parenthesized_join_target() -> None:
+    safe_query, error = await sql_safety.prepare_safe_sql_query(
+        query="SELECT * FROM contacts c JOIN (pending_operations p JOIN contacts c2 ON true) x ON true",
+        organization_id="00000000-0000-0000-0000-000000000001",
+        user_id="00000000-0000-0000-0000-000000000002",
+    )
+
+    assert safe_query is None
+    assert error == "Access to tables not allowed: {'pending_operations'}"
+
+
+def test_extract_tables_from_query_parses_all_tables_then_discards_ctes() -> None:
+    tables = sql_safety.extract_tables_from_query(
+        """
+        WITH recent AS (SELECT * FROM contacts),
+             hidden AS (SELECT * FROM pending_operations)
+        SELECT * FROM recent JOIN hidden ON true
+        """
+    )
+
+    assert tables == {"contacts", "pending_operations"}

--- a/backend/tests/test_sql_safety.py
+++ b/backend/tests/test_sql_safety.py
@@ -110,3 +110,29 @@ async def test_prepare_safe_sql_query_rejects_disallowed_comma_separated_table()
 
     assert safe_query is None
     assert error == "Access to tables not allowed: {'pending_operations'}"
+
+
+def test_extract_tables_from_query_reads_left_side_of_parenthesized_join() -> None:
+    tables = sql_safety.extract_tables_from_query(
+        "SELECT * FROM (pending_operations JOIN contacts ON true) AS p"
+    )
+
+    assert tables == {"pending_operations", "contacts"}
+
+
+@pytest.mark.asyncio
+async def test_prepare_safe_sql_query_rejects_disallowed_parenthesized_join_left_side() -> None:
+    safe_query, error = await sql_safety.prepare_safe_sql_query(
+        query="SELECT * FROM (pending_operations JOIN contacts ON true) AS p",
+        organization_id="00000000-0000-0000-0000-000000000001",
+        user_id="00000000-0000-0000-0000-000000000002",
+    )
+
+    assert safe_query is None
+    assert error == "Access to tables not allowed: {'pending_operations'}"
+
+
+def test_extract_tables_from_query_does_not_treat_parenthesized_subquery_keyword_as_table() -> None:
+    tables = sql_safety.extract_tables_from_query("SELECT * FROM (SELECT * FROM contacts) AS c")
+
+    assert tables == {"contacts"}

--- a/backend/tests/test_sql_safety.py
+++ b/backend/tests/test_sql_safety.py
@@ -136,3 +136,52 @@ def test_extract_tables_from_query_does_not_treat_parenthesized_subquery_keyword
     tables = sql_safety.extract_tables_from_query("SELECT * FROM (SELECT * FROM contacts) AS c")
 
     assert tables == {"contacts"}
+
+
+def test_extract_tables_from_query_ignores_cte_table_names() -> None:
+    tables = sql_safety.extract_tables_from_query(
+        "WITH recent AS (SELECT * FROM contacts) SELECT * FROM recent"
+    )
+
+    assert tables == {"contacts"}
+
+
+def test_extract_tables_from_query_ignores_cte_names_in_joins() -> None:
+    tables = sql_safety.extract_tables_from_query(
+        """
+        WITH recent AS (SELECT * FROM contacts),
+             account_rollup AS (SELECT * FROM accounts)
+        SELECT * FROM recent JOIN account_rollup ON true
+        """
+    )
+
+    assert tables == {"contacts", "accounts"}
+
+
+@pytest.mark.asyncio
+async def test_prepare_safe_sql_query_allows_query_reading_allowed_tables_through_cte(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_check_sql(context, query, params):
+        assert query == "WITH recent AS (SELECT * FROM contacts) SELECT * FROM recent"
+        return RightsResult(allowed=True)
+
+    monkeypatch.setattr(sql_safety, "check_sql", _fake_check_sql)
+
+    safe_query, error = await sql_safety.prepare_safe_sql_query(
+        query="WITH recent AS (SELECT * FROM contacts) SELECT * FROM recent",
+        organization_id="org-1",
+        user_id="user-1",
+    )
+
+    assert error is None
+    assert safe_query is not None
+    assert safe_query.tables == {"contacts"}
+
+
+def test_extract_tables_from_query_keeps_schema_qualified_table_matching_cte_name() -> None:
+    tables = sql_safety.extract_tables_from_query(
+        "WITH pending_operations AS (SELECT * FROM contacts) SELECT * FROM public.pending_operations"
+    )
+
+    assert tables == {"contacts", "pending_operations"}

--- a/backend/tests/test_sql_safety.py
+++ b/backend/tests/test_sql_safety.py
@@ -78,3 +78,35 @@ def test_extract_tables_from_query_rejects_qualified_disallowed_table_not_schema
     tables = sql_safety.extract_tables_from_query("SELECT * FROM public.pending_operations")
 
     assert tables == {"pending_operations"}
+
+
+def test_extract_tables_from_query_reads_all_comma_separated_from_tables() -> None:
+    tables = sql_safety.extract_tables_from_query("SELECT * FROM contacts, pending_operations")
+
+    assert tables == {"contacts", "pending_operations"}
+
+
+def test_extract_tables_from_query_reads_qualified_comma_separated_from_tables() -> None:
+    tables = sql_safety.extract_tables_from_query(
+        'SELECT * FROM public.contacts c, "custom_schema"."pending_operations" p WHERE c.id = p.contact_id'
+    )
+
+    assert tables == {"contacts", "pending_operations"}
+
+
+def test_extract_tables_from_query_ignores_select_list_commas() -> None:
+    tables = sql_safety.extract_tables_from_query("SELECT id, name, email FROM contacts")
+
+    assert tables == {"contacts"}
+
+
+@pytest.mark.asyncio
+async def test_prepare_safe_sql_query_rejects_disallowed_comma_separated_table() -> None:
+    safe_query, error = await sql_safety.prepare_safe_sql_query(
+        query="SELECT * FROM contacts, pending_operations",
+        organization_id="00000000-0000-0000-0000-000000000001",
+        user_id="00000000-0000-0000-0000-000000000002",
+    )
+
+    assert safe_query is None
+    assert error == "Access to tables not allowed: {'pending_operations'}"

--- a/backend/tests/test_tool_visibility.py
+++ b/backend/tests/test_tool_visibility.py
@@ -31,5 +31,5 @@ def test_run_sql_query_documents_conversation_tables() -> None:
 
 
 def test_run_sql_query_allows_conversation_tables() -> None:
-    tools_source = (Path(__file__).resolve().parents[1] / "agents" / "tools.py").read_text()
-    assert '"conversations", "chat_messages"' in tools_source
+    safety_source = (Path(__file__).resolve().parents[1] / "services" / "sql_safety.py").read_text()
+    assert '"conversations", "chat_messages"' in safety_source


### PR DESCRIPTION
### Motivation
- Consolidate duplicate SQL safety logic (table extraction, allowlist, validation and rights checks) so agent tools and app queries use the same enforcement.
- Ensure `test_query` and named app queries are subject to the same allowlist/rights checks as `run_sql_query` to close an enforcement gap.

### Description
- Added a new shared helper module `services/sql_safety.py` exposing `prepare_safe_sql_query()` and related helpers which own `ALLOWED_TABLES`, SQL validation, table extraction, and rights (`check_sql`) handling.
- Updated `run_sql_query` in `backend/agents/tools.py` to call `prepare_safe_sql_query()` after embedding resolution and to execute the returned safe/transformed query instead of running local checks.
- Updated the Apps connector (`backend/connectors/apps.py`) `test_query` flow to call `prepare_safe_sql_query()` and use its returned query/params, so sample/test queries pass the same allowlist and rights checks.
- Updated named app query execution in `backend/services/app_query_runner.py` to use `prepare_safe_sql_query()` and adjusted `validate_sql_is_select()` to rely on the shared validator.
- Added unit tests: `backend/tests/test_sql_safety.py` (shared helper tests) and `backend/tests/test_apps_connector_test_query_safety.py` (Apps `test_query` safety), and updated `backend/tests/test_tool_visibility.py` to assert on the new shared source.

### Testing
- Ran `pytest -q backend/tests/test_sql_safety.py backend/tests/test_apps_connector_test_query_safety.py backend/tests/test_tool_visibility.py`, and all tests passed (`10 passed`).
- Verified bytecode/compilation with `python -m py_compile` on the modified modules, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab2f3eedc8321af0dd3e026aedf00)