### PR TITLE
Scope meetings to connector visibility

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -3331,6 +3331,51 @@ class UpdateSharingRequest(BaseModel):
     share_write_access: bool
 
 
+async def _propagate_integration_synced_data_visibility(
+    integration_id: UUID,
+    *,
+    share_synced_data: bool,
+) -> None:
+    """Propagate connector synced-data visibility to already-ingested rows."""
+    new_visibility: str = "team" if share_synced_data else "owner_only"
+    logger.info(
+        "Propagating integration synced-data visibility integration_id=%s visibility=%s",
+        integration_id,
+        new_visibility,
+    )
+
+    async with get_admin_session() as prop_session:
+        # Update in a stable order and only touch rows that need to change to
+        # keep row locks short when sharing settings are toggled.
+        activity_result = await prop_session.execute(
+            text(
+                "UPDATE activities "
+                "SET visibility = :vis "
+                "WHERE integration_id = :iid "
+                "AND visibility IS DISTINCT FROM :vis"
+            ),
+            {"vis": new_visibility, "iid": integration_id},
+        )
+        meeting_result = await prop_session.execute(
+            text(
+                "UPDATE meetings "
+                "SET visibility = :vis "
+                "WHERE integration_id = :iid "
+                "AND visibility IS DISTINCT FROM :vis"
+            ),
+            {"vis": new_visibility, "iid": integration_id},
+        )
+        await prop_session.commit()
+
+    logger.info(
+        "Propagated integration synced-data visibility integration_id=%s visibility=%s activities=%s meetings=%s",
+        integration_id,
+        new_visibility,
+        getattr(activity_result, "rowcount", None),
+        getattr(meeting_result, "rowcount", None),
+    )
+
+
 @router.post("/integrations/{integration_id}/sharing")
 async def update_integration_sharing(
     integration_id: str,
@@ -3389,16 +3434,9 @@ async def update_integration_sharing(
         user_id_str = str(integration.user_id) if integration.user_id else ""
         provider = integration.connector
 
-    # Propagate share_synced_data to activity visibility
-    new_visibility: str = "team" if request.share_synced_data else "owner_only"
-    async with get_admin_session() as prop_session:
-        await prop_session.execute(
-            text(
-                "UPDATE activities SET visibility = :vis WHERE integration_id = :iid"
-            ),
-            {"vis": new_visibility, "iid": integration_uuid},
-        )
-        await prop_session.commit()
+    await _propagate_integration_synced_data_visibility(
+        integration_uuid, share_synced_data=request.share_synced_data
+    )
 
     # If this was the initial sharing config, trigger sync now
     if was_pending:
@@ -3461,16 +3499,9 @@ async def patch_integration_sharing(
 
         await session.commit()
 
-    # Propagate share_synced_data to activity visibility
-    new_visibility: str = "team" if request.share_synced_data else "owner_only"
-    async with get_admin_session() as prop_session:
-        await prop_session.execute(
-            text(
-                "UPDATE activities SET visibility = :vis WHERE integration_id = :iid"
-            ),
-            {"vis": new_visibility, "iid": integration_uuid},
-        )
-        await prop_session.commit()
+    await _propagate_integration_synced_data_visibility(
+        integration_uuid, share_synced_data=request.share_synced_data
+    )
 
     return {
         "status": "updated",

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -3335,6 +3335,7 @@ async def _propagate_integration_synced_data_visibility(
     integration_id: UUID,
     *,
     share_synced_data: bool,
+    owner_user_id: UUID | None = None,
 ) -> None:
     """Propagate connector synced-data visibility to already-ingested rows."""
     new_visibility: str = "team" if share_synced_data else "owner_only"
@@ -3359,11 +3360,27 @@ async def _propagate_integration_synced_data_visibility(
         meeting_result = await prop_session.execute(
             text(
                 "UPDATE meetings "
-                "SET visibility = :vis "
+                "SET visibility = :vis, "
+                "owner_user_id = CASE "
+                "WHEN :vis = 'owner_only' AND :owner_user_id IS NOT NULL "
+                "THEN :owner_user_id "
+                "ELSE owner_user_id "
+                "END "
                 "WHERE integration_id = :iid "
-                "AND visibility IS DISTINCT FROM :vis"
+                "AND ("
+                "visibility IS DISTINCT FROM :vis "
+                "OR ("
+                ":vis = 'owner_only' "
+                "AND :owner_user_id IS NOT NULL "
+                "AND owner_user_id IS DISTINCT FROM :owner_user_id"
+                ")"
+                ")"
             ),
-            {"vis": new_visibility, "iid": integration_id},
+            {
+                "vis": new_visibility,
+                "iid": integration_id,
+                "owner_user_id": owner_user_id,
+            },
         )
         await prop_session.commit()
 
@@ -3428,14 +3445,17 @@ async def update_integration_sharing(
         integration.pending_sharing_config = False
         integration.updated_at = datetime.utcnow()
 
-        await session.commit()
-
         org_id_str = str(integration.organization_id)
-        user_id_str = str(integration.user_id) if integration.user_id else ""
+        owner_user_uuid = integration.user_id
+        user_id_str = str(owner_user_uuid) if owner_user_uuid else ""
         provider = integration.connector
 
+        await session.commit()
+
     await _propagate_integration_synced_data_visibility(
-        integration_uuid, share_synced_data=request.share_synced_data
+        integration_uuid,
+        share_synced_data=request.share_synced_data,
+        owner_user_id=owner_user_uuid,
     )
 
     # If this was the initial sharing config, trigger sync now
@@ -3496,11 +3516,14 @@ async def patch_integration_sharing(
         integration.share_query_access = request.share_query_access
         integration.share_write_access = request.share_write_access
         integration.updated_at = datetime.utcnow()
+        owner_user_uuid = integration.user_id
 
         await session.commit()
 
     await _propagate_integration_synced_data_visibility(
-        integration_uuid, share_synced_data=request.share_synced_data
+        integration_uuid,
+        share_synced_data=request.share_synced_data,
+        owner_user_id=owner_user_uuid,
     )
 
     return {

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -253,10 +253,13 @@ class BaseConnector(ABC):
 
         self._integration = integration
 
-    def _activity_visibility_fields(self) -> dict[str, Any]:
-        """Return integration_id, owner_user_id, visibility for Activity creation.
+    def _scoped_ingest_fields(self) -> dict[str, Any]:
+        """Return ingestion scope fields derived from the active Integration.
 
-        Call after ensure_sync_active. Returns empty dict if no integration.
+        Call after ensure_sync_active. Returns empty dict if no integration has
+        been loaded yet. Calendar/transcript connectors should apply these to
+        both Activity and Meeting rows so private connector data remains visible
+        only to the user who connected it.
         """
         if not self._integration:
             return {}
@@ -265,6 +268,17 @@ class BaseConnector(ABC):
             "owner_user_id": self._integration.user_id,
             "visibility": "team" if self._integration.share_synced_data else "owner_only",
         }
+
+    def _activity_visibility_fields(self) -> dict[str, Any]:
+        """Return integration_id, owner_user_id, visibility for Activity creation.
+
+        Call after ensure_sync_active. Returns empty dict if no integration.
+        """
+        return self._scoped_ingest_fields()
+
+    def _meeting_visibility_fields(self) -> dict[str, Any]:
+        """Return integration_id, owner_user_id, visibility for Meeting ingestion."""
+        return self._scoped_ingest_fields()
 
     async def _resolve_stale_pending_sharing_config(
         self,

--- a/backend/connectors/fireflies.py
+++ b/backend/connectors/fireflies.py
@@ -269,6 +269,7 @@ class FirefliesConnector(BaseConnector):
                             notes_text=parsed["overview"],
                             action_items=parsed["action_items_structured"],
                             key_topics=parsed["keywords"],
+                            **self._meeting_visibility_fields(),
                             status="completed",
                         )
 

--- a/backend/connectors/google_calendar.py
+++ b/backend/connectors/google_calendar.py
@@ -1030,7 +1030,9 @@ class GoogleCalendarConnector(BaseConnector):
         organizer_email = None
         if self.user_id:
             from models.user import User
-            async with get_session(organization_id=self.organization_id) as session:
+            async with get_session(
+                organization_id=self.organization_id, user_id=self.user_id
+            ) as session:
                 user = await session.get(User, uuid.UUID(self.user_id))
                 if user:
                     organizer_email = user.email
@@ -1050,7 +1052,9 @@ class GoogleCalendarConnector(BaseConnector):
 
         # Re-fetch in a new session to set Meet-specific fields and create Activity
         from models.meeting import Meeting
-        async with get_session(organization_id=self.organization_id) as session:
+        async with get_session(
+            organization_id=self.organization_id, user_id=self.user_id
+        ) as session:
             m = await session.get(Meeting, meeting.id)
             m.conference_link = meeting_uri
             m.meet_space_name = meet_space_name
@@ -1095,7 +1099,9 @@ class GoogleCalendarConnector(BaseConnector):
         if not meeting_id:
             raise ValueError("end_huddle requires meeting_id")
 
-        async with get_session(organization_id=self.organization_id) as session:
+        async with get_session(
+            organization_id=self.organization_id, user_id=self.user_id
+        ) as session:
             meeting = await session.get(Meeting, uuid.UUID(meeting_id))
             if not meeting:
                 raise ValueError(f"Meeting {meeting_id} not found")

--- a/backend/connectors/google_calendar.py
+++ b/backend/connectors/google_calendar.py
@@ -370,6 +370,7 @@ class GoogleCalendarConnector(BaseConnector):
                                     title=parsed["summary"],
                                     duration_minutes=parsed["duration_minutes"],
                                     organizer_email=parsed["organizer_email"],
+                                    **self._meeting_visibility_fields(),
                                     status=parsed["meeting_status"],
                                 )
                                 meeting = await session.merge(meeting)
@@ -401,6 +402,7 @@ class GoogleCalendarConnector(BaseConnector):
                                 title=parsed["summary"],
                                 duration_minutes=parsed["duration_minutes"],
                                 organizer_email=parsed["organizer_email"],
+                                **self._meeting_visibility_fields(),
                                 status=parsed["meeting_status"],
                             )
                             meeting = await session.merge(meeting)
@@ -1042,6 +1044,7 @@ class GoogleCalendarConnector(BaseConnector):
             title=title,
             duration_minutes=duration_minutes,
             organizer_email=organizer_email,
+            **self._meeting_visibility_fields(),
             status="scheduled",
         )
 

--- a/backend/connectors/granola.py
+++ b/backend/connectors/granola.py
@@ -478,6 +478,7 @@ class GranolaConnector(BaseConnector):
                             notes_text=notes_text[:500] if notes_text else None,
                             action_items=parsed.get("action_items_structured"),
                             key_topics=parsed.get("keywords"),
+                            **self._meeting_visibility_fields(),
                             status="completed",
                         )
 

--- a/backend/connectors/microsoft_calendar.py
+++ b/backend/connectors/microsoft_calendar.py
@@ -220,6 +220,7 @@ class MicrosoftCalendarConnector(BaseConnector):
                             title=parsed["subject"],
                             duration_minutes=parsed["duration_minutes"],
                             organizer_email=parsed["organizer_email"],
+                            **self._meeting_visibility_fields(),
                             status=parsed["meeting_status"],
                         )
                         meeting = await session.merge(meeting)

--- a/backend/connectors/zoom.py
+++ b/backend/connectors/zoom.py
@@ -252,6 +252,7 @@ class ZoomConnector(BaseConnector):
                         participants=participants or None,
                         organizer_email=host_email if isinstance(host_email, str) else None,
                         title=topic,
+                        **self._meeting_visibility_fields(),
                         status="completed",
                     )
                     meeting_record_id: uuid.UUID = _safe_meeting_id(meeting_record)

--- a/backend/db/migrations/versions/137_meeting_scope.py
+++ b/backend/db/migrations/versions/137_meeting_scope.py
@@ -1,0 +1,155 @@
+"""Scope meetings to ingesting connector.
+
+Revision ID: 137_meeting_scope
+Revises: 136_web_search_integration
+Create Date: 2026-05-06
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+
+revision: str = "137_meeting_scope"
+down_revision: Union[str, None] = "136_web_search_integration"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+NULL_UUID: str = "00000000-0000-0000-0000-000000000000"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    op.add_column(
+        "meetings",
+        sa.Column(
+            "integration_id",
+            sa.UUID(),
+            sa.ForeignKey("integrations.id", ondelete="SET NULL", onupdate="CASCADE"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "meetings",
+        sa.Column(
+            "owner_user_id",
+            sa.UUID(),
+            sa.ForeignKey("users.id", ondelete="SET NULL", onupdate="CASCADE"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "meetings",
+        sa.Column("visibility", sa.String(20), nullable=False, server_default="team"),
+    )
+
+    # Backfill from linked activities. If any linked activity is team-visible, the
+    # meeting remains team-visible; otherwise keep it private to the owner of the
+    # most recently synced linked activity. The grouped CTE keeps the update
+    # set-based and avoids broad table locks beyond normal UPDATE row locks.
+    conn.execute(
+        text("""
+            WITH scoped AS (
+                SELECT
+                    a.meeting_id,
+                    CASE
+                        WHEN bool_or(a.visibility = 'team') THEN 'team'::varchar
+                        ELSE 'owner_only'::varchar
+                    END AS visibility,
+                    (
+                        array_agg(a.integration_id ORDER BY a.synced_at DESC NULLS LAST)
+                    )[1] AS integration_id,
+                    CASE
+                        WHEN bool_or(a.visibility = 'team') THEN NULL::uuid
+                        ELSE (
+                            array_agg(a.owner_user_id ORDER BY a.synced_at DESC NULLS LAST)
+                        )[1]
+                    END AS owner_user_id
+                FROM activities a
+                WHERE a.meeting_id IS NOT NULL
+                GROUP BY a.meeting_id
+            )
+            UPDATE meetings m
+            SET
+                integration_id = scoped.integration_id,
+                owner_user_id = scoped.owner_user_id,
+                visibility = scoped.visibility
+            FROM scoped
+            WHERE scoped.meeting_id = m.id
+        """)
+    )
+
+    op.create_index("ix_meetings_integration_id", "meetings", ["integration_id"])
+    op.create_index("ix_meetings_owner_user_id", "meetings", ["owner_user_id"])
+    op.create_index(
+        "ix_meetings_org_visibility",
+        "meetings",
+        ["organization_id", "visibility"],
+    )
+
+    conn.execute(text("DROP POLICY IF EXISTS org_isolation ON meetings"))
+    conn.execute(text("DROP POLICY IF EXISTS org_and_user_isolation ON meetings"))
+    conn.execute(
+        text(f"""
+            CREATE POLICY org_and_user_isolation ON meetings
+            FOR ALL
+            USING (
+                organization_id::text = COALESCE(
+                    NULLIF(current_setting('app.current_org_id', true), ''),
+                    '{NULL_UUID}'
+                )
+                AND (
+                    visibility = 'team'
+                    OR owner_user_id IS NULL
+                    OR owner_user_id::text = COALESCE(
+                        NULLIF(current_setting('app.current_user_id', true), ''),
+                        '{NULL_UUID}'
+                    )
+                )
+            )
+            WITH CHECK (
+                organization_id::text = COALESCE(
+                    NULLIF(current_setting('app.current_org_id', true), ''),
+                    '{NULL_UUID}'
+                )
+                AND (
+                    visibility = 'team'
+                    OR owner_user_id IS NULL
+                    OR owner_user_id::text = COALESCE(
+                        NULLIF(current_setting('app.current_user_id', true), ''),
+                        '{NULL_UUID}'
+                    )
+                )
+            )
+        """)
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(text("DROP POLICY IF EXISTS org_and_user_isolation ON meetings"))
+    conn.execute(
+        text(f"""
+            CREATE POLICY org_isolation ON meetings
+            FOR ALL
+            USING (
+                organization_id::text = COALESCE(
+                    NULLIF(current_setting('app.current_org_id', true), ''),
+                    '{NULL_UUID}'
+                )
+            )
+        """)
+    )
+
+    op.drop_index("ix_meetings_org_visibility", table_name="meetings")
+    op.drop_index("ix_meetings_owner_user_id", table_name="meetings")
+    op.drop_index("ix_meetings_integration_id", table_name="meetings")
+    op.drop_column("meetings", "visibility")
+    op.drop_column("meetings", "owner_user_id")
+    op.drop_column("meetings", "integration_id")

--- a/backend/models/meeting.py
+++ b/backend/models/meeting.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from datetime import timezone as tz
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -38,12 +38,30 @@ class Meeting(Base):
     """
 
     __tablename__ = "meetings"
+    __table_args__ = (
+        Index("ix_meetings_integration_id", "integration_id"),
+        Index("ix_meetings_owner_user_id", "owner_user_id"),
+        Index("ix_meetings_org_visibility", "organization_id", "visibility"),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
     organization_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False
+    )
+    integration_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("integrations.id", ondelete="SET NULL", onupdate="CASCADE"),
+        nullable=True,
+    )
+    owner_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL", onupdate="CASCADE"),
+        nullable=True,
+    )
+    visibility: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="team", server_default="team"
     )
 
     # Core meeting info (normalized from best available source)
@@ -165,6 +183,9 @@ class Meeting(Base):
         return {
             "id": str(self.id),
             "title": self.title,
+            "integration_id": str(self.integration_id) if self.integration_id else None,
+            "owner_user_id": str(self.owner_user_id) if self.owner_user_id else None,
+            "visibility": self.visibility,
             "scheduled_start": f"{self.scheduled_start.isoformat()}Z" if self.scheduled_start else None,
             "scheduled_end": f"{self.scheduled_end.isoformat()}Z" if self.scheduled_end else None,
             "duration_minutes": self.duration_minutes,
@@ -190,6 +211,9 @@ class Meeting(Base):
         return {
             "id": str(self.id),
             "title": self.title,
+            "integration_id": str(self.integration_id) if self.integration_id else None,
+            "owner_user_id": str(self.owner_user_id) if self.owner_user_id else None,
+            "visibility": self.visibility,
             "scheduled_start": f"{self.scheduled_start.isoformat()}Z" if self.scheduled_start else None,
             "duration_minutes": self.duration_minutes,
             "participant_count": self.participant_count,

--- a/backend/services/meeting_dedup.py
+++ b/backend/services/meeting_dedup.py
@@ -114,6 +114,8 @@ async def find_matching_meeting(
     scheduled_start: datetime,
     participants: list[dict[str, Any]] | None = None,
     title: str | None = None,
+    owner_user_id: UUID | None = None,
+    visibility: str = "team",
 ) -> Meeting | None:
     """
     Find an existing meeting that matches the given criteria.
@@ -136,13 +138,21 @@ async def find_matching_meeting(
     start_min = scheduled_start - time_window
     start_max = scheduled_start + time_window
     
-    # Query meetings in the time window
+    # Query meetings in the same connector visibility scope. Private
+    # (owner_only) ingests intentionally do not merge into team meetings or
+    # another user's private meetings; this preserves connector sharing
+    # choices on the canonical Meeting row.
+    scope_conditions: list[Any] = [Meeting.visibility == visibility]
+    if visibility == "owner_only":
+        scope_conditions.append(Meeting.owner_user_id == owner_user_id)
+
     result = await session.execute(
         select(Meeting).where(
             and_(
                 Meeting.organization_id == organization_id,
                 Meeting.scheduled_start >= start_min,
                 Meeting.scheduled_start <= start_max,
+                *scope_conditions,
             )
         )
     )
@@ -191,6 +201,9 @@ async def find_or_create_meeting(
     notes_text: str | None = None,
     notes_doc_id: str | None = None,
     status: str = "scheduled",
+    integration_id: str | UUID | None = None,
+    owner_user_id: str | UUID | None = None,
+    visibility: str = "team",
 ) -> Meeting:
     """
     Find an existing meeting or create a new one.
@@ -218,7 +231,12 @@ async def find_or_create_meeting(
     """
     if isinstance(organization_id, str):
         organization_id = UUID(organization_id)
-    
+    if isinstance(integration_id, str):
+        integration_id = UUID(integration_id)
+    if isinstance(owner_user_id, str):
+        owner_user_id = UUID(owner_user_id)
+    visibility = "owner_only" if visibility == "owner_only" else "team"
+
     # Convert to UTC then strip timezone for database compatibility
     from datetime import timezone as tz
     if scheduled_start.tzinfo is not None:
@@ -226,7 +244,10 @@ async def find_or_create_meeting(
     if scheduled_end is not None and scheduled_end.tzinfo is not None:
         scheduled_end = scheduled_end.astimezone(tz.utc).replace(tzinfo=None)
     
-    async with get_session(organization_id=str(organization_id)) as session:
+    async with get_session(
+        organization_id=str(organization_id),
+        user_id=str(owner_user_id) if owner_user_id else None,
+    ) as session:
         # Try to find existing meeting
         meeting = await find_matching_meeting(
             session=session,
@@ -234,12 +255,21 @@ async def find_or_create_meeting(
             scheduled_start=scheduled_start,
             participants=participants,
             title=title,
+            owner_user_id=owner_user_id,
+            visibility=visibility,
         )
         
         if meeting:
             # Update existing meeting with new data
             logger.info("Found existing meeting %s, updating with new data", meeting.id)
             
+            # Keep the meeting scoped to the connector that owns this ingest.
+            # Legacy rows may not have scope fields yet; fill them without
+            # broadening private data to the whole team.
+            meeting.integration_id = integration_id or meeting.integration_id
+            meeting.owner_user_id = owner_user_id or meeting.owner_user_id
+            meeting.visibility = visibility
+
             # Merge participants
             if participants:
                 meeting.participants = merge_participants(meeting.participants, participants)
@@ -290,6 +320,9 @@ async def find_or_create_meeting(
         meeting = Meeting(
             id=uuid4(),
             organization_id=organization_id,
+            integration_id=integration_id,
+            owner_user_id=owner_user_id,
+            visibility=visibility,
             title=title,
             scheduled_start=scheduled_start,
             scheduled_end=scheduled_end,

--- a/backend/tests/test_google_calendar_huddle_rls.py
+++ b/backend/tests/test_google_calendar_huddle_rls.py
@@ -1,0 +1,86 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import uuid4
+
+from connectors import google_calendar
+from connectors.google_calendar import GoogleCalendarConnector
+
+
+class _FakeSession:
+    def __init__(self, meeting):
+        self.meeting = meeting
+        self.added = []
+        self.commits = 0
+
+    async def get(self, model, _identifier):
+        if model.__name__ == "User":
+            return SimpleNamespace(email="owner@example.com")
+        if model.__name__ == "Meeting":
+            return self.meeting
+        return None
+
+    def add(self, row):
+        self.added.append(row)
+
+    async def commit(self):
+        self.commits += 1
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_create_huddle_refetches_meeting_with_owner_rls_context(monkeypatch):
+    org_id = str(uuid4())
+    owner_user_id = str(uuid4())
+    integration_id = uuid4()
+    meeting_id = uuid4()
+    refetched_meeting = SimpleNamespace(id=meeting_id)
+    session = _FakeSession(refetched_meeting)
+    get_session_calls = []
+
+    def fake_get_session(**kwargs):
+        get_session_calls.append(kwargs)
+        return _FakeSessionContext(session)
+
+    async def fake_make_meet_request(*_args, **_kwargs):
+        return {
+            "name": "spaces/abc123",
+            "meetingUri": "https://meet.google.com/abc-defg-hij",
+            "meetingCode": "abc-defg-hij",
+        }
+
+    async def fake_find_or_create_meeting(**kwargs):
+        assert kwargs["owner_user_id"] == owner_user_id
+        assert kwargs["visibility"] == "owner_only"
+        return SimpleNamespace(id=meeting_id)
+
+    monkeypatch.setattr(google_calendar, "get_session", fake_get_session)
+    monkeypatch.setattr(google_calendar, "find_or_create_meeting", fake_find_or_create_meeting)
+
+    connector = GoogleCalendarConnector(organization_id=org_id, user_id=owner_user_id)
+    connector._integration = SimpleNamespace(
+        id=integration_id,
+        user_id=owner_user_id,
+        share_synced_data=False,
+    )
+    monkeypatch.setattr(connector, "_make_meet_request", fake_make_meet_request)
+
+    result = asyncio.run(connector._action_create_huddle({"title": "Private huddle"}))
+
+    assert result["status"] == "ok"
+    assert refetched_meeting.conference_link == "https://meet.google.com/abc-defg-hij"
+    assert refetched_meeting.huddle_status == "active"
+    assert session.added[0].owner_user_id == owner_user_id
+    assert session.added[0].visibility == "owner_only"
+    assert get_session_calls == [
+        {"organization_id": org_id, "user_id": owner_user_id},
+        {"organization_id": org_id, "user_id": owner_user_id},
+    ]

--- a/backend/tests/test_integration_sharing_visibility.py
+++ b/backend/tests/test_integration_sharing_visibility.py
@@ -1,0 +1,72 @@
+import asyncio
+from uuid import UUID
+
+from api.routes import auth
+
+
+class _FakeExecuteResult:
+    def __init__(self, rowcount: int):
+        self.rowcount = rowcount
+
+
+class _FakeSession:
+    def __init__(self):
+        self.executed = []
+        self.committed = False
+
+    async def execute(self, query, params=None):
+        self.executed.append((str(query), params))
+        return _FakeExecuteResult(len(self.executed))
+
+    async def commit(self):
+        self.committed = True
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_sharing_visibility_propagates_to_activities_and_meetings(monkeypatch):
+    integration_id = UUID("11111111-1111-1111-1111-111111111111")
+    session = _FakeSession()
+
+    monkeypatch.setattr(auth, "get_admin_session", lambda: _FakeSessionContext(session))
+
+    asyncio.run(
+        auth._propagate_integration_synced_data_visibility(
+            integration_id,
+            share_synced_data=False,
+        )
+    )
+
+    assert session.committed
+    assert len(session.executed) == 2
+    assert "UPDATE activities" in session.executed[0][0]
+    assert "visibility IS DISTINCT FROM" in session.executed[0][0]
+    assert session.executed[0][1] == {"vis": "owner_only", "iid": integration_id}
+    assert "UPDATE meetings" in session.executed[1][0]
+    assert "visibility IS DISTINCT FROM" in session.executed[1][0]
+    assert session.executed[1][1] == {"vis": "owner_only", "iid": integration_id}
+
+
+def test_sharing_visibility_propagates_team_visibility(monkeypatch):
+    integration_id = UUID("22222222-2222-2222-2222-222222222222")
+    session = _FakeSession()
+
+    monkeypatch.setattr(auth, "get_admin_session", lambda: _FakeSessionContext(session))
+
+    asyncio.run(
+        auth._propagate_integration_synced_data_visibility(
+            integration_id,
+            share_synced_data=True,
+        )
+    )
+
+    assert [params["vis"] for _query, params in session.executed] == ["team", "team"]

--- a/backend/tests/test_integration_sharing_visibility.py
+++ b/backend/tests/test_integration_sharing_visibility.py
@@ -35,6 +35,7 @@ class _FakeSessionContext:
 
 def test_sharing_visibility_propagates_to_activities_and_meetings(monkeypatch):
     integration_id = UUID("11111111-1111-1111-1111-111111111111")
+    owner_user_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
     session = _FakeSession()
 
     monkeypatch.setattr(auth, "get_admin_session", lambda: _FakeSessionContext(session))
@@ -43,6 +44,7 @@ def test_sharing_visibility_propagates_to_activities_and_meetings(monkeypatch):
         auth._propagate_integration_synced_data_visibility(
             integration_id,
             share_synced_data=False,
+            owner_user_id=owner_user_id,
         )
     )
 
@@ -53,11 +55,18 @@ def test_sharing_visibility_propagates_to_activities_and_meetings(monkeypatch):
     assert session.executed[0][1] == {"vis": "owner_only", "iid": integration_id}
     assert "UPDATE meetings" in session.executed[1][0]
     assert "visibility IS DISTINCT FROM" in session.executed[1][0]
-    assert session.executed[1][1] == {"vis": "owner_only", "iid": integration_id}
+    assert "owner_user_id = CASE" in session.executed[1][0]
+    assert "owner_user_id IS DISTINCT FROM" in session.executed[1][0]
+    assert session.executed[1][1] == {
+        "vis": "owner_only",
+        "iid": integration_id,
+        "owner_user_id": owner_user_id,
+    }
 
 
 def test_sharing_visibility_propagates_team_visibility(monkeypatch):
     integration_id = UUID("22222222-2222-2222-2222-222222222222")
+    owner_user_id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
     session = _FakeSession()
 
     monkeypatch.setattr(auth, "get_admin_session", lambda: _FakeSessionContext(session))
@@ -66,7 +75,9 @@ def test_sharing_visibility_propagates_team_visibility(monkeypatch):
         auth._propagate_integration_synced_data_visibility(
             integration_id,
             share_synced_data=True,
+            owner_user_id=owner_user_id,
         )
     )
 
     assert [params["vis"] for _query, params in session.executed] == ["team", "team"]
+    assert session.executed[1][1]["owner_user_id"] == owner_user_id

--- a/backend/tests/test_meeting_external_notes.py
+++ b/backend/tests/test_meeting_external_notes.py
@@ -169,6 +169,97 @@ class TestToDict:
         assert d["external_notes"] is None
 
 
+class TestMeetingScope:
+    def test_to_dict_includes_scope_fields(self):
+        integration_id = uuid4()
+        owner_user_id = uuid4()
+        m = Meeting(
+            id=uuid4(),
+            organization_id=uuid4(),
+            integration_id=integration_id,
+            owner_user_id=owner_user_id,
+            visibility="owner_only",
+            scheduled_start=datetime(2026, 1, 1),
+            status="scheduled",
+        )
+
+        d = m.to_dict()
+
+        assert d["integration_id"] == str(integration_id)
+        assert d["owner_user_id"] == str(owner_user_id)
+        assert d["visibility"] == "owner_only"
+
+    @pytest.mark.asyncio
+    async def test_private_find_or_create_keeps_meeting_owner_scope(self):
+        from services.meeting_dedup import find_or_create_meeting
+
+        org_id = uuid4()
+        integration_id = uuid4()
+        owner_user_id = uuid4()
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        added = []
+        mock_session.add = lambda obj: added.append(obj)
+        mock_session.commit = AsyncMock()
+        mock_session.refresh = AsyncMock()
+
+        with patch("services.meeting_dedup.get_session") as mock_gs:
+            mock_gs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_gs.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await find_or_create_meeting(
+                organization_id=org_id,
+                scheduled_start=datetime(2026, 3, 1, 10, 0, tzinfo=timezone.utc),
+                title="Private Calendar Event",
+                integration_id=integration_id,
+                owner_user_id=owner_user_id,
+                visibility="owner_only",
+            )
+
+        mock_gs.assert_called_once_with(
+            organization_id=str(org_id),
+            user_id=str(owner_user_id),
+        )
+        assert len(added) == 1
+        assert added[0].integration_id == integration_id
+        assert added[0].owner_user_id == owner_user_id
+        assert added[0].visibility == "owner_only"
+
+    @pytest.mark.asyncio
+    async def test_matching_private_meetings_filters_to_same_owner(self):
+        from services.meeting_dedup import find_matching_meeting
+
+        org_id = uuid4()
+        owner_user_id = uuid4()
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        await find_matching_meeting(
+            session=mock_session,
+            organization_id=org_id,
+            scheduled_start=datetime(2026, 3, 1, 10, 0, tzinfo=timezone.utc),
+            title="Private Calendar Event",
+            owner_user_id=owner_user_id,
+            visibility="owner_only",
+        )
+
+        compiled = str(
+            mock_session.execute.call_args.args[0].compile(
+                compile_kwargs={"literal_binds": True}
+            )
+        )
+        assert "meetings.visibility = 'owner_only'" in compiled
+        assert f"meetings.owner_user_id = '{owner_user_id.hex}'" in compiled
+
+
 # ── Dedup service integration ─────────────────────────────────────
 
 
@@ -203,9 +294,11 @@ class TestFindOrCreateMeetingNotes:
 
         org_id = uuid4()
         mock_session = AsyncMock()
-        mock_session.execute = AsyncMock(
-            return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None))
-        )
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
         # Capture the Meeting that gets added
         added = []
         mock_session.add = lambda obj: added.append(obj)
@@ -275,9 +368,11 @@ class TestFindOrCreateMeetingNotes:
 
         org_id = uuid4()
         mock_session = AsyncMock()
-        mock_session.execute = AsyncMock(
-            return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None))
-        )
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
         added = []
         mock_session.add = lambda obj: added.append(obj)
         mock_session.commit = AsyncMock()


### PR DESCRIPTION
### Motivation
- Ensure meetings inherit the same ingestion scope as the connector that created them (integration, owner, visibility) so private calendar/transcript ingests are not visible to other users.
- Prevent cross-user leakage by making deduplication and RLS enforce connector-scoped visibility for meetings.

### Description
- Add `integration_id`, `owner_user_id`, and `visibility` columns plus indexes to the `meetings` model and include them in `to_dict`/search serialization (`backend/models/meeting.py`).
- Add Alembic migration `137_meeting_scope` that backfills meeting scope from linked `activities`, creates indexes, and replaces the meetings RLS policy with an org+user visibility policy (`backend/db/migrations/versions/137_meeting_scope.py`).
- Make dedup logic scope-aware by changing `find_matching_meeting`/`find_or_create_meeting` to accept `integration_id`, `owner_user_id`, and `visibility`, restrict matching to the same visibility scope, and populate scope fields on create/update (`backend/services/meeting_dedup.py`).
- Add a connector helper (`_scoped_ingest_fields`) and expose `_meeting_visibility_fields()` on `BaseConnector`, and update calendar/transcript connectors to pass the meeting-scope fields when creating/updating meetings (Google Calendar, Microsoft Calendar, Fireflies, Zoom, Granola) (`backend/connectors/*`).
- Add unit tests for meeting scope serialization and private-ingest behavior and update test harnesses to exercise the new scope-aware paths (`backend/tests/test_meeting_external_notes.py`).

### Testing
- Ran `pytest backend/tests/test_meeting_external_notes.py` and all tests passed (31 passed, 0 failed).
- Ran `python -m compileall -q` across modified modules and the migration file and compilation succeeded.
- Ran Alembic preflight checks on the new migration: `revision` and `down_revision` length assertions passed and `alembic heads` shows the new migration as head.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad8cd44808321855b6834ff391842)