### PR TITLE
Security :: Require global admin for user merge

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -4502,7 +4502,7 @@ class MergeUsersResponse(BaseModel):
 @router.post("/users/merge", response_model=MergeUsersResponse)
 async def merge_users_endpoint(
     request: MergeUsersRequest,
-    auth: AuthContext = Depends(get_current_auth),
+    auth: AuthContext = Depends(require_global_admin),
 ) -> MergeUsersResponse:
     """
     Merge two user accounts into one.
@@ -4514,26 +4514,35 @@ async def merge_users_endpoint(
     - Reassigned to the target user (ownership, authorship)
     - Deleted (conversations, messages, user mappings)
     
-    Requires admin role or global_admin.
+    Requires global_admin. Org admins cannot merge users because the merge may
+    reassign or delete records across every organization the source user belongs to.
     """
-    from services.user_merge import merge_users
-    
+    if not auth.is_global_admin:
+        logger.warning(
+            "[user_merge] Blocked non-global-admin merge attempt requester=%s org=%s",
+            auth.user_id,
+            auth.organization_id,
+        )
+        raise HTTPException(status_code=403, detail="Global admin access required")
+
     if not auth.organization_id:
         raise HTTPException(status_code=400, detail="Organization context required")
-    
-    # Check admin permissions (org admin for current org, or global_admin).
-    async with get_admin_session() as session:
-        requester: Optional[User] = await session.get(User, auth.user_id)
-        if not await _can_administer_org(session, requester, auth.organization_id):
-            raise HTTPException(
-                status_code=403,
-                detail="Org admin for this organization or global_admin role required",
-            )
-    
+
+    from services.user_merge import merge_users
+
+    logger.info(
+        "[user_merge] Global admin requester=%s initiated merge source=%s target=%s org=%s delete_source=%s",
+        auth.user_id,
+        request.source_user_id,
+        request.target_user_id,
+        auth.organization_id,
+        request.delete_source,
+    )
+
     result = await merge_users(
         target_user_id=request.target_user_id,
         source_user_id=request.source_user_id,
-        organization_id=auth.organization_id,
+        organization_id=str(auth.organization_id),
         delete_source=request.delete_source,
     )
     

--- a/backend/tests/test_user_merge_authz.py
+++ b/backend/tests/test_user_merge_authz.py
@@ -1,0 +1,97 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+from fastapi import HTTPException
+
+from api.auth_middleware import AuthContext
+from api.routes import auth
+
+
+ORG_ID = UUID("11111111-1111-1111-1111-111111111111")
+REQUESTER_ID = UUID("22222222-2222-2222-2222-222222222222")
+TARGET_ID = UUID("33333333-3333-3333-3333-333333333333")
+SOURCE_ID = UUID("44444444-4444-4444-4444-444444444444")
+
+
+def _auth_context(*, is_global_admin: bool) -> AuthContext:
+    return AuthContext(
+        user_id=REQUESTER_ID,
+        organization_id=ORG_ID,
+        email="admin@example.com",
+        role="global_admin" if is_global_admin else "admin",
+        is_global_admin=is_global_admin,
+    )
+
+
+def _merge_request() -> auth.MergeUsersRequest:
+    return auth.MergeUsersRequest(
+        target_user_id=str(TARGET_ID),
+        source_user_id=str(SOURCE_ID),
+        delete_source=True,
+    )
+
+
+def test_merge_users_endpoint_rejects_org_admin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Org admins cannot merge users; the operation is global-admin only."""
+
+    async def _unexpected_merge(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("merge_users should not run for non-global admins")
+
+    import services.user_merge as user_merge
+
+    monkeypatch.setattr(user_merge, "merge_users", _unexpected_merge)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            auth.merge_users_endpoint(
+                request=_merge_request(),
+                auth=_auth_context(is_global_admin=False),
+            )
+        )
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Global admin access required"
+
+
+def test_merge_users_endpoint_allows_global_admin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Global admins can initiate user merges."""
+
+    calls: list[dict[str, object]] = []
+
+    async def _fake_merge_users(**kwargs: object) -> object:
+        calls.append(kwargs)
+        return SimpleNamespace(
+            success=True,
+            target_user_id=kwargs["target_user_id"],
+            source_user_id=kwargs["source_user_id"],
+            source_email="source@example.com",
+            tables_updated={"users (deleted)": 1},
+            error=None,
+        )
+
+    import services.user_merge as user_merge
+
+    monkeypatch.setattr(user_merge, "merge_users", _fake_merge_users)
+
+    response = asyncio.run(
+        auth.merge_users_endpoint(
+            request=_merge_request(),
+            auth=_auth_context(is_global_admin=True),
+        )
+    )
+
+    assert response.success is True
+    assert response.target_user_id == str(TARGET_ID)
+    assert response.source_user_id == str(SOURCE_ID)
+    assert response.source_email == "source@example.com"
+    assert response.tables_updated == {"users (deleted)": 1}
+    assert calls == [
+        {
+            "target_user_id": str(TARGET_ID),
+            "source_user_id": str(SOURCE_ID),
+            "organization_id": str(ORG_ID),
+            "delete_source": True,
+        }
+    ]


### PR DESCRIPTION
### Motivation
- The user-merge operation can reassign or delete records across every organization a source user belongs to, so it must be restricted to global administrators to prevent org-admins from performing cross-org destructive actions.

### Description
- Change the `/users/merge` route to depend on `require_global_admin` instead of `get_current_auth` to enforce global-admin-only access at the dependency level in `backend/api/routes/auth.py`.
- Add a defensive runtime guard that rejects non-global-admin callers and emits a warning log, and add an info log when a global-admin initiates a merge in `merge_users_endpoint`.
- Pass the `organization_id` to `services.user_merge.merge_users` as a string and remove the prior per-request org-admin DB permission check in the route handler.
- Add `backend/tests/test_user_merge_authz.py` with tests verifying that org-admins are rejected and global-admins can invoke the merge.

### Testing
- Ran `pytest -q backend/tests/test_user_merge_authz.py` and it passed (2 tests).
- Ran `python -m py_compile backend/api/routes/auth.py backend/tests/test_user_merge_authz.py && pytest -q backend/tests/test_connect_builtin_authz.py` and it passed.
- Ran `pytest -q backend/tests/test_user_merge_authz.py backend/tests/test_connect_builtin_authz.py backend/tests/test_update_member_role_blocks_global_admin.py` and the run failed due to a pre-existing test that calls `update_organization_member_role(..., user_id=...)` which does not match the current route signature; this failure is unrelated to the user-merge auth changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fadca76b108321a8dc6352e726ea8f)