### PR TITLE
Update test to use AuthContext for update_organization_member_role

### DIFF
--- a/backend/tests/test_update_member_role_blocks_global_admin.py
+++ b/backend/tests/test_update_member_role_blocks_global_admin.py
@@ -64,7 +64,13 @@ def test_update_role_rejects_demotion_of_global_admin(monkeypatch):
                 org_id=str(org_id),
                 target_user_id=str(target_id),
                 request=request,
-                user_id=str(requester_id),
+                auth=auth.AuthContext(
+                    user_id=requester_id,
+                    organization_id=org_id,
+                    email="requester@example.com",
+                    role="admin",
+                    is_global_admin=False,
+                ),
             )
         )
 


### PR DESCRIPTION
### Motivation
- The `update_organization_member_role` endpoint signature no longer accepts a `user_id` keyword, so the test must pass an `AuthContext` to match the current API surface.

### Description
- Updated `backend/tests/test_update_member_role_blocks_global_admin.py` to call `update_organization_member_role` with `auth=auth.AuthContext(...)` instead of the removed `user_id` parameter.

### Testing
- Ran `pytest backend/tests/test_update_member_role_blocks_global_admin.py -q` which succeeded (1 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fadfb68d2c83219aedb2c7fe8fc43d)