### PR TITLE
Fix stray > glyphs in Slack blockquotes from email-style content

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -30,6 +30,16 @@ _SLACK_MESSAGE_PERMALINK_RE: re.Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 _MARKDOWN_TABLE_CODE_BLOCK_TEMPLATE: str = "```\n{table}\n```"
+# A line that contains nothing but a blockquote marker (``>`` or ``> ``).
+# In email-style quoting these mark paragraph breaks inside a quoted reply,
+# but Slack mrkdwn renders them as a literal ``>`` character because there's
+# no content after the marker. We strip them so consecutive ``> ...`` lines
+# collapse into one continuous Slack blockquote instead of leaving stray
+# ``>`` glyphs floating between paragraphs.
+_BARE_BLOCKQUOTE_LINE_RE: re.Pattern[str] = re.compile(
+    r'^[ \t]*>[ \t]*$\n?',
+    re.MULTILINE,
+)
 _markdown_logger = logging.getLogger(__name__)
 _SLACK_ALLOWED_FILE_HOST_SUFFIXES: tuple[str, ...] = ("slack.com",)
 
@@ -41,6 +51,20 @@ def _clean_table_lines(raw: str) -> str:
         line for line in lines if not _SEPARATOR_ROW_RE.match(line.strip())
     ]
     return '\n'.join(filtered)
+
+
+def _strip_bare_blockquote_lines(text: str) -> str:
+    """Drop email-style ``>`` paragraph-separator lines so Slack renders quotes cleanly.
+
+    Slack mrkdwn does not support paragraph breaks inside a single blockquote
+    block: a line that is just ``>`` renders as a literal ``>`` character, and
+    a blank line breaks the quote into separate gray-bar blocks. Forwarded /
+    replied emails routinely include ``>`` lines as paragraph separators inside
+    a quoted reply, which produces stray ``>`` glyphs in the rendered Slack
+    message. Removing those marker-only lines collapses the surrounding
+    ``> ...`` lines into one continuous Slack blockquote.
+    """
+    return _BARE_BLOCKQUOTE_LINE_RE.sub('', text)
 
 
 def markdown_to_mrkdwn(text: str) -> tuple[str, Optional[list[dict[str, Any]]]]:
@@ -72,6 +96,12 @@ def markdown_to_mrkdwn(text: str) -> tuple[str, Optional[list[dict[str, Any]]]]:
         return f'\x00CB{idx}\x00'
 
     text = _FENCE_RE.sub(_extract_fence, text)
+
+    # -- Step 1.5: normalize email-style blockquote paragraph separators ----
+    # Bare ``>`` lines (used as paragraph breaks in forwarded/replied emails)
+    # render as literal ``>`` characters in Slack mrkdwn; strip them now that
+    # fenced content is safely placeholdered out.
+    text = _strip_bare_blockquote_lines(text)
 
     # -- Step 2: wrap bare markdown tables that weren't already fenced ------
     _TABLE_RE: re.Pattern[str] = re.compile(

--- a/backend/tests/test_slack_markdown_to_mrkdwn.py
+++ b/backend/tests/test_slack_markdown_to_mrkdwn.py
@@ -1,6 +1,59 @@
 from connectors.slack import markdown_to_mrkdwn
 
 
+def test_markdown_to_mrkdwn_strips_email_style_blockquote_separators() -> None:
+    """Bare ``>`` lines (email reply paragraph separators) must not pass through.
+
+    Slack mrkdwn renders a line containing only ``>`` as a literal ``>`` character
+    (since there's no content after the marker). When forwarded/replied email
+    content gets sent to Slack, those marker-only lines produced stray ``>``
+    glyphs floating between blockquote paragraphs. We strip them so consecutive
+    quoted lines collapse into one continuous Slack blockquote.
+    """
+    sample: str = (
+        "> Subject: Deck + next steps\n"
+        "> Ash,\n"
+        ">\n"
+        "> Good conversation today.\n"
+        "\n"
+        "Deck is attached.\n"
+        "\n"
+        ">\n"
+        "> We are moving quickly on the round.\n"
+        "\n"
+        "Happy to meet the broader team.\n"
+        "\n"
+        ">\n"
+        "> Looking forward to it.\n"
+        ">\n"
+        "> Teg"
+    )
+
+    text, _blocks = markdown_to_mrkdwn(sample)
+
+    for line in text.split("\n"):
+        assert line.strip() != ">", f"stray bare '>' line found: {line!r}"
+
+    assert "> Subject: Deck + next steps\n> Ash,\n> Good conversation today." in text
+    assert "> Looking forward to it.\n> Teg" in text
+
+
+def test_markdown_to_mrkdwn_preserves_blockquote_chars_inside_code_blocks() -> None:
+    """``>`` inside fenced code blocks must not be stripped by blockquote normalization."""
+    sample: str = (
+        "intro\n"
+        "\n"
+        "```\n"
+        ">\n"
+        "> some quoted output\n"
+        "```\n"
+    )
+
+    text, _blocks = markdown_to_mrkdwn(sample)
+
+    assert "```\n>\n> some quoted output\n```" in text
+
+
 def test_markdown_to_mrkdwn_uses_blocks_for_single_table() -> None:
     text, blocks = markdown_to_mrkdwn(
         """


### PR DESCRIPTION
## Summary

Slack messages that include forwarded/replied email content frequently render with stray `>` glyphs floating between disjointed gray-bar blockquote groups. Email replies use bare `>` lines as paragraph separators inside a quote, but Slack mrkdwn renders a marker-only `>` line as a literal `>` character (no content after the marker), and the surrounding blank lines also break the blockquote into separate blocks.

This PR strips bare `>` lines in `markdown_to_mrkdwn` (right after fenced-code extraction so `>` inside code blocks is preserved), so consecutive `> ...` lines collapse into one continuous Slack blockquote.

- Adds `_strip_bare_blockquote_lines` helper + `_BARE_BLOCKQUOTE_LINE_RE` in `backend/connectors/slack.py`
- Wires it into `markdown_to_mrkdwn` after fence extraction, before table wrap / inline formatting
- Adds two tests: email-style separator stripping, and code-block preservation

## Before / After

Input:

```
> Subject: Deck + next steps
> Ash,
>
> Good conversation today.

Deck is attached.

>
> We are moving quickly...
```

Before: stray `>` chars rendered between two disjoint gray-bar blocks.
After: two clean continuous blockquotes with plain text in between.

## Test plan

- [x] `pytest -q backend/tests/test_slack_markdown_to_mrkdwn.py` — 4/4 pass
- [x] Full backend suite: `pytest -q backend/tests` — 655 passed
- [x] `npm run build` in `frontend/` — clean
- [ ] Spot-check in Slack with a real forwarded-email message


Made with [Cursor](https://cursor.com)