### PR TITLE
Restrict email activity visibility (migration 139_email_scope)

### DIFF
--- a/backend/db/migrations/versions/139_email_scope.py
+++ b/backend/db/migrations/versions/139_email_scope.py
@@ -1,0 +1,108 @@
+"""Restrict email activity visibility for non-global admins.
+
+Revision ID: 139_email_scope
+Revises: 138_users_self_update
+Create Date: 2026-05-07
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "139_email_scope"
+down_revision: Union[str, None] = "138_users_self_update"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_EMPTY_UUID: str = "00000000-0000-0000-0000-000000000000"
+
+_CURRENT_ORG_ID: str = f"""
+COALESCE(
+    NULLIF(current_setting('app.current_org_id', true), ''),
+    '{_EMPTY_UUID}'
+)::uuid
+""".strip()
+
+_CURRENT_USER_ID: str = f"""
+COALESCE(
+    NULLIF(current_setting('app.current_user_id', true), ''),
+    '{_EMPTY_UUID}'
+)::uuid
+""".strip()
+
+_ORG_MATCH: str = f"activities.organization_id = {_CURRENT_ORG_ID}"
+
+_EMAIL_IS_OWNED_BY_CURRENT_USER: str = (
+    f"activities.owner_user_id = {_CURRENT_USER_ID}"
+)
+
+_EMAIL_SHARED_BY_OWNER_INTEGRATION: str = """
+EXISTS (
+    SELECT 1
+    FROM integrations i
+    WHERE i.id = activities.integration_id
+      AND i.organization_id = activities.organization_id
+      AND i.user_id = activities.owner_user_id
+      AND i.is_active = TRUE
+      AND i.share_synced_data = TRUE
+)
+""".strip()
+
+_LEGACY_ACTIVITY_VISIBLE: str = f"""
+activities.visibility = 'team'
+OR activities.owner_user_id IS NULL
+OR activities.owner_user_id = {_CURRENT_USER_ID}
+""".strip()
+
+_ACTIVITY_VISIBLE: str = f"""
+current_app_user_is_global_admin()
+OR (
+    activities.type = 'email'
+    AND (
+        {_EMAIL_IS_OWNED_BY_CURRENT_USER}
+        OR {_EMAIL_SHARED_BY_OWNER_INTEGRATION}
+    )
+)
+OR (
+    COALESCE(activities.type, '') <> 'email'
+    AND ({_LEGACY_ACTIVITY_VISIBLE})
+)
+""".strip()
+
+_POLICY_BODY: str = f"""
+({_ORG_MATCH})
+AND (
+    {_ACTIVITY_VISIBLE}
+)
+""".strip()
+
+_LEGACY_POLICY_BODY: str = f"""
+({_ORG_MATCH})
+AND (
+    {_LEGACY_ACTIVITY_VISIBLE}
+)
+""".strip()
+
+
+def upgrade() -> None:
+    assert len(revision) <= 32
+    assert isinstance(down_revision, str) and len(down_revision) <= 32
+
+    op.execute("DROP POLICY IF EXISTS org_and_user_isolation ON activities")
+    op.execute(f"""
+        CREATE POLICY org_and_user_isolation ON activities
+        FOR ALL
+        USING ({_POLICY_BODY})
+        WITH CHECK ({_POLICY_BODY})
+        """)
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS org_and_user_isolation ON activities")
+    op.execute(f"""
+        CREATE POLICY org_and_user_isolation ON activities
+        FOR ALL
+        USING ({_LEGACY_POLICY_BODY})
+        WITH CHECK ({_LEGACY_POLICY_BODY})
+        """)

--- a/backend/tests/test_email_activity_scope_migration.py
+++ b/backend/tests/test_email_activity_scope_migration.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "db"
+    / "migrations"
+    / "versions"
+    / "139_email_scope.py"
+)
+
+
+class TestEmailActivityScopeMigration:
+    def _load_migration(self) -> ModuleType:
+        spec = importlib.util.spec_from_file_location(
+            "migration_139_email_scope", MIGRATION_PATH
+        )
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_revision_ids_fit_alembic_limit(self) -> None:
+        mig = self._load_migration()
+
+        assert mig.revision == "139_email_scope"
+        assert mig.down_revision == "138_users_self_update"
+        assert len(mig.revision) <= 32
+        assert isinstance(mig.down_revision, str)
+        assert len(mig.down_revision) <= 32
+
+    def test_upgrade_policy_limits_non_global_admin_email_visibility(self) -> None:
+        mig = self._load_migration()
+        executed_sql: list[str] = []
+
+        with patch.object(
+            mig.op, "execute", side_effect=lambda sql: executed_sql.append(str(sql))
+        ):
+            mig.upgrade()
+
+        combined_sql = "\n".join(executed_sql)
+
+        assert (
+            "DROP POLICY IF EXISTS org_and_user_isolation ON activities"
+            in combined_sql
+        )
+        assert (
+            "CREATE POLICY org_and_user_isolation ON activities"
+            in combined_sql
+        )
+        assert "current_app_user_is_global_admin()" in combined_sql
+        assert "activities.type = 'email'" in combined_sql
+        assert "COALESCE(activities.type, '') <> 'email'" in combined_sql
+        assert "activities.visibility = 'team'" in combined_sql
+        assert "activities.owner_user_id = COALESCE" in combined_sql
+        assert "FROM integrations i" in combined_sql
+        assert "i.id = activities.integration_id" in combined_sql
+        assert "i.user_id = activities.owner_user_id" in combined_sql
+        assert "i.share_synced_data = TRUE" in combined_sql
+        assert "WITH CHECK" in combined_sql
+
+    def test_downgrade_restores_legacy_activity_visibility_policy(self) -> None:
+        mig = self._load_migration()
+        executed_sql: list[str] = []
+
+        with patch.object(
+            mig.op, "execute", side_effect=lambda sql: executed_sql.append(str(sql))
+        ):
+            mig.downgrade()
+
+        combined_sql = "\n".join(executed_sql)
+
+        assert (
+            "DROP POLICY IF EXISTS org_and_user_isolation ON activities"
+            in combined_sql
+        )
+        assert (
+            "CREATE POLICY org_and_user_isolation ON activities"
+            in combined_sql
+        )
+        assert "activities.visibility = 'team'" in combined_sql
+        assert "activities.owner_user_id IS NULL" in combined_sql
+        assert "activities.owner_user_id = COALESCE" in combined_sql


### PR DESCRIPTION
### Motivation
- Ensure users who are not global admins cannot see arbitrary teammates' emails unless the owner explicitly shared that connector's synced data with the team, while preserving prior visibility rules for non-email activities.

### Description
- Add Alembic migration `139_email_scope` (`backend/db/migrations/versions/139_email_scope.py`) that replaces the `activities` RLS policy to allow activity rows when the actor is a global admin, when the row is not an email, or when the email is owned by the current user or the owner's integration has `share_synced_data = TRUE`.
- Include migration safety preflight assertions for `revision` and `down_revision` lengths and provide a reversible `downgrade()` that restores the legacy activity visibility policy.
- Add unit tests `backend/tests/test_email_activity_scope_migration.py` that validate revision id length, the upgraded policy SQL contains the expected checks (global admin, email-specific ownership/shared integration checks), and that downgrade restores the legacy policy.

### Testing
- Ran migration/unit tests: `python -m pytest backend/tests/test_email_activity_scope_migration.py backend/tests/test_migration_safety.py backend/tests/test_alembic_migration_numbering.py` and all tests passed (5 passed). 
- Verified syntax/compilation with `python -m py_compile backend/db/migrations/versions/139_email_scope.py backend/tests/test_email_activity_scope_migration.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbfb63b1988321ae21bdf27fc16920)