### PR TITLE
Restrict global admin email visibility

### DIFF
--- a/backend/db/migrations/versions/140_global_email_scope.py
+++ b/backend/db/migrations/versions/140_global_email_scope.py
@@ -1,0 +1,116 @@
+"""Apply email activity scope to global admins.
+
+Revision ID: 140_global_email_scope
+Revises: 139_email_scope
+Create Date: 2026-05-07
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "140_global_email_scope"
+down_revision: Union[str, None] = "139_email_scope"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_EMPTY_UUID: str = "00000000-0000-0000-0000-000000000000"
+
+_CURRENT_ORG_ID: str = f"""
+COALESCE(
+    NULLIF(current_setting('app.current_org_id', true), ''),
+    '{_EMPTY_UUID}'
+)::uuid
+""".strip()
+
+_CURRENT_USER_ID: str = f"""
+COALESCE(
+    NULLIF(current_setting('app.current_user_id', true), ''),
+    '{_EMPTY_UUID}'
+)::uuid
+""".strip()
+
+_ORG_MATCH: str = f"activities.organization_id = {_CURRENT_ORG_ID}"
+
+_EMAIL_VISIBLE_TO_CURRENT_USER: str = f"""
+activities.owner_user_id = {_CURRENT_USER_ID}
+OR EXISTS (
+    SELECT 1
+    FROM integrations i
+    WHERE i.id = activities.integration_id
+      AND i.organization_id = activities.organization_id
+      AND i.user_id = activities.owner_user_id
+      AND i.is_active = TRUE
+      AND i.share_synced_data = TRUE
+)
+""".strip()
+
+_LEGACY_ACTIVITY_VISIBLE: str = f"""
+activities.visibility = 'team'
+OR activities.owner_user_id IS NULL
+OR activities.owner_user_id = {_CURRENT_USER_ID}
+""".strip()
+
+_ACTIVITY_VISIBLE: str = f"""
+(
+    activities.type = 'email'
+    AND ({_EMAIL_VISIBLE_TO_CURRENT_USER})
+)
+OR (
+    COALESCE(activities.type, '') <> 'email'
+    AND (
+        current_app_user_is_global_admin()
+        OR ({_LEGACY_ACTIVITY_VISIBLE})
+    )
+)
+""".strip()
+
+_POLICY_BODY: str = f"""
+({_ORG_MATCH})
+AND (
+    {_ACTIVITY_VISIBLE}
+)
+""".strip()
+
+_PREVIOUS_ACTIVITY_VISIBLE: str = f"""
+current_app_user_is_global_admin()
+OR (
+    activities.type = 'email'
+    AND ({_EMAIL_VISIBLE_TO_CURRENT_USER})
+)
+OR (
+    COALESCE(activities.type, '') <> 'email'
+    AND ({_LEGACY_ACTIVITY_VISIBLE})
+)
+""".strip()
+
+_PREVIOUS_POLICY_BODY: str = f"""
+({_ORG_MATCH})
+AND (
+    {_PREVIOUS_ACTIVITY_VISIBLE}
+)
+""".strip()
+
+
+def upgrade() -> None:
+    assert len(revision) <= 32
+    assert isinstance(down_revision, str) and len(down_revision) <= 32
+
+    op.execute("DROP POLICY IF EXISTS org_and_user_isolation ON activities")
+    op.execute(f"""
+        CREATE POLICY org_and_user_isolation ON activities
+        FOR ALL
+        USING ({_POLICY_BODY})
+        WITH CHECK ({_POLICY_BODY})
+        """)
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS org_and_user_isolation ON activities")
+    op.execute(f"""
+        CREATE POLICY org_and_user_isolation ON activities
+        FOR ALL
+        USING ({_PREVIOUS_POLICY_BODY})
+        WITH CHECK ({_PREVIOUS_POLICY_BODY})
+        """)

--- a/backend/tests/test_global_email_activity_scope_migration.py
+++ b/backend/tests/test_global_email_activity_scope_migration.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "db"
+    / "migrations"
+    / "versions"
+    / "140_global_email_scope.py"
+)
+
+
+class TestGlobalEmailActivityScopeMigration:
+    def _load_migration(self) -> ModuleType:
+        spec = importlib.util.spec_from_file_location(
+            "migration_140_global_email_scope", MIGRATION_PATH
+        )
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_revision_ids_fit_alembic_limit(self) -> None:
+        mig = self._load_migration()
+
+        assert mig.revision == "140_global_email_scope"
+        assert mig.down_revision == "139_email_scope"
+        assert len(mig.revision) <= 32
+        assert isinstance(mig.down_revision, str)
+        assert len(mig.down_revision) <= 32
+
+    def test_upgrade_policy_applies_email_scope_before_global_admin_bypass(self) -> None:
+        mig = self._load_migration()
+        executed_sql: list[str] = []
+
+        with patch.object(
+            mig.op, "execute", side_effect=lambda sql: executed_sql.append(str(sql))
+        ):
+            mig.upgrade()
+
+        combined_sql = "\n".join(executed_sql)
+
+        assert (
+            "DROP POLICY IF EXISTS org_and_user_isolation ON activities"
+            in combined_sql
+        )
+        assert "CREATE POLICY org_and_user_isolation ON activities" in combined_sql
+        assert "activities.type = 'email'" in combined_sql
+        assert "COALESCE(activities.type, '') <> 'email'" in combined_sql
+        assert "activities.owner_user_id = COALESCE" in combined_sql
+        assert "FROM integrations i" in combined_sql
+        assert "i.id = activities.integration_id" in combined_sql
+        assert "i.user_id = activities.owner_user_id" in combined_sql
+        assert "i.is_active = TRUE" in combined_sql
+        assert "i.share_synced_data = TRUE" in combined_sql
+        assert "current_app_user_is_global_admin()" in combined_sql
+        assert "WITH CHECK" in combined_sql
+
+        email_branch_start = combined_sql.index("activities.type = 'email'")
+        non_email_branch_start = combined_sql.index(
+            "COALESCE(activities.type, '') <> 'email'"
+        )
+        global_admin_check = combined_sql.index("current_app_user_is_global_admin()")
+
+        assert email_branch_start < non_email_branch_start
+        assert non_email_branch_start < global_admin_check
+
+    def test_downgrade_restores_previous_global_admin_email_bypass(self) -> None:
+        mig = self._load_migration()
+        executed_sql: list[str] = []
+
+        with patch.object(
+            mig.op, "execute", side_effect=lambda sql: executed_sql.append(str(sql))
+        ):
+            mig.downgrade()
+
+        combined_sql = "\n".join(executed_sql)
+
+        assert "CREATE POLICY org_and_user_isolation ON activities" in combined_sql
+        assert "current_app_user_is_global_admin()" in combined_sql
+        assert "activities.type = 'email'" in combined_sql
+        assert "i.share_synced_data = TRUE" in combined_sql
+
+        global_admin_check = combined_sql.index("current_app_user_is_global_admin()")
+        email_branch_start = combined_sql.index("activities.type = 'email'")
+
+        assert global_admin_check < email_branch_start


### PR DESCRIPTION
### Motivation
- Ensure that email activities remain private to the owner unless the owner’s integration explicitly sets `share_synced_data = TRUE`, even when the requester is a global admin.
- Preserve existing global-admin bypass behavior for non-email activities while tightening email visibility to avoid cross-user leakage.

### Description
- Add Alembic migration `backend/db/migrations/versions/140_global_email_scope.py` which recreates the `org_and_user_isolation` RLS policy so email rows are allowed only when owned by the current user or when the owner’s active integration has `share_synced_data = TRUE`, and non-email rows retain the global-admin bypass and legacy team/owner visibility.
- Keep safety assertions in the migration ensuring `len(revision) <= 32` and `len(down_revision) <= 32` to satisfy Alembic ID limits.
- Add unit tests `backend/tests/test_global_email_activity_scope_migration.py` that validate revision ID lengths, the ordering of the policy branches (email-first, non-email then global-admin), and downgrade behavior.

### Testing
- Ran `pytest backend/tests/test_global_email_activity_scope_migration.py backend/tests/test_email_activity_scope_migration.py` and all tests passed (`6 passed`), validating upgrade and downgrade SQL and policy semantics.
- Ran a Python preflight that loaded the migration and asserted Alembic `revision`/`down_revision` lengths, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc032afe6c8321bc2a33c72642a4a4)