### PR TITLE
Gate app preview behind explicit user action

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2588,7 +2588,7 @@ export function Chat({
                         toolApprovals={toolApprovals}
                         onArtifactClick={(a) => { setCurrentArtifactId(a.id); setCurrentAttachmentId(null); setCurrentAttachmentMeta(null); }}
                         onAttachmentClick={(id, meta) => { setCurrentAttachmentId(id); setCurrentAttachmentMeta(meta); setCurrentArtifactId(null); }}
-                        onAppClick={(app: AppBlock["app"]) => { setPreviewAppId(app.id); setPreviewCollapsed(false); setPreviewDismissed(false); setCurrentArtifactId(null); setCurrentAttachmentId(null); setCurrentAttachmentMeta(null); }}
+                        onAppClick={(app: AppBlock["app"]) => { setPreviewAppId(app.id); setPreviewArmed(true); setPreviewCollapsed(false); setPreviewDismissed(false); setCurrentArtifactId(null); setCurrentAttachmentId(null); setCurrentAttachmentMeta(null); }}
                         onToolApprove={handleToolApprove}
                         onToolCancel={handleToolCancel}
                         onToolClick={(block) => setSelectedToolCall({

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -494,6 +494,7 @@ export function Chat({
 
   // App preview panel state
   const [previewAppId, setPreviewAppId] = useState<string | null>(null);
+  const [previewArmed, setPreviewArmed] = useState(false);
   const [previewCollapsed, setPreviewCollapsed] = useState(false);
   const [previewDismissed, setPreviewDismissed] = useState(false);
   const [previewHeight, setPreviewHeight] = useState(300);
@@ -749,8 +750,9 @@ export function Chat({
       const latestApp = conversationApps[conversationApps.length - 1];
       if (latestApp) {
         setPreviewAppId(latestApp.id);
-        setPreviewCollapsed(false);
-        setPreviewDismissed(false);
+        if (previewArmed && !previewDismissed) {
+          setPreviewCollapsed(false);
+        }
       }
     }
     // Default to latest app if no selection yet
@@ -761,7 +763,7 @@ export function Chat({
       }
     }
     prevAppCountRef.current = conversationApps.length;
-  }, [conversationApps, previewAppId]);
+  }, [conversationApps, previewAppId, previewArmed, previewDismissed]);
 
   // Track if this conversation has uncommitted changes (write tools completed)
   const hasUncommittedChanges = useMemo(() => {
@@ -861,6 +863,7 @@ export function Chat({
     setCurrentAttachmentId(null);
     setCurrentAttachmentMeta(null);
     // Reset preview state for new conversation
+    setPreviewArmed(false);
     setPreviewDismissed(false);
     setPreviewAppId(null);
     setPreviewCollapsed(false);
@@ -2461,8 +2464,34 @@ export function Chat({
       <div className="flex-1 flex overflow-hidden">
         {/* Messages column (vertical flex with optional app preview above) */}
         <div ref={dragContainerRef} className={`flex flex-col md:transition-[width] md:duration-300 md:ease-in-out ${currentArtifact ? 'md:w-1/2' : ''} flex-1 min-w-0 min-h-0`}>
+          {/* App preview launcher (requires explicit click to execute app code) */}
+          {conversationApps.length > 0 && (!previewArmed || previewDismissed) && (
+            <div className="border-b border-surface-800 bg-surface-900/90 px-3 md:px-5 py-2.5">
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-xs md:text-sm text-surface-300">
+                  App preview is available for this conversation.
+                </p>
+                <button
+                  type="button"
+                  className="px-2.5 py-1.5 rounded-md text-xs font-medium bg-primary-600 hover:bg-primary-500 text-white transition-colors"
+                  onClick={() => {
+                    const latestApp = conversationApps[conversationApps.length - 1];
+                    if (latestApp && previewAppId === null) {
+                      setPreviewAppId(latestApp.id);
+                    }
+                    setPreviewDismissed(false);
+                    setPreviewArmed(true);
+                    setPreviewCollapsed(false);
+                  }}
+                >
+                  Open app preview
+                </button>
+              </div>
+            </div>
+          )}
+
           {/* App preview panel (above messages) */}
-          {conversationApps.length > 0 && !previewDismissed && (
+          {conversationApps.length > 0 && previewArmed && !previewDismissed && (
             <>
               <AppPreviewPanel
                 apps={conversationApps}


### PR DESCRIPTION
### Motivation
- Prevent untrusted app frontend code from executing automatically when a conversation with app blocks is opened by requiring explicit user interaction before rendering the preview.
- Preserve existing app selection behavior while removing the automatic expand/unhide that previously executed app code on chat load.

### Description
- Add a `previewArmed` state in `Chat.tsx` and reset it when the conversation changes to require explicit user action before preview rendering. 
- Gate `AppPreviewPanel` rendering behind `previewArmed && !previewDismissed` so the Sandpack iframe is not created until the user opens the preview. 
- Add a lightweight in-chat launcher UI (`Open app preview`) that arms the preview and selects the latest app id when clicked. 
- Update the "new app detected" effect to still track and select the latest app id but only auto-expand the preview when it has been explicitly armed and not dismissed.

### Testing
- Built the frontend to validate the change with `npm --prefix frontend run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0fb9c1b48321a7847b7485c21988)