### PR TITLE
Enforce org scoping for conversation summary/title generation and validate conversation in send_message

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -1458,6 +1458,14 @@ async def send_message(
             conv_uuid = conversation.id
             await session.commit()
             # Note: don't call refresh() - it can fail due to RLS after commit
+        else:
+            existing_conversation = (
+                await session.execute(
+                    select(Conversation.id).where(Conversation.id == conv_uuid)
+                )
+            ).scalar_one_or_none()
+            if existing_conversation is None:
+                raise HTTPException(status_code=404, detail="Conversation not found")
 
         # Allow users without organization to chat with limited functionality
         orchestrator = ChatOrchestrator(

--- a/backend/services/conversation_summary.py
+++ b/backend/services/conversation_summary.py
@@ -180,6 +180,7 @@ async def generate_conversation_summary(
     """
     try:
         conv_uuid = uuid.UUID(conversation_id)
+        org_uuid = uuid.UUID(organization_id)
         formatted: str = ""
         semantic_words: int = 0
         user_display: str = "the user"
@@ -187,9 +188,20 @@ async def generate_conversation_summary(
         summary_word_count_col: int | None = None
 
         async with get_admin_session() as session:
-            conv = await session.get(Conversation, conv_uuid)
+            conv = (
+                await session.execute(
+                    select(Conversation).where(
+                        Conversation.id == conv_uuid,
+                        Conversation.organization_id == org_uuid,
+                    )
+                )
+            ).scalar_one_or_none()
             if not conv:
-                logger.warning("Summary: conversation %s not found", conversation_id)
+                logger.warning(
+                    "Summary: conversation %s not found for organization %s",
+                    conversation_id,
+                    organization_id,
+                )
                 return None
 
             semantic_words = await count_semantic_words_for_conversation(session, conv_uuid)
@@ -255,7 +267,10 @@ async def generate_conversation_summary(
         async with get_admin_session() as session:
             await session.execute(
                 update(Conversation)
-                .where(Conversation.id == conv_uuid)
+                .where(
+                    Conversation.id == conv_uuid,
+                    Conversation.organization_id == org_uuid,
+                )
                 .values(
                     summary=raw_text,
                     summary_word_count=semantic_words,
@@ -287,12 +302,20 @@ async def generate_conversation_title(
     """
     try:
         conv_uuid = uuid.UUID(conversation_id)
+        org_uuid = uuid.UUID(organization_id)
         formatted: str = ""
         semantic_words: int = 0
         user_display: str = "the user"
 
         async with get_admin_session() as session:
-            conv = await session.get(Conversation, conv_uuid)
+            conv = (
+                await session.execute(
+                    select(Conversation).where(
+                        Conversation.id == conv_uuid,
+                        Conversation.organization_id == org_uuid,
+                    )
+                )
+            ).scalar_one_or_none()
             if not conv:
                 return None
             if conv.title_llm_upgraded:
@@ -363,7 +386,10 @@ async def generate_conversation_title(
         async with get_admin_session() as session:
             await session.execute(
                 update(Conversation)
-                .where(Conversation.id == conv_uuid)
+                .where(
+                    Conversation.id == conv_uuid,
+                    Conversation.organization_id == org_uuid,
+                )
                 .values(
                     title=title[:255],
                     title_llm_upgraded=True,


### PR DESCRIPTION
### Motivation
- Summary/title generation used an admin DB session and selected conversations by `conversation_id` only, which bypasses RLS and can expose or overwrite another tenant's summaries/titles. 
- The `POST /chat/message` endpoint accepted a client-supplied `conversation_id` without verifying visibility, enabling callers to trigger the vulnerable flow with a foreign UUID.

### Description
- In `backend/services/conversation_summary.py` the handlers now parse `organization_id` to a UUID and load the `Conversation` with both `Conversation.id == conv_uuid` and `Conversation.organization_id == org_uuid` instead of `session.get(conv_uuid)`, and write updates using the same `(id, organization_id)` predicate; missing-conversation cases log a warning. 
- Title generation in `backend/services/conversation_summary.py` receives the same scoping fix (read and update queries constrained by `organization_id`).
- In `backend/api/routes/chat.py` the `send_message` route now validates a client-supplied `conversation_id` inside the RLS-scoped `get_session` by selecting `Conversation.id` before invoking the `ChatOrchestrator`, returning `404 Conversation not found` when inaccessible as defense-in-depth.

### Testing
- Ran compile checks: `python -m compileall backend/services/conversation_summary.py backend/api/routes/chat.py` and compilation succeeded. 
- Ran targeted tests: `pytest -q backend/tests/test_chat_scope_pill_control.py backend/tests/test_chat_slack_user_id_cache.py` which completed successfully (`4 passed`). 
- Changes are minimal and focused on DB query predicates and one API guard to preserve existing functionality while preventing cross-tenant access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecfa323eb083219d56ef298ad6e763)