### PR TITLE
Fix conversation deletion RLS errors

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -29,7 +29,7 @@ import redis.asyncio as aioredis
 
 
 from pydantic import BaseModel
-from sqlalchemy import and_, column, or_, select
+from sqlalchemy import and_, column, delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.auth_middleware import AuthContext, get_current_auth
@@ -1126,6 +1126,23 @@ async def delete_conversation(
 
         if not is_owner and not is_admin:
             raise HTTPException(status_code=403, detail="Only the conversation creator or an org admin can delete it")
+
+        # Delete messages explicitly before deleting the conversation. Without this,
+        # SQLAlchemy may try to NULL chat_messages.conversation_id during flush, but
+        # the chat_messages RLS WITH CHECK policy requires the row to remain linked
+        # to a visible conversation. Deleting children first avoids that invalid
+        # transitional update and leaves remaining dependent rows to their FK actions.
+        messages_result = await session.execute(
+            delete(ChatMessage).where(ChatMessage.conversation_id == conv_uuid)
+        )
+        deleted_messages = messages_result.rowcount or 0
+        logger.info(
+            "[chat] Deleting conversation %s for org=%s user=%s; deleted %d messages first",
+            conversation_id,
+            org_id,
+            auth.user_id,
+            deleted_messages,
+        )
 
         await session.delete(conversation)
         await session.commit()

--- a/backend/db/migrations/versions/141_conv_delete.py
+++ b/backend/db/migrations/versions/141_conv_delete.py
@@ -1,0 +1,62 @@
+"""Cascade chat message deletes with conversations.
+
+Revision ID: 141_conv_delete
+Revises: 140_global_email_scope
+Create Date: 2026-05-07
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "141_conv_delete"
+down_revision: Union[str, None] = "140_global_email_scope"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _replace_chat_messages_conversation_fk(on_delete: str | None) -> None:
+    action_sql = f" ON DELETE {on_delete}" if on_delete else ""
+    op.execute(
+        sa.text(
+            f"""
+            DO $$
+            DECLARE
+                constraint_name text;
+            BEGIN
+                SELECT con.conname INTO constraint_name
+                FROM pg_constraint con
+                JOIN pg_class rel ON rel.oid = con.conrelid
+                JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+                JOIN pg_attribute att ON att.attrelid = rel.oid
+                    AND att.attnum = ANY(con.conkey)
+                JOIN pg_class foreign_rel ON foreign_rel.oid = con.confrelid
+                WHERE con.contype = 'f'
+                  AND nsp.nspname = current_schema()
+                  AND rel.relname = 'chat_messages'
+                  AND att.attname = 'conversation_id'
+                  AND foreign_rel.relname = 'conversations'
+                LIMIT 1;
+
+                IF constraint_name IS NOT NULL THEN
+                    EXECUTE format('ALTER TABLE chat_messages DROP CONSTRAINT %I', constraint_name);
+                END IF;
+
+                ALTER TABLE chat_messages
+                ADD CONSTRAINT fk_chat_messages_conversation_id
+                FOREIGN KEY (conversation_id)
+                REFERENCES conversations(id){action_sql};
+            END $$;
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    _replace_chat_messages_conversation_fk("CASCADE")
+
+
+def downgrade() -> None:
+    _replace_chat_messages_conversation_fk(None)

--- a/backend/models/chat_message.py
+++ b/backend/models/chat_message.py
@@ -30,7 +30,7 @@ class ChatMessage(Base):
         UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
     conversation_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("conversations.id"), nullable=True, index=True
+        UUID(as_uuid=True), ForeignKey("conversations.id", ondelete="CASCADE"), nullable=True, index=True
     )
     # user_id is nullable for Slack conversations where we don't know the RevTops user
     user_id: Mapped[Optional[uuid.UUID]] = mapped_column(

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -144,7 +144,11 @@ class Conversation(Base):
 
     # Relationships
     messages: Mapped[list["ChatMessage"]] = relationship(
-        "ChatMessage", back_populates="conversation", order_by="ChatMessage.created_at"
+        "ChatMessage",
+        back_populates="conversation",
+        order_by="ChatMessage.created_at",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
     )
     workflow: Mapped[Optional["Workflow"]] = relationship(
         "Workflow", back_populates="conversations"
@@ -153,7 +157,10 @@ class Conversation(Base):
         "ChangeSession", back_populates="conversation"
     )
     notifications: Mapped[list["Notification"]] = relationship(
-        "Notification", back_populates="conversation"
+        "Notification",
+        back_populates="conversation",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
     )
 
     def to_dict(self) -> dict[str, Any]:

--- a/backend/tests/test_conversation_delete.py
+++ b/backend/tests/test_conversation_delete.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sqlalchemy import delete
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.inspection import inspect
+
+from models.chat_message import ChatMessage
+from models.conversation import Conversation
+
+
+def test_chat_message_conversation_fk_cascades_in_model() -> None:
+    fk = next(iter(ChatMessage.__table__.c.conversation_id.foreign_keys))
+
+    assert fk.column.table.name == "conversations"
+    assert fk.ondelete == "CASCADE"
+
+
+def test_conversation_child_relationships_do_not_null_messages_or_notifications() -> None:
+    relationships = inspect(Conversation).relationships
+
+    messages = relationships.messages
+    assert messages.passive_deletes is True
+    assert "delete-orphan" in messages.cascade
+
+    notifications = relationships.notifications
+    assert notifications.passive_deletes is True
+    assert "delete-orphan" in notifications.cascade
+
+
+def test_delete_conversation_route_deletes_messages_before_parent() -> None:
+    route_source = (Path(__file__).resolve().parents[1] / "api/routes/chat.py").read_text(encoding="utf-8")
+
+    message_delete = "delete(ChatMessage).where(ChatMessage.conversation_id == conv_uuid)"
+    parent_delete = "await session.delete(conversation)"
+    assert message_delete in route_source
+    assert parent_delete in route_source
+    assert route_source.index(message_delete) < route_source.index(parent_delete)
+
+
+def test_chat_message_delete_statement_targets_conversation_id() -> None:
+    statement = delete(ChatMessage).where(ChatMessage.conversation_id == "00000000-0000-0000-0000-000000000001")
+    compiled = str(statement.compile(dialect=postgresql.dialect()))
+
+    assert "DELETE FROM chat_messages" in compiled
+    assert "chat_messages.conversation_id" in compiled


### PR DESCRIPTION
### Motivation
- Deleting a conversation could trigger SQLAlchemy to NULL `chat_messages.conversation_id` during flush which violated the row-level-security `WITH CHECK` policy and caused `InsufficientPrivilegeError` exceptions. 

### Description
- Update the `DELETE /api/chat/conversations/{id}` route to explicitly run `delete(ChatMessage).where(ChatMessage.conversation_id == conv_uuid)` before removing the `Conversation` and add an informative `logger.info` call. 
- Align the ORM and DB behavior by adding `ondelete="CASCADE"` to `ChatMessage.conversation_id` and setting `Conversation.messages` and `Conversation.notifications` to `cascade="all, delete-orphan"` with `passive_deletes=True`. 
- Add Alembic migration `141_conv_delete` which replaces the existing `chat_messages.conversation_id` foreign key with an `ON DELETE CASCADE` foreign key (upgrade/downgrade implemented and revision lengths validated). 
- Add `backend/tests/test_conversation_delete.py` to assert the FK `ondelete`, relationship `passive_deletes`/`delete-orphan`, that the route deletes messages before the parent, and the compiled `DELETE` statement shape. 

### Testing
- Ran `pytest -q backend/tests/test_conversation_delete.py` and the test suite passed. 
- Ran `pytest -q backend/tests/test_migration_safety.py` and it passed. 
- Verified syntax with `python -m py_compile backend/api/routes/chat.py backend/models/chat_message.py backend/models/conversation.py backend/db/migrations/versions/141_conv_delete.py`. 
- Performed migration preflight check asserting `revision`/`down_revision` lengths for `141_conv_delete.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc33819c1c832197de6c62f0413d09)