### PR TITLE
Fix org settings auth bypass by requiring verified auth context

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -2302,18 +2302,15 @@ async def update_organization_member(
     org_id: str,
     target_user_id: str,
     request: UpdateMemberRequest,
-    user_id: Optional[str] = None,
+    auth: AuthContext = Depends(get_current_auth),
 ) -> dict[str, Optional[str]]:
     """Update a member row. Users can edit themselves; org/global admins can edit anyone in-org."""
     from models.org_member import OrgMember, ORG_MEMBER_SCOPING_STATUSES
 
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Not authenticated")
-
     try:
         org_uuid = UUID(org_id)
         target_uuid = UUID(target_user_id)
-        requester_uuid = UUID(user_id)
+        requester_uuid = auth.user_id
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ID format")
 
@@ -2451,7 +2448,7 @@ async def update_organization_member_role(
 async def remove_organization_member(
     org_id: str,
     target_user_id: str,
-    user_id: Optional[str] = None,
+    auth: AuthContext = Depends(get_current_auth),
 ) -> dict[str, str]:
     """Remove a member from an organization, and unlink all identities.
 
@@ -2460,13 +2457,10 @@ async def remove_organization_member(
     from models.org_member import OrgMember
     from models.external_identity_mapping import ExternalIdentityMapping
 
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Not authenticated")
-
     try:
         org_uuid = UUID(org_id)
         target_uuid = UUID(target_user_id)
-        requester_uuid = UUID(user_id)
+        requester_uuid = auth.user_id
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ID format")
 
@@ -2544,23 +2538,19 @@ class UpdateGuestUserRequest(BaseModel):
 async def update_organization(
     org_id: str,
     request: UpdateOrganizationRequest,
-    user_id: Optional[str] = None,
+    auth: AuthContext = Depends(get_current_auth),
 ) -> OrganizationResponse:
     """Update organization settings.
 
     Requires org admin for this organization, or global_admin.
     """
-    if not user_id:
-        raise HTTPException(status_code=401, detail="Not authenticated")
-
     try:
         org_uuid = UUID(org_id)
-        user_uuid = UUID(user_id)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid ID format")
 
-    async with get_session(organization_id=org_id) as session:
-        requesting_user = await session.get(User, user_uuid)
+    async with get_session(organization_id=org_id, user_id=auth.user_id_str) as session:
+        requesting_user = await session.get(User, auth.user_id)
         if not await _can_administer_org(session, requesting_user, org_uuid):
             raise HTTPException(status_code=403, detail="Org admin or global_admin required for this organization")
 
@@ -2790,7 +2780,7 @@ async def update_guest_user(
 
     user_uuid = auth.user_id
 
-    async with get_session(organization_id=org_id) as session:
+    async with get_session(organization_id=org_id, user_id=auth.user_id_str) as session:
         requesting_user = await session.get(User, user_uuid)
         if not await _can_administer_org(session, requesting_user, org_uuid):
             raise HTTPException(status_code=403, detail="Org admin or global_admin required for this organization")

--- a/backend/tests/test_org_settings_auth_required.py
+++ b/backend/tests/test_org_settings_auth_required.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+from fastapi.testclient import TestClient
+
+from api.auth_middleware import AuthContext, get_current_auth
+from api.main import app
+from api.routes import auth
+
+client = TestClient(app)
+
+
+def test_update_organization_rejects_unauthenticated_user_id_query() -> None:
+    """A guessed admin UUID in query params must not authenticate org updates."""
+    org_id = uuid4()
+    guessed_admin_id = uuid4()
+
+    response = client.patch(
+        f"/api/auth/organizations/{org_id}",
+        params={"user_id": str(guessed_admin_id)},
+        json={"name": "attacker controlled"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_update_organization_uses_verified_auth_context(monkeypatch) -> None:
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    auth_user_id = UUID("22222222-2222-2222-2222-222222222222")
+    attacker_query_user_id = UUID("33333333-3333-3333-3333-333333333333")
+
+    app.dependency_overrides[get_current_auth] = lambda: AuthContext(
+        user_id=auth_user_id,
+        organization_id=org_id,
+        email="admin@example.com",
+        role="user",
+        is_global_admin=False,
+    )
+
+    captured_session_context: dict[str, str | None] = {}
+    captured_admin_user_ids: list[UUID] = []
+
+    org = SimpleNamespace(
+        id=org_id,
+        name="Before",
+        email_domain="example.com",
+        logo_url=None,
+        company_summary=None,
+        llm_provider=None,
+        llm_primary_model=None,
+        llm_cheap_model=None,
+        llm_workflow_model=None,
+    )
+    auth_user = SimpleNamespace(id=auth_user_id, role="user", roles=[])
+
+    class FakeSession:
+        async def get(self, model, model_id):
+            if model is auth.User:
+                captured_admin_user_ids.append(model_id)
+                return auth_user if model_id == auth_user_id else None
+            if model is auth.Organization and model_id == org_id:
+                return org
+            return None
+
+        async def commit(self):
+            return None
+
+        async def refresh(self, _obj):
+            return None
+
+    class FakeSessionContext:
+        async def __aenter__(self):
+            return FakeSession()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_get_session(*, organization_id=None, user_id=None):
+        captured_session_context["organization_id"] = organization_id
+        captured_session_context["user_id"] = user_id
+        return FakeSessionContext()
+
+    async def allow_admin(_session, user, checked_org_id):
+        assert user is auth_user
+        assert checked_org_id == org_id
+        return True
+
+    monkeypatch.setattr(auth, "get_session", fake_get_session)
+    monkeypatch.setattr(auth, "_can_administer_org", allow_admin)
+
+    try:
+        response = client.patch(
+            f"/api/auth/organizations/{org_id}",
+            params={"user_id": str(attacker_query_user_id)},
+            json={"name": "After"},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["name"] == "After"
+    assert captured_session_context == {
+        "organization_id": str(org_id),
+        "user_id": str(auth_user_id),
+    }
+    assert captured_admin_user_ids == [auth_user_id]
+    assert org.name == "After"
+
+
+def test_remove_organization_member_rejects_unauthenticated_user_id_query() -> None:
+    org_id = uuid4()
+    target_user_id = uuid4()
+    guessed_admin_id = uuid4()
+
+    response = client.delete(
+        f"/api/auth/organizations/{org_id}/members/{target_user_id}",
+        params={"user_id": str(guessed_admin_id)},
+    )
+
+    assert response.status_code == 401
+
+
+def test_update_organization_member_rejects_unauthenticated_user_id_query() -> None:
+    org_id = uuid4()
+    target_user_id = uuid4()
+    guessed_admin_id = uuid4()
+
+    response = client.patch(
+        f"/api/auth/organizations/{org_id}/members/{target_user_id}",
+        params={"user_id": str(guessed_admin_id)},
+        json={"title": "CEO"},
+    )
+
+    assert response.status_code == 401

--- a/backend/tests/test_org_settings_auth_required.py
+++ b/backend/tests/test_org_settings_auth_required.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from uuid import UUID, uuid4
 
@@ -10,6 +11,25 @@ from api.main import app
 from api.routes import auth
 
 client = TestClient(app)
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
 
 
 def test_update_organization_rejects_unauthenticated_user_id_query() -> None:
@@ -134,3 +154,67 @@ def test_update_organization_member_rejects_unauthenticated_user_id_query() -> N
     )
 
     assert response.status_code == 401
+
+
+def test_update_organization_member_allows_org_admin_to_edit_other_org_user(
+    monkeypatch,
+) -> None:
+    """Org admins must be able to administer another user's org-scoped profile."""
+    org_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    admin_user_id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    target_user_id = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+    admin_user = SimpleNamespace(id=admin_user_id, role="member", roles=[])
+    target_membership = SimpleNamespace(
+        id=UUID("dddddddd-dddd-dddd-dddd-dddddddddddd"),
+        user_id=target_user_id,
+        organization_id=org_id,
+        status="active",
+        role="member",
+        title=None,
+        reports_to_membership_id=None,
+    )
+
+    class FakeSession:
+        committed = False
+
+        async def get(self, model, model_id):
+            if model is auth.User and model_id == admin_user_id:
+                return admin_user
+            return None
+
+        async def execute(self, _query):
+            return _ScalarResult(target_membership)
+
+        async def commit(self):
+            self.committed = True
+
+    fake_session = FakeSession()
+
+    async def allow_admin(_session, user, checked_org_id):
+        assert _session is fake_session
+        assert user is admin_user
+        assert checked_org_id == org_id
+        return True
+
+    monkeypatch.setattr(
+        auth, "get_admin_session", lambda: _FakeSessionContext(fake_session)
+    )
+    monkeypatch.setattr(auth, "_can_administer_org", allow_admin)
+
+    response = asyncio.run(
+        auth.update_organization_member(
+            org_id=str(org_id),
+            target_user_id=str(target_user_id),
+            request=auth.UpdateMemberRequest(title="VP Sales"),
+            auth=SimpleNamespace(user_id=admin_user_id),
+        )
+    )
+
+    assert response == {
+        "status": "updated",
+        "title": "VP Sales",
+        "reports_to_membership_id": None,
+    }
+    assert target_membership.title == "VP Sales"
+    assert fake_session.committed is True

--- a/backend/tests/test_remove_member_unlinks_identities.py
+++ b/backend/tests/test_remove_member_unlinks_identities.py
@@ -69,15 +69,23 @@ def test_remove_member_rejects_guest_user(monkeypatch):
     requester_id = UUID("22222222-2222-2222-2222-222222222222")
     guest_user_id = UUID("33333333-3333-3333-3333-333333333333")
 
-    membership = SimpleNamespace(user_id=guest_user_id, organization_id=org_id, status="active")
-    requester = SimpleNamespace(id=requester_id, is_guest=False, role="member", roles=[])
-    guest_user = SimpleNamespace(id=guest_user_id, is_guest=True, organization_id=org_id)
+    membership = SimpleNamespace(
+        user_id=guest_user_id, organization_id=org_id, status="active"
+    )
+    requester = SimpleNamespace(
+        id=requester_id, is_guest=False, role="member", roles=[]
+    )
+    guest_user = SimpleNamespace(
+        id=guest_user_id, is_guest=True, organization_id=org_id
+    )
 
     fake_session = _FakeSession(
         users={requester_id: requester, guest_user_id: guest_user},
         execute_results=[_ScalarResult(membership)],
     )
-    monkeypatch.setattr(auth, "get_admin_session", lambda: _FakeSessionContext(fake_session))
+    monkeypatch.setattr(
+        auth, "get_admin_session", lambda: _FakeSessionContext(fake_session)
+    )
 
     async def _allow_admin(*_args, **_kwargs):
         return True
@@ -89,7 +97,7 @@ def test_remove_member_rejects_guest_user(monkeypatch):
             auth.remove_organization_member(
                 org_id=str(org_id),
                 target_user_id=str(guest_user_id),
-                user_id=str(requester_id),
+                auth=SimpleNamespace(user_id=requester_id),
             )
         )
 
@@ -102,21 +110,31 @@ def test_remove_member_unlinks_all_identities(monkeypatch):
     requester_id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
     target_user_id = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
 
-    membership = SimpleNamespace(user_id=target_user_id, organization_id=org_id, status="active")
-    requester = SimpleNamespace(id=requester_id, is_guest=False, role="member", roles=[])
+    membership = SimpleNamespace(
+        user_id=target_user_id, organization_id=org_id, status="active"
+    )
+    requester = SimpleNamespace(
+        id=requester_id, is_guest=False, role="member", roles=[]
+    )
     target_user = SimpleNamespace(
         id=target_user_id, is_guest=False, guest_organization_id=None
     )
     mappings = [
-        SimpleNamespace(user_id=target_user_id, revtops_email="one@example.com", match_source="auto"),
-        SimpleNamespace(user_id=target_user_id, revtops_email="two@example.com", match_source="auto"),
+        SimpleNamespace(
+            user_id=target_user_id, revtops_email="one@example.com", match_source="auto"
+        ),
+        SimpleNamespace(
+            user_id=target_user_id, revtops_email="two@example.com", match_source="auto"
+        ),
     ]
 
     fake_session = _FakeSession(
         users={requester_id: requester, target_user_id: target_user},
         execute_results=[_ScalarResult(membership), _ListResult(mappings)],
     )
-    monkeypatch.setattr(auth, "get_admin_session", lambda: _FakeSessionContext(fake_session))
+    monkeypatch.setattr(
+        auth, "get_admin_session", lambda: _FakeSessionContext(fake_session)
+    )
 
     async def _allow_admin(*_args, **_kwargs):
         return True
@@ -131,7 +149,7 @@ def test_remove_member_unlinks_all_identities(monkeypatch):
         auth.remove_organization_member(
             org_id=str(org_id),
             target_user_id=str(target_user_id),
-            user_id=str(requester_id),
+            auth=SimpleNamespace(user_id=requester_id),
         )
     )
 
@@ -150,15 +168,23 @@ def test_remove_invited_member_rejects_non_admin_requester(monkeypatch):
     requester_id = UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee")
     invited_user_id = UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
 
-    requester = SimpleNamespace(id=requester_id, is_guest=False, role="member", roles=[])
-    invited_user = SimpleNamespace(id=invited_user_id, is_guest=False, organization_id=org_id)
-    invited_membership = SimpleNamespace(user_id=invited_user_id, organization_id=org_id, status="invited", role="member")
+    requester = SimpleNamespace(
+        id=requester_id, is_guest=False, role="member", roles=[]
+    )
+    invited_user = SimpleNamespace(
+        id=invited_user_id, is_guest=False, organization_id=org_id
+    )
+    invited_membership = SimpleNamespace(
+        user_id=invited_user_id, organization_id=org_id, status="invited", role="member"
+    )
 
     fake_session = _FakeSession(
         users={requester_id: requester, invited_user_id: invited_user},
         execute_results=[_ScalarResult(invited_membership)],
     )
-    monkeypatch.setattr(auth, "get_admin_session", lambda: _FakeSessionContext(fake_session))
+    monkeypatch.setattr(
+        auth, "get_admin_session", lambda: _FakeSessionContext(fake_session)
+    )
 
     async def _deny_admin(*_args, **_kwargs):
         return False
@@ -170,7 +196,7 @@ def test_remove_invited_member_rejects_non_admin_requester(monkeypatch):
             auth.remove_organization_member(
                 org_id=str(org_id),
                 target_user_id=str(invited_user_id),
-                user_id=str(requester_id),
+                auth=SimpleNamespace(user_id=requester_id),
             )
         )
 


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated callers from impersonating users by passing a `user_id` query parameter to org settings and member endpoints, which previously allowed guessed UUIDs to act as the requester when RLS context was set separately.

### Description
- Replace caller-supplied `user_id` query parameters with a verified `AuthContext` dependency (`Depends(get_current_auth)`) on the org settings and adjacent member mutation endpoints.
- Use `auth.user_id` as the canonical requester identity and pass `user_id=auth.user_id_str` into `get_session(...)` so RLS context and admin checks are executed with the verified user.
- Updated endpoints: `PATCH /organizations/{org_id}` (`update_organization`), `PATCH /organizations/{org_id}/members/{target_user_id}` (`update_organization_member`), `DELETE /organizations/{org_id}/members/{target_user_id}` (`remove_organization_member`), and `PATCH /organizations/{org_id}/guest-user` (`update_guest_user`).
- Added regression tests in `backend/tests/test_org_settings_auth_required.py` to assert that guessed `user_id` query params no longer authenticate requests and that the verified auth context is used for RLS/session user scoping.

### Testing
- Ran the new regression test suite: `python -m pytest backend/tests/test_org_settings_auth_required.py -q` and it passed (`4 passed`).
- Ran additional related tests: `python -m pytest backend/tests/test_org_settings_auth_required.py backend/tests/test_update_member_role_blocks_global_admin.py backend/tests/test_delete_organization_guest_cleanup.py -q` and they all passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3403322c8321b34408de3ba09c75)