### PR TITLE
fix(foreach): snapshot BulkOperation before session closes

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -6584,6 +6584,7 @@ async def _poll_bulk_operation(
             succeeded: int = int(succeeded_raw) if succeeded_raw else 0
             failed: int = int(failed_raw) if failed_raw else 0
 
+            bulk_snapshot: dict[str, Any] | None
             async with get_session(organization_id=organization_id) as session:
                 result = await session.execute(
                     select(BulkOperation).where(
@@ -6591,19 +6592,33 @@ async def _poll_bulk_operation(
                         BulkOperation.organization_id == UUID(organization_id),
                     )
                 )
-                operation: BulkOperation | None = result.scalar_one_or_none()
+                op_row: BulkOperation | None = result.scalar_one_or_none()
+                if op_row is None:
+                    bulk_snapshot = None
+                else:
+                    # Copy primitives inside the session scope — the ORM instance is
+                    # expired/detached after exit and must not be read outside.
+                    bulk_snapshot = {
+                        "status": op_row.status,
+                        "operation_name": op_row.operation_name or "foreach",
+                        "total_items": op_row.total_items,
+                        "completed_items": op_row.completed_items,
+                        "succeeded_items": op_row.succeeded_items,
+                        "failed_items": op_row.failed_items,
+                        "error": op_row.error,
+                    }
 
-            if not operation:
+            if bulk_snapshot is None:
                 return {"error": f"Bulk operation {op_id} not found."}
 
-            status: str = operation.status
-            op_name: str = operation.operation_name or "foreach"
+            status: str = bulk_snapshot["status"]
+            op_name: str = bulk_snapshot["operation_name"]
 
             if total == 0:
-                total = operation.total_items
-                completed = operation.completed_items
-                succeeded = operation.succeeded_items
-                failed = operation.failed_items
+                total = bulk_snapshot["total_items"]
+                completed = bulk_snapshot["completed_items"]
+                succeeded = bulk_snapshot["succeeded_items"]
+                failed = bulk_snapshot["failed_items"]
 
             if completed != last_completed:
                 last_completed = completed
@@ -6651,8 +6666,9 @@ async def _poll_bulk_operation(
                         f"Completed: {succeeded} succeeded, {failed} failed out of {total}."
                     )
                 elif status == "failed":
-                    response["error"] = operation.error
-                    response["message"] = f"Failed: {operation.error}"
+                    err_text: str | None = bulk_snapshot.get("error")
+                    response["error"] = err_text
+                    response["message"] = f"Failed: {err_text}"
                 else:
                     response["message"] = "Cancelled."
                 return response


### PR DESCRIPTION
## Summary
Cherry-pick of the foreach polling fix: `_poll_bulk_operation` was reading `BulkOperation` ORM attributes after the SQLAlchemy session closed, causing detached-instance errors in production.

## Change
Copy status, counters, and error fields into a plain dict inside the `get_session` block before use.

## Verification
- Full backend test suite: **706 passed**
- Cherry-pick applied cleanly onto current `main`

Merge to `main` triggers automatic deploy.

Made with [Cursor](https://cursor.com)