### PR TITLE
feat(attio): list_statuses for deal stages

### DIFF
--- a/backend/connectors/attio.py
+++ b/backend/connectors/attio.py
@@ -300,6 +300,27 @@ class AttioConnector(BaseConnector):
                     {"name": "offset", "type": "integer", "required": False},
                 ],
             ),
+            ConnectorAction(
+                name="list_statuses",
+                description=(
+                    "GET /v2/objects/{object}/attributes/{attribute}/statuses — "
+                    "list selectable status values (titles and IDs). Default: deals.stage for pipeline stages."
+                ),
+                parameters=[
+                    {
+                        "name": "object",
+                        "type": "string",
+                        "required": False,
+                        "description": "Object api_slug (default: deals)",
+                    },
+                    {
+                        "name": "attribute",
+                        "type": "string",
+                        "required": False,
+                        "description": "Status attribute api_slug (default: stage)",
+                    },
+                ],
+            ),
         ],
         nango_integration_id="attio",
         query_description=(
@@ -321,7 +342,7 @@ After connecting and syncing, query SQL on `contacts`, `accounts`, `deals`, `act
 - **update_person** — Required: `id` (Attio `record_id`).
 - **create_company** — Required: `name`. Optional: `domains` (array) or `domain` (string). Assert uses `domains`.
 - **update_company** — Required: `id`.
-- **create_deal** — Required: `name`, `stage` (status title or UUID, e.g. `Lead`), and **either** `owner_email` **or** `owner_workspace_member_id` (standard Attio deals require an owner). Optional: `value`, `currency`, `company_id`.
+- **create_deal** — Required: `name`, `stage` (must match a configured pipeline status **title** or **status UUID**), and **either** `owner_email` **or** `owner_workspace_member_id`. Call **`list_statuses`** first (default: deals + stage) to see exact titles/IDs for this workspace—do not guess. Optional: `value`, `currency`, `company_id`.
 - **update_deal** — Required: `id`. Optional: `name`, `stage`, `owner_email`, `owner_workspace_member_id`, `value`, `currency`, `company_id`.
 - **create_note** — Required: `parent_object`, `parent_record_id`, `title`, `content`. Optional: `format` (`plaintext`|`markdown`).
 
@@ -332,6 +353,7 @@ After connecting and syncing, query SQL on `contacts`, `accounts`, `deals`, `act
 - **list_workspace_members** — no params.
 - **list_lists** — no params.
 - **list_list_entries** — `list` (slug or id), optional `filter`, `sorts`, `limit`, `offset`.
+- **list_statuses** — Optional `object` (default `deals`), optional `attribute` (default `stage`). Returns workspace-specific status titles/UUIDs; **use before create_deal** so `stage` matches Attio.
 """,
     )
 
@@ -1033,5 +1055,14 @@ After connecting and syncing, query SQL on `contacts`, `accounts`, `deals`, `act
                 "POST",
                 f"/v2/lists/{lst}/entries/query",
                 json_body=body_le,
+            )
+        if action == "list_statuses":
+            obj_ls: str = str(raw.get("object") or "deals").strip()
+            attr_ls: str = str(raw.get("attribute") or "stage").strip()
+            if not obj_ls or not attr_ls:
+                raise ValueError("list_statuses requires non-empty object and attribute (or omit both for defaults deals/stage)")
+            return await self._make_request(
+                "GET",
+                f"/v2/objects/{obj_ls}/attributes/{attr_ls}/statuses",
             )
         raise ValueError(f"Unknown Attio action: {action}")

--- a/backend/tests/test_attio_connector.py
+++ b/backend/tests/test_attio_connector.py
@@ -326,6 +326,33 @@ async def test_execute_action_search_records(monkeypatch: pytest.MonkeyPatch) ->
 
 
 @pytest.mark.asyncio
+async def test_execute_action_list_statuses_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    c = _connector()
+    recorded: list[tuple[str, str]] = []
+
+    async def fake_make_request(
+        self: AttioConnector,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        recorded.append((method, endpoint))
+        return {"data": [{"title": "Lead", "id": {"status_id": "s1"}}]}
+
+    async def fake_token(self: AttioConnector) -> tuple[str, str]:
+        return ("tok", "")
+
+    monkeypatch.setattr(AttioConnector, "_make_request", fake_make_request)
+    monkeypatch.setattr(AttioConnector, "get_oauth_token", fake_token)
+
+    out: dict[str, Any] = await c.execute_action("list_statuses", {})
+    assert recorded == [("GET", "/v2/objects/deals/attributes/stage/statuses")]
+    assert out["data"][0]["title"] == "Lead"
+
+
+@pytest.mark.asyncio
 async def test_get_schema_builds_manifest(monkeypatch: pytest.MonkeyPatch) -> None:
     c = _connector()
     calls: list[tuple[str, str]] = []


### PR DESCRIPTION
## Summary
Adds `list_statuses` to `run_on_connector` for Attio: `GET /v2/objects/{object}/attributes/{attribute}/statuses` with defaults `deals` + `stage` so agents can discover pipeline status titles/UUIDs before `create_deal`.

## Docs
- Usage guide + `create_deal` bullet updated; `get_connector_docs` auto-appends the new action via connector meta.

## Tests
`pytest tests/test_attio_connector.py` — 11 passed.

Made with [Cursor](https://cursor.com)