### PR TITLE
fix(auth): unblock /users/sync ID migration for invited users

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -746,13 +746,31 @@ async def sync_user(
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid user ID")
 
-    if auth.user_id != user_uuid:
-        raise HTTPException(status_code=403, detail="User ID does not match authenticated user")
-
-    request_email = request.email.strip().lower()
-    auth_email = (auth.email or "").strip().lower()
-    if auth_email and request_email != auth_email:
+    # Email is the durable identity for /users/sync. Validate it strictly:
+    # the request's email must match the JWT-verified email on the auth
+    # context. The JWT signature is already verified upstream, so a
+    # matching email proves request and token belong to the same person.
+    request_email: str = request.email.strip().lower()
+    auth_email: str = (auth.email or "").strip().lower()
+    if not auth_email or request_email != auth_email:
         raise HTTPException(status_code=403, detail="Email does not match authenticated user")
+
+    # NOTE: Do NOT 403 on `auth.user_id != user_uuid` here. `request.id` is
+    # the Supabase auth `sub`, while `auth.user_id` is the DB primary key
+    # — and `_get_user_from_token` falls back to email-lookup when the DB
+    # has no user with that PK (the case for invited / waitlist users
+    # whose row was created with an auto-generated UUID before they
+    # signed in via OAuth). This very endpoint then migrates `users.id`
+    # to the Supabase `sub` further below; a 403 here would create a
+    # deadlock that prevents invited users from completing onboarding.
+    if auth.user_id != user_uuid:
+        logger.info(
+            "User ID mismatch on /users/sync — proceeding with migration: "
+            "auth.user_id=%s request.id=%s email=%s",
+            auth.user_id,
+            user_uuid,
+            auth_email,
+        )
 
     org_uuid: Optional[UUID] = None
     if request.organization_id:

--- a/backend/tests/test_users_sync_id_migration.py
+++ b/backend/tests/test_users_sync_id_migration.py
@@ -1,0 +1,163 @@
+"""Regression tests for ``POST /auth/users/sync`` ID-migration handling.
+
+Invited / waitlist users have a `users.id` auto-generated before they ever
+sign in via Supabase OAuth. When they later sign in, their JWT `sub`
+differs from `users.id`. The sync endpoint is supposed to migrate
+`users.id` to match the Supabase `sub`, but historically a 403 guard
+fired before the migration code ran, leaving the user permanently stuck
+("invited" status, can't connect integrations, can't bootstrap).
+
+These tests pin the desired behaviour: validation trusts the
+JWT-verified email — not the (potentially mismatched) DB primary key —
+so the migration path can run.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from uuid import UUID
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes import auth
+
+
+_DB_ID = UUID("ee3c1568-3df0-4a4c-b0bb-a29d79aa6bc9")
+_SUPABASE_SUB = UUID("5ee8316b-ca2d-41c9-be55-b0b355bd71ce")
+
+
+class _StopValidation(Exception):
+    """Sentinel raised inside the fake admin session.
+
+    If the test reaches the admin-session block it means validation has
+    accepted the request. We don't want to model the full DB
+    interaction, so we raise to short-circuit the rest of the endpoint.
+    """
+
+
+class _FakeAdminSession:
+    async def get(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise _StopValidation
+
+
+class _FakeAdminSessionContext:
+    async def __aenter__(self) -> _FakeAdminSession:
+        return _FakeAdminSession()
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:  # noqa: ANN001
+        return False
+
+
+def _auth_ctx(user_id: UUID, email: str) -> auth.AuthContext:
+    return auth.AuthContext(
+        user_id=user_id,
+        organization_id=None,
+        email=email,
+        role="member",
+        is_global_admin=False,
+    )
+
+
+def _request(user_id: UUID, email: str) -> auth.SyncUserRequest:
+    return auth.SyncUserRequest(id=str(user_id), email=email)
+
+
+def _run_sync(
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    auth_user_id: UUID,
+    auth_email: str,
+    request_id: UUID,
+    request_email: str,
+) -> None:
+    monkeypatch.setattr(
+        auth, "get_admin_session", lambda: _FakeAdminSessionContext()
+    )
+    asyncio.run(
+        auth.sync_user(
+            request=_request(request_id, request_email),
+            auth=_auth_ctx(auth_user_id, auth_email),
+        )
+    )
+
+
+def test_sync_user_accepts_id_mismatch_when_email_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The invited-user ID-migration path must not be blocked.
+
+    Reproduces the production deadlock: an invited user's `auth.user_id`
+    (resolved by email-fallback in auth_middleware) is the legacy
+    auto-generated DB id, while `request.id` is their Supabase `sub`.
+    The fix lets validation pass when emails match so the migration
+    UPDATE can run.
+    """
+    with pytest.raises(_StopValidation):
+        _run_sync(
+            monkeypatch=monkeypatch,
+            auth_user_id=_DB_ID,
+            auth_email="jim@example.com",
+            request_id=_SUPABASE_SUB,
+            request_email="jim@example.com",
+        )
+
+
+def test_sync_user_accepts_id_mismatch_when_email_case_differs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Email comparison must be case-insensitive (matches production behaviour)."""
+    with pytest.raises(_StopValidation):
+        _run_sync(
+            monkeypatch=monkeypatch,
+            auth_user_id=_DB_ID,
+            auth_email="Jim@Example.com",
+            request_id=_SUPABASE_SUB,
+            request_email="jim@example.com",
+        )
+
+
+def test_sync_user_rejects_when_emails_differ(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        _run_sync(
+            monkeypatch=monkeypatch,
+            auth_user_id=_DB_ID,
+            auth_email="other@example.com",
+            request_id=_SUPABASE_SUB,
+            request_email="jim@example.com",
+        )
+    assert exc_info.value.status_code == 403
+    assert "Email" in exc_info.value.detail
+
+
+def test_sync_user_rejects_when_auth_context_has_no_email(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty auth.email must not silently bypass validation."""
+    with pytest.raises(HTTPException) as exc_info:
+        _run_sync(
+            monkeypatch=monkeypatch,
+            auth_user_id=_DB_ID,
+            auth_email="",
+            request_id=_SUPABASE_SUB,
+            request_email="jim@example.com",
+        )
+    assert exc_info.value.status_code == 403
+
+
+def test_sync_user_rejects_invalid_user_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        auth, "get_admin_session", lambda: _FakeAdminSessionContext()
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            auth.sync_user(
+                request=auth.SyncUserRequest(id="not-a-uuid", email="jim@example.com"),
+                auth=_auth_ctx(_DB_ID, "jim@example.com"),
+            )
+        )
+    assert exc_info.value.status_code == 400


### PR DESCRIPTION
## Summary

`POST /auth/users/sync` is the endpoint that migrates `users.id` from an auto-generated invite-time UUID to the user's Supabase auth `sub` (see the `UPDATE users SET id = :new_id WHERE id = :old_id` later in the function). But it was 403'ing whenever the very mismatch it exists to fix was present:

- For an invited user, `auth_middleware._get_user_from_token` falls back to email-lookup (`auth_middleware.py:421`), so `auth.user_id` is the legacy DB id (`ee3c1568-…`).
- The frontend correctly sends the Supabase `sub` (`5ee8316b-…`) as `request.id`.
- The check `if auth.user_id != user_uuid: raise HTTPException(status_code=403, ...)` rejected the request before the migration UPDATE could run.

Trust the JWT-verified email instead: strict, case-insensitive comparison of `request.email` and `auth.email`. The JWT signature is already verified upstream, so a matching email proves it's the same person — and lets the migration path actually run.

### Production impact this fixes

Today an invited user (Cynthia → Jim at GAIA) hit this exact deadlock:

1. `POST /auth/users/sync` → **403 Forbidden** (this fix)
2. Membership stays `status='invited'`, `joined_at=null`
3. `POST /auth/integrations/confirm` for Slack → **403 Forbidden** (because `_get_org_membership` only matches `('active','onboarding')`)
4. `upsert_bot_install` never runs → no `messenger_bot_installs` row → `Cannot create SlackConnector` on every inbound Slack event from that workspace
5. Eventually triggers a `Rolling Query Success` PagerDuty incident

Once `/users/sync` succeeds, it auto-promotes pending memberships from `invited` → `onboarding` (lines 870-877), which unblocks `/integrations/confirm` and the rest of the bootstrap chain.

## Test plan

- [x] `pytest -q backend/tests/test_users_sync_id_migration.py` — 5 new regression tests
- [x] `pytest -q backend/tests` — 711 tests pass
- [x] `npm run build` (frontend) — clean build
- [ ] Have Jim retry the Slack OAuth on production (already manually unstuck via DB; this PR prevents recurrence for future invitees)

The new tests cover:
- ID mismatch + matching email → validation passes (the deadlock fix)
- ID mismatch + case-different email → validation passes (case-insensitive)
- Email mismatch → 403
- Empty `auth.email` → 403 (no silent bypass)
- Invalid UUID in `request.id` → 400

Made with [Cursor](https://cursor.com)