### PR TITLE
Show all pinned chats in sidebar

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -251,6 +251,29 @@ class ConversationListResponse(BaseModel):
     server_time: str
 
 
+def _parse_conversation_ids(raw_ids: str | None) -> list[UUID]:
+    """Parse comma-separated conversation IDs from a query parameter."""
+    if not raw_ids:
+        return []
+
+    parsed: list[UUID] = []
+    seen: set[UUID] = set()
+    for raw_id in raw_ids.split(","):
+        value = raw_id.strip()
+        if not value:
+            continue
+        try:
+            conversation_id = UUID(value)
+        except ValueError:
+            logger.info("[chat] Ignoring invalid pinned conversation id=%s", value)
+            continue
+        if conversation_id in seen:
+            continue
+        seen.add(conversation_id)
+        parsed.append(conversation_id)
+    return parsed
+
+
 def _normalize_channel_id(source: str | None, source_channel_id: str | None) -> str | None:
     if source != "slack" or not source_channel_id:
         return None
@@ -518,6 +541,7 @@ async def list_conversations(
     scope: Optional[str] = None,
     mine: bool = False,
     search: Optional[str] = None,
+    pinned_ids: Optional[str] = None,
 ) -> ConversationListResponse:
     """List conversations for the authenticated user, ordered by most recent.
 
@@ -525,9 +549,12 @@ async def list_conversations(
         scope: Optional filter - "shared" or "private". If not provided, returns all.
         mine: If true, only return conversations created by the current user.
         search: Optional text search across title, summary, preview, and message content.
+        pinned_ids: Optional comma-separated conversation IDs to include even when
+            they fall outside the recency-limited page.
     """
     org_id = auth.organization_id_str
     normalized_search = (search or "").strip()
+    pinned_conversation_ids = _parse_conversation_ids(pinned_ids)
 
     async with get_session(organization_id=org_id, user_id=auth.user_id) as session:
         # Fast path: query without Slack filter first
@@ -597,6 +624,21 @@ async def list_conversations(
         # can keep pagination controls enabled immediately while we reconcile
         # Slack-only rows that may need to be merged into the visible page.
         slack_user_ids = await _get_slack_user_ids(auth, session=session)
+        pinned_rows: list[Conversation] = []
+        if pinned_conversation_ids and not normalized_search:
+            pinned_result = await session.execute(
+                select(Conversation)
+                .where(Conversation.type != "workflow")
+                .where(Conversation.id.in_(pinned_conversation_ids))
+                .where(_build_conversation_access_filter(auth, slack_user_ids))
+            )
+            pinned_rows = list(pinned_result.scalars().all())
+            logger.info(
+                "[chat] Including pinned conversation summaries requested=%d accessible=%d user=%s",
+                len(pinned_conversation_ids),
+                len(pinned_rows),
+                auth.user_id_str,
+            )
         # Slack-only rows must be considered before advancing cursor pagination.
         # For non-cursor requests, we only reconcile on the first page (offset=0)
         # to avoid reordering/duplication issues on legacy offset pages. Older
@@ -691,6 +733,17 @@ async def list_conversations(
         if conversations and has_more:
             last = conversations[-1]
             next_cursor = _encode_cursor(last.updated_at, last.id)
+
+        if pinned_rows:
+            seen_ids = {c.id for c in conversations}
+            for conv in pinned_rows:
+                if conv.id not in seen_ids:
+                    conversations.append(conv)
+                    seen_ids.add(conv.id)
+            conversations.sort(
+                key=lambda c: (c.updated_at, c.id),
+                reverse=True,
+            )
 
         # Collect all participant user IDs to fetch in one query
         all_participant_ids: set[UUID] = set()

--- a/backend/tests/test_chat_bucket_derivation.py
+++ b/backend/tests/test_chat_bucket_derivation.py
@@ -34,3 +34,17 @@ def test_derive_bucket_returns_uncategorized_for_other_sources() -> None:
         "uncategorized",
         "uncategorized",
     )
+
+
+def test_parse_conversation_ids_preserves_order_and_deduplicates_valid_ids() -> None:
+    first = "11111111-1111-4111-8111-111111111111"
+    second = "22222222-2222-4222-8222-222222222222"
+
+    parsed = chat._parse_conversation_ids(f" {first},not-a-uuid,{second},{first}, ")
+
+    assert [str(value) for value in parsed] == [first, second]
+
+
+def test_parse_conversation_ids_returns_empty_for_blank_values() -> None:
+    assert chat._parse_conversation_ids(None) == []
+    assert chat._parse_conversation_ids(" , ") == []

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -749,7 +749,7 @@ function ChatAccordion({
       remaining -= selected.length;
       return selected;
     };
-    const limitedPinned = take(pinned.sort(byNewest));
+    const limitedPinned = pinned.sort(byNewest);
     const limitedDirect = take(direct.sort(byNewest));
     const limitedChannels = channelSections
       .map((section) => ({ ...section, chats: take(section.chats) }))

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -402,8 +402,14 @@ export const useChatStore = create<ChatState>()(
           server_time?: string;
         };
 
+        const pinnedChatIds = useUIStore.getState().pinnedChatIds;
+        const query = new URLSearchParams({ limit: "20" });
+        if (pinnedChatIds.length > 0) {
+          query.set("pinned_ids", pinnedChatIds.join(","));
+        }
+
         const { data, error } = await apiRequest<ConversationApiResponse>(
-          `/chat/conversations?limit=20`,
+          `/chat/conversations?${query.toString()}`,
         );
 
         if (error) {


### PR DESCRIPTION
### Motivation
- Ensure that conversations the user has pinned always appear in the left-hand sidebar even if they are not among the most-recent conversations. 
- Avoid truncating pinned items by the global recency cap while preserving existing pagination behavior for non-pinned rows.

### Description
- Add a backend helper `_parse_conversation_ids` and a `pinned_ids` query parameter to `GET /api/chat/conversations` to accept a comma-separated list of conversation IDs and ignore invalid/duplicate entries. 
- Fetch accessible pinned conversation rows server-side and merge them into the response after pagination/cursor computation so pinned summaries are included without breaking recency pagination. 
- Send local pinned chat IDs from the frontend when fetching conversations by updating the sidebar conversation fetch in `frontend/src/store/chatStore.ts` to include `pinned_ids`. 
- Stop applying the sidebar global cap to pinned conversations by returning all pinned conversations (sorted by newest) in the sidebar grouping logic in `frontend/src/components/Sidebar.tsx`. 
- Add unit tests for the pinned ID parser to cover ordering, deduplication, invalid IDs, and blank input (`backend/tests/test_chat_bucket_derivation.py`).

### Testing
- Ran `pytest backend/tests/test_chat_bucket_derivation.py` and the test file passed (7 tests, all passed). 
- Built the frontend with `npm run build` and the build completed successfully (production bundle produced, with informational chunk-size warnings). 
- Ran `npm run lint` for the frontend and it exited successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0afc27548321a617d083d669c6c1)