### PR TITLE
Use stored snapshots for app list previews

### DIFF
--- a/backend/api/routes/apps.py
+++ b/backend/api/routes/apps.py
@@ -1002,11 +1002,20 @@ async def save_screenshot(
             raise HTTPException(status_code=404, detail="App not found")
 
         config = dict(app.widget_config) if app.widget_config else {}
+        captured_at = datetime.utcnow().isoformat() + "Z"
         config["screenshot"] = body.screenshot
+        config["screenshot_captured_at"] = captured_at
         app.widget_config = config
+        logger.info(
+            "Saved latest app snapshot app_id=%s organization_id=%s captured_at=%s bytes=%d",
+            app_id,
+            auth.organization_id_str,
+            captured_at,
+            len(body.screenshot),
+        )
         await session.commit()
 
-    return {"status": "ok"}
+    return {"status": "ok", "screenshot_captured_at": captured_at}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_app_snapshot_previews.py
+++ b/backend/tests/test_app_snapshot_previews.py
@@ -1,0 +1,25 @@
+from api.routes.apps import _strip_screenshot
+
+
+def test_strip_screenshot_keeps_snapshot_metadata_without_payload() -> None:
+    config = {
+        "screenshot": "data:image/jpeg;base64,abc",
+        "screenshot_captured_at": "2026-05-08T12:00:00Z",
+        "preferred_mode": "mini_app",
+    }
+
+    stripped = _strip_screenshot(config)
+
+    assert stripped == {
+        "has_screenshot": True,
+        "screenshot_captured_at": "2026-05-08T12:00:00Z",
+        "preferred_mode": "mini_app",
+    }
+    assert "screenshot" not in stripped
+    assert config["screenshot"] == "data:image/jpeg;base64,abc"
+
+
+def test_strip_screenshot_leaves_configs_without_snapshot_unchanged() -> None:
+    config = {"preferred_mode": "icon"}
+
+    assert _strip_screenshot(config) is config

--- a/frontend/src/components/apps/SandpackAppRenderer.tsx
+++ b/frontend/src/components/apps/SandpackAppRenderer.tsx
@@ -43,8 +43,8 @@ interface SandpackAppRendererProps {
   /** Use unauthenticated /api/public/apps/:id and query routes (no Bearer token). */
   publicMode?: boolean;
   onError?: (message: string) => void;
-  /** If true, skip screenshot capture (screenshot already exists). */
-  hasScreenshot?: boolean;
+  /** If false, skip saving a latest snapshot after the app renders. */
+  captureSnapshot?: boolean;
 }
 
 // ---- helpers --------------------------------------------------------------
@@ -349,7 +349,7 @@ export function SandpackAppRenderer({
   embedToken,
   publicMode = false,
   onError,
-  hasScreenshot,
+  captureSnapshot = true,
 }: SandpackAppRendererProps): JSX.Element {
   const [tokenData, setTokenData] = useState<AppTokenData | null>(null);
   const [appCode, setAppCode] = useState<string | null>(initialCode ?? null);
@@ -614,9 +614,11 @@ export function SandpackAppRenderer({
     void fetchToken();
   }, [fetchToken, tokenRetry]);
 
-  // Screenshot capture: after iframe loads and data settles, capture via html2canvas
+  // Snapshot capture: after iframe loads and data settles, save the latest rendered view.
+  // This runs on opened/full app surfaces (not list cards), so galleries can display
+  // the last opened/created snapshot without re-rendering app code in list views.
   useEffect(() => {
-    if (hasScreenshot || screenshotCapturedRef.current || embedToken || publicMode) return;
+    if (!captureSnapshot || screenshotCapturedRef.current || embedToken || publicMode) return;
     if (!iframeRef.current || !tokenData || !appCode) return;
 
     // Try capture at 3s, retry at 6s if first attempt skipped (still loading)
@@ -684,7 +686,7 @@ export function SandpackAppRenderer({
 
     const timer = setTimeout(tryCapture, 3000);
     return () => clearTimeout(timer);
-  }, [appId, tokenData, appCode, hasScreenshot, embedToken, publicMode]);
+  }, [appId, tokenData, appCode, captureSnapshot, embedToken, publicMode]);
 
   if (error) {
     return (

--- a/frontend/src/components/widgets/AppPreview.tsx
+++ b/frontend/src/components/widgets/AppPreview.tsx
@@ -1,21 +1,13 @@
 /**
  * AppPreview — universal app preview component.
  *
- * Renders in priority order based on preferred_mode (from widget_config) or auto:
- * 1. Screenshot (data URL from html2canvas capture)
- * 2. Widget (LLM-inferred data summary card)
- * 3. Mini App (CSS-scaled iframe of the full app)
- * 4. Default chart icon placeholder
+ * List views must never render live apps: they show the last stored screenshot
+ * captured when the app was opened/created, falling back to a static icon.
  */
 
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { apiRequest } from '../../lib/api';
 import type { WidgetConfig } from '../../store/types';
-import { WidgetCard } from './WidgetCard';
-
-const LazySandpackAppRenderer = lazy(() =>
-  import('../apps/SandpackAppRenderer').then((m) => ({ default: m.SandpackAppRenderer }))
-);
 
 type PreviewMode = 'auto' | 'screenshot' | 'widget' | 'mini_app' | 'icon';
 
@@ -29,45 +21,6 @@ interface AppPreviewProps {
 function ScreenshotView({ src, title }: { src: string; title: string }): JSX.Element {
   return (
     <img src={src} alt={title} className="w-full h-full object-cover object-top" />
-  );
-}
-
-function WidgetView({ appId, appTitle, widgetConfig, onClick }: {
-  appId: string; appTitle: string; widgetConfig: WidgetConfig; onClick?: (id: string) => void;
-}): JSX.Element {
-  return (
-    <WidgetCard appId={appId} appTitle={appTitle} widgetConfig={widgetConfig} onClick={onClick} />
-  );
-}
-
-function MiniAppView({ appId, onClick }: { appId: string; onClick?: (id: string) => void }): JSX.Element {
-  return (
-    <div
-      className="w-full aspect-video overflow-hidden relative rounded-xl border border-surface-800 cursor-pointer bg-surface-900"
-    >
-      {/* Transparent overlay captures clicks instead of the iframe */}
-      <div
-        className="absolute inset-0 z-10"
-        onClick={() => onClick?.(appId)}
-        role="button"
-        tabIndex={0}
-        onKeyDown={(e) => { if (e.key === 'Enter') onClick?.(appId); }}
-      />
-      <div className="pointer-events-none" style={{ width: 1280, height: 720, transform: 'scale(var(--preview-scale, 0.2))', transformOrigin: 'top left' }} ref={(el) => {
-        if (el) {
-          const parent = el.parentElement;
-          if (parent) {
-            const scale = parent.clientWidth / 1280;
-            el.style.setProperty('--preview-scale', String(scale));
-            el.style.transform = `scale(${scale})`;
-          }
-        }
-      }}>
-        <Suspense fallback={<div className="w-full h-full bg-surface-900" />}>
-          <LazySandpackAppRenderer appId={appId} />
-        </Suspense>
-      </div>
-    </div>
   );
 }
 
@@ -108,35 +61,25 @@ export function AppPreview({ appId, appTitle, widgetConfig, onClick }: AppPrevie
     return () => { cancelled = true; };
   }, [appId, hasScreenshotFlag, screenshotUrl, widgetConfig?.screenshot]);
 
-  // Determine effective mode with fallback chain
-  let effectiveMode: 'screenshot' | 'widget' | 'mini_app' | 'icon';
-  if (defaultMode === 'auto') {
-    effectiveMode = (hasScreenshotFlag && screenshotUrl)
-      ? 'screenshot'
-      : hasWidget
-        ? 'widget'
-        : 'icon';
-  } else if (defaultMode === 'screenshot') {
-    effectiveMode = (hasScreenshotFlag && screenshotUrl) ? 'screenshot' : hasWidget ? 'widget' : 'icon';
-  } else if (defaultMode === 'widget') {
-    effectiveMode = hasWidget ? 'widget' : 'icon';
-  } else if (defaultMode === 'mini_app') {
-    effectiveMode = 'mini_app';
-  } else {
-    effectiveMode = 'icon';
-  }
+  // List previews are static snapshots only. Even if a user previously chose
+  // widget/mini_app as their preview mode, do not execute app code or queries here.
+  const effectiveMode: 'screenshot' | 'icon' =
+    defaultMode !== 'icon' && hasScreenshotFlag && screenshotUrl ? 'screenshot' : 'icon';
 
-  // For widget mode, render WidgetCard directly (it's its own button)
-  if (effectiveMode === 'widget' && widgetConfig?.layout) {
-    return (
-      <WidgetView appId={appId} appTitle={appTitle} widgetConfig={widgetConfig} onClick={onClick} />
-    );
-  }
-
-  // Mini app mode
-  if (effectiveMode === 'mini_app') {
-    return <MiniAppView appId={appId} onClick={onClick} />;
-  }
+  useEffect(() => {
+    if (hasWidget && defaultMode === 'widget') {
+      console.debug('[AppPreview] Widget preview mode requested in list view; using stored screenshot instead', {
+        appId,
+        hasScreenshot: Boolean(screenshotUrl),
+      });
+    }
+    if (defaultMode === 'mini_app') {
+      console.debug('[AppPreview] Mini-app preview mode requested in list view; live render is disabled', {
+        appId,
+        hasScreenshot: Boolean(screenshotUrl),
+      });
+    }
+  }, [appId, defaultMode, hasWidget, screenshotUrl]);
 
   return (
     <button


### PR DESCRIPTION
### Motivation
- Avoid running live app code inside list/gallery views to improve performance, privacy, and stability by showing the last saved snapshot instead.  
- Ensure list previews reflect the most recently opened/created rendering by saving a fresh snapshot when the full app renderer runs.

### Description
- Frontend: `AppPreview` (list/grid cards) no longer renders live app code or mini-app widgets and instead displays the stored screenshot or a static icon fallback; it lazy-fetches the inline snapshot via the existing `/apps/widgets/:id/screenshot` endpoint.  
- Frontend: `SandpackAppRenderer` now has a `captureSnapshot` prop (default `true`) and will capture/save a fresh snapshot after the app is opened (via `html2canvas`) so galleries can show the latest rendered snapshot.  
- Backend: `POST /api/apps/{app_id}/screenshot` stores `screenshot` plus `screenshot_captured_at` and logs capture metadata, and `_strip_screenshot` still strips large payloads from list responses but preserves snapshot metadata (`has_screenshot` and timestamp).  
- Tests: added `backend/tests/test_app_snapshot_previews.py` to assert `_strip_screenshot` behavior and metadata preservation.

### Testing
- Frontend build: ran `npm run build` and the build completed successfully (warnings only).  
- Backend unit tests: ran `pytest backend/tests/test_app_snapshot_previews.py` and both tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd48a4f72483218433a36003bc0ccc)