### PR TITLE
fix(slack): extract DOCX/PPTX/XLSX in read_file connector

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -1398,22 +1398,40 @@ Returns normalized messages for one channel since a cutoff (does not write to th
         mime_type: str = str((file_data or {}).get("mimetype") or "application/octet-stream")
         size: int = len(raw_bytes)
 
-        content_text: str | None = None
-        if mime_type.startswith("text/") or filename.lower().endswith((".txt", ".md", ".csv", ".json", ".yaml", ".yml", ".xml")):
-            content_text = raw_bytes.decode("utf-8", errors="replace")
-        elif mime_type == "application/pdf" or filename.lower().endswith(".pdf"):
-            from services.file_handler import StoredFile, pdf_to_text_block
+        from services.file_handler import (
+            DOCX_MIME,
+            PDF_MIME,
+            PPTX_MIME,
+            StoredFile,
+            XLSX_MIME,
+            docx_to_text_block,
+            pdf_to_text_block,
+            pptx_to_text_block,
+            xlsx_to_text_block,
+        )
 
-            block = pdf_to_text_block(
-                StoredFile(
-                    upload_id="slack_query_file",
-                    filename=filename,
-                    mime_type=mime_type,
-                    size=size,
-                    data=raw_bytes,
-                )
-            )
-            content_text = str(block.get("text") or "")
+        sf = StoredFile(
+            upload_id="slack_query_file",
+            filename=filename,
+            mime_type=mime_type,
+            size=size,
+            data=raw_bytes,
+        )
+
+        content_text: str | None = None
+        lower_name: str = filename.lower()
+        if mime_type.startswith("text/") or lower_name.endswith(
+            (".txt", ".md", ".csv", ".json", ".yaml", ".yml", ".xml")
+        ):
+            content_text = raw_bytes.decode("utf-8", errors="replace")
+        elif mime_type == PDF_MIME or lower_name.endswith(".pdf"):
+            content_text = str(pdf_to_text_block(sf).get("text") or "")
+        elif mime_type == DOCX_MIME or lower_name.endswith(".docx"):
+            content_text = str(docx_to_text_block(sf).get("text") or "")
+        elif mime_type == PPTX_MIME or lower_name.endswith(".pptx"):
+            content_text = str(pptx_to_text_block(sf).get("text") or "")
+        elif mime_type == XLSX_MIME or lower_name.endswith(".xlsx"):
+            content_text = str(xlsx_to_text_block(sf).get("text") or "")
 
         if content_text is not None:
             max_chars = 200_000

--- a/backend/services/file_handler.py
+++ b/backend/services/file_handler.py
@@ -245,11 +245,11 @@ def build_claude_content_blocks(
         elif mime == PDF_MIME:
             blocks.append(_pdf_block(sf))
         elif mime == XLSX_MIME or sf.filename.endswith(".xlsx"):
-            blocks.append(_xlsx_to_text_block(sf))
+            blocks.append(xlsx_to_text_block(sf))
         elif mime == DOCX_MIME or sf.filename.endswith(".docx"):
-            blocks.append(_docx_to_text_block(sf))
+            blocks.append(docx_to_text_block(sf))
         elif mime == PPTX_MIME or sf.filename.endswith(".pptx"):
-            blocks.append(_pptx_to_text_block(sf))
+            blocks.append(pptx_to_text_block(sf))
         elif _is_text_mime(mime) or sf.filename.endswith(".csv"):
             blocks.append(_text_file_block(sf))
         else:
@@ -339,7 +339,7 @@ def pdf_to_text_block(sf: StoredFile) -> dict[str, Any]:
     }
 
 
-def _xlsx_to_text_block(sf: StoredFile) -> dict[str, Any]:
+def xlsx_to_text_block(sf: StoredFile) -> dict[str, Any]:
     """Parse XLSX to CSV text using openpyxl."""
     try:
         import openpyxl
@@ -387,7 +387,7 @@ def _xlsx_to_text_block(sf: StoredFile) -> dict[str, Any]:
         }
 
 
-def _docx_to_text_block(sf: StoredFile) -> dict[str, Any]:
+def docx_to_text_block(sf: StoredFile) -> dict[str, Any]:
     """Extract the main document XML from a DOCX and send it raw — Claude groks XML natively."""
     import zipfile
 
@@ -412,7 +412,7 @@ def _docx_to_text_block(sf: StoredFile) -> dict[str, Any]:
         }
 
 
-def _pptx_to_text_block(sf: StoredFile) -> dict[str, Any]:
+def pptx_to_text_block(sf: StoredFile) -> dict[str, Any]:
     """Extract all slide XML from a PPTX and concatenate — same ZIP-of-XML approach as DOCX."""
     import zipfile
 
@@ -493,3 +493,9 @@ def _pptx_slide_sort_key(name: str) -> tuple[int, str]:
         return (int(numeric_part), name)
     except ValueError:
         return (10**9, name)
+
+
+# Back-compat with imports of previous private names
+_xlsx_to_text_block = xlsx_to_text_block
+_docx_to_text_block = docx_to_text_block
+_pptx_to_text_block = pptx_to_text_block

--- a/backend/tests/test_file_handler_truncation.py
+++ b/backend/tests/test_file_handler_truncation.py
@@ -3,7 +3,7 @@ import sys
 import types
 import zipfile
 
-from services.file_handler import StoredFile, _pptx_to_text_block, _pptx_slide_sort_key, pdf_to_text_block
+from services.file_handler import StoredFile, _pptx_slide_sort_key, pdf_to_text_block, pptx_to_text_block
 
 
 def test_pdf_to_text_block_truncates_to_first_250k_chars(monkeypatch):
@@ -51,7 +51,7 @@ def test_pptx_to_text_block_uses_numeric_slide_order_and_250k_truncation():
         zf.writestr("ppt/slides/slide2.xml", "<s2>" + ("Z" * 260_000))
 
     sf = StoredFile("2", "deck.pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation", len(payload.getvalue()), payload.getvalue())
-    block = _pptx_to_text_block(sf)
+    block = pptx_to_text_block(sf)
     text = block["text"]
 
     assert text.index("<s1>") < text.index("<s2>")

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -1,4 +1,6 @@
 import asyncio
+import io
+import zipfile
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
@@ -189,6 +191,121 @@ def test_query_read_file_by_url_returns_base64_for_binary(monkeypatch) -> None:
     assert result["file"]["mime_type"] == "application/octet-stream"
     assert result["file"]["content_base64"] == "AQI="
     assert "Binary file returned as base64" in result["file"]["note"]
+
+
+def _minimal_docx_bytes() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("word/document.xml", b"<hello/>")
+    return buf.getvalue()
+
+
+def test_query_read_file_docx_returns_extracted_text(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+    docx_bytes: bytes = _minimal_docx_bytes()
+
+    async def _fake_make_request(method: str, endpoint: str, **kwargs: object):
+        assert method == "GET"
+        assert endpoint == "files.info"
+        assert kwargs.get("params") == {"file": "F456"}
+        return {
+            "ok": True,
+            "file": {
+                "id": "F456",
+                "name": "whitepaper.docx",
+                "mimetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "url_private_download": "https://files.slack.com/files-pri/T/F456/download/whitepaper.docx",
+            },
+        }
+
+    async def _fake_download_file(url_private: str) -> bytes:
+        assert "F456" in url_private
+        return docx_bytes
+
+    monkeypatch.setattr(connector, "_make_request", _fake_make_request)
+    monkeypatch.setattr(connector, "download_file", _fake_download_file)
+
+    result = asyncio.run(connector.query("read_file:F456"))
+    assert result["ok"] is True
+    assert result["file"]["filename"] == "whitepaper.docx"
+    assert "<hello/>" in result["file"]["content"]
+    assert "Word XML" in result["file"]["content"]
+    assert "content_base64" not in result["file"]
+
+
+def _minimal_pptx_bytes() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("ppt/slides/slide1.xml", b"<slide_one/>")
+    return buf.getvalue()
+
+
+def test_query_read_file_pptx_returns_extracted_text(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+    pptx_bytes: bytes = _minimal_pptx_bytes()
+
+    async def _fake_make_request(method: str, endpoint: str, **kwargs: object):
+        return {
+            "ok": True,
+            "file": {
+                "id": "F789",
+                "name": "deck.pptx",
+                "mimetype": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                "url_private_download": "https://files.slack.com/files-pri/T/F789/download/deck.pptx",
+            },
+        }
+
+    async def _fake_download_file(url_private: str) -> bytes:
+        return pptx_bytes
+
+    monkeypatch.setattr(connector, "_make_request", _fake_make_request)
+    monkeypatch.setattr(connector, "download_file", _fake_download_file)
+
+    result = asyncio.run(connector.query("read_file:F789"))
+    assert result["ok"] is True
+    assert result["file"]["filename"] == "deck.pptx"
+    assert "<slide_one/>" in result["file"]["content"]
+    assert "content_base64" not in result["file"]
+
+
+def _minimal_xlsx_bytes() -> bytes:
+    import openpyxl
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    assert ws is not None
+    ws["A1"] = "cell_a1"
+    buffer = io.BytesIO()
+    wb.save(buffer)
+    return buffer.getvalue()
+
+
+def test_query_read_file_xlsx_returns_extracted_text(monkeypatch) -> None:
+    connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
+    xlsx_bytes: bytes = _minimal_xlsx_bytes()
+
+    async def _fake_make_request(method: str, endpoint: str, **kwargs: object):
+        return {
+            "ok": True,
+            "file": {
+                "id": "F321",
+                "name": "sheet.xlsx",
+                "mimetype": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "url_private_download": "https://files.slack.com/files-pri/T/F321/download/sheet.xlsx",
+            },
+        }
+
+    async def _fake_download_file(url_private: str) -> bytes:
+        return xlsx_bytes
+
+    monkeypatch.setattr(connector, "_make_request", _fake_make_request)
+    monkeypatch.setattr(connector, "download_file", _fake_download_file)
+
+    result = asyncio.run(connector.query("read_file:F321"))
+    assert result["ok"] is True
+    assert result["file"]["filename"] == "sheet.xlsx"
+    assert "cell_a1" in result["file"]["content"]
+    assert "content_base64" not in result["file"]
 
 
 def test_query_read_file_rejects_non_slack_url(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
Slack `read_file:` queries returned DOCX and other Office files as base64, so the agent saw unusable binary instead of text.

## Changes
- Route DOCX, PPTX, and XLSX through the same extractors as chat uploads (`docx_to_text_block`, `pptx_to_text_block`, `xlsx_to_text_block`), alongside the existing PDF path.
- Promote those helpers from private names in `file_handler.py`; keep `_*` aliases for compatibility.

## Testing
`pytest -q tests` (targeted + full suite previously passing).

Made with [Cursor](https://cursor.com)