### PR TITLE
Push workflow tool progress via Redis pub/sub

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -14,6 +14,7 @@ import asyncio
 import json
 import logging
 import re
+import redis.asyncio as aioredis
 from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any, AsyncGenerator, Sequence
@@ -25,7 +26,7 @@ from sqlalchemy import select, update
 
 from agents.registry import format_tool_status
 from agents.tools import execute_tool, get_tools, get_tool_defs_for_context
-from config import settings
+from config import get_redis_connection_kwargs, settings
 from services.llm_adapter import (
     AnthropicAdapter,
     LLMConfig,
@@ -47,6 +48,61 @@ from models.memory import Memory
 from services.anthropic_health import report_anthropic_call_failure, report_anthropic_call_success
 
 logger = logging.getLogger(__name__)
+
+
+def _workflow_tool_progress_channel(organization_id: str) -> str:
+    """Redis pub/sub channel for workflow tool progress within one organization."""
+    return f"workflow_tool_progress:{organization_id}"
+
+
+async def _publish_tool_progress_update(
+    *,
+    organization_id: str,
+    conversation_id: str,
+    tool_id: str,
+    tool_name: str,
+    result: dict[str, Any],
+    status: str,
+) -> bool:
+    """Publish a tool progress update for API websocket processes to fan out."""
+    payload = {
+        "type": "tool_progress",
+        "conversation_id": conversation_id,
+        "tool_id": tool_id,
+        "tool_name": tool_name,
+        "result": result,
+        "status": status,
+    }
+    redis_client: aioredis.Redis | None = None
+    try:
+        redis_client = aioredis.from_url(
+            settings.REDIS_URL,
+            **get_redis_connection_kwargs(decode_responses=True),
+        )
+        subscriber_count = await redis_client.publish(
+            _workflow_tool_progress_channel(organization_id),
+            _json_dumps(payload),
+        )
+        logger.debug(
+            "[update_tool_result] Published tool progress: conv=%s tool=%s status=%s subscribers=%s",
+            conversation_id[:8] if conversation_id else None,
+            tool_id[:8] if tool_id else None,
+            status,
+            subscriber_count,
+        )
+        return True
+    except Exception as exc:
+        logger.warning(
+            "[update_tool_result] Failed to publish tool progress via Redis: conv=%s tool=%s status=%s error=%s",
+            conversation_id[:8] if conversation_id else None,
+            tool_id[:8] if tool_id else None,
+            status,
+            exc,
+        )
+        return False
+    finally:
+        if redis_client is not None:
+            await redis_client.aclose()
 
 
 def _normalize_model_lookup_key(model: str) -> str:
@@ -239,7 +295,7 @@ async def update_tool_result(
     Update a tool call's result in an existing conversation message.
     
     This enables long-running tools (like foreach) to report progress
-    that the frontend can poll for and display.
+    that websocket API processes can push to clients via Redis pub/sub.
     
     Args:
         conversation_id: The conversation containing the tool call
@@ -308,16 +364,17 @@ async def update_tool_result(
             
             logger.info(f"[update_tool_result] SUCCESS: Updated tool {tool_id[:8]} with status={status}")
             
-            # Broadcast progress to connected websockets
+            # Publish progress from the process that actually updated the tool.
+            # Workflow tools often run inside Celery workers, so in-memory API
+            # websocket fanout is not shared with the executing process. Redis
+            # pub/sub lets API websocket processes push worker-originated deltas.
             if organization_id:
-                from api.websockets import broadcast_tool_progress
-                # Get tool name from the block
                 tool_name: str = "unknown"
                 for block in new_blocks:
                     if block.get("id") == tool_id:
                         tool_name = block.get("name", "unknown")
                         break
-                await broadcast_tool_progress(
+                await _publish_tool_progress_update(
                     organization_id=organization_id,
                     conversation_id=conversation_id,
                     tool_id=tool_id,

--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -19,11 +19,14 @@ Architecture:
 import json
 import logging
 import asyncio
+import contextlib
+import time
 from collections import defaultdict
 from typing import Dict, Optional, Set
 from uuid import UUID, uuid4
 
 from fastapi import WebSocket, WebSocketDisconnect
+import redis.asyncio as aioredis
 
 logger = logging.getLogger(__name__)
 
@@ -300,10 +303,9 @@ async def broadcast_conversation_message(
 
 from models.conversation import Conversation
 from models.database import get_session
+from config import get_redis_connection_kwargs, settings
 from models.user import User
-from models.chat_message import ChatMessage
-from models.workflow import WorkflowRun
-from sqlalchemy import and_, select
+from sqlalchemy import select
 
 
 def _generate_title(message: str) -> str:
@@ -335,121 +337,124 @@ def _warn_org_required_rejection(
     )
 
 
-async def _collect_running_workflow_tool_updates(organization_id: str) -> list[dict]:
-    """
-    Collect running workflow tool states from persisted chat messages.
+WORKFLOW_TOOL_STATUS_BASE_INTERVAL_SECONDS: float = 1.5
+WORKFLOW_TOOL_STATUS_MAX_BACKOFF_SECONDS: float = 30.0
+WORKFLOW_TOOL_STATUS_SANITY_TIMEOUT_SECONDS: float = 90.0
 
-    This is used to keep clients in sync when tool execution happens inside
-    Celery workers (separate process) where in-memory websocket broadcasters
-    are not shared with the API process.
-    """
-    from models.conversation import Conversation
 
-    updates: list[dict] = []
-    logger.debug("[WebSocket] Collecting running workflow tool updates for org %s", organization_id)
-    async with get_session(organization_id=organization_id) as session:
-        run_rows = await session.execute(
-            select(WorkflowRun.output)
-            .where(
-                and_(
-                    WorkflowRun.organization_id == UUID(organization_id),
-                    WorkflowRun.status == "running",
-                )
-            )
-        )
+def _workflow_tool_progress_channel(organization_id: str) -> str:
+    """Redis pub/sub channel for tool progress produced by workflow workers."""
+    return f"workflow_tool_progress:{organization_id}"
 
-        conversation_ids: list[UUID] = []
-        for output in run_rows.scalars().all():
-            if not isinstance(output, dict):
-                continue
-            conv_id = output.get("conversation_id")
-            if not conv_id:
-                continue
-            try:
-                conversation_ids.append(UUID(str(conv_id)))
-            except ValueError:
-                continue
 
-        if not conversation_ids:
-            logger.debug("[WebSocket] No running workflow conversations found for org %s", organization_id)
-            return updates
+def _normalize_tool_progress_payload(raw_payload: object) -> dict | None:
+    """Validate and normalize a Redis tool-progress payload before websocket fanout."""
+    try:
+        payload = json.loads(raw_payload if isinstance(raw_payload, str) else raw_payload.decode("utf-8"))
+    except (AttributeError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        logger.warning("[WebSocket] Ignoring malformed workflow tool progress payload: %s", exc)
+        return None
 
-        message_rows = await session.execute(
-            select(ChatMessage)
-            .join(Conversation, ChatMessage.conversation_id == Conversation.id)
-            .where(
-                and_(
-                    Conversation.id.in_(conversation_ids),
-                    Conversation.type == "workflow",
-                    ChatMessage.role == "assistant",
-                    ChatMessage.content_blocks.isnot(None),
-                )
-            )
-            .order_by(ChatMessage.created_at.desc())
-        )
+    if not isinstance(payload, dict):
+        logger.warning("[WebSocket] Ignoring non-object workflow tool progress payload: %r", payload)
+        return None
 
-        for message in message_rows.scalars().all():
-            for block in message.content_blocks or []:
-                if block.get("type") != "tool_use":
-                    continue
-                status = block.get("status")
-                if status not in {"running", "streaming", "pending"}:
-                    continue
-                updates.append(
-                    {
-                        "conversation_id": str(message.conversation_id),
-                        "tool_id": str(block.get("id", "")),
-                        "tool_name": str(block.get("name", "unknown")),
-                        "result": block.get("result") if isinstance(block.get("result"), dict) else {},
-                        "status": "running",
-                    }
-                )
+    conversation_id = str(payload.get("conversation_id") or "").strip()
+    tool_id = str(payload.get("tool_id") or "").strip()
+    if not conversation_id or not tool_id:
+        logger.warning("[WebSocket] Ignoring workflow tool progress payload missing IDs: %s", payload)
+        return None
 
-    return updates
+    result = payload.get("result")
+    return {
+        "type": "tool_progress",
+        "conversation_id": conversation_id,
+        "tool_id": tool_id,
+        "tool_name": str(payload.get("tool_name") or "unknown"),
+        "result": result if isinstance(result, dict) else {},
+        "status": str(payload.get("status") or "running"),
+    }
 
 
 async def _stream_workflow_tool_status(websocket: WebSocket, organization_id: str) -> None:
-    """Poll persisted workflow tool states and push deltas to this websocket."""
+    """Subscribe to worker-published workflow tool progress and push deltas."""
     last_sent: dict[str, str] = {}
     consecutive_errors: int = 0
-    BASE_INTERVAL: float = 1.5
-    MAX_BACKOFF: float = 30.0
-    logger.info("[WebSocket] Starting workflow tool status stream for org %s", organization_id)
+    logger.info("[WebSocket] Starting Redis workflow tool status stream for org %s", organization_id)
+
     while True:
+        redis_client: aioredis.Redis | None = None
+        pubsub: aioredis.client.PubSub | None = None
         try:
-            updates = await _collect_running_workflow_tool_updates(organization_id)
+            redis_client = aioredis.from_url(
+                settings.REDIS_URL,
+                **get_redis_connection_kwargs(decode_responses=True),
+            )
+            pubsub = redis_client.pubsub()
+            channel = _workflow_tool_progress_channel(organization_id)
+            await pubsub.subscribe(channel)
             consecutive_errors = 0
-            for update in updates:
+            last_heard_at = time.monotonic()
+            logger.debug("[WebSocket] Subscribed to workflow tool progress channel %s", channel)
+
+            while True:
+                message = await pubsub.get_message(
+                    ignore_subscribe_messages=True,
+                    timeout=WORKFLOW_TOOL_STATUS_BASE_INTERVAL_SECONDS,
+                )
+                now = time.monotonic()
+                if message is None:
+                    if now - last_heard_at >= WORKFLOW_TOOL_STATUS_SANITY_TIMEOUT_SECONDS:
+                        raise TimeoutError(
+                            "No Redis workflow tool progress messages received within sanity timeout"
+                        )
+                    continue
+
+                last_heard_at = now
+                update = _normalize_tool_progress_payload(message.get("data"))
+                if update is None:
+                    continue
+
                 key: str = f"{update['conversation_id']}:{update['tool_id']}"
-                signature: str = json.dumps(update.get("result") or {}, sort_keys=True, default=str)
-                signature = f"{update.get('status')}::{signature}"
+                signature: str = json.dumps(
+                    {"status": update.get("status"), "result": update.get("result") or {}},
+                    sort_keys=True,
+                    default=str,
+                )
                 if last_sent.get(key) == signature:
                     continue
-                await websocket.send_text(
-                    json.dumps(
-                        {
-                            "type": "tool_progress",
-                            **update,
-                        }
-                    )
-                )
+
+                await websocket.send_text(json.dumps(update))
+                last_sent[key] = signature
                 logger.debug(
-                    "[WebSocket] Sent workflow tool status: conv=%s tool=%s",
+                    "[WebSocket] Sent worker-published workflow tool status: conv=%s tool=%s status=%s",
                     update["conversation_id"],
                     update["tool_id"],
+                    update.get("status"),
                 )
-                last_sent[key] = signature
+        except asyncio.CancelledError:
+            raise
         except Exception as exc:
             consecutive_errors += 1
             if consecutive_errors <= 3:
-                logger.warning("[WebSocket] Workflow status stream error: %s", exc)
+                logger.warning("[WebSocket] Workflow status Redis stream error: %s", exc)
             elif consecutive_errors == 4:
                 logger.warning(
-                    "[WebSocket] Workflow status stream error (suppressing further): %s", exc
+                    "[WebSocket] Workflow status Redis stream error (suppressing further): %s", exc
                 )
+        finally:
+            if pubsub is not None:
+                with contextlib.suppress(Exception):
+                    await pubsub.unsubscribe(_workflow_tool_progress_channel(organization_id))
+                with contextlib.suppress(Exception):
+                    await pubsub.close()
+            if redis_client is not None:
+                with contextlib.suppress(Exception):
+                    await redis_client.aclose()
+
         sleep_time: float = min(
-            BASE_INTERVAL * (2 ** consecutive_errors) if consecutive_errors > 0 else BASE_INTERVAL,
-            MAX_BACKOFF,
+            WORKFLOW_TOOL_STATUS_BASE_INTERVAL_SECONDS * (2 ** consecutive_errors),
+            WORKFLOW_TOOL_STATUS_MAX_BACKOFF_SECONDS,
         )
         await asyncio.sleep(sleep_time)
 

--- a/backend/tests/test_tool_progress_dedup.py
+++ b/backend/tests/test_tool_progress_dedup.py
@@ -1,20 +1,6 @@
 import asyncio
-import sys
-import types
 from types import SimpleNamespace
 from uuid import uuid4
-
-_fake_websockets = types.ModuleType("api.websockets")
-
-async def _noop_broadcast_sync_progress(**_kwargs: object) -> None:
-    return None
-
-async def _noop_broadcast_tool_progress(**_kwargs: object) -> None:
-    return None
-
-_fake_websockets.broadcast_sync_progress = _noop_broadcast_sync_progress
-_fake_websockets.broadcast_tool_progress = _noop_broadcast_tool_progress
-sys.modules.setdefault("api.websockets", _fake_websockets)
 
 from agents import orchestrator
 
@@ -65,10 +51,11 @@ def test_update_tool_result_skips_duplicate_progress_updates(monkeypatch) -> Non
         ]
     )
     fake_session = _FakeSession(message)
-    broadcasts: list[dict[str, object]] = []
+    published: list[dict[str, object]] = []
 
-    async def _fake_broadcast_tool_progress(**kwargs: object) -> None:
-        broadcasts.append(kwargs)
+    async def _fake_publish_tool_progress_update(**kwargs: object) -> bool:
+        published.append(kwargs)
+        return True
 
     monkeypatch.setattr(
         orchestrator,
@@ -76,9 +63,9 @@ def test_update_tool_result_skips_duplicate_progress_updates(monkeypatch) -> Non
         lambda **_kwargs: _FakeSessionContext(fake_session),
     )
     monkeypatch.setattr(
-        sys.modules["api.websockets"],
-        "broadcast_tool_progress",
-        _fake_broadcast_tool_progress,
+        orchestrator,
+        "_publish_tool_progress_update",
+        _fake_publish_tool_progress_update,
     )
 
     updated = asyncio.run(
@@ -93,7 +80,7 @@ def test_update_tool_result_skips_duplicate_progress_updates(monkeypatch) -> Non
 
     assert updated is False
     assert fake_session.commit_calls == 0
-    assert broadcasts == []
+    assert published == []
     assert message.content_blocks[0]["result"] == {"message": "Writing to Linear"}
 
 
@@ -113,10 +100,11 @@ def test_update_tool_result_allows_status_change_with_same_result(monkeypatch) -
         ]
     )
     fake_session = _FakeSession(message)
-    broadcasts: list[dict[str, object]] = []
+    published: list[dict[str, object]] = []
 
-    async def _fake_broadcast_tool_progress(**kwargs: object) -> None:
-        broadcasts.append(kwargs)
+    async def _fake_publish_tool_progress_update(**kwargs: object) -> bool:
+        published.append(kwargs)
+        return True
 
     monkeypatch.setattr(
         orchestrator,
@@ -124,9 +112,9 @@ def test_update_tool_result_allows_status_change_with_same_result(monkeypatch) -
         lambda **_kwargs: _FakeSessionContext(fake_session),
     )
     monkeypatch.setattr(
-        sys.modules["api.websockets"],
-        "broadcast_tool_progress",
-        _fake_broadcast_tool_progress,
+        orchestrator,
+        "_publish_tool_progress_update",
+        _fake_publish_tool_progress_update,
     )
 
     updated = asyncio.run(
@@ -142,7 +130,7 @@ def test_update_tool_result_allows_status_change_with_same_result(monkeypatch) -
     assert updated is True
     assert fake_session.commit_calls == 1
     assert message.content_blocks[0]["status"] == "complete"
-    assert broadcasts == [
+    assert published == [
         {
             "organization_id": organization_id,
             "conversation_id": conversation_id,

--- a/backend/tests/test_websocket_fanout.py
+++ b/backend/tests/test_websocket_fanout.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
 from typing import Any
 
@@ -139,3 +140,84 @@ def test_task_manager_broadcast_snapshots_message_before_session_close(monkeypat
 
     asyncio.run(_run())
     assert captured_payloads == [{"id": "assistant-msg-1", "role": "assistant", "content_blocks": []}]
+
+
+def test_normalize_tool_progress_payload_accepts_valid_json() -> None:
+    payload = websockets._normalize_tool_progress_payload(  # noqa: SLF001
+        '{"type":"tool_progress","conversation_id":"conv-1","tool_id":"tool-1","tool_name":"foreach","result":{"completed":1},"status":"running"}'
+    )
+
+    assert payload == {
+        "type": "tool_progress",
+        "conversation_id": "conv-1",
+        "tool_id": "tool-1",
+        "tool_name": "foreach",
+        "result": {"completed": 1},
+        "status": "running",
+    }
+
+
+def test_normalize_tool_progress_payload_rejects_missing_ids() -> None:
+    payload = websockets._normalize_tool_progress_payload('{"tool_id":"tool-1"}')  # noqa: SLF001
+
+    assert payload is None
+
+
+def test_stream_workflow_tool_status_sends_worker_published_delta(monkeypatch: Any) -> None:
+    class _FakePubSub:
+        def __init__(self) -> None:
+            self.subscribed: list[str] = []
+            self.closed = False
+            self._messages = [
+                {
+                    "type": "message",
+                    "data": '{"conversation_id":"conv-1","tool_id":"tool-1","tool_name":"foreach","result":{"completed":2},"status":"running"}',
+                },
+            ]
+
+        async def subscribe(self, channel: str) -> None:
+            self.subscribed.append(channel)
+
+        async def get_message(self, **_kwargs: Any) -> dict[str, Any] | None:
+            if self._messages:
+                return self._messages.pop(0)
+            await asyncio.sleep(0)
+            raise asyncio.CancelledError()
+
+        async def unsubscribe(self, _channel: str) -> None:
+            return None
+
+        async def close(self) -> None:
+            self.closed = True
+
+    class _FakeRedis:
+        def __init__(self) -> None:
+            self.pubsub_instance = _FakePubSub()
+            self.closed = False
+
+        def pubsub(self) -> _FakePubSub:
+            return self.pubsub_instance
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    fake_redis = _FakeRedis()
+    monkeypatch.setattr(websockets.aioredis, "from_url", lambda *_args, **_kwargs: fake_redis)
+
+    socket = _FakeSocket()
+
+    async def _run() -> None:
+        task = asyncio.create_task(
+            websockets._stream_workflow_tool_status(socket, "org-1")  # noqa: SLF001
+        )
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    asyncio.run(_run())
+
+    assert fake_redis.pubsub_instance.subscribed == ["workflow_tool_progress:org-1"]
+    assert socket.messages == [
+        '{"type": "tool_progress", "conversation_id": "conv-1", "tool_id": "tool-1", "tool_name": "foreach", "result": {"completed": 2}, "status": "running"}'
+    ]
+    assert fake_redis.pubsub_instance.closed is True
+    assert fake_redis.closed is True


### PR DESCRIPTION
### Motivation
- Worker processes that call `update_tool_result` should broadcast progress from the process that actually executed the tool so API websocket processes (which have in-memory connections) can fan out updates reliably.
- Replace DB polling by websocket processes with a push-based mechanism to avoid lost/duplicated updates when workers and API are in separate processes.
- Add a sanity timeout so websocket subscribers can fail/reconnect if no worker-originated messages are heard for a configurable window while preserving the existing still-working cadence.

### Description
- Added a publisher helper `._publish_tool_progress_update` and per-org channel naming `workflow_tool_progress:{org}` in `backend/agents/orchestrator.py`, and wired `update_tool_result` to publish progress after persisting the tool block (instead of calling the in-process websocket broadcast). 
- Replaced the websocket-side DB polling for workflow tool states with a Redis subscriber in `backend/api/websockets.py` that: validates/normalizes worker-published payloads (`_normalize_tool_progress_payload`), deduplicates by `conversation_id:tool_id` + signature, preserves the 1.5s base cadence, applies exponential backoff, and raises a sanity timeout (`WORKFLOW_TOOL_STATUS_SANITY_TIMEOUT_SECONDS`, 90s) to trigger reconnect behavior.
- Kept websocket connection setup unchanged so organization-scoped sockets still start the workflow status stream (`_stream_workflow_tool_status`).
- Updated unit tests to reflect the new push-based behavior by mocking the orchestrator publisher and a fake Redis pubsub; changes are in `backend/tests/test_tool_progress_dedup.py` and `backend/tests/test_websocket_fanout.py`.

### Testing
- Ran `pytest backend/tests/test_tool_progress_dedup.py backend/tests/test_websocket_fanout.py` and all tests passed (8 passed).
- Compiled modified modules with `python -m py_compile backend/agents/orchestrator.py backend/api/websockets.py backend/tests/test_tool_progress_dedup.py backend/tests/test_websocket_fanout.py` with no syntax errors.
- Updated tests exercise both duplicate-suppression and status-change publishing paths and simulate Redis pub/sub delivery; they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5afaa5048321a7d11869dcd14598)