### PR TITLE
Use Redis pub/sub for workflow tool progress

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -307,26 +307,28 @@ async def update_tool_result(
             await session.commit()
             
             logger.info(f"[update_tool_result] SUCCESS: Updated tool {tool_id[:8]} with status={status}")
-            
-            # Broadcast progress to connected websockets
-            if organization_id:
-                from api.websockets import broadcast_tool_progress
-                # Get tool name from the block
-                tool_name: str = "unknown"
-                for block in new_blocks:
-                    if block.get("id") == tool_id:
-                        tool_name = block.get("name", "unknown")
-                        break
-                await broadcast_tool_progress(
-                    organization_id=organization_id,
-                    conversation_id=conversation_id,
-                    tool_id=tool_id,
-                    tool_name=tool_name,
-                    result=result,
-                    status=status,
-                )
-            
-            return True
+
+            tool_name: str = "unknown"
+            for block in new_blocks:
+                if block.get("id") == tool_id:
+                    tool_name = block.get("name", "unknown")
+                    break
+
+        # Publish progress after the DB transaction scope is closed. Redis
+        # pub/sub is best-effort and should never hold database resources.
+        if organization_id:
+            from services.tool_progress_pubsub import publish_tool_progress
+
+            await publish_tool_progress(
+                organization_id=organization_id,
+                conversation_id=conversation_id,
+                tool_id=tool_id,
+                tool_name=tool_name,
+                result=result,
+                status=status,
+            )
+
+        return True
             
     except Exception as e:
         logger.error(f"[update_tool_result] Error: {e}")

--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -301,9 +301,7 @@ async def broadcast_conversation_message(
 from models.conversation import Conversation
 from models.database import get_session
 from models.user import User
-from models.chat_message import ChatMessage
-from models.workflow import WorkflowRun
-from sqlalchemy import and_, select
+from sqlalchemy import select
 
 
 def _generate_title(message: str) -> str:
@@ -335,123 +333,139 @@ def _warn_org_required_rejection(
     )
 
 
-async def _collect_running_workflow_tool_updates(organization_id: str) -> list[dict]:
-    """
-    Collect running workflow tool states from persisted chat messages.
+WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS: float = 1.5
+WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS: float = 60.0
 
-    This is used to keep clients in sync when tool execution happens inside
-    Celery workers (separate process) where in-memory websocket broadcasters
-    are not shared with the API process.
-    """
-    from models.conversation import Conversation
 
-    updates: list[dict] = []
-    logger.debug("[WebSocket] Collecting running workflow tool updates for org %s", organization_id)
-    async with get_session(organization_id=organization_id) as session:
-        run_rows = await session.execute(
-            select(WorkflowRun.output)
-            .where(
-                and_(
-                    WorkflowRun.organization_id == UUID(organization_id),
-                    WorkflowRun.status == "running",
-                )
+async def _subscribe_workflow_tool_progress(websocket: WebSocket, organization_id: str) -> None:
+    """Subscribe this websocket to Redis-published workflow tool progress."""
+    from services.tool_progress_pubsub import (
+        TOOL_PROGRESS_TERMINAL_STATUSES,
+        build_tool_progress_event,
+        get_tool_progress_redis,
+        tool_progress_channel,
+    )
+
+    channel: str = tool_progress_channel(organization_id)
+    redis = await get_tool_progress_redis()
+    pubsub = redis.pubsub()
+    active_tools: dict[str, dict[str, object]] = {}
+    last_worker_message_at: float | None = None
+
+    logger.info(
+        "[WebSocket] Subscribing to workflow tool progress channel=%s org=%s",
+        channel,
+        organization_id,
+    )
+    try:
+        await pubsub.subscribe(channel)
+        while True:
+            message = await pubsub.get_message(
+                ignore_subscribe_messages=True,
+                timeout=WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS,
             )
-        )
+            now = asyncio.get_running_loop().time()
 
-        conversation_ids: list[UUID] = []
-        for output in run_rows.scalars().all():
-            if not isinstance(output, dict):
+            if message is None:
+                if (
+                    active_tools
+                    and last_worker_message_at is not None
+                    and now - last_worker_message_at >= WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS
+                ):
+                    logger.error(
+                        "[WebSocket] Tool progress worker silence timeout after %.0fs org=%s active_tools=%s",
+                        WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS,
+                        organization_id,
+                        list(active_tools),
+                    )
+                    timed_out_tools = list(active_tools.values())
+                    active_tools.clear()
+                    for timed_out in timed_out_tools:
+                        timeout_event = build_tool_progress_event(
+                            conversation_id=str(timed_out.get("conversation_id", "")),
+                            tool_id=str(timed_out.get("tool_id", "")),
+                            tool_name=str(timed_out.get("tool_name", "unknown")),
+                            result={
+                                "error": "Tool progress timed out while waiting for worker updates.",
+                                "message": "Tool progress timed out while waiting for worker updates.",
+                            },
+                            status="complete",
+                        )
+                        sent = await _send_with_timeout(
+                            websocket, json.dumps(timeout_event, default=str)
+                        )
+                        if not sent:
+                            logger.debug(
+                                "[WebSocket] Closing tool progress subscription after timeout send failure org=%s",
+                                organization_id,
+                            )
+                            return
+                    last_worker_message_at = None
                 continue
-            conv_id = output.get("conversation_id")
-            if not conv_id:
+
+            raw_data = message.get("data")
+            if not raw_data:
                 continue
             try:
-                conversation_ids.append(UUID(str(conv_id)))
-            except ValueError:
+                event = json.loads(
+                    raw_data if isinstance(raw_data, str) else raw_data.decode("utf-8")
+                )
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                logger.warning(
+                    "[WebSocket] Ignoring invalid tool progress pub/sub payload channel=%s: %s",
+                    channel,
+                    exc,
+                )
                 continue
 
-        if not conversation_ids:
-            logger.debug("[WebSocket] No running workflow conversations found for org %s", organization_id)
-            return updates
+            if not isinstance(event, dict) or event.get("type") != "tool_progress":
+                logger.debug("[WebSocket] Ignoring unexpected tool progress event: %s", event)
+                continue
 
-        message_rows = await session.execute(
-            select(ChatMessage)
-            .join(Conversation, ChatMessage.conversation_id == Conversation.id)
-            .where(
-                and_(
-                    Conversation.id.in_(conversation_ids),
-                    Conversation.type == "workflow",
-                    ChatMessage.role == "assistant",
-                    ChatMessage.content_blocks.isnot(None),
-                )
-            )
-            .order_by(ChatMessage.created_at.desc())
-        )
+            key = f"{event.get('conversation_id')}:{event.get('tool_id')}"
+            status = str(event.get("status") or "running")
+            if status in TOOL_PROGRESS_TERMINAL_STATUSES:
+                active_tools.pop(key, None)
+            else:
+                active_tools[key] = event
+            last_worker_message_at = now
 
-        for message in message_rows.scalars().all():
-            for block in message.content_blocks or []:
-                if block.get("type") != "tool_use":
-                    continue
-                status = block.get("status")
-                if status not in {"running", "streaming", "pending"}:
-                    continue
-                updates.append(
-                    {
-                        "conversation_id": str(message.conversation_id),
-                        "tool_id": str(block.get("id", "")),
-                        "tool_name": str(block.get("name", "unknown")),
-                        "result": block.get("result") if isinstance(block.get("result"), dict) else {},
-                        "status": "running",
-                    }
-                )
-
-    return updates
-
-
-async def _stream_workflow_tool_status(websocket: WebSocket, organization_id: str) -> None:
-    """Poll persisted workflow tool states and push deltas to this websocket."""
-    last_sent: dict[str, str] = {}
-    consecutive_errors: int = 0
-    BASE_INTERVAL: float = 1.5
-    MAX_BACKOFF: float = 30.0
-    logger.info("[WebSocket] Starting workflow tool status stream for org %s", organization_id)
-    while True:
-        try:
-            updates = await _collect_running_workflow_tool_updates(organization_id)
-            consecutive_errors = 0
-            for update in updates:
-                key: str = f"{update['conversation_id']}:{update['tool_id']}"
-                signature: str = json.dumps(update.get("result") or {}, sort_keys=True, default=str)
-                signature = f"{update.get('status')}::{signature}"
-                if last_sent.get(key) == signature:
-                    continue
-                await websocket.send_text(
-                    json.dumps(
-                        {
-                            "type": "tool_progress",
-                            **update,
-                        }
-                    )
-                )
+            sent = await _send_with_timeout(websocket, json.dumps(event, default=str))
+            if not sent:
                 logger.debug(
-                    "[WebSocket] Sent workflow tool status: conv=%s tool=%s",
-                    update["conversation_id"],
-                    update["tool_id"],
+                    "[WebSocket] Closing tool progress subscription after send failure org=%s",
+                    organization_id,
                 )
-                last_sent[key] = signature
-        except Exception as exc:
-            consecutive_errors += 1
-            if consecutive_errors <= 3:
-                logger.warning("[WebSocket] Workflow status stream error: %s", exc)
-            elif consecutive_errors == 4:
-                logger.warning(
-                    "[WebSocket] Workflow status stream error (suppressing further): %s", exc
-                )
-        sleep_time: float = min(
-            BASE_INTERVAL * (2 ** consecutive_errors) if consecutive_errors > 0 else BASE_INTERVAL,
-            MAX_BACKOFF,
+                return
+            logger.debug(
+                "[WebSocket] Forwarded tool progress from Redis: conv=%s tool=%s status=%s",
+                event.get("conversation_id"),
+                event.get("tool_id"),
+                status,
+            )
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "[WebSocket] Tool progress subscription failed for org %s: %s",
+            organization_id,
+            exc,
         )
-        await asyncio.sleep(sleep_time)
+    finally:
+        try:
+            await pubsub.unsubscribe(channel)
+            await pubsub.close()
+        except Exception as exc:
+            logger.debug(
+                "[WebSocket] Error closing tool progress pub/sub channel=%s: %s",
+                channel,
+                exc,
+            )
+        logger.info(
+            "[WebSocket] Stopped workflow tool progress subscription channel=%s org=%s",
+            channel,
+            organization_id,
+        )
 
 
 async def _execute_tool_approval(
@@ -635,7 +649,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
         if organization_id:
             sync_broadcaster.register(organization_id, websocket)
             workflow_status_task = asyncio.create_task(
-                _stream_workflow_tool_status(websocket, organization_id)
+                _subscribe_workflow_tool_progress(websocket, organization_id)
             )
         
         # Register for conversation message broadcasts (multi-user support)

--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -301,7 +301,8 @@ async def broadcast_conversation_message(
 from models.conversation import Conversation
 from models.database import get_session
 from models.user import User
-from sqlalchemy import select
+from models.workflow import WorkflowRun
+from sqlalchemy import and_, select
 
 
 def _generate_title(message: str) -> str:
@@ -337,7 +338,178 @@ WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS: float = 1.5
 WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS: float = 60.0
 
 
-async def _subscribe_workflow_tool_progress(websocket: WebSocket, organization_id: str) -> None:
+def _tool_progress_signature(event: dict[str, object]) -> str:
+    """Return a stable signature for de-duping rehydrated tool progress events."""
+    result = event.get("result") if isinstance(event.get("result"), dict) else {}
+    return f"{event.get('status')}::{json.dumps(result, sort_keys=True, default=str)}"
+
+
+async def _send_tool_progress_event(
+    websocket: WebSocket,
+    organization_id: str,
+    event: dict[str, object],
+) -> bool:
+    """Send one tool progress event with timeout protection."""
+    sent = await _send_with_timeout(websocket, json.dumps(event, default=str))
+    if not sent:
+        logger.debug(
+            "[WebSocket] Closing tool progress subscription after send failure org=%s",
+            organization_id,
+        )
+    return sent
+
+
+async def _collect_running_workflow_tool_updates(
+    organization_id: str,
+) -> list[dict[str, object]]:
+    """Collect persisted running workflow tool states for connect/Redis-outage rehydration."""
+    updates: list[dict[str, object]] = []
+    logger.debug(
+        "[WebSocket] Rehydrating running workflow tool updates for org %s",
+        organization_id,
+    )
+    async with get_session(organization_id=organization_id) as session:
+        run_rows = await session.execute(
+            select(WorkflowRun.output)
+            .where(
+                and_(
+                    WorkflowRun.organization_id == UUID(organization_id),
+                    WorkflowRun.status == "running",
+                )
+            )
+        )
+
+        conversation_ids: list[UUID] = []
+        for output in run_rows.scalars().all():
+            if not isinstance(output, dict):
+                continue
+            conv_id = output.get("conversation_id")
+            if not conv_id:
+                continue
+            try:
+                conversation_ids.append(UUID(str(conv_id)))
+            except ValueError:
+                continue
+
+        if not conversation_ids:
+            return updates
+
+        from models.chat_message import ChatMessage
+
+        message_rows = await session.execute(
+            select(ChatMessage)
+            .join(Conversation, ChatMessage.conversation_id == Conversation.id)
+            .where(
+                and_(
+                    Conversation.id.in_(conversation_ids),
+                    Conversation.type == "workflow",
+                    ChatMessage.role == "assistant",
+                    ChatMessage.content_blocks.isnot(None),
+                )
+            )
+            .order_by(ChatMessage.created_at.desc())
+        )
+
+        for message in message_rows.scalars().all():
+            for block in message.content_blocks or []:
+                if block.get("type") != "tool_use":
+                    continue
+                status = block.get("status")
+                if status not in {"running", "streaming", "pending"}:
+                    continue
+                updates.append(
+                    {
+                        "type": "tool_progress",
+                        "conversation_id": str(message.conversation_id),
+                        "tool_id": str(block.get("id", "")),
+                        "tool_name": str(block.get("name", "unknown")),
+                        "result": (
+                            block.get("result")
+                            if isinstance(block.get("result"), dict)
+                            else {}
+                        ),
+                        "status": "running",
+                    }
+                )
+
+    return updates
+
+
+async def _rehydrate_running_workflow_tool_status(
+    websocket: WebSocket,
+    organization_id: str,
+    last_sent: dict[str, str],
+) -> bool:
+    """Send persisted running workflow tool states, de-duped against prior sends."""
+    try:
+        updates = await _collect_running_workflow_tool_updates(organization_id)
+    except Exception as exc:
+        logger.warning(
+            "[WebSocket] Failed to rehydrate workflow tool status for org %s: %s",
+            organization_id,
+            exc,
+        )
+        return True
+
+    for update in updates:
+        key = f"{update.get('conversation_id')}:{update.get('tool_id')}"
+        signature = _tool_progress_signature(update)
+        if last_sent.get(key) == signature:
+            continue
+        if not await _send_tool_progress_event(websocket, organization_id, update):
+            return False
+        last_sent[key] = signature
+        logger.debug(
+            "[WebSocket] Rehydrated workflow tool status: conv=%s tool=%s",
+            update.get("conversation_id"),
+            update.get("tool_id"),
+        )
+    return True
+
+
+async def _redis_tool_progress_available() -> bool:
+    """Return whether Redis pub/sub appears reachable now."""
+    from services.tool_progress_pubsub import get_tool_progress_redis
+
+    try:
+        redis = await get_tool_progress_redis()
+        await redis.ping()
+        return True
+    except Exception as exc:
+        logger.debug("[WebSocket] Redis tool progress ping failed: %s", exc)
+        return False
+
+
+async def _poll_workflow_tool_status_until_redis_recovers(
+    websocket: WebSocket,
+    organization_id: str,
+    last_sent: dict[str, str],
+) -> bool:
+    """Poll persisted workflow tool status while Redis is unavailable."""
+    logger.warning(
+        "[WebSocket] Redis unavailable; falling back to DB rehydration for workflow tool progress org=%s",
+        organization_id,
+    )
+    while True:
+        if not await _rehydrate_running_workflow_tool_status(
+            websocket,
+            organization_id,
+            last_sent,
+        ):
+            return False
+        await asyncio.sleep(WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS)
+        if await _redis_tool_progress_available():
+            logger.info(
+                "[WebSocket] Redis recovered; resubscribing to workflow tool progress org=%s",
+                organization_id,
+            )
+            return True
+
+
+async def _subscribe_workflow_tool_progress(
+    websocket: WebSocket,
+    organization_id: str,
+) -> None:
     """Subscribe this websocket to Redis-published workflow tool progress."""
     from services.tool_progress_pubsub import (
         TOOL_PROGRESS_TERMINAL_STATUSES,
@@ -347,125 +519,142 @@ async def _subscribe_workflow_tool_progress(websocket: WebSocket, organization_i
     )
 
     channel: str = tool_progress_channel(organization_id)
-    redis = await get_tool_progress_redis()
-    pubsub = redis.pubsub()
-    active_tools: dict[str, dict[str, object]] = {}
-    last_worker_message_at: float | None = None
+    last_sent: dict[str, str] = {}
 
-    logger.info(
-        "[WebSocket] Subscribing to workflow tool progress channel=%s org=%s",
-        channel,
-        organization_id,
-    )
-    try:
-        await pubsub.subscribe(channel)
-        while True:
-            message = await pubsub.get_message(
-                ignore_subscribe_messages=True,
-                timeout=WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS,
-            )
-            now = asyncio.get_running_loop().time()
-
-            if message is None:
-                if (
-                    active_tools
-                    and last_worker_message_at is not None
-                    and now - last_worker_message_at >= WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS
-                ):
-                    logger.error(
-                        "[WebSocket] Tool progress worker silence timeout after %.0fs org=%s active_tools=%s",
-                        WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS,
-                        organization_id,
-                        list(active_tools),
-                    )
-                    timed_out_tools = list(active_tools.values())
-                    active_tools.clear()
-                    for timed_out in timed_out_tools:
-                        timeout_event = build_tool_progress_event(
-                            conversation_id=str(timed_out.get("conversation_id", "")),
-                            tool_id=str(timed_out.get("tool_id", "")),
-                            tool_name=str(timed_out.get("tool_name", "unknown")),
-                            result={
-                                "error": "Tool progress timed out while waiting for worker updates.",
-                                "message": "Tool progress timed out while waiting for worker updates.",
-                            },
-                            status="complete",
-                        )
-                        sent = await _send_with_timeout(
-                            websocket, json.dumps(timeout_event, default=str)
-                        )
-                        if not sent:
-                            logger.debug(
-                                "[WebSocket] Closing tool progress subscription after timeout send failure org=%s",
-                                organization_id,
-                            )
-                            return
-                    last_worker_message_at = None
-                continue
-
-            raw_data = message.get("data")
-            if not raw_data:
-                continue
-            try:
-                event = json.loads(
-                    raw_data if isinstance(raw_data, str) else raw_data.decode("utf-8")
-                )
-            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-                logger.warning(
-                    "[WebSocket] Ignoring invalid tool progress pub/sub payload channel=%s: %s",
-                    channel,
-                    exc,
-                )
-                continue
-
-            if not isinstance(event, dict) or event.get("type") != "tool_progress":
-                logger.debug("[WebSocket] Ignoring unexpected tool progress event: %s", event)
-                continue
-
-            key = f"{event.get('conversation_id')}:{event.get('tool_id')}"
-            status = str(event.get("status") or "running")
-            if status in TOOL_PROGRESS_TERMINAL_STATUSES:
-                active_tools.pop(key, None)
-            else:
-                active_tools[key] = event
-            last_worker_message_at = now
-
-            sent = await _send_with_timeout(websocket, json.dumps(event, default=str))
-            if not sent:
-                logger.debug(
-                    "[WebSocket] Closing tool progress subscription after send failure org=%s",
-                    organization_id,
-                )
-                return
-            logger.debug(
-                "[WebSocket] Forwarded tool progress from Redis: conv=%s tool=%s status=%s",
-                event.get("conversation_id"),
-                event.get("tool_id"),
-                status,
-            )
-    except asyncio.CancelledError:
-        raise
-    except Exception as exc:
-        logger.warning(
-            "[WebSocket] Tool progress subscription failed for org %s: %s",
+    while True:
+        if not await _rehydrate_running_workflow_tool_status(
+            websocket,
             organization_id,
-            exc,
-        )
-    finally:
+            last_sent,
+        ):
+            return
+
+        pubsub = None
+        active_tools: dict[str, dict[str, object]] = {}
+        last_worker_message_at: float | None = None
         try:
-            await pubsub.unsubscribe(channel)
-            await pubsub.close()
-        except Exception as exc:
-            logger.debug(
-                "[WebSocket] Error closing tool progress pub/sub channel=%s: %s",
+            redis = await get_tool_progress_redis()
+            pubsub = redis.pubsub()
+            logger.info(
+                "[WebSocket] Subscribing to workflow tool progress channel=%s org=%s",
                 channel,
+                organization_id,
+            )
+            await pubsub.subscribe(channel)
+            while True:
+                message = await pubsub.get_message(
+                    ignore_subscribe_messages=True,
+                    timeout=WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS,
+                )
+                now = asyncio.get_running_loop().time()
+
+                if message is None:
+                    if (
+                        active_tools
+                        and last_worker_message_at is not None
+                        and now - last_worker_message_at
+                        >= WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS
+                    ):
+                        logger.error(
+                            "[WebSocket] Tool progress worker silence timeout after %.0fs org=%s active_tools=%s",
+                            WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS,
+                            organization_id,
+                            list(active_tools),
+                        )
+                        timed_out_tools = list(active_tools.values())
+                        active_tools.clear()
+                        for timed_out in timed_out_tools:
+                            timeout_event = build_tool_progress_event(
+                                conversation_id=str(timed_out.get("conversation_id", "")),
+                                tool_id=str(timed_out.get("tool_id", "")),
+                                tool_name=str(timed_out.get("tool_name", "unknown")),
+                                result={
+                                    "error": (
+                                        "Tool progress timed out while waiting for worker updates."
+                                    ),
+                                    "message": (
+                                        "Tool progress timed out while waiting for worker updates."
+                                    ),
+                                },
+                                status="complete",
+                            )
+                            if not await _send_tool_progress_event(
+                                websocket,
+                                organization_id,
+                                timeout_event,
+                            ):
+                                return
+                        last_worker_message_at = None
+                    continue
+
+                raw_data = message.get("data")
+                if not raw_data:
+                    continue
+                try:
+                    event = json.loads(
+                        raw_data
+                        if isinstance(raw_data, str)
+                        else raw_data.decode("utf-8")
+                    )
+                except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                    logger.warning(
+                        "[WebSocket] Ignoring invalid tool progress pub/sub payload channel=%s: %s",
+                        channel,
+                        exc,
+                    )
+                    continue
+
+                if not isinstance(event, dict) or event.get("type") != "tool_progress":
+                    logger.debug("[WebSocket] Ignoring unexpected tool progress event: %s", event)
+                    continue
+
+                key = f"{event.get('conversation_id')}:{event.get('tool_id')}"
+                status = str(event.get("status") or "running")
+                if status in TOOL_PROGRESS_TERMINAL_STATUSES:
+                    active_tools.pop(key, None)
+                else:
+                    active_tools[key] = event
+                last_worker_message_at = now
+                last_sent[key] = _tool_progress_signature(event)
+
+                if not await _send_tool_progress_event(websocket, organization_id, event):
+                    return
+                logger.debug(
+                    "[WebSocket] Forwarded tool progress from Redis: conv=%s tool=%s status=%s",
+                    event.get("conversation_id"),
+                    event.get("tool_id"),
+                    status,
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "[WebSocket] Tool progress subscription failed for org %s: %s",
+                organization_id,
                 exc,
             )
-        logger.info(
-            "[WebSocket] Stopped workflow tool progress subscription channel=%s org=%s",
-            channel,
-            organization_id,
-        )
+            if not await _poll_workflow_tool_status_until_redis_recovers(
+                websocket,
+                organization_id,
+                last_sent,
+            ):
+                return
+        finally:
+            if pubsub is not None:
+                try:
+                    await pubsub.unsubscribe(channel)
+                    await pubsub.close()
+                except Exception as exc:
+                    logger.debug(
+                        "[WebSocket] Error closing tool progress pub/sub channel=%s: %s",
+                        channel,
+                        exc,
+                    )
+            logger.info(
+                "[WebSocket] Stopped workflow tool progress subscription channel=%s org=%s",
+                channel,
+                organization_id,
+            )
 
 
 async def _execute_tool_approval(

--- a/backend/services/tool_progress_pubsub.py
+++ b/backend/services/tool_progress_pubsub.py
@@ -1,0 +1,100 @@
+"""Redis pub/sub helpers for cross-process tool progress updates."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import redis.asyncio as aioredis
+
+from config import get_redis_connection_kwargs, settings
+
+logger = logging.getLogger(__name__)
+
+TOOL_PROGRESS_CHANNEL_PREFIX = "tool_progress"
+TOOL_PROGRESS_TERMINAL_STATUSES = {
+    "complete",
+    "completed",
+    "failed",
+    "error",
+    "cancelled",
+    "canceled",
+}
+
+_redis_client: aioredis.Redis | None = None
+
+
+def tool_progress_channel(organization_id: str) -> str:
+    """Return the Redis channel used for an organization's tool progress."""
+    return f"{TOOL_PROGRESS_CHANNEL_PREFIX}:{organization_id}"
+
+
+def build_tool_progress_event(
+    *,
+    conversation_id: str,
+    tool_id: str,
+    tool_name: str,
+    result: dict[str, Any],
+    status: str = "running",
+) -> dict[str, Any]:
+    """Build a websocket-compatible tool progress event payload."""
+    return {
+        "type": "tool_progress",
+        "conversation_id": conversation_id,
+        "tool_id": tool_id,
+        "tool_name": tool_name,
+        "result": result,
+        "status": status,
+    }
+
+
+async def get_tool_progress_redis() -> aioredis.Redis:
+    """Lazy-initialize a module-level async Redis client for tool progress."""
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = aioredis.from_url(
+            settings.REDIS_URL,
+            **get_redis_connection_kwargs(decode_responses=True),
+        )
+    return _redis_client
+
+
+async def publish_tool_progress(
+    *,
+    organization_id: str,
+    conversation_id: str,
+    tool_id: str,
+    tool_name: str,
+    result: dict[str, Any],
+    status: str = "running",
+) -> bool:
+    """Publish a tool progress event to Redis for API websocket workers."""
+    event = build_tool_progress_event(
+        conversation_id=conversation_id,
+        tool_id=tool_id,
+        tool_name=tool_name,
+        result=result,
+        status=status,
+    )
+    channel = tool_progress_channel(organization_id)
+    try:
+        redis = await get_tool_progress_redis()
+        await redis.publish(channel, json.dumps(event, default=str))
+        logger.debug(
+            "[ToolProgressPubSub] Published tool progress channel=%s conv=%s tool=%s status=%s",
+            channel,
+            conversation_id[:8] if conversation_id else None,
+            tool_id[:8] if tool_id else None,
+            status,
+        )
+        return True
+    except Exception as exc:
+        logger.warning(
+            "[ToolProgressPubSub] Failed to publish tool progress conv=%s tool=%s status=%s: %s",
+            conversation_id[:8] if conversation_id else None,
+            tool_id[:8] if tool_id else None,
+            status,
+            exc,
+        )
+        return False

--- a/backend/tests/test_tool_progress_dedup.py
+++ b/backend/tests/test_tool_progress_dedup.py
@@ -1,22 +1,9 @@
 import asyncio
-import sys
-import types
 from types import SimpleNamespace
 from uuid import uuid4
 
-_fake_websockets = types.ModuleType("api.websockets")
-
-async def _noop_broadcast_sync_progress(**_kwargs: object) -> None:
-    return None
-
-async def _noop_broadcast_tool_progress(**_kwargs: object) -> None:
-    return None
-
-_fake_websockets.broadcast_sync_progress = _noop_broadcast_sync_progress
-_fake_websockets.broadcast_tool_progress = _noop_broadcast_tool_progress
-sys.modules.setdefault("api.websockets", _fake_websockets)
-
 from agents import orchestrator
+from services import tool_progress_pubsub
 
 
 class _FakeExecuteResult:
@@ -67,8 +54,9 @@ def test_update_tool_result_skips_duplicate_progress_updates(monkeypatch) -> Non
     fake_session = _FakeSession(message)
     broadcasts: list[dict[str, object]] = []
 
-    async def _fake_broadcast_tool_progress(**kwargs: object) -> None:
+    async def _fake_publish_tool_progress(**kwargs: object) -> bool:
         broadcasts.append(kwargs)
+        return True
 
     monkeypatch.setattr(
         orchestrator,
@@ -76,9 +64,9 @@ def test_update_tool_result_skips_duplicate_progress_updates(monkeypatch) -> Non
         lambda **_kwargs: _FakeSessionContext(fake_session),
     )
     monkeypatch.setattr(
-        sys.modules["api.websockets"],
-        "broadcast_tool_progress",
-        _fake_broadcast_tool_progress,
+        tool_progress_pubsub,
+        "publish_tool_progress",
+        _fake_publish_tool_progress,
     )
 
     updated = asyncio.run(
@@ -115,8 +103,9 @@ def test_update_tool_result_allows_status_change_with_same_result(monkeypatch) -
     fake_session = _FakeSession(message)
     broadcasts: list[dict[str, object]] = []
 
-    async def _fake_broadcast_tool_progress(**kwargs: object) -> None:
+    async def _fake_publish_tool_progress(**kwargs: object) -> bool:
         broadcasts.append(kwargs)
+        return True
 
     monkeypatch.setattr(
         orchestrator,
@@ -124,9 +113,9 @@ def test_update_tool_result_allows_status_change_with_same_result(monkeypatch) -
         lambda **_kwargs: _FakeSessionContext(fake_session),
     )
     monkeypatch.setattr(
-        sys.modules["api.websockets"],
-        "broadcast_tool_progress",
-        _fake_broadcast_tool_progress,
+        tool_progress_pubsub,
+        "publish_tool_progress",
+        _fake_publish_tool_progress,
     )
 
     updated = asyncio.run(

--- a/backend/tests/test_websocket_fanout.py
+++ b/backend/tests/test_websocket_fanout.py
@@ -273,3 +273,94 @@ def test_workflow_tool_progress_subscription_times_out_silent_worker(monkeypatch
     assert timeout_event["tool_id"] == "tool-timeout"
     assert timeout_event["status"] == "complete"
     assert "timed out" in timeout_event["result"]["error"]
+
+
+def test_workflow_tool_progress_rehydrate_sends_persisted_state(monkeypatch: Any) -> None:
+    socket = _FakeSocket()
+    persisted_event = {
+        "type": "tool_progress",
+        "conversation_id": "conv-rehydrate",
+        "tool_id": "tool-rehydrate",
+        "tool_name": "foreach",
+        "result": {"message": "Still working", "completed": 1, "total": 3},
+        "status": "running",
+    }
+
+    async def _fake_collect(_organization_id: str) -> list[dict[str, object]]:
+        return [persisted_event]
+
+    monkeypatch.setattr(
+        websockets,
+        "_collect_running_workflow_tool_updates",
+        _fake_collect,
+    )
+
+    async def _run() -> dict[str, str]:
+        last_sent: dict[str, str] = {}
+        sent = await websockets._rehydrate_running_workflow_tool_status(  # noqa: SLF001
+            socket,
+            "org-1",
+            last_sent,
+        )
+        assert sent is True
+        # Same persisted payload should be de-duped on the next rehydrate pass.
+        sent = await websockets._rehydrate_running_workflow_tool_status(  # noqa: SLF001
+            socket,
+            "org-1",
+            last_sent,
+        )
+        assert sent is True
+        return last_sent
+
+    last_sent = asyncio.run(_run())
+    assert len(socket.messages) == 1
+    assert json.loads(socket.messages[0]) == persisted_event
+    assert last_sent == {
+        "conv-rehydrate:tool-rehydrate": websockets._tool_progress_signature(  # noqa: SLF001
+            persisted_event
+        )
+    }
+
+
+def test_workflow_tool_progress_polls_rehydrate_until_redis_recovers(monkeypatch: Any) -> None:
+    socket = _FakeSocket()
+    persisted_event = {
+        "type": "tool_progress",
+        "conversation_id": "conv-fallback",
+        "tool_id": "tool-fallback",
+        "tool_name": "foreach",
+        "result": {"message": "Still working"},
+        "status": "running",
+    }
+    redis_checks = 0
+
+    async def _fake_collect(_organization_id: str) -> list[dict[str, object]]:
+        return [persisted_event]
+
+    async def _fake_redis_available() -> bool:
+        nonlocal redis_checks
+        redis_checks += 1
+        return redis_checks >= 1
+
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS", 0.001)
+    monkeypatch.setattr(
+        websockets,
+        "_collect_running_workflow_tool_updates",
+        _fake_collect,
+    )
+    monkeypatch.setattr(
+        websockets,
+        "_redis_tool_progress_available",
+        _fake_redis_available,
+    )
+
+    async def _run() -> bool:
+        return await websockets._poll_workflow_tool_status_until_redis_recovers(  # noqa: SLF001
+            socket,
+            "org-1",
+            {},
+        )
+
+    assert asyncio.run(_run()) is True
+    assert redis_checks == 1
+    assert json.loads(socket.messages[0]) == persisted_event

--- a/backend/tests/test_websocket_fanout.py
+++ b/backend/tests/test_websocket_fanout.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from typing import Any
 
@@ -139,3 +140,136 @@ def test_task_manager_broadcast_snapshots_message_before_session_close(monkeypat
 
     asyncio.run(_run())
     assert captured_payloads == [{"id": "assistant-msg-1", "role": "assistant", "content_blocks": []}]
+
+
+def test_workflow_tool_progress_subscription_forwards_redis_events(monkeypatch: Any) -> None:
+    socket = _FakeSocket()
+    event = {
+        "type": "tool_progress",
+        "conversation_id": "conv-1",
+        "tool_id": "tool-1",
+        "tool_name": "query_on_connector",
+        "result": {"message": "Still working"},
+        "status": "running",
+    }
+
+    class _FakePubSub:
+        def __init__(self) -> None:
+            self.sent = False
+            self.subscribed: list[str] = []
+
+        async def subscribe(self, channel: str) -> None:
+            self.subscribed.append(channel)
+
+        async def get_message(self, **_kwargs: Any) -> dict[str, Any] | None:
+            if not self.sent:
+                self.sent = True
+                return {"data": json.dumps(event)}
+            await asyncio.sleep(10)
+            return None
+
+        async def unsubscribe(self, _channel: str) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    class _FakeRedis:
+        def __init__(self) -> None:
+            self.pubsub_instance = _FakePubSub()
+
+        def pubsub(self) -> _FakePubSub:
+            return self.pubsub_instance
+
+    fake_redis = _FakeRedis()
+
+    async def _fake_get_tool_progress_redis() -> _FakeRedis:
+        return fake_redis
+
+    monkeypatch.setattr(
+        __import__("services.tool_progress_pubsub", fromlist=["get_tool_progress_redis"]),
+        "get_tool_progress_redis",
+        _fake_get_tool_progress_redis,
+    )
+
+    async def _run() -> None:
+        task = asyncio.create_task(
+            websockets._subscribe_workflow_tool_progress(socket, "org-1")  # noqa: SLF001
+        )
+        while not socket.messages:
+            await asyncio.sleep(0.001)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_run())
+    assert fake_redis.pubsub_instance.subscribed == ["tool_progress:org-1"]
+    assert json.loads(socket.messages[0]) == event
+
+
+def test_workflow_tool_progress_subscription_times_out_silent_worker(monkeypatch: Any) -> None:
+    socket = _FakeSocket()
+    running_event = {
+        "type": "tool_progress",
+        "conversation_id": "conv-timeout",
+        "tool_id": "tool-timeout",
+        "tool_name": "foreach",
+        "result": {"message": "Still working"},
+        "status": "running",
+    }
+
+    class _FakePubSub:
+        def __init__(self) -> None:
+            self.sent_running = False
+
+        async def subscribe(self, _channel: str) -> None:
+            return None
+
+        async def get_message(self, **_kwargs: Any) -> dict[str, Any] | None:
+            if not self.sent_running:
+                self.sent_running = True
+                return {"data": json.dumps(running_event)}
+            await asyncio.sleep(0.002)
+            return None
+
+        async def unsubscribe(self, _channel: str) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    class _FakeRedis:
+        def pubsub(self) -> _FakePubSub:
+            return _FakePubSub()
+
+    async def _fake_get_tool_progress_redis() -> _FakeRedis:
+        return _FakeRedis()
+
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS", 0.005)
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS", 0.001)
+    monkeypatch.setattr(
+        __import__("services.tool_progress_pubsub", fromlist=["get_tool_progress_redis"]),
+        "get_tool_progress_redis",
+        _fake_get_tool_progress_redis,
+    )
+
+    async def _run() -> None:
+        task = asyncio.create_task(
+            websockets._subscribe_workflow_tool_progress(socket, "org-1")  # noqa: SLF001
+        )
+        while len(socket.messages) < 2:
+            await asyncio.sleep(0.001)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_run())
+    timeout_event = json.loads(socket.messages[1])
+    assert timeout_event["conversation_id"] == "conv-timeout"
+    assert timeout_event["tool_id"] == "tool-timeout"
+    assert timeout_event["status"] == "complete"
+    assert "timed out" in timeout_event["result"]["error"]


### PR DESCRIPTION
### Motivation
- Move tool progress broadcasting to a push model so the worker that calls `update_tool_result` can directly notify API websocket processes across processes. 
- Avoid expensive DB polling from websocket workers and ensure worker-emitted updates reach all API processes reliably. 
- Fail-fast when a worker becomes silent for an active tool run (sanity timeout) while preserving the existing cadence for ‘still working’ updates.

### Description
- Add `backend/services/tool_progress_pubsub.py` with helpers: `tool_progress_channel`, `build_tool_progress_event`, `get_tool_progress_redis`, and `publish_tool_progress` to publish `tool_progress` events to an org-scoped Redis channel. 
- Update `update_tool_result` in `backend/agents/orchestrator.py` to compute `tool_name` and call `publish_tool_progress` after committing DB changes so Redis publishing does not hold DB resources. 
- Replace the DB-polling websocket path with a Redis subscription: add `_subscribe_workflow_tool_progress` in `backend/api/websockets.py` that subscribes to `tool_progress:<org>`, forwards worker-published events to the websocket, and keeps the pub/sub poll interval at `1.5s` (preserving the previous cadence). 
- Implement a worker-silence sanity timeout (`WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS`, default `60s`) that emits a terminal timeout `tool_progress` event if previously-active tools stop publishing. 
- Use `_send_with_timeout` to protect websocket sends and close the subscription on send failure. 
- Update tests to mock and assert Redis publishing and subscription behavior: switch `test_tool_progress_dedup.py` to expect `publish_tool_progress`, and add tests in `test_websocket_fanout.py` to verify Redis event forwarding and the silence timeout.

### Testing
- Compiled updated modules: `python -m py_compile backend/api/websockets.py backend/agents/orchestrator.py backend/services/tool_progress_pubsub.py` (succeeded). 
- Ran targeted test suite: `pytest -q backend/tests/test_tool_progress_dedup.py backend/tests/test_websocket_fanout.py` and all tests passed (`7 passed`). 
- Verified module-level lint/check with `git diff --check` (no issues detected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5afaa5048321a7d11869dcd14598)