### PR TITLE
Publish tool progress via Redis pub/sub and add websocket rehydration/subscription logic

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -307,26 +307,28 @@ async def update_tool_result(
             await session.commit()
             
             logger.info(f"[update_tool_result] SUCCESS: Updated tool {tool_id[:8]} with status={status}")
-            
-            # Broadcast progress to connected websockets
-            if organization_id:
-                from api.websockets import broadcast_tool_progress
-                # Get tool name from the block
-                tool_name: str = "unknown"
-                for block in new_blocks:
-                    if block.get("id") == tool_id:
-                        tool_name = block.get("name", "unknown")
-                        break
-                await broadcast_tool_progress(
-                    organization_id=organization_id,
-                    conversation_id=conversation_id,
-                    tool_id=tool_id,
-                    tool_name=tool_name,
-                    result=result,
-                    status=status,
-                )
-            
-            return True
+
+            tool_name: str = "unknown"
+            for block in new_blocks:
+                if block.get("id") == tool_id:
+                    tool_name = block.get("name", "unknown")
+                    break
+
+        # Publish progress after the DB transaction scope is closed. Redis
+        # pub/sub is best-effort and should never hold database resources.
+        if organization_id:
+            from services.tool_progress_pubsub import publish_tool_progress
+
+            await publish_tool_progress(
+                organization_id=organization_id,
+                conversation_id=conversation_id,
+                tool_id=tool_id,
+                tool_name=tool_name,
+                result=result,
+                status=status,
+            )
+
+        return True
             
     except Exception as e:
         logger.error(f"[update_tool_result] Error: {e}")

--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -301,7 +301,6 @@ async def broadcast_conversation_message(
 from models.conversation import Conversation
 from models.database import get_session
 from models.user import User
-from models.chat_message import ChatMessage
 from models.workflow import WorkflowRun
 from sqlalchemy import and_, select
 
@@ -335,18 +334,42 @@ def _warn_org_required_rejection(
     )
 
 
-async def _collect_running_workflow_tool_updates(organization_id: str) -> list[dict]:
-    """
-    Collect running workflow tool states from persisted chat messages.
+WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS: float = 1.5
+WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS: float = 60.0
+REDIS_TOOL_PROGRESS_RECONNECT_BASE_SECONDS: float = 1.5
+REDIS_TOOL_PROGRESS_RECONNECT_MAX_SECONDS: float = 30.0
 
-    This is used to keep clients in sync when tool execution happens inside
-    Celery workers (separate process) where in-memory websocket broadcasters
-    are not shared with the API process.
-    """
-    from models.conversation import Conversation
 
-    updates: list[dict] = []
-    logger.debug("[WebSocket] Collecting running workflow tool updates for org %s", organization_id)
+def _tool_progress_signature(event: dict[str, object]) -> str:
+    """Return a stable signature for de-duping rehydrated tool progress events."""
+    result = event.get("result") if isinstance(event.get("result"), dict) else {}
+    return f"{event.get('status')}::{json.dumps(result, sort_keys=True, default=str)}"
+
+
+async def _send_tool_progress_event(
+    websocket: WebSocket,
+    organization_id: str,
+    event: dict[str, object],
+) -> bool:
+    """Send one tool progress event with timeout protection."""
+    sent = await _send_with_timeout(websocket, json.dumps(event, default=str))
+    if not sent:
+        logger.debug(
+            "[WebSocket] Closing tool progress subscription after send failure org=%s",
+            organization_id,
+        )
+    return sent
+
+
+async def _collect_running_workflow_tool_updates(
+    organization_id: str,
+) -> list[dict[str, object]]:
+    """Collect persisted running workflow tool states for connect/resubscribe rehydration."""
+    updates: list[dict[str, object]] = []
+    logger.debug(
+        "[WebSocket] Rehydrating running workflow tool updates for org %s",
+        organization_id,
+    )
     async with get_session(organization_id=organization_id) as session:
         run_rows = await session.execute(
             select(WorkflowRun.output)
@@ -371,8 +394,9 @@ async def _collect_running_workflow_tool_updates(organization_id: str) -> list[d
                 continue
 
         if not conversation_ids:
-            logger.debug("[WebSocket] No running workflow conversations found for org %s", organization_id)
             return updates
+
+        from models.chat_message import ChatMessage
 
         message_rows = await session.execute(
             select(ChatMessage)
@@ -397,10 +421,15 @@ async def _collect_running_workflow_tool_updates(organization_id: str) -> list[d
                     continue
                 updates.append(
                     {
+                        "type": "tool_progress",
                         "conversation_id": str(message.conversation_id),
                         "tool_id": str(block.get("id", "")),
                         "tool_name": str(block.get("name", "unknown")),
-                        "result": block.get("result") if isinstance(block.get("result"), dict) else {},
+                        "result": (
+                            block.get("result")
+                            if isinstance(block.get("result"), dict)
+                            else {}
+                        ),
                         "status": "running",
                     }
                 )
@@ -408,50 +437,214 @@ async def _collect_running_workflow_tool_updates(organization_id: str) -> list[d
     return updates
 
 
-async def _stream_workflow_tool_status(websocket: WebSocket, organization_id: str) -> None:
-    """Poll persisted workflow tool states and push deltas to this websocket."""
-    last_sent: dict[str, str] = {}
-    consecutive_errors: int = 0
-    BASE_INTERVAL: float = 1.5
-    MAX_BACKOFF: float = 30.0
-    logger.info("[WebSocket] Starting workflow tool status stream for org %s", organization_id)
-    while True:
-        try:
-            updates = await _collect_running_workflow_tool_updates(organization_id)
-            consecutive_errors = 0
-            for update in updates:
-                key: str = f"{update['conversation_id']}:{update['tool_id']}"
-                signature: str = json.dumps(update.get("result") or {}, sort_keys=True, default=str)
-                signature = f"{update.get('status')}::{signature}"
-                if last_sent.get(key) == signature:
-                    continue
-                await websocket.send_text(
-                    json.dumps(
-                        {
-                            "type": "tool_progress",
-                            **update,
-                        }
-                    )
-                )
-                logger.debug(
-                    "[WebSocket] Sent workflow tool status: conv=%s tool=%s",
-                    update["conversation_id"],
-                    update["tool_id"],
-                )
-                last_sent[key] = signature
-        except Exception as exc:
-            consecutive_errors += 1
-            if consecutive_errors <= 3:
-                logger.warning("[WebSocket] Workflow status stream error: %s", exc)
-            elif consecutive_errors == 4:
-                logger.warning(
-                    "[WebSocket] Workflow status stream error (suppressing further): %s", exc
-                )
-        sleep_time: float = min(
-            BASE_INTERVAL * (2 ** consecutive_errors) if consecutive_errors > 0 else BASE_INTERVAL,
-            MAX_BACKOFF,
+async def _rehydrate_running_workflow_tool_status(
+    websocket: WebSocket,
+    organization_id: str,
+    last_sent: dict[str, str],
+) -> bool:
+    """Send persisted running workflow tool states, de-duped against prior sends."""
+    try:
+        updates = await _collect_running_workflow_tool_updates(organization_id)
+    except Exception as exc:
+        logger.warning(
+            "[WebSocket] Failed to rehydrate workflow tool status for org %s: %s",
+            organization_id,
+            exc,
         )
-        await asyncio.sleep(sleep_time)
+        return True
+
+    for update in updates:
+        key = f"{update.get('conversation_id')}:{update.get('tool_id')}"
+        signature = _tool_progress_signature(update)
+        if last_sent.get(key) == signature:
+            continue
+        if not await _send_tool_progress_event(websocket, organization_id, update):
+            return False
+        last_sent[key] = signature
+        logger.debug(
+            "[WebSocket] Rehydrated workflow tool status: conv=%s tool=%s",
+            update.get("conversation_id"),
+            update.get("tool_id"),
+        )
+    return True
+
+
+async def _redis_tool_progress_available() -> bool:
+    """Return whether Redis pub/sub appears reachable now."""
+    from services.tool_progress_pubsub import get_tool_progress_redis
+
+    try:
+        redis = await get_tool_progress_redis()
+        await redis.ping()
+        return True
+    except Exception as exc:
+        logger.debug("[WebSocket] Redis tool progress ping failed: %s", exc)
+        return False
+
+
+async def _wait_for_redis_tool_progress_recovery(organization_id: str) -> None:
+    """Wait for Redis to recover without polling persisted workflow tool state."""
+    retry_delay = REDIS_TOOL_PROGRESS_RECONNECT_BASE_SECONDS
+    logger.warning(
+        "[WebSocket] Redis unavailable for workflow tool progress; "
+        "pausing pub/sub until Redis recovers org=%s",
+        organization_id,
+    )
+    while True:
+        await asyncio.sleep(retry_delay)
+        if await _redis_tool_progress_available():
+            logger.info(
+                "[WebSocket] Redis recovered; rehydrating once before resubscribe org=%s",
+                organization_id,
+            )
+            return
+        retry_delay = min(retry_delay * 2, REDIS_TOOL_PROGRESS_RECONNECT_MAX_SECONDS)
+
+
+async def _subscribe_workflow_tool_progress(
+    websocket: WebSocket,
+    organization_id: str,
+) -> None:
+    """Subscribe this websocket to Redis-published workflow tool progress."""
+    from services.tool_progress_pubsub import (
+        TOOL_PROGRESS_TERMINAL_STATUSES,
+        build_tool_progress_event,
+        get_tool_progress_redis,
+        tool_progress_channel,
+    )
+
+    channel: str = tool_progress_channel(organization_id)
+    last_sent: dict[str, str] = {}
+
+    while True:
+        if not await _rehydrate_running_workflow_tool_status(
+            websocket,
+            organization_id,
+            last_sent,
+        ):
+            return
+
+        pubsub = None
+        active_tools: dict[str, dict[str, object]] = {}
+        last_worker_message_at: float | None = None
+        try:
+            redis = await get_tool_progress_redis()
+            pubsub = redis.pubsub()
+            logger.info(
+                "[WebSocket] Subscribing to workflow tool progress channel=%s org=%s",
+                channel,
+                organization_id,
+            )
+            await pubsub.subscribe(channel)
+            while True:
+                message = await pubsub.get_message(
+                    ignore_subscribe_messages=True,
+                    timeout=WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS,
+                )
+                now = asyncio.get_running_loop().time()
+
+                if message is None:
+                    if (
+                        active_tools
+                        and last_worker_message_at is not None
+                        and now - last_worker_message_at
+                        >= WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS
+                    ):
+                        logger.error(
+                            "[WebSocket] Tool progress worker silence timeout after %.0fs org=%s active_tools=%s",
+                            WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS,
+                            organization_id,
+                            list(active_tools),
+                        )
+                        timed_out_tools = list(active_tools.values())
+                        active_tools.clear()
+                        for timed_out in timed_out_tools:
+                            timeout_event = build_tool_progress_event(
+                                conversation_id=str(timed_out.get("conversation_id", "")),
+                                tool_id=str(timed_out.get("tool_id", "")),
+                                tool_name=str(timed_out.get("tool_name", "unknown")),
+                                result={
+                                    "error": (
+                                        "Tool progress timed out while waiting for worker updates."
+                                    ),
+                                    "message": (
+                                        "Tool progress timed out while waiting for worker updates."
+                                    ),
+                                },
+                                status="complete",
+                            )
+                            if not await _send_tool_progress_event(
+                                websocket,
+                                organization_id,
+                                timeout_event,
+                            ):
+                                return
+                        last_worker_message_at = None
+                    continue
+
+                raw_data = message.get("data")
+                if not raw_data:
+                    continue
+                try:
+                    event = json.loads(
+                        raw_data
+                        if isinstance(raw_data, str)
+                        else raw_data.decode("utf-8")
+                    )
+                except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                    logger.warning(
+                        "[WebSocket] Ignoring invalid tool progress pub/sub payload channel=%s: %s",
+                        channel,
+                        exc,
+                    )
+                    continue
+
+                if not isinstance(event, dict) or event.get("type") != "tool_progress":
+                    logger.debug("[WebSocket] Ignoring unexpected tool progress event: %s", event)
+                    continue
+
+                key = f"{event.get('conversation_id')}:{event.get('tool_id')}"
+                status = str(event.get("status") or "running")
+                if status in TOOL_PROGRESS_TERMINAL_STATUSES:
+                    active_tools.pop(key, None)
+                else:
+                    active_tools[key] = event
+                last_worker_message_at = now
+                last_sent[key] = _tool_progress_signature(event)
+
+                if not await _send_tool_progress_event(websocket, organization_id, event):
+                    return
+                logger.debug(
+                    "[WebSocket] Forwarded tool progress from Redis: conv=%s tool=%s status=%s",
+                    event.get("conversation_id"),
+                    event.get("tool_id"),
+                    status,
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "[WebSocket] Tool progress subscription failed for org %s: %s",
+                organization_id,
+                exc,
+            )
+            await _wait_for_redis_tool_progress_recovery(organization_id)
+        finally:
+            if pubsub is not None:
+                try:
+                    await pubsub.unsubscribe(channel)
+                    await pubsub.close()
+                except Exception as exc:
+                    logger.debug(
+                        "[WebSocket] Error closing tool progress pub/sub channel=%s: %s",
+                        channel,
+                        exc,
+                    )
+            logger.info(
+                "[WebSocket] Stopped workflow tool progress subscription channel=%s org=%s",
+                channel,
+                organization_id,
+            )
 
 
 async def _execute_tool_approval(
@@ -635,7 +828,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
         if organization_id:
             sync_broadcaster.register(organization_id, websocket)
             workflow_status_task = asyncio.create_task(
-                _stream_workflow_tool_status(websocket, organization_id)
+                _subscribe_workflow_tool_progress(websocket, organization_id)
             )
         
         # Register for conversation message broadcasts (multi-user support)

--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -530,11 +530,11 @@ async def _subscribe_workflow_tool_progress(
 
     channel: str = tool_progress_channel(organization_id)
     last_sent: dict[str, str] = {}
+    active_tools: dict[str, dict[str, object]] = {}
+    last_silence_log_at: float | None = None
 
     while True:
         pubsub = None
-        active_tools: dict[str, dict[str, object]] = {}
-        last_silence_log_at: float | None = None
         try:
             redis = await get_tool_progress_redis()
             pubsub = redis.pubsub()

--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -442,8 +442,15 @@ async def _rehydrate_running_workflow_tool_status(
     websocket: WebSocket,
     organization_id: str,
     last_sent: dict[str, str],
+    active_tools: dict[str, dict[str, object]] | None = None,
+    observed_at: float | None = None,
 ) -> bool:
-    """Send persisted running workflow tool states, de-duped against prior sends."""
+    """Send persisted running workflow tool states, de-duped against prior sends.
+
+    When active_tools is provided, also track rehydrated running tools so the
+    subscription timeout path can resolve stale tool progress for reconnecting
+    clients even if no further Redis event arrives.
+    """
     try:
         updates = await _collect_running_workflow_tool_updates(organization_id)
     except Exception as exc:
@@ -457,6 +464,13 @@ async def _rehydrate_running_workflow_tool_status(
     for update in updates:
         key = f"{update.get('conversation_id')}:{update.get('tool_id')}"
         signature = _tool_progress_signature(update)
+        if active_tools is not None:
+            tracked_update = dict(update)
+            tracked_update["first_seen_at"] = active_tools.get(key, {}).get(
+                "first_seen_at",
+                observed_at if observed_at is not None else asyncio.get_running_loop().time(),
+            )
+            active_tools[key] = tracked_update
         if last_sent.get(key) == signature:
             continue
         if not await _send_tool_progress_event(websocket, organization_id, update):
@@ -535,6 +549,8 @@ async def _subscribe_workflow_tool_progress(
                 websocket,
                 organization_id,
                 last_sent,
+                active_tools,
+                asyncio.get_running_loop().time(),
             ):
                 return
 

--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -336,6 +336,7 @@ def _warn_org_required_rejection(
 
 WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS: float = 1.5
 WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS: float = 60.0
+WORKFLOW_TOOL_PROGRESS_MAX_TIMEOUT_SECONDS: float = 60.0 * 60.0
 REDIS_TOOL_PROGRESS_RECONNECT_BASE_SECONDS: float = 1.5
 REDIS_TOOL_PROGRESS_RECONNECT_MAX_SECONDS: float = 30.0
 
@@ -517,16 +518,9 @@ async def _subscribe_workflow_tool_progress(
     last_sent: dict[str, str] = {}
 
     while True:
-        if not await _rehydrate_running_workflow_tool_status(
-            websocket,
-            organization_id,
-            last_sent,
-        ):
-            return
-
         pubsub = None
         active_tools: dict[str, dict[str, object]] = {}
-        last_worker_message_at: float | None = None
+        last_silence_log_at: float | None = None
         try:
             redis = await get_tool_progress_redis()
             pubsub = redis.pubsub()
@@ -536,6 +530,14 @@ async def _subscribe_workflow_tool_progress(
                 organization_id,
             )
             await pubsub.subscribe(channel)
+
+            if not await _rehydrate_running_workflow_tool_status(
+                websocket,
+                organization_id,
+                last_sent,
+            ):
+                return
+
             while True:
                 message = await pubsub.get_message(
                     ignore_subscribe_messages=True,
@@ -544,21 +546,26 @@ async def _subscribe_workflow_tool_progress(
                 now = asyncio.get_running_loop().time()
 
                 if message is None:
-                    if (
-                        active_tools
-                        and last_worker_message_at is not None
-                        and now - last_worker_message_at
-                        >= WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS
-                    ):
-                        logger.error(
-                            "[WebSocket] Tool progress worker silence timeout after %.0fs org=%s active_tools=%s",
-                            WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS,
-                            organization_id,
-                            list(active_tools),
-                        )
-                        timed_out_tools = list(active_tools.values())
-                        active_tools.clear()
+                    if active_tools:
+                        timed_out_tools = [
+                            tool
+                            for tool in active_tools.values()
+                            if now - float(tool.get("first_seen_at", now))
+                            >= WORKFLOW_TOOL_PROGRESS_MAX_TIMEOUT_SECONDS
+                        ]
+                        if timed_out_tools:
+                            logger.error(
+                                "[WebSocket] Tool progress max timeout after %.0fs org=%s active_tools=%s",
+                                WORKFLOW_TOOL_PROGRESS_MAX_TIMEOUT_SECONDS,
+                                organization_id,
+                                [
+                                    f"{tool.get('conversation_id')}:{tool.get('tool_id')}"
+                                    for tool in timed_out_tools
+                                ],
+                            )
                         for timed_out in timed_out_tools:
+                            key = f"{timed_out.get('conversation_id')}:{timed_out.get('tool_id')}"
+                            active_tools.pop(key, None)
                             timeout_event = build_tool_progress_event(
                                 conversation_id=str(timed_out.get("conversation_id", "")),
                                 tool_id=str(timed_out.get("tool_id", "")),
@@ -573,13 +580,29 @@ async def _subscribe_workflow_tool_progress(
                                 },
                                 status="complete",
                             )
+                            last_sent[key] = _tool_progress_signature(timeout_event)
                             if not await _send_tool_progress_event(
                                 websocket,
                                 organization_id,
                                 timeout_event,
                             ):
                                 return
-                        last_worker_message_at = None
+
+                        if (
+                            active_tools
+                            and (
+                                last_silence_log_at is None
+                                or now - last_silence_log_at
+                                >= WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS
+                            )
+                        ):
+                            logger.warning(
+                                "[WebSocket] Tool progress worker silent for %.0fs org=%s active_tools=%s",
+                                WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS,
+                                organization_id,
+                                list(active_tools),
+                            )
+                            last_silence_log_at = now
                     continue
 
                 raw_data = message.get("data")
@@ -608,8 +631,13 @@ async def _subscribe_workflow_tool_progress(
                 if status in TOOL_PROGRESS_TERMINAL_STATUSES:
                     active_tools.pop(key, None)
                 else:
-                    active_tools[key] = event
-                last_worker_message_at = now
+                    tracked_event = dict(event)
+                    tracked_event["first_seen_at"] = active_tools.get(key, {}).get(
+                        "first_seen_at",
+                        now,
+                    )
+                    active_tools[key] = tracked_event
+                    last_silence_log_at = None
                 last_sent[key] = _tool_progress_signature(event)
 
                 if not await _send_tool_progress_event(websocket, organization_id, event):

--- a/backend/services/tool_progress_pubsub.py
+++ b/backend/services/tool_progress_pubsub.py
@@ -1,0 +1,100 @@
+"""Redis pub/sub helpers for cross-process tool progress updates."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import redis.asyncio as aioredis
+
+from config import get_redis_connection_kwargs, settings
+
+logger = logging.getLogger(__name__)
+
+TOOL_PROGRESS_CHANNEL_PREFIX = "tool_progress"
+TOOL_PROGRESS_TERMINAL_STATUSES = {
+    "complete",
+    "completed",
+    "failed",
+    "error",
+    "cancelled",
+    "canceled",
+}
+
+_redis_client: aioredis.Redis | None = None
+
+
+def tool_progress_channel(organization_id: str) -> str:
+    """Return the Redis channel used for an organization's tool progress."""
+    return f"{TOOL_PROGRESS_CHANNEL_PREFIX}:{organization_id}"
+
+
+def build_tool_progress_event(
+    *,
+    conversation_id: str,
+    tool_id: str,
+    tool_name: str,
+    result: dict[str, Any],
+    status: str = "running",
+) -> dict[str, Any]:
+    """Build a websocket-compatible tool progress event payload."""
+    return {
+        "type": "tool_progress",
+        "conversation_id": conversation_id,
+        "tool_id": tool_id,
+        "tool_name": tool_name,
+        "result": result,
+        "status": status,
+    }
+
+
+async def get_tool_progress_redis() -> aioredis.Redis:
+    """Lazy-initialize a module-level async Redis client for tool progress."""
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = aioredis.from_url(
+            settings.REDIS_URL,
+            **get_redis_connection_kwargs(decode_responses=True),
+        )
+    return _redis_client
+
+
+async def publish_tool_progress(
+    *,
+    organization_id: str,
+    conversation_id: str,
+    tool_id: str,
+    tool_name: str,
+    result: dict[str, Any],
+    status: str = "running",
+) -> bool:
+    """Publish a tool progress event to Redis for API websocket workers."""
+    event = build_tool_progress_event(
+        conversation_id=conversation_id,
+        tool_id=tool_id,
+        tool_name=tool_name,
+        result=result,
+        status=status,
+    )
+    channel = tool_progress_channel(organization_id)
+    try:
+        redis = await get_tool_progress_redis()
+        await redis.publish(channel, json.dumps(event, default=str))
+        logger.debug(
+            "[ToolProgressPubSub] Published tool progress channel=%s conv=%s tool=%s status=%s",
+            channel,
+            conversation_id[:8] if conversation_id else None,
+            tool_id[:8] if tool_id else None,
+            status,
+        )
+        return True
+    except Exception as exc:
+        logger.warning(
+            "[ToolProgressPubSub] Failed to publish tool progress conv=%s tool=%s status=%s: %s",
+            conversation_id[:8] if conversation_id else None,
+            tool_id[:8] if tool_id else None,
+            status,
+            exc,
+        )
+        return False

--- a/backend/tests/test_tool_progress_dedup.py
+++ b/backend/tests/test_tool_progress_dedup.py
@@ -1,22 +1,9 @@
 import asyncio
-import sys
-import types
 from types import SimpleNamespace
 from uuid import uuid4
 
-_fake_websockets = types.ModuleType("api.websockets")
-
-async def _noop_broadcast_sync_progress(**_kwargs: object) -> None:
-    return None
-
-async def _noop_broadcast_tool_progress(**_kwargs: object) -> None:
-    return None
-
-_fake_websockets.broadcast_sync_progress = _noop_broadcast_sync_progress
-_fake_websockets.broadcast_tool_progress = _noop_broadcast_tool_progress
-sys.modules.setdefault("api.websockets", _fake_websockets)
-
 from agents import orchestrator
+from services import tool_progress_pubsub
 
 
 class _FakeExecuteResult:
@@ -67,8 +54,9 @@ def test_update_tool_result_skips_duplicate_progress_updates(monkeypatch) -> Non
     fake_session = _FakeSession(message)
     broadcasts: list[dict[str, object]] = []
 
-    async def _fake_broadcast_tool_progress(**kwargs: object) -> None:
+    async def _fake_publish_tool_progress(**kwargs: object) -> bool:
         broadcasts.append(kwargs)
+        return True
 
     monkeypatch.setattr(
         orchestrator,
@@ -76,9 +64,9 @@ def test_update_tool_result_skips_duplicate_progress_updates(monkeypatch) -> Non
         lambda **_kwargs: _FakeSessionContext(fake_session),
     )
     monkeypatch.setattr(
-        sys.modules["api.websockets"],
-        "broadcast_tool_progress",
-        _fake_broadcast_tool_progress,
+        tool_progress_pubsub,
+        "publish_tool_progress",
+        _fake_publish_tool_progress,
     )
 
     updated = asyncio.run(
@@ -115,8 +103,9 @@ def test_update_tool_result_allows_status_change_with_same_result(monkeypatch) -
     fake_session = _FakeSession(message)
     broadcasts: list[dict[str, object]] = []
 
-    async def _fake_broadcast_tool_progress(**kwargs: object) -> None:
+    async def _fake_publish_tool_progress(**kwargs: object) -> bool:
         broadcasts.append(kwargs)
+        return True
 
     monkeypatch.setattr(
         orchestrator,
@@ -124,9 +113,9 @@ def test_update_tool_result_allows_status_change_with_same_result(monkeypatch) -
         lambda **_kwargs: _FakeSessionContext(fake_session),
     )
     monkeypatch.setattr(
-        sys.modules["api.websockets"],
-        "broadcast_tool_progress",
-        _fake_broadcast_tool_progress,
+        tool_progress_pubsub,
+        "publish_tool_progress",
+        _fake_publish_tool_progress,
     )
 
     updated = asyncio.run(

--- a/backend/tests/test_websocket_fanout.py
+++ b/backend/tests/test_websocket_fanout.py
@@ -344,6 +344,75 @@ def test_workflow_tool_progress_subscription_completes_after_max_timeout(
     assert "timed out" in timeout_event["result"]["error"]
 
 
+def test_workflow_tool_progress_subscription_times_out_rehydrated_state(
+    monkeypatch: Any,
+) -> None:
+    socket = _FakeSocket()
+    persisted_event = {
+        "type": "tool_progress",
+        "conversation_id": "conv-rehydrate-timeout",
+        "tool_id": "tool-rehydrate-timeout",
+        "tool_name": "foreach",
+        "result": {"message": "Still working"},
+        "status": "running",
+    }
+
+    class _FakePubSub:
+        async def subscribe(self, _channel: str) -> None:
+            return None
+
+        async def get_message(self, **_kwargs: Any) -> dict[str, Any] | None:
+            await asyncio.sleep(0.002)
+            return None
+
+        async def unsubscribe(self, _channel: str) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    class _FakeRedis:
+        def pubsub(self) -> _FakePubSub:
+            return _FakePubSub()
+
+    async def _fake_get_tool_progress_redis() -> _FakeRedis:
+        return _FakeRedis()
+
+    async def _fake_collect(_organization_id: str) -> list[dict[str, object]]:
+        return [persisted_event]
+
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS", 60.0)
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_MAX_TIMEOUT_SECONDS", 0.005)
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS", 0.001)
+    monkeypatch.setattr(websockets, "_collect_running_workflow_tool_updates", _fake_collect)
+    monkeypatch.setattr(
+        __import__("services.tool_progress_pubsub", fromlist=["get_tool_progress_redis"]),
+        "get_tool_progress_redis",
+        _fake_get_tool_progress_redis,
+    )
+
+    async def _run() -> None:
+        task = asyncio.create_task(
+            websockets._subscribe_workflow_tool_progress(socket, "org-1")  # noqa: SLF001
+        )
+        while len(socket.messages) < 2:
+            await asyncio.sleep(0.001)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_run())
+    rehydrated_event = json.loads(socket.messages[0])
+    timeout_event = json.loads(socket.messages[1])
+    assert rehydrated_event == persisted_event
+    assert timeout_event["conversation_id"] == "conv-rehydrate-timeout"
+    assert timeout_event["tool_id"] == "tool-rehydrate-timeout"
+    assert timeout_event["status"] == "complete"
+    assert "timed out" in timeout_event["result"]["error"]
+
+
 def test_workflow_tool_progress_subscribes_before_rehydrate(monkeypatch: Any) -> None:
     socket = _FakeSocket()
     calls: list[str] = []

--- a/backend/tests/test_websocket_fanout.py
+++ b/backend/tests/test_websocket_fanout.py
@@ -209,7 +209,9 @@ def test_workflow_tool_progress_subscription_forwards_redis_events(monkeypatch: 
     assert json.loads(socket.messages[0]) == event
 
 
-def test_workflow_tool_progress_subscription_times_out_silent_worker(monkeypatch: Any) -> None:
+def test_workflow_tool_progress_subscription_does_not_complete_on_worker_silence(
+    monkeypatch: Any,
+) -> None:
     socket = _FakeSocket()
     running_event = {
         "type": "tool_progress",
@@ -248,6 +250,73 @@ def test_workflow_tool_progress_subscription_times_out_silent_worker(monkeypatch
         return _FakeRedis()
 
     monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS", 0.005)
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_MAX_TIMEOUT_SECONDS", 60.0)
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS", 0.001)
+    monkeypatch.setattr(
+        __import__("services.tool_progress_pubsub", fromlist=["get_tool_progress_redis"]),
+        "get_tool_progress_redis",
+        _fake_get_tool_progress_redis,
+    )
+
+    async def _run() -> None:
+        task = asyncio.create_task(
+            websockets._subscribe_workflow_tool_progress(socket, "org-1")  # noqa: SLF001
+        )
+        while not socket.messages:
+            await asyncio.sleep(0.001)
+        await asyncio.sleep(0.02)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_run())
+    assert [json.loads(message) for message in socket.messages] == [running_event]
+
+
+def test_workflow_tool_progress_subscription_completes_after_max_timeout(
+    monkeypatch: Any,
+) -> None:
+    socket = _FakeSocket()
+    running_event = {
+        "type": "tool_progress",
+        "conversation_id": "conv-timeout",
+        "tool_id": "tool-timeout",
+        "tool_name": "foreach",
+        "result": {"message": "Still working"},
+        "status": "running",
+    }
+
+    class _FakePubSub:
+        def __init__(self) -> None:
+            self.sent_running = False
+
+        async def subscribe(self, _channel: str) -> None:
+            return None
+
+        async def get_message(self, **_kwargs: Any) -> dict[str, Any] | None:
+            if not self.sent_running:
+                self.sent_running = True
+                return {"data": json.dumps(running_event)}
+            await asyncio.sleep(0.002)
+            return None
+
+        async def unsubscribe(self, _channel: str) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    class _FakeRedis:
+        def pubsub(self) -> _FakePubSub:
+            return _FakePubSub()
+
+    async def _fake_get_tool_progress_redis() -> _FakeRedis:
+        return _FakeRedis()
+
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS", 60.0)
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_MAX_TIMEOUT_SECONDS", 0.005)
     monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS", 0.001)
     monkeypatch.setattr(
         __import__("services.tool_progress_pubsub", fromlist=["get_tool_progress_redis"]),
@@ -273,6 +342,58 @@ def test_workflow_tool_progress_subscription_times_out_silent_worker(monkeypatch
     assert timeout_event["tool_id"] == "tool-timeout"
     assert timeout_event["status"] == "complete"
     assert "timed out" in timeout_event["result"]["error"]
+
+
+def test_workflow_tool_progress_subscribes_before_rehydrate(monkeypatch: Any) -> None:
+    socket = _FakeSocket()
+    calls: list[str] = []
+
+    class _FakePubSub:
+        async def subscribe(self, _channel: str) -> None:
+            calls.append("subscribe")
+
+        async def get_message(self, **_kwargs: Any) -> dict[str, Any] | None:
+            await asyncio.sleep(10)
+            return None
+
+        async def unsubscribe(self, _channel: str) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    class _FakeRedis:
+        def pubsub(self) -> _FakePubSub:
+            return _FakePubSub()
+
+    async def _fake_get_tool_progress_redis() -> _FakeRedis:
+        return _FakeRedis()
+
+    async def _fake_rehydrate(*_args: Any, **_kwargs: Any) -> bool:
+        calls.append("rehydrate")
+        return True
+
+    monkeypatch.setattr(
+        __import__("services.tool_progress_pubsub", fromlist=["get_tool_progress_redis"]),
+        "get_tool_progress_redis",
+        _fake_get_tool_progress_redis,
+    )
+    monkeypatch.setattr(websockets, "_rehydrate_running_workflow_tool_status", _fake_rehydrate)
+
+    async def _run() -> None:
+        task = asyncio.create_task(
+            websockets._subscribe_workflow_tool_progress(socket, "org-1")  # noqa: SLF001
+        )
+        while calls != ["subscribe", "rehydrate"]:
+            await asyncio.sleep(0.001)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_run())
+    assert calls == ["subscribe", "rehydrate"]
 
 
 def test_workflow_tool_progress_rehydrate_sends_persisted_state(monkeypatch: Any) -> None:

--- a/backend/tests/test_websocket_fanout.py
+++ b/backend/tests/test_websocket_fanout.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from typing import Any
 
@@ -139,3 +140,222 @@ def test_task_manager_broadcast_snapshots_message_before_session_close(monkeypat
 
     asyncio.run(_run())
     assert captured_payloads == [{"id": "assistant-msg-1", "role": "assistant", "content_blocks": []}]
+
+
+def test_workflow_tool_progress_subscription_forwards_redis_events(monkeypatch: Any) -> None:
+    socket = _FakeSocket()
+    event = {
+        "type": "tool_progress",
+        "conversation_id": "conv-1",
+        "tool_id": "tool-1",
+        "tool_name": "query_on_connector",
+        "result": {"message": "Still working"},
+        "status": "running",
+    }
+
+    class _FakePubSub:
+        def __init__(self) -> None:
+            self.sent = False
+            self.subscribed: list[str] = []
+
+        async def subscribe(self, channel: str) -> None:
+            self.subscribed.append(channel)
+
+        async def get_message(self, **_kwargs: Any) -> dict[str, Any] | None:
+            if not self.sent:
+                self.sent = True
+                return {"data": json.dumps(event)}
+            await asyncio.sleep(10)
+            return None
+
+        async def unsubscribe(self, _channel: str) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    class _FakeRedis:
+        def __init__(self) -> None:
+            self.pubsub_instance = _FakePubSub()
+
+        def pubsub(self) -> _FakePubSub:
+            return self.pubsub_instance
+
+    fake_redis = _FakeRedis()
+
+    async def _fake_get_tool_progress_redis() -> _FakeRedis:
+        return fake_redis
+
+    monkeypatch.setattr(
+        __import__("services.tool_progress_pubsub", fromlist=["get_tool_progress_redis"]),
+        "get_tool_progress_redis",
+        _fake_get_tool_progress_redis,
+    )
+
+    async def _run() -> None:
+        task = asyncio.create_task(
+            websockets._subscribe_workflow_tool_progress(socket, "org-1")  # noqa: SLF001
+        )
+        while not socket.messages:
+            await asyncio.sleep(0.001)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_run())
+    assert fake_redis.pubsub_instance.subscribed == ["tool_progress:org-1"]
+    assert json.loads(socket.messages[0]) == event
+
+
+def test_workflow_tool_progress_subscription_times_out_silent_worker(monkeypatch: Any) -> None:
+    socket = _FakeSocket()
+    running_event = {
+        "type": "tool_progress",
+        "conversation_id": "conv-timeout",
+        "tool_id": "tool-timeout",
+        "tool_name": "foreach",
+        "result": {"message": "Still working"},
+        "status": "running",
+    }
+
+    class _FakePubSub:
+        def __init__(self) -> None:
+            self.sent_running = False
+
+        async def subscribe(self, _channel: str) -> None:
+            return None
+
+        async def get_message(self, **_kwargs: Any) -> dict[str, Any] | None:
+            if not self.sent_running:
+                self.sent_running = True
+                return {"data": json.dumps(running_event)}
+            await asyncio.sleep(0.002)
+            return None
+
+        async def unsubscribe(self, _channel: str) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    class _FakeRedis:
+        def pubsub(self) -> _FakePubSub:
+            return _FakePubSub()
+
+    async def _fake_get_tool_progress_redis() -> _FakeRedis:
+        return _FakeRedis()
+
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS", 0.005)
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS", 0.001)
+    monkeypatch.setattr(
+        __import__("services.tool_progress_pubsub", fromlist=["get_tool_progress_redis"]),
+        "get_tool_progress_redis",
+        _fake_get_tool_progress_redis,
+    )
+
+    async def _run() -> None:
+        task = asyncio.create_task(
+            websockets._subscribe_workflow_tool_progress(socket, "org-1")  # noqa: SLF001
+        )
+        while len(socket.messages) < 2:
+            await asyncio.sleep(0.001)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_run())
+    timeout_event = json.loads(socket.messages[1])
+    assert timeout_event["conversation_id"] == "conv-timeout"
+    assert timeout_event["tool_id"] == "tool-timeout"
+    assert timeout_event["status"] == "complete"
+    assert "timed out" in timeout_event["result"]["error"]
+
+
+def test_workflow_tool_progress_rehydrate_sends_persisted_state(monkeypatch: Any) -> None:
+    socket = _FakeSocket()
+    persisted_event = {
+        "type": "tool_progress",
+        "conversation_id": "conv-rehydrate",
+        "tool_id": "tool-rehydrate",
+        "tool_name": "foreach",
+        "result": {"message": "Still working", "completed": 1, "total": 3},
+        "status": "running",
+    }
+
+    async def _fake_collect(_organization_id: str) -> list[dict[str, object]]:
+        return [persisted_event]
+
+    monkeypatch.setattr(
+        websockets,
+        "_collect_running_workflow_tool_updates",
+        _fake_collect,
+    )
+
+    async def _run() -> dict[str, str]:
+        last_sent: dict[str, str] = {}
+        sent = await websockets._rehydrate_running_workflow_tool_status(  # noqa: SLF001
+            socket,
+            "org-1",
+            last_sent,
+        )
+        assert sent is True
+        # Same persisted payload should be de-duped on the next rehydrate pass.
+        sent = await websockets._rehydrate_running_workflow_tool_status(  # noqa: SLF001
+            socket,
+            "org-1",
+            last_sent,
+        )
+        assert sent is True
+        return last_sent
+
+    last_sent = asyncio.run(_run())
+    assert len(socket.messages) == 1
+    assert json.loads(socket.messages[0]) == persisted_event
+    assert last_sent == {
+        "conv-rehydrate:tool-rehydrate": websockets._tool_progress_signature(  # noqa: SLF001
+            persisted_event
+        )
+    }
+
+
+def test_workflow_tool_progress_waits_for_redis_recovery_without_db_polling(monkeypatch: Any) -> None:
+    redis_checks = 0
+    collect_calls = 0
+    sleep_delays: list[float] = []
+
+    async def _fake_redis_available() -> bool:
+        nonlocal redis_checks
+        redis_checks += 1
+        return redis_checks >= 2
+
+    async def _fake_collect(_organization_id: str) -> list[dict[str, object]]:
+        nonlocal collect_calls
+        collect_calls += 1
+        return []
+
+    async def _fake_sleep(delay: float) -> None:
+        sleep_delays.append(delay)
+
+    monkeypatch.setattr(websockets, "REDIS_TOOL_PROGRESS_RECONNECT_BASE_SECONDS", 0.5)
+    monkeypatch.setattr(websockets, "REDIS_TOOL_PROGRESS_RECONNECT_MAX_SECONDS", 2.0)
+    monkeypatch.setattr(
+        websockets,
+        "_redis_tool_progress_available",
+        _fake_redis_available,
+    )
+    monkeypatch.setattr(
+        websockets,
+        "_collect_running_workflow_tool_updates",
+        _fake_collect,
+    )
+    monkeypatch.setattr(websockets.asyncio, "sleep", _fake_sleep)
+
+    asyncio.run(websockets._wait_for_redis_tool_progress_recovery("org-1"))  # noqa: SLF001
+
+    assert redis_checks == 2
+    assert collect_calls == 0
+    assert sleep_delays == [0.5, 1.0]

--- a/backend/tests/test_websocket_fanout.py
+++ b/backend/tests/test_websocket_fanout.py
@@ -413,6 +413,106 @@ def test_workflow_tool_progress_subscription_times_out_rehydrated_state(
     assert "timed out" in timeout_event["result"]["error"]
 
 
+def test_workflow_tool_progress_preserves_active_tools_across_reconnect(
+    monkeypatch: Any,
+) -> None:
+    socket = _FakeSocket()
+    running_event = {
+        "type": "tool_progress",
+        "conversation_id": "conv-reconnect",
+        "tool_id": "tool-reconnect",
+        "tool_name": "foreach",
+        "result": {"message": "Still working"},
+        "status": "running",
+    }
+
+    class _FailingPubSub:
+        def __init__(self) -> None:
+            self.sent_running = False
+
+        async def subscribe(self, _channel: str) -> None:
+            return None
+
+        async def get_message(self, **_kwargs: Any) -> dict[str, Any] | None:
+            if not self.sent_running:
+                self.sent_running = True
+                return {"data": json.dumps(running_event)}
+            raise ConnectionError("redis dropped")
+
+        async def unsubscribe(self, _channel: str) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    class _SilentPubSub:
+        async def subscribe(self, _channel: str) -> None:
+            return None
+
+        async def get_message(self, **_kwargs: Any) -> dict[str, Any] | None:
+            await asyncio.sleep(0.002)
+            return None
+
+        async def unsubscribe(self, _channel: str) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    class _FakeRedis:
+        def __init__(self, pubsub: Any) -> None:
+            self._pubsub = pubsub
+
+        def pubsub(self) -> Any:
+            return self._pubsub
+
+    redis_instances = [_FakeRedis(_FailingPubSub()), _FakeRedis(_SilentPubSub())]
+
+    async def _fake_get_tool_progress_redis() -> _FakeRedis:
+        return redis_instances.pop(0)
+
+    async def _fake_wait_for_redis_tool_progress_recovery(_organization_id: str) -> None:
+        return None
+
+    async def _fake_collect(_organization_id: str) -> list[dict[str, object]]:
+        return []
+
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_SANITY_TIMEOUT_SECONDS", 60.0)
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_MAX_TIMEOUT_SECONDS", 0.005)
+    monkeypatch.setattr(websockets, "WORKFLOW_TOOL_PROGRESS_PUBSUB_POLL_SECONDS", 0.001)
+    monkeypatch.setattr(websockets, "_collect_running_workflow_tool_updates", _fake_collect)
+    monkeypatch.setattr(
+        websockets,
+        "_wait_for_redis_tool_progress_recovery",
+        _fake_wait_for_redis_tool_progress_recovery,
+    )
+    monkeypatch.setattr(
+        __import__("services.tool_progress_pubsub", fromlist=["get_tool_progress_redis"]),
+        "get_tool_progress_redis",
+        _fake_get_tool_progress_redis,
+    )
+
+    async def _run() -> None:
+        task = asyncio.create_task(
+            websockets._subscribe_workflow_tool_progress(socket, "org-1")  # noqa: SLF001
+        )
+        while len(socket.messages) < 2:
+            await asyncio.sleep(0.001)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_run())
+    assert json.loads(socket.messages[0]) == running_event
+    timeout_event = json.loads(socket.messages[1])
+    assert timeout_event["conversation_id"] == "conv-reconnect"
+    assert timeout_event["tool_id"] == "tool-reconnect"
+    assert timeout_event["status"] == "complete"
+    assert "timed out" in timeout_event["result"]["error"]
+
+
 def test_workflow_tool_progress_subscribes_before_rehydrate(monkeypatch: Any) -> None:
     socket = _FakeSocket()
     calls: list[str] = []


### PR DESCRIPTION
### Motivation
- Decouple tool progress broadcasting from the database transaction so pub/sub publishing cannot hold DB resources and can work across processes.  
- Ensure websocket clients can rehydrate running workflow tool states on connect and handle Redis outages and worker silence robustly.

### Description
- In `agents.orchestrator.update_tool_result` the DB commit is performed first and progress is published via the new `services.tool_progress_pubsub.publish_tool_progress` instead of directly calling `api.websockets.broadcast_tool_progress`.  
- Added `backend/services/tool_progress_pubsub.py` which provides a lazy async Redis client, `publish_tool_progress`, `build_tool_progress_event`, channel helpers, and terminal status constants.  
- Reworked `backend/api/websockets.py` to add Redis-backed tooling: `_collect_running_workflow_tool_updates`, `_tool_progress_signature`, `_send_tool_progress_event`, `_rehydrate_running_workflow_tool_status`, `_redis_tool_progress_available`, `_wait_for_redis_tool_progress_recovery`, and `_subscribe_workflow_tool_progress` which subscribe to Redis pub/sub, de-dupe events, handle worker silence timeouts, and perform reconnection/backoff.  
- Updated websocket endpoint to start the new `_subscribe_workflow_tool_progress` task and updated tests to patch `services.tool_progress_pubsub` and add unit tests for subscription, forwarding, timeout, rehydrate, and Redis recovery behaviors.

### Testing
- Ran `backend/tests/test_tool_progress_dedup.py` which passed and verifies duplicate-skip behavior and that `publish_tool_progress` is invoked.  
- Ran `backend/tests/test_websocket_fanout.py` which passed and verifies Redis subscription forwarding, worker silence timeout handling, rehydrate de-duplication, and Redis-recovery waiting logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5afaa5048321a7d11869dcd14598)