### PR TITLE
Denormalize chat_messages.semantic_word_count + project columns in summary/title/embedding readers

### DIFF
--- a/backend/db/migrations/versions/142_chat_messages_semantic_word_count.py
+++ b/backend/db/migrations/versions/142_chat_messages_semantic_word_count.py
@@ -35,6 +35,27 @@ def upgrade() -> None:
             server_default="0",
         ),
     )
+    # Existing rows need a marker so the online backfill can make progress
+    # through rows whose true semantic word count is also 0. Add the column with
+    # a false default for existing rows, then change the default so future
+    # database-level inserts are treated as already maintained by app writers.
+    op.add_column(
+        "chat_messages",
+        sa.Column(
+            "semantic_word_count_backfilled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.alter_column(
+        "chat_messages",
+        "semantic_word_count_backfilled",
+        server_default=sa.text("true"),
+        existing_type=sa.Boolean(),
+        existing_nullable=False,
+    )
+
     # Backfill is intentionally NOT run here — see
     # ``backend/scripts/backfill_chat_message_semantic_word_count.py`` for an
     # operator-controlled batched backfill. New writes are kept correct by the
@@ -43,4 +64,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    op.drop_column("chat_messages", "semantic_word_count_backfilled")
     op.drop_column("chat_messages", "semantic_word_count")

--- a/backend/db/migrations/versions/142_chat_messages_semantic_word_count.py
+++ b/backend/db/migrations/versions/142_chat_messages_semantic_word_count.py
@@ -1,0 +1,46 @@
+"""Add semantic_word_count to chat_messages.
+
+Denormalizes per-message word count of text-type content blocks so that
+``services.conversation_summary.count_semantic_words_for_conversation`` can
+become ``SELECT sum(semantic_word_count) WHERE conversation_id = $1`` instead
+of streaming every row's full ``content_blocks`` JSONB back to Python on every
+assistant reply.
+
+Revision ID: 142_chat_msg_swc
+Revises: 141_conv_delete
+Create Date: 2026-05-08
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "142_chat_msg_swc"
+down_revision: Union[str, None] = "141_conv_delete"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Adding a column with a non-volatile default is a metadata-only operation
+    # in PG 11+, so this is fast even on very large tables.
+    op.add_column(
+        "chat_messages",
+        sa.Column(
+            "semantic_word_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    # Backfill is intentionally NOT run here — see
+    # ``backend/scripts/backfill_chat_message_semantic_word_count.py`` for an
+    # operator-controlled batched backfill. New writes are kept correct by the
+    # SQLAlchemy ``before_insert`` / ``before_update`` event listener on the
+    # ``ChatMessage`` model.
+
+
+def downgrade() -> None:
+    op.drop_column("chat_messages", "semantic_word_count")

--- a/backend/models/chat_message.py
+++ b/backend/models/chat_message.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Optional, TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, event
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -19,6 +19,27 @@ from models.database import Base
 
 if TYPE_CHECKING:
     from models.conversation import Conversation
+
+
+def semantic_word_count_from_blocks(blocks: list[dict[str, Any]] | None) -> int:
+    """Count words in text-type content blocks only.
+
+    Tool-use, tool-result, and attachment blocks are excluded — they hold
+    structured payloads, not user-facing prose, and we don't want a foreach
+    over 10k records to count as 10k "words" for summary-staleness gating.
+    """
+    if not blocks:
+        return 0
+    total: int = 0
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "text":
+            continue
+        text_val: str = str(block.get("text") or "").strip()
+        if text_val:
+            total += len(text_val.split())
+    return total
 
 
 class ChatMessage(Base):
@@ -53,7 +74,15 @@ class ChatMessage(Base):
     content_blocks: Mapped[Optional[list[dict[str, Any]]]] = mapped_column(
         JSONB, nullable=True
     )
-    
+
+    # Denormalized count of words across text-type content blocks only.
+    # Kept in sync by the before_insert / before_update event listener below
+    # so that conversation-summary staleness checks can SUM this column instead
+    # of streaming every row's content_blocks JSONB back to Python.
+    semantic_word_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+
     # Legacy fields - kept for backwards compatibility during migration
     content: Mapped[str] = mapped_column(Text, nullable=False, default="")
     tool_calls: Mapped[Optional[list[dict[str, Any]]]] = mapped_column(
@@ -118,5 +147,18 @@ class ChatMessage(Base):
                     "result": tc.get("result"),
                     "status": "complete",
                 })
-        
+
         return blocks
+
+
+def _sync_semantic_word_count(_mapper, _connection, target: ChatMessage) -> None:
+    """Recompute ``semantic_word_count`` from ``content_blocks`` on every write.
+
+    Centralized here so all 6+ ChatMessage writer sites stay in sync without
+    each having to remember to update the column.
+    """
+    target.semantic_word_count = semantic_word_count_from_blocks(target.content_blocks)
+
+
+event.listen(ChatMessage, "before_insert", _sync_semantic_word_count)
+event.listen(ChatMessage, "before_update", _sync_semantic_word_count)

--- a/backend/models/chat_message.py
+++ b/backend/models/chat_message.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Optional, TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, event
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, event
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -81,6 +81,9 @@ class ChatMessage(Base):
     # of streaming every row's content_blocks JSONB back to Python.
     semantic_word_count: Mapped[int] = mapped_column(
         Integer, nullable=False, default=0, server_default="0"
+    )
+    semantic_word_count_backfilled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
     )
 
     # Legacy fields - kept for backwards compatibility during migration
@@ -158,6 +161,7 @@ def _sync_semantic_word_count(_mapper, _connection, target: ChatMessage) -> None
     each having to remember to update the column.
     """
     target.semantic_word_count = semantic_word_count_from_blocks(target.content_blocks)
+    target.semantic_word_count_backfilled = True
 
 
 event.listen(ChatMessage, "before_insert", _sync_semantic_word_count)

--- a/backend/scripts/backfill_chat_message_semantic_word_count.py
+++ b/backend/scripts/backfill_chat_message_semantic_word_count.py
@@ -7,12 +7,13 @@ The column was added with ``DEFAULT 0`` so existing rows have a wrong (always
 zero) value until this script runs. New writes are kept correct by the
 ``before_insert`` / ``before_update`` event listener on the ChatMessage model.
 
-Strategy: batched, online, idempotent. Picks rows with
-``semantic_word_count = 0 AND content_blocks IS NOT NULL`` and recomputes from
-``content_blocks``. Idle rows that genuinely have zero text words (tool-only
-messages, attachment-only messages) get re-checked each pass and stay at 0,
-which is correct — they just incur a bit of extra work on each run. Use
-``--once`` to do a single pass and exit; default loops until no rows match.
+Strategy: batched, online, idempotent. Picks rows where
+``semantic_word_count_backfilled = false`` and recomputes from
+``content_blocks``. Rows that genuinely have zero text words (tool-only, blank,
+attachment-only, or legacy-null messages) are marked as backfilled too, so an
+old all-zero batch cannot make the outer loop think the whole backfill is done
+before later non-zero rows are reached. Use ``--once`` to do a single pass and
+exit; default loops until no rows match.
 
 Usage:
     cd backend && python scripts/backfill_chat_message_semantic_word_count.py
@@ -24,6 +25,7 @@ import argparse
 import asyncio
 import sys
 import time
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -40,17 +42,25 @@ def _log(msg: str) -> None:
     print(f"[{datetime.now().strftime('%H:%M:%S')}] {msg}", flush=True)
 
 
-async def _backfill_batch(batch: int) -> int:
-    """Update one batch. Returns the number of rows updated."""
-    # Pick the oldest un-backfilled rows that actually have content_blocks. We
-    # filter on ``semantic_word_count = 0`` and ``content_blocks IS NOT NULL``
-    # so we never reread a row whose backfill produced a non-zero value.
+@dataclass(frozen=True)
+class BackfillBatchResult:
+    """Outcome for a single selected batch."""
+
+    selected: int
+    updated: int
+
+
+async def _backfill_batch(batch: int) -> BackfillBatchResult:
+    """Update one batch and return both selected and updated row counts."""
+    # Pick the oldest rows that this backfill has not processed yet. The
+    # explicit marker is important: rows whose true semantic count is 0 must be
+    # marked processed, otherwise an all-zero batch would be selected again and
+    # again (or be mistaken for completion if callers only track changed counts).
     select_sql = text(
         """
         SELECT id, content_blocks
         FROM chat_messages
-        WHERE semantic_word_count = 0
-          AND content_blocks IS NOT NULL
+        WHERE semantic_word_count_backfilled = false
         ORDER BY created_at ASC NULLS LAST
         LIMIT :batch
         FOR UPDATE SKIP LOCKED
@@ -60,12 +70,12 @@ async def _backfill_batch(batch: int) -> int:
     async with get_admin_session() as session:
         rows = (await session.execute(select_sql, {"batch": batch})).all()
         if not rows:
-            return 0
+            return BackfillBatchResult(selected=0, updated=0)
 
         # Compute new values in Python (cheap; saves a server-side jsonb walk).
         # Group rows by computed count so the UPDATE fires once per distinct
-        # value rather than once per row — most messages share the count of 0
-        # (tool-only / attachment-only) so this collapses dramatically.
+        # value rather than once per row — many messages share the count of 0
+        # (tool-only / attachment-only / blank) so this collapses dramatically.
         by_count: dict[int, list[Any]] = {}
         for row_id, blocks in rows:
             count = semantic_word_count_from_blocks(blocks)
@@ -73,15 +83,12 @@ async def _backfill_batch(batch: int) -> int:
 
         updated = 0
         for count, ids in by_count.items():
-            # Skip the all-zero bucket — column already 0, no-op write would
-            # just churn the row and trigger our own event listener.
-            if count == 0:
-                continue
             res = await session.execute(
                 text(
                     """
                     UPDATE chat_messages
-                    SET semantic_word_count = :count
+                    SET semantic_word_count = :count,
+                        semantic_word_count_backfilled = true
                     WHERE id = ANY(:ids)
                     """
                 ),
@@ -90,7 +97,7 @@ async def _backfill_batch(batch: int) -> int:
             updated += int(res.rowcount or 0)
 
         await session.commit()
-        return updated
+        return BackfillBatchResult(selected=len(rows), updated=updated)
 
 
 async def backfill(batch: int, delay: float, once: bool) -> None:
@@ -101,21 +108,21 @@ async def backfill(batch: int, delay: float, once: bool) -> None:
     while True:
         pass_index += 1
         try:
-            updated = await _backfill_batch(batch)
+            result = await _backfill_batch(batch)
         except Exception as exc:
             _log(f"ERROR in batch {pass_index}: {exc}")
             await asyncio.sleep(max(delay * 5, 2.0))
             continue
 
-        total_updated += updated
+        total_updated += result.updated
         elapsed = time.monotonic() - started
         rate = total_updated / elapsed if elapsed > 0 else 0.0
         _log(
-            f"batch {pass_index}: updated={updated} total={total_updated} "
+            f"batch {pass_index}: selected={result.selected} updated={result.updated} total={total_updated} "
             f"elapsed={elapsed:.1f}s rate={rate:.0f}/s"
         )
 
-        if updated == 0:
+        if result.selected == 0:
             _log("no more rows to backfill — done")
             return
         if once:

--- a/backend/scripts/backfill_chat_message_semantic_word_count.py
+++ b/backend/scripts/backfill_chat_message_semantic_word_count.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Backfill ``chat_messages.semantic_word_count`` for rows written before the
+denormalization landed (migration 142).
+
+The column was added with ``DEFAULT 0`` so existing rows have a wrong (always
+zero) value until this script runs. New writes are kept correct by the
+``before_insert`` / ``before_update`` event listener on the ChatMessage model.
+
+Strategy: batched, online, idempotent. Picks rows with
+``semantic_word_count = 0 AND content_blocks IS NOT NULL`` and recomputes from
+``content_blocks``. Idle rows that genuinely have zero text words (tool-only
+messages, attachment-only messages) get re-checked each pass and stay at 0,
+which is correct — they just incur a bit of extra work on each run. Use
+``--once`` to do a single pass and exit; default loops until no rows match.
+
+Usage:
+    cd backend && python scripts/backfill_chat_message_semantic_word_count.py
+    cd backend && python scripts/backfill_chat_message_semantic_word_count.py --batch 5000 --delay 0.5 --once
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import text
+
+from models.chat_message import semantic_word_count_from_blocks
+from models.database import get_admin_session
+
+
+def _log(msg: str) -> None:
+    print(f"[{datetime.now().strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+async def _backfill_batch(batch: int) -> int:
+    """Update one batch. Returns the number of rows updated."""
+    # Pick the oldest un-backfilled rows that actually have content_blocks. We
+    # filter on ``semantic_word_count = 0`` and ``content_blocks IS NOT NULL``
+    # so we never reread a row whose backfill produced a non-zero value.
+    select_sql = text(
+        """
+        SELECT id, content_blocks
+        FROM chat_messages
+        WHERE semantic_word_count = 0
+          AND content_blocks IS NOT NULL
+        ORDER BY created_at ASC NULLS LAST
+        LIMIT :batch
+        FOR UPDATE SKIP LOCKED
+        """
+    )
+
+    async with get_admin_session() as session:
+        rows = (await session.execute(select_sql, {"batch": batch})).all()
+        if not rows:
+            return 0
+
+        # Compute new values in Python (cheap; saves a server-side jsonb walk).
+        # Group rows by computed count so the UPDATE fires once per distinct
+        # value rather than once per row — most messages share the count of 0
+        # (tool-only / attachment-only) so this collapses dramatically.
+        by_count: dict[int, list[Any]] = {}
+        for row_id, blocks in rows:
+            count = semantic_word_count_from_blocks(blocks)
+            by_count.setdefault(count, []).append(row_id)
+
+        updated = 0
+        for count, ids in by_count.items():
+            # Skip the all-zero bucket — column already 0, no-op write would
+            # just churn the row and trigger our own event listener.
+            if count == 0:
+                continue
+            res = await session.execute(
+                text(
+                    """
+                    UPDATE chat_messages
+                    SET semantic_word_count = :count
+                    WHERE id = ANY(:ids)
+                    """
+                ),
+                {"count": count, "ids": ids},
+            )
+            updated += int(res.rowcount or 0)
+
+        await session.commit()
+        return updated
+
+
+async def backfill(batch: int, delay: float, once: bool) -> None:
+    total_updated = 0
+    started = time.monotonic()
+    pass_index = 0
+
+    while True:
+        pass_index += 1
+        try:
+            updated = await _backfill_batch(batch)
+        except Exception as exc:
+            _log(f"ERROR in batch {pass_index}: {exc}")
+            await asyncio.sleep(max(delay * 5, 2.0))
+            continue
+
+        total_updated += updated
+        elapsed = time.monotonic() - started
+        rate = total_updated / elapsed if elapsed > 0 else 0.0
+        _log(
+            f"batch {pass_index}: updated={updated} total={total_updated} "
+            f"elapsed={elapsed:.1f}s rate={rate:.0f}/s"
+        )
+
+        if updated == 0:
+            _log("no more rows to backfill — done")
+            return
+        if once:
+            return
+        await asyncio.sleep(delay)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batch", type=int, default=2000, help="Rows per batch (default: 2000)")
+    parser.add_argument("--delay", type=float, default=0.25, help="Sleep between batches in seconds (default: 0.25)")
+    parser.add_argument("--once", action="store_true", help="Run a single batch and exit")
+    args = parser.parse_args()
+
+    asyncio.run(backfill(args.batch, args.delay, args.once))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/services/conversation_embeddings.py
+++ b/backend/services/conversation_embeddings.py
@@ -104,7 +104,7 @@ async def update_conversation_embedding(
             summary_text = (conv.summary or "").strip() or None
 
             result = await session.execute(
-                select(ChatMessageModel)
+                select(ChatMessageModel.content, ChatMessageModel.content_blocks)
                 .where(
                     ChatMessageModel.conversation_id == conv.id,
                     ChatMessageModel.role == "user",
@@ -112,7 +112,7 @@ async def update_conversation_embedding(
                 .order_by(ChatMessageModel.created_at.desc())
                 .limit(_MAX_MESSAGES_FOR_RECENT)
             )
-            user_messages = list(result.scalars().all())
+            user_messages = list(result.all())
             total_chars = 0
             for msg in reversed(user_messages):
                 text = _extract_text_from_blocks(msg.content_blocks)

--- a/backend/services/conversation_summary.py
+++ b/backend/services/conversation_summary.py
@@ -20,7 +20,7 @@ from models.chat_message import ChatMessage as ChatMessageModel
 from models.conversation import Conversation
 from models.database import get_admin_session, get_session
 from models.user import User
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 
 from services.anthropic_health import report_anthropic_call_failure, report_anthropic_call_success
 from services.llm_provider import resolve_llm_config, get_adapter
@@ -63,37 +63,22 @@ _TITLE_SYSTEM_PROMPT = (
 )
 
 
-def _semantic_word_count_from_blocks(blocks: list[dict[str, Any]] | None) -> int:
-    """Count words in text-type content blocks only (exclude tool_use, attachments, etc.)."""
-    if not blocks:
-        return 0
-    total: int = 0
-    for block in blocks:
-        if not isinstance(block, dict):
-            continue
-        if block.get("type") != "text":
-            continue
-        text_val: str = str(block.get("text") or "").strip()
-        if text_val:
-            total += len(text_val.split())
-    return total
-
-
 async def count_semantic_words_for_conversation(
     session: Any,
     conversation_id: uuid.UUID,
 ) -> int:
-    """Sum semantic word counts across all messages in the conversation."""
+    """Sum semantic word counts across all messages in the conversation.
+
+    Reads the denormalized ``chat_messages.semantic_word_count`` column rather
+    than streaming every row's ``content_blocks`` JSONB back to Python. The
+    column is kept in sync by an event listener on the ChatMessage model.
+    """
     result = await session.execute(
-        select(ChatMessageModel.content_blocks).where(
+        select(func.coalesce(func.sum(ChatMessageModel.semantic_word_count), 0)).where(
             ChatMessageModel.conversation_id == conversation_id
         )
     )
-    total: int = 0
-    for row in result:
-        blocks: list[dict[str, Any]] | None = row[0]
-        total += _semantic_word_count_from_blocks(blocks)
-    return total
+    return int(result.scalar_one() or 0)
 
 
 def _should_regenerate_summary(
@@ -110,8 +95,12 @@ def _should_regenerate_summary(
     return (semantic_words - summary_word_count_at_generation) >= _SEMANTIC_REGEN_WORD_DELTA
 
 
-def _format_messages(messages: list[ChatMessageModel]) -> str:
-    """Format messages into a compact text representation for the prompt."""
+def _format_messages(messages: list[Any]) -> str:
+    """Format messages into a compact text representation for the prompt.
+
+    Accepts anything with ``.role`` and ``.content_blocks`` attributes —
+    typically SQLAlchemy ``Row`` tuples from a projected select.
+    """
     lines: list[str] = []
     for msg in messages:
         role: str = str(msg.role).upper()
@@ -216,12 +205,12 @@ async def generate_conversation_summary(
                 return None
 
             result = await session.execute(
-                select(ChatMessageModel)
+                select(ChatMessageModel.role, ChatMessageModel.content_blocks)
                 .where(ChatMessageModel.conversation_id == conv.id)
                 .order_by(ChatMessageModel.created_at.desc())
                 .limit(_MAX_MESSAGES_FOR_PROMPT)
             )
-            messages: list[ChatMessageModel] = list(reversed(result.scalars().all()))
+            messages = list(reversed(result.all()))
             if len(messages) < 1:
                 return None
 
@@ -326,12 +315,12 @@ async def generate_conversation_title(
                 return None
 
             result = await session.execute(
-                select(ChatMessageModel)
+                select(ChatMessageModel.role, ChatMessageModel.content_blocks)
                 .where(ChatMessageModel.conversation_id == conv.id)
                 .order_by(ChatMessageModel.created_at.desc())
                 .limit(_MAX_MESSAGES_FOR_PROMPT)
             )
-            messages: list[ChatMessageModel] = list(reversed(result.scalars().all()))
+            messages = list(reversed(result.all()))
             if not messages:
                 return None
             formatted = _format_messages(messages)

--- a/backend/tests/test_chat_message_semantic_word_count.py
+++ b/backend/tests/test_chat_message_semantic_word_count.py
@@ -11,6 +11,8 @@ import asyncio
 import uuid
 from typing import Any
 
+import scripts.backfill_chat_message_semantic_word_count as backfill_script
+
 from models.chat_message import (
     ChatMessage,
     _sync_semantic_word_count,
@@ -67,6 +69,7 @@ def test_event_listener_sets_count_on_insert() -> None:
     # doesn't need a DB.
     _sync_semantic_word_count(None, None, msg)
     assert msg.semantic_word_count == 3
+    assert msg.semantic_word_count_backfilled is True
 
 
 def test_event_listener_recomputes_on_update() -> None:
@@ -81,9 +84,11 @@ def test_event_listener_recomputes_on_update() -> None:
         {"type": "tool_use", "id": "t1", "name": "noop", "input": {}, "result": {}},
         {"type": "text", "text": "and one more"},
     ]
+    msg.semantic_word_count_backfilled = False
     _sync_semantic_word_count(None, None, msg)
     # Tool use ignored; 5 + 3 = 8.
     assert msg.semantic_word_count == 8
+    assert msg.semantic_word_count_backfilled is True
 
 
 def test_event_listener_drops_to_zero_when_blocks_cleared() -> None:
@@ -159,3 +164,97 @@ def test_count_semantic_words_returns_zero_when_sum_is_null() -> None:
     session = _CapturingSession(return_value=0)
     result = asyncio.run(count_semantic_words_for_conversation(session, uuid.uuid4()))
     assert result == 0
+
+
+# ---------- backfill script -------------------------------------------------
+
+
+class _FakeRowsResult:
+    def __init__(self, rows: list[tuple[Any, Any]]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[tuple[Any, Any]]:
+        return self._rows
+
+
+class _FakeUpdateResult:
+    def __init__(self, rowcount: int) -> None:
+        self.rowcount = rowcount
+
+
+class _FakeBackfillSession:
+    def __init__(self, rows: list[tuple[Any, Any]]) -> None:
+        self.rows = rows
+        self.executed: list[tuple[str, dict[str, Any] | None]] = []
+        self.committed = False
+
+    async def execute(self, stmt: Any, params: dict[str, Any] | None = None) -> Any:
+        rendered = str(stmt).lower()
+        self.executed.append((rendered, params))
+        if rendered.lstrip().startswith("select"):
+            return _FakeRowsResult(self.rows)
+        return _FakeUpdateResult(len(params["ids"]) if params else 0)
+
+    async def commit(self) -> None:
+        self.committed = True
+
+
+class _FakeBackfillSessionContext:
+    def __init__(self, session: _FakeBackfillSession) -> None:
+        self.session = session
+
+    async def __aenter__(self) -> _FakeBackfillSession:
+        return self.session
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+
+def test_backfill_batch_marks_zero_count_rows_processed(monkeypatch) -> None:
+    """Zero-word rows must not make the backfill stop before later rows.
+
+    The script used to skip the zero-count bucket entirely, so an oldest batch
+    containing only tool/blank messages returned ``updated == 0`` while those
+    rows still matched the next SELECT. The explicit backfilled marker lets the
+    batch make progress even when the semantic count remains 0.
+    """
+    zero_id = uuid.uuid4()
+    nonzero_id = uuid.uuid4()
+    session = _FakeBackfillSession(
+        rows=[
+            (zero_id, [{"type": "tool_use", "id": "t1"}]),
+            (nonzero_id, [{"type": "text", "text": "hello world"}]),
+        ]
+    )
+    monkeypatch.setattr(
+        backfill_script,
+        "get_admin_session",
+        lambda: _FakeBackfillSessionContext(session),
+    )
+
+    result = asyncio.run(backfill_script._backfill_batch(batch=2))
+
+    assert result.selected == 2
+    assert result.updated == 2
+    assert session.committed is True
+    select_sql = session.executed[0][0]
+    assert "semantic_word_count_backfilled = false" in select_sql
+    update_calls = session.executed[1:]
+    assert len(update_calls) == 2
+    assert {params["count"] for _, params in update_calls if params} == {0, 2}
+    assert all("semantic_word_count_backfilled = true" in sql for sql, _ in update_calls)
+
+
+def test_backfill_batch_reports_done_only_when_no_rows_selected(monkeypatch) -> None:
+    session = _FakeBackfillSession(rows=[])
+    monkeypatch.setattr(
+        backfill_script,
+        "get_admin_session",
+        lambda: _FakeBackfillSessionContext(session),
+    )
+
+    result = asyncio.run(backfill_script._backfill_batch(batch=2))
+
+    assert result.selected == 0
+    assert result.updated == 0
+    assert session.committed is False

--- a/backend/tests/test_chat_message_semantic_word_count.py
+++ b/backend/tests/test_chat_message_semantic_word_count.py
@@ -1,0 +1,161 @@
+"""Tests for the chat_messages.semantic_word_count denormalization.
+
+Covers:
+  - The pure helper that counts text-block words (excludes tool_use, attachment, etc.)
+  - The before_insert / before_update event listener that keeps the column in sync
+  - The SUM-based ``count_semantic_words_for_conversation`` query path
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+from models.chat_message import (
+    ChatMessage,
+    _sync_semantic_word_count,
+    semantic_word_count_from_blocks,
+)
+from services.conversation_summary import count_semantic_words_for_conversation
+
+
+# ---------- semantic_word_count_from_blocks (pure helper) -------------------
+
+
+def test_word_count_handles_none_and_empty() -> None:
+    assert semantic_word_count_from_blocks(None) == 0
+    assert semantic_word_count_from_blocks([]) == 0
+
+
+def test_word_count_only_counts_text_blocks() -> None:
+    blocks = [
+        {"type": "text", "text": "hello world from the user"},
+        {"type": "tool_use", "id": "t1", "name": "search", "input": {"q": "ignored"}, "result": {"a": "ignored too"}},
+        {"type": "attachment", "id": "att-1"},
+        {"type": "text", "text": "and a follow up"},
+    ]
+    # 5 + 4 = 9 words; tool_use input/result and attachment are excluded.
+    assert semantic_word_count_from_blocks(blocks) == 9
+
+
+def test_word_count_skips_non_dict_entries_and_blank_text() -> None:
+    blocks = [
+        "not a dict",
+        {"type": "text"},                # missing text key
+        {"type": "text", "text": ""},    # empty
+        {"type": "text", "text": "   "}, # whitespace only
+        {"type": "text", "text": "three real words"},
+    ]
+    assert semantic_word_count_from_blocks(blocks) == 3
+
+
+def test_word_count_collapses_runs_of_whitespace_via_split() -> None:
+    blocks = [{"type": "text", "text": "   one\t two\nthree    four "}]
+    assert semantic_word_count_from_blocks(blocks) == 4
+
+
+# ---------- ChatMessage event listener --------------------------------------
+
+
+def test_event_listener_sets_count_on_insert() -> None:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        role="user",
+        content_blocks=[{"type": "text", "text": "hi there friend"}],
+    )
+    # before_insert fires this synchronously; simulate it directly so the test
+    # doesn't need a DB.
+    _sync_semantic_word_count(None, None, msg)
+    assert msg.semantic_word_count == 3
+
+
+def test_event_listener_recomputes_on_update() -> None:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        role="assistant",
+        content_blocks=[{"type": "text", "text": "first reply with five words"}],
+        semantic_word_count=5,
+    )
+    msg.content_blocks = [
+        {"type": "text", "text": "first reply with five words"},
+        {"type": "tool_use", "id": "t1", "name": "noop", "input": {}, "result": {}},
+        {"type": "text", "text": "and one more"},
+    ]
+    _sync_semantic_word_count(None, None, msg)
+    # Tool use ignored; 5 + 3 = 8.
+    assert msg.semantic_word_count == 8
+
+
+def test_event_listener_drops_to_zero_when_blocks_cleared() -> None:
+    msg = ChatMessage(id=uuid.uuid4(), role="user", semantic_word_count=42)
+    msg.content_blocks = None
+    _sync_semantic_word_count(None, None, msg)
+    assert msg.semantic_word_count == 0
+
+
+def test_event_listener_handles_tool_only_message() -> None:
+    """A tool-only message has no semantic words and must store 0 — important
+    so that a foreach over thousands of records doesn't push a conversation
+    over the summary-regeneration threshold."""
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        role="assistant",
+        content_blocks=[
+            {"type": "tool_use", "id": "t1", "name": "foreach", "input": {"items": list(range(1000))}, "result": {}}
+            for _ in range(20)
+        ],
+    )
+    _sync_semantic_word_count(None, None, msg)
+    assert msg.semantic_word_count == 0
+
+
+# ---------- count_semantic_words_for_conversation (SUM path) ----------------
+
+
+class _FakeResult:
+    def __init__(self, value: int) -> None:
+        self._value = value
+
+    def scalar_one(self) -> int:
+        return self._value
+
+
+class _CapturingSession:
+    """Minimal fake that records the executed statement and returns a scalar."""
+
+    def __init__(self, return_value: int) -> None:
+        self.return_value = return_value
+        self.executed: list[Any] = []
+
+    async def execute(self, stmt: Any) -> _FakeResult:
+        self.executed.append(stmt)
+        return _FakeResult(self.return_value)
+
+
+def test_count_semantic_words_uses_sum_query_not_content_blocks() -> None:
+    """Smoke-test that the SUM path is used.
+
+    Critical: this function used to ``select(content_blocks)`` with no LIMIT,
+    streaming every row's JSONB back to Python on every assistant reply
+    (~14 TB scanned in the prod pg_stat_statements snapshot). It now must SUM
+    a denormalized integer column.
+    """
+    session = _CapturingSession(return_value=137)
+    conv_id = uuid.uuid4()
+
+    result = asyncio.run(count_semantic_words_for_conversation(session, conv_id))
+
+    assert result == 137
+    assert len(session.executed) == 1
+    rendered = str(session.executed[0]).lower()
+    # The new query must SUM the denormalized column, not stream content_blocks.
+    assert "sum" in rendered
+    assert "semantic_word_count" in rendered
+    assert "content_blocks" not in rendered
+
+
+def test_count_semantic_words_returns_zero_when_sum_is_null() -> None:
+    """A conversation with no rows yields SUM=NULL; helper must return 0."""
+    session = _CapturingSession(return_value=0)
+    result = asyncio.run(count_semantic_words_for_conversation(session, uuid.uuid4()))
+    assert result == 0


### PR DESCRIPTION
## Summary

Tackles the chronic ~61 TB of `chat_messages` reads that dominated `pg_stat_statements` in last week's egress investigation. (PR #1278 takes out the workflow-runs polling loop; this one takes out the next two largest line items.)

- **`count_semantic_words_for_conversation`** used to `select(content_blocks)` with no `LIMIT` and stream every row's JSONB back to Python on every assistant reply (called twice per reply, from `generate_conversation_summary` and `generate_conversation_title`). It now `SUM`s a denormalized `semantic_word_count` column on `chat_messages`.
- **`generate_conversation_summary`, `generate_conversation_title`, `update_conversation_embedding`** used to `select(ChatMessage)` (every column, including the fat `content_blocks` JSONB) for the last 50 rows. They now project only the columns each formatter actually reads (`role, content_blocks` for summary/title; `content, content_blocks` for embedding).

## Implementation

- **Migration 142** — adds `chat_messages.semantic_word_count int NOT NULL DEFAULT 0`. Metadata-only on PG 11+, fast even on a huge table.
- **`before_insert` / `before_update` event listener** on the `ChatMessage` model recomputes the column from `content_blocks` on every write. Centralizing it on the model avoids touching all 6+ writer sites and prevents future writers from forgetting to update the column.
- **`backend/scripts/backfill_chat_message_semantic_word_count.py`** — operator-controlled batched online backfill for pre-existing rows. Idempotent, uses `FOR UPDATE SKIP LOCKED`, groups by computed value to collapse UPDATEs, and skips the all-zero bucket so tool-only / attachment-only messages don't churn.

## Why a denormalized column instead of a query rewrite

A `SELECT sum(jsonb_array_length(content_blocks))`-style query in Postgres still has to read every row's `content_blocks` JSONB (which is exactly the toast read we're trying to avoid). Storing the count as an `int` column on the row and SUMming it lets Postgres satisfy the query from the heap (or the index, if we add one later) without touching the toasted JSONB at all.

## What this does **not** address (saved for follow-ups)

Both are real but need orchestrator-state changes that don't belong in this PR:

1. **`_load_history`** in `backend/agents/orchestrator.py:2178` still pulls 20 prior messages full-row + re-fetches `ChatAttachment.content` bytes per turn. The attachment re-fetch in particular is a multiplier on every chat turn for any conversation that ever uploaded a file. Cleanest fix is per-turn caching on the orchestrator instance.
2. **`update_tool_result`** in `backend/agents/orchestrator.py:230` still SELECTs the assistant message before mutating `content_blocks` for every tool progress tick (foreach loops do this dozens of times per turn). Cleanest fix is a `jsonb_set`-based UPDATE that mutates a specific block by ID without reading first, but that's a behavior change worth its own review.

## Test plan

- [x] New unit tests in `backend/tests/test_chat_message_semantic_word_count.py` cover:
  - The pure word-count helper (None, empty, text-only, mixed types, whitespace handling)
  - The event listener on insert, on update, on clearing blocks, and on a tool-only message (must stay at 0 so a foreach over 10k items doesn't push a conversation over the summary-regeneration threshold)
  - That `count_semantic_words_for_conversation` issues a SUM query and never references `content_blocks`
- [x] Full existing test suite (`pytest backend/tests/`) — 744 passed, no regressions
- [ ] After deploy: run `python scripts/backfill_chat_message_semantic_word_count.py` once
- [ ] After backfill: confirm via Supabase dashboard that the `chat_messages.content_blocks` reads in `pg_stat_statements` shrink by the share attributable to summary/title/embedding paths

## Deploy order

1. Merge — migration adds the column with default 0; new writes are immediately correct via the event listener.
2. The new readers (`SUM`, projected columns) work immediately for new conversations. Existing conversations will return `0` until the backfill runs, which means their summary/title regeneration is paused but not broken (the existing summary stays valid).
3. Run the backfill script. Idempotent, safe to interrupt and resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)