### PR TITLE
Optimize chat message projections

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -21,7 +21,7 @@ from uuid import UUID, uuid4
 
 from anthropic import APIStatusError as AnthropicAPIStatusError
 from openai import APIStatusError as OpenAIAPIStatusError
-from sqlalchemy import select, update
+from sqlalchemy import select, text, update
 
 from agents.registry import format_tool_status
 from agents.tools import execute_tool, get_tools, get_tool_defs_for_context
@@ -230,93 +230,104 @@ def _should_include_cross_conversation_history(user_message: str) -> bool:
 async def update_tool_result(
     conversation_id: str,
     tool_id: str,
-    result: dict[str, Any],
+    result: Any,
     status: str = "running",
     organization_id: str | None = None,
     user_id: str | None = None,
 ) -> bool:
-    """
-    Update a tool call's result in an existing conversation message.
-    
-    This enables long-running tools (like foreach) to report progress
-    that the frontend can poll for and display.
-    
-    Args:
-        conversation_id: The conversation containing the tool call
-        tool_id: The tool_use block ID to update
-        result: The new result dict (can be partial progress or final)
-        status: "running" for progress updates, "complete" when done
-        organization_id: Organization ID for RLS context
-        user_id: User ID for RLS visibility context
-        
-    Returns:
-        True if update succeeded, False otherwise
+    """Update a tool result block without fetching the fat chat_messages row.
+
+    Tool progress ticks can happen many times per assistant reply. Keep this as a
+    single JSONB UPDATE/RETURNING statement so the database rewrites the changed
+    JSONB value, but the app server does not repeatedly pull content_blocks (and
+    other chat_messages columns) over the wire just to patch one tool block.
     """
     logger.info(
-        "[update_tool_result] Called: conv=%s, tool=%s, status=%s",
-        conversation_id[:8] if conversation_id else None,
+        "[update_tool_result] Updating tool %s in conversation %s with status=%s",
         tool_id[:8] if tool_id else None,
+        conversation_id,
         status,
     )
     try:
+        result_json = json.dumps(result)
         async with get_session(organization_id=organization_id, user_id=user_id) as session:
-            # Find the latest assistant message in this conversation
-            query = (
-                select(ChatMessage)
-                .where(ChatMessage.conversation_id == UUID(conversation_id))
-                .where(ChatMessage.role == "assistant")
-                .order_by(ChatMessage.created_at.desc())
-                .limit(1)
+            update_stmt = text(
+                """
+                WITH latest_assistant AS (
+                    SELECT id
+                    FROM chat_messages
+                    WHERE conversation_id = CAST(:conversation_id AS uuid)
+                      AND role = 'assistant'
+                      AND content_blocks IS NOT NULL
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                ), matched_tool AS (
+                    SELECT
+                        cm.id,
+                        block.elem ->> 'name' AS tool_name,
+                        block.elem ->> 'status' AS previous_status,
+                        block.elem -> 'result' AS previous_result
+                    FROM chat_messages cm
+                    JOIN latest_assistant la ON la.id = cm.id
+                    CROSS JOIN LATERAL jsonb_array_elements(cm.content_blocks) AS block(elem)
+                    WHERE block.elem ->> 'type' = 'tool_use'
+                      AND block.elem ->> 'id' = :tool_id
+                    LIMIT 1
+                )
+                UPDATE chat_messages cm
+                SET content_blocks = (
+                    SELECT jsonb_agg(
+                        CASE
+                            WHEN block.elem ->> 'type' = 'tool_use'
+                             AND block.elem ->> 'id' = :tool_id
+                            THEN jsonb_set(
+                                jsonb_set(block.elem, '{result}', CAST(:result_json AS jsonb), true),
+                                '{status}',
+                                to_jsonb(CAST(:status AS text)),
+                                true
+                            )
+                            ELSE block.elem
+                        END
+                        ORDER BY block.ordinality
+                    )
+                    FROM jsonb_array_elements(cm.content_blocks) WITH ORDINALITY AS block(elem, ordinality)
+                )
+                FROM matched_tool mt
+                WHERE cm.id = mt.id
+                  AND NOT (
+                      mt.previous_status IS NOT DISTINCT FROM :status
+                      AND mt.previous_result IS NOT DISTINCT FROM CAST(:result_json AS jsonb)
+                  )
+                RETURNING COALESCE(mt.tool_name, 'unknown') AS tool_name
+                """
             )
-            db_result = await session.execute(query)
-            message = db_result.scalar_one_or_none()
-            
-            if not message or not message.content_blocks:
-                logger.warning(f"[update_tool_result] No message found for conversation {conversation_id}")
+            db_result = await session.execute(
+                update_stmt,
+                {
+                    "conversation_id": conversation_id,
+                    "tool_id": tool_id,
+                    "result_json": result_json,
+                    "status": status,
+                },
+            )
+            row = db_result.first()
+            if row is None:
+                logger.info(
+                    "[update_tool_result] No non-duplicate tool update applied for tool=%s status=%s",
+                    tool_id[:8] if tool_id else None,
+                    status,
+                )
                 return False
-            
-            # Find and update the tool_use block
-            # IMPORTANT: Deep-copy blocks to avoid in-place mutation of the original
-            # dicts. SQLAlchemy JSONB columns compare old vs new by value; if we mutate
-            # in-place the old value changes too, so SQLAlchemy sees no diff and skips
-            # the UPDATE statement entirely.
-            import copy
-            updated = False
-            new_blocks: list[dict[str, Any]] = copy.deepcopy(message.content_blocks)
-            
-            for block in new_blocks:
-                if block.get("type") == "tool_use" and block.get("id") == tool_id:
-                    if block.get("status") == status and block.get("result") == result:
-                        logger.info(
-                            "[update_tool_result] Skipping duplicate tool update for tool=%s status=%s",
-                            tool_id[:8] if tool_id else None,
-                            status,
-                        )
-                        return False
-                    block["result"] = result
-                    block["status"] = status
-                    updated = True
-                    logger.info("[update_tool_result] Found and updating tool block")
-            
-            if not updated:
-                logger.warning(f"[update_tool_result] Tool {tool_id} not found in message")
-                return False
-            
-            # Save updated blocks — new list with new dicts ensures SQLAlchemy detects the change
-            message.content_blocks = new_blocks
+
             await session.commit()
-            
-            logger.info(f"[update_tool_result] SUCCESS: Updated tool {tool_id[:8]} with status={status}")
-            
+            tool_name: str = str(row.tool_name or "unknown")
+
+            logger.info("[update_tool_result] SUCCESS: Updated tool %s with status=%s", tool_id[:8], status)
+
             # Broadcast progress to connected websockets
             if organization_id:
                 from api.websockets import broadcast_tool_progress
-                # Get tool name from the block
-                tool_name: str = "unknown"
-                for block in new_blocks:
-                    if block.get("id") == tool_id:
-                        tool_name = block.get("name", "unknown")
-                        break
+
                 await broadcast_tool_progress(
                     organization_id=organization_id,
                     conversation_id=conversation_id,
@@ -325,9 +336,9 @@ async def update_tool_result(
                     result=result,
                     status=status,
                 )
-            
+
             return True
-            
+
     except Exception as e:
         logger.error(f"[update_tool_result] Error: {e}")
         return False
@@ -1124,12 +1135,12 @@ class ChatOrchestrator:
                 conversation_summaries: list[dict[str, Any]] = []
                 for conv in candidate_conversations[:max_conversations]:
                     message_result = await session.execute(
-                        select(ChatMessage)
+                        select(ChatMessage.role, ChatMessage.content, ChatMessage.content_blocks)
                         .where(ChatMessage.conversation_id == conv.id)
                         .order_by(ChatMessage.created_at.desc())
                         .limit(messages_per_conversation)
                     )
-                    recent_messages: list[ChatMessage] = list(message_result.scalars().all())
+                    recent_messages = list(message_result.all())
                     if not recent_messages:
                         continue
 
@@ -2254,17 +2265,38 @@ class ChatOrchestrator:
 
         async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
             result = await session.execute(
-                select(ChatMessage)
+                select(
+                    ChatMessage.id,
+                    ChatMessage.conversation_id,
+                    ChatMessage.role,
+                    ChatMessage.content,
+                    ChatMessage.content_blocks,
+                    ChatMessage.tool_calls,
+                )
                 .where(ChatMessage.conversation_id == UUID(self.conversation_id))
                 .order_by(ChatMessage.created_at.desc())
                 .limit(limit)
             )
-            messages = result.scalars().all()
+            messages = result.all()
 
             history: list[dict[str, Any]] = []
             for msg in reversed(messages):
                 # Get content blocks (new format or convert from legacy)
-                blocks = msg.content_blocks if msg.content_blocks else msg._legacy_to_blocks()
+                blocks = msg.content_blocks
+                if not blocks:
+                    blocks = []
+                    if msg.content and str(msg.content).strip():
+                        blocks.append({"type": "text", "text": msg.content})
+                    if msg.tool_calls:
+                        for tool_call in msg.tool_calls:
+                            blocks.append({
+                                "type": "tool_use",
+                                "id": tool_call.get("id", ""),
+                                "name": tool_call.get("name", ""),
+                                "input": tool_call.get("input", {}),
+                                "result": tool_call.get("result"),
+                                "status": "complete",
+                            })
                 
                 if msg.role == "user":
                     # User messages: preserve attachment metadata + reload bytes for multimodal context
@@ -2563,13 +2595,13 @@ class ChatOrchestrator:
                 # Using the exact ID avoids the old bug where "find latest assistant
                 # message" would match a *previous* turn's row and overwrite it.
                 result = await session.execute(
-                    select(ChatMessage).where(ChatMessage.id == self._current_message_id)
+                    update(ChatMessage)
+                    .where(ChatMessage.id == self._current_message_id)
+                    .values(content_blocks=assistant_blocks)
                 )
-                message: ChatMessage | None = result.scalar_one_or_none()
 
-                if message:
-                    logger.info("[Orchestrator] UPDATE assistant message %s", message.id)
-                    message.content_blocks = assistant_blocks
+                if result.rowcount:
+                    logger.info("[Orchestrator] UPDATE assistant message %s", self._current_message_id)
                 else:
                     # Early INSERT may not have committed yet — insert with the same ID
                     logger.info("[Orchestrator] Early INSERT not found, INSERT msg_id=%s", self._current_message_id)

--- a/backend/services/conversation_embeddings.py
+++ b/backend/services/conversation_embeddings.py
@@ -15,10 +15,27 @@ from models.conversation import Conversation
 from models.chat_message import ChatMessage as ChatMessageModel
 from models.database import get_session
 from sqlalchemy import select, update
+from sqlalchemy.sql import Select
 
 from services.embeddings import get_embedding_service
 
 logger = logging.getLogger(__name__)
+
+
+def _recent_user_message_text_query(
+    conversation_id: Any,
+    limit: int,
+) -> Select[tuple[str, list[dict[str, Any]] | None]]:
+    """Return only legacy text + blocks needed for embedding text extraction."""
+    return (
+        select(ChatMessageModel.content, ChatMessageModel.content_blocks)
+        .where(
+            ChatMessageModel.conversation_id == conversation_id,
+            ChatMessageModel.role == "user",
+        )
+        .order_by(ChatMessageModel.created_at.desc())
+        .limit(limit)
+    )
 
 _STALENESS_THRESHOLD = 2
 _MAX_RECENT_CHARS = 12_000
@@ -104,15 +121,9 @@ async def update_conversation_embedding(
             summary_text = (conv.summary or "").strip() or None
 
             result = await session.execute(
-                select(ChatMessageModel)
-                .where(
-                    ChatMessageModel.conversation_id == conv.id,
-                    ChatMessageModel.role == "user",
-                )
-                .order_by(ChatMessageModel.created_at.desc())
-                .limit(_MAX_MESSAGES_FOR_RECENT)
+                _recent_user_message_text_query(conv.id, _MAX_MESSAGES_FOR_RECENT)
             )
-            user_messages = list(result.scalars().all())
+            user_messages = list(result.all())
             total_chars = 0
             for msg in reversed(user_messages):
                 text = _extract_text_from_blocks(msg.content_blocks)

--- a/backend/services/conversation_summary.py
+++ b/backend/services/conversation_summary.py
@@ -13,7 +13,7 @@ import logging
 import re
 import uuid
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Protocol
 
 from config import settings
 from models.chat_message import ChatMessage as ChatMessageModel
@@ -21,11 +21,30 @@ from models.conversation import Conversation
 from models.database import get_admin_session, get_session
 from models.user import User
 from sqlalchemy import select, update
+from sqlalchemy.sql import Select
 
 from services.anthropic_health import report_anthropic_call_failure, report_anthropic_call_success
 from services.llm_provider import resolve_llm_config, get_adapter
 
 logger = logging.getLogger(__name__)
+
+
+class _MessageForPrompt(Protocol):
+    role: str
+    content_blocks: list[dict[str, Any]] | None
+
+
+def _recent_message_blocks_query(
+    conversation_id: uuid.UUID,
+    limit: int,
+) -> Select[tuple[str, list[dict[str, Any]] | None]]:
+    """Return only columns needed for prompt formatting, never full chat_messages rows."""
+    return (
+        select(ChatMessageModel.role, ChatMessageModel.content_blocks)
+        .where(ChatMessageModel.conversation_id == conversation_id)
+        .order_by(ChatMessageModel.created_at.desc())
+        .limit(limit)
+    )
 
 _SEMANTIC_MIN_WORDS = 100
 _SEMANTIC_REGEN_WORD_DELTA = 50
@@ -110,7 +129,7 @@ def _should_regenerate_summary(
     return (semantic_words - summary_word_count_at_generation) >= _SEMANTIC_REGEN_WORD_DELTA
 
 
-def _format_messages(messages: list[ChatMessageModel]) -> str:
+def _format_messages(messages: list[_MessageForPrompt]) -> str:
     """Format messages into a compact text representation for the prompt."""
     lines: list[str] = []
     for msg in messages:
@@ -216,12 +235,9 @@ async def generate_conversation_summary(
                 return None
 
             result = await session.execute(
-                select(ChatMessageModel)
-                .where(ChatMessageModel.conversation_id == conv.id)
-                .order_by(ChatMessageModel.created_at.desc())
-                .limit(_MAX_MESSAGES_FOR_PROMPT)
+                _recent_message_blocks_query(conv.id, _MAX_MESSAGES_FOR_PROMPT)
             )
-            messages: list[ChatMessageModel] = list(reversed(result.scalars().all()))
+            messages: list[_MessageForPrompt] = list(reversed(result.all()))
             if len(messages) < 1:
                 return None
 
@@ -326,12 +342,9 @@ async def generate_conversation_title(
                 return None
 
             result = await session.execute(
-                select(ChatMessageModel)
-                .where(ChatMessageModel.conversation_id == conv.id)
-                .order_by(ChatMessageModel.created_at.desc())
-                .limit(_MAX_MESSAGES_FOR_PROMPT)
+                _recent_message_blocks_query(conv.id, _MAX_MESSAGES_FOR_PROMPT)
             )
-            messages: list[ChatMessageModel] = list(reversed(result.scalars().all()))
+            messages: list[_MessageForPrompt] = list(reversed(result.all()))
             if not messages:
                 return None
             formatted = _format_messages(messages)

--- a/backend/tests/test_chat_message_projection_queries.py
+++ b/backend/tests/test_chat_message_projection_queries.py
@@ -1,0 +1,35 @@
+from uuid import uuid4
+
+from sqlalchemy.dialects import postgresql
+
+from services.conversation_embeddings import _recent_user_message_text_query
+from services.conversation_summary import _recent_message_blocks_query
+
+
+def _compile(query: object) -> str:
+    return str(
+        query.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+def test_summary_prompt_query_projects_only_role_and_blocks() -> None:
+    sql = _compile(_recent_message_blocks_query(uuid4(), 50))
+
+    assert "chat_messages.role" in sql
+    assert "chat_messages.content_blocks" in sql
+    assert "chat_messages.content," not in sql
+    assert "chat_messages.tool_calls" not in sql
+    assert "chat_messages.user_id" not in sql
+
+
+def test_embedding_recent_query_projects_only_text_sources() -> None:
+    sql = _compile(_recent_user_message_text_query(uuid4(), 50))
+
+    assert "chat_messages.content" in sql
+    assert "chat_messages.content_blocks" in sql
+    assert "chat_messages.tool_calls" not in sql
+    assert "chat_messages.user_id" not in sql
+    assert "chat_messages.organization_id" not in sql

--- a/backend/tests/test_tool_progress_dedup.py
+++ b/backend/tests/test_tool_progress_dedup.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import sys
 import types
 from types import SimpleNamespace
@@ -20,10 +21,10 @@ from agents import orchestrator
 
 
 class _FakeExecuteResult:
-    def __init__(self, row: object) -> None:
+    def __init__(self, row: object | None) -> None:
         self._row = row
 
-    def scalar_one_or_none(self) -> object:
+    def first(self) -> object | None:
         return self._row
 
 
@@ -31,9 +32,21 @@ class _FakeSession:
     def __init__(self, message: object) -> None:
         self._message = message
         self.commit_calls = 0
+        self.executed_queries: list[str] = []
 
-    async def execute(self, _query: object) -> _FakeExecuteResult:
-        return _FakeExecuteResult(self._message)
+    async def execute(self, query: object, params: dict[str, object] | None = None) -> _FakeExecuteResult:
+        query_text = str(query)
+        self.executed_queries.append(query_text)
+        params = params or {}
+        result_payload = json.loads(str(params.get("result_json", "null")))
+        for block in self._message.content_blocks:
+            if block.get("type") == "tool_use" and block.get("id") == params.get("tool_id"):
+                if block.get("status") == params.get("status") and block.get("result") == result_payload:
+                    return _FakeExecuteResult(None)
+                block["status"] = params.get("status")
+                block["result"] = result_payload
+                return _FakeExecuteResult(SimpleNamespace(tool_name=block.get("name", "unknown")))
+        return _FakeExecuteResult(None)
 
     async def commit(self) -> None:
         self.commit_calls += 1
@@ -95,6 +108,9 @@ def test_update_tool_result_skips_duplicate_progress_updates(monkeypatch) -> Non
     assert fake_session.commit_calls == 0
     assert broadcasts == []
     assert message.content_blocks[0]["result"] == {"message": "Writing to Linear"}
+    assert len(fake_session.executed_queries) == 1
+    assert "UPDATE chat_messages" in fake_session.executed_queries[0]
+    assert "SELECT *" not in fake_session.executed_queries[0]
 
 
 def test_update_tool_result_allows_status_change_with_same_result(monkeypatch) -> None:
@@ -142,6 +158,9 @@ def test_update_tool_result_allows_status_change_with_same_result(monkeypatch) -
     assert updated is True
     assert fake_session.commit_calls == 1
     assert message.content_blocks[0]["status"] == "complete"
+    assert len(fake_session.executed_queries) == 1
+    assert "UPDATE chat_messages" in fake_session.executed_queries[0]
+    assert "SELECT *" not in fake_session.executed_queries[0]
     assert broadcasts == [
         {
             "organization_id": organization_id,


### PR DESCRIPTION
### Motivation
- Reduce bandwidth and CPU waste from repeatedly loading full `chat_messages` rows (including large `content_blocks`) for common per-reply work like summaries, embeddings, history reconstruction, and tool progress ticks.
- Make tool-progress updates and history loading cheaper and less likely to trigger heavy row materialization or repeated JSONB shipping.

### Description
- Replace full-row message loads in summary/title generation with a projection helper `_recent_message_blocks_query` that selects only `role` and `content_blocks` for the prompt window and update `_format_messages` to accept a lightweight protocol type; files changed: `backend/services/conversation_summary.py`.
- Replace recent-user-message loads for embeddings with `_recent_user_message_text_query` that selects only `content` and `content_blocks`; file changed: `backend/services/conversation_embeddings.py`.
- Rework tool progress path in `update_tool_result` to a single `UPDATE ... RETURNING` JSONB statement that patches the matching `tool_use` block in SQL without reading the full `chat_messages` row into Python, skipping duplicate writes at the DB level and returning the tool name for broadcasting; file changed: `backend/agents/orchestrator.py`.
- Narrow other orchestrator projections to explicit columns and change assistant-message finalization to an `UPDATE` by id (checking `rowcount`) rather than load-then-mutate, and reconstruct legacy blocks from projected columns when needed; file changed: `backend/agents/orchestrator.py`.
- Add tests asserting the projection-only query shapes and that the tool-progress path uses an `UPDATE` rather than a full `SELECT`: new `backend/tests/test_chat_message_projection_queries.py` and adjustments to `backend/tests/test_tool_progress_dedup.py`.

### Testing
- Ran unit tests covering the modified flows and new assertions: `pytest -q backend/tests/test_tool_progress_dedup.py backend/tests/test_chat_message_projection_queries.py` and `pytest -q backend/tests/test_orchestrator_context_window.py backend/tests/test_tool_progress_dedup.py backend/tests/test_chat_message_projection_queries.py`, all completed successfully with the test suite passing.
- New projection tests validate SQL compilation includes only the intended `chat_messages` columns and tool-progress tests assert the `UPDATE chat_messages` path is executed and no full-row `SELECT` is used.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe8c20915483218f8e2d954ad1ba77)