### PR TITLE
Optimize chat message projections to avoid hydrating fat rows

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -22,6 +22,7 @@ from uuid import UUID, uuid4
 from anthropic import APIStatusError as AnthropicAPIStatusError
 from openai import APIStatusError as OpenAIAPIStatusError
 from sqlalchemy import select, update
+from sqlalchemy.orm import load_only
 
 from agents.registry import format_tool_status
 from agents.tools import execute_tool, get_tools, get_tool_defs_for_context
@@ -263,6 +264,7 @@ async def update_tool_result(
             # Find the latest assistant message in this conversation
             query = (
                 select(ChatMessage)
+                .options(load_only(ChatMessage.id, ChatMessage.content_blocks))
                 .where(ChatMessage.conversation_id == UUID(conversation_id))
                 .where(ChatMessage.role == "assistant")
                 .order_by(ChatMessage.created_at.desc())
@@ -2255,6 +2257,16 @@ class ChatOrchestrator:
         async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
             result = await session.execute(
                 select(ChatMessage)
+                .options(
+                    load_only(
+                        ChatMessage.id,
+                        ChatMessage.conversation_id,
+                        ChatMessage.role,
+                        ChatMessage.content_blocks,
+                        ChatMessage.content,
+                        ChatMessage.tool_calls,
+                    )
+                )
                 .where(ChatMessage.conversation_id == UUID(self.conversation_id))
                 .order_by(ChatMessage.created_at.desc())
                 .limit(limit)
@@ -2563,13 +2575,13 @@ class ChatOrchestrator:
                 # Using the exact ID avoids the old bug where "find latest assistant
                 # message" would match a *previous* turn's row and overwrite it.
                 result = await session.execute(
-                    select(ChatMessage).where(ChatMessage.id == self._current_message_id)
+                    update(ChatMessage)
+                    .where(ChatMessage.id == self._current_message_id)
+                    .values(content_blocks=assistant_blocks)
                 )
-                message: ChatMessage | None = result.scalar_one_or_none()
 
-                if message:
-                    logger.info("[Orchestrator] UPDATE assistant message %s", message.id)
-                    message.content_blocks = assistant_blocks
+                if result.rowcount:
+                    logger.info("[Orchestrator] UPDATE assistant message %s", self._current_message_id)
                 else:
                     # Early INSERT may not have committed yet — insert with the same ID
                     logger.info("[Orchestrator] Early INSERT not found, INSERT msg_id=%s", self._current_message_id)

--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -1578,20 +1578,20 @@ async def send_message(
 
         # Get the message IDs from the database
         result = await session.execute(
-            select(ChatMessage)
+            select(ChatMessage.id, ChatMessage.role)
             .where(ChatMessage.conversation_id == conv_uuid)
             .order_by(ChatMessage.created_at.desc())
             .limit(2)
         )
-        recent_messages = result.scalars().all()
+        recent_messages = result.all()
 
         user_msg_id = ""
         assistant_msg_id = ""
-        for msg in recent_messages:
-            if msg.role == "user":
-                user_msg_id = str(msg.id)
-            elif msg.role == "assistant":
-                assistant_msg_id = str(msg.id)
+        for msg_id, role in recent_messages:
+            if role == "user":
+                user_msg_id = str(msg_id)
+            elif role == "assistant":
+                assistant_msg_id = str(msg_id)
 
         return SendMessageResponse(
             conversation_id=str(conv_uuid),

--- a/backend/scripts/backfill_conversation_embeddings.py
+++ b/backend/scripts/backfill_conversation_embeddings.py
@@ -20,35 +20,16 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from sqlalchemy import select
-
 from models.conversation import Conversation
-from models.chat_message import ChatMessage as ChatMessageModel
 from models.database import get_admin_session, get_session
 from services.conversation_embeddings import (
     _MAX_RECENT_CHARS,
     _MAX_MESSAGES_FOR_RECENT,
     build_embedding_text,
 )
+from services.chat_message_projections import fetch_recent_user_text_projections
 from services.embeddings import get_embedding_service
 
-
-def _extract_text_from_blocks(blocks: list | None) -> str:
-    if not blocks:
-        return ""
-    parts: list[str] = []
-    for block in blocks:
-        if not isinstance(block, dict):
-            continue
-        if block.get("type") == "text":
-            text = block.get("text")
-            if text:
-                parts.append(str(text))
-        elif block.get("type") == "tool_use":
-            name = block.get("name")
-            if name:
-                parts.append(f"[{name}]")
-    return " ".join(parts)
 
 
 async def backfill(
@@ -107,23 +88,18 @@ async def backfill(
             summary_overall: str | None = (conv.summary or "").strip() or None
 
             async with get_session(organization_id=oid) as session:
-                result = await session.execute(
-                    select(ChatMessageModel)
-                    .where(
-                        ChatMessageModel.conversation_id == conv.id,
-                        ChatMessageModel.role == "user",
-                    )
-                    .order_by(ChatMessageModel.created_at.desc())
-                    .limit(_MAX_MESSAGES_FOR_RECENT)
+                user_messages = await fetch_recent_user_text_projections(
+                    session,
+                    conv.id,
+                    limit=_MAX_MESSAGES_FOR_RECENT,
                 )
-                user_messages = list(result.scalars().all())
 
             recent_texts: list[str] = []
             total_chars = 0
             for msg in reversed(user_messages):
-                text = _extract_text_from_blocks(msg.content_blocks)
-                if not text and getattr(msg, "content", None):
-                    text = msg.content or ""
+                text = msg.block_text
+                if not text and msg.legacy_content:
+                    text = msg.legacy_content
                 if text:
                     recent_texts.append(text)
                     total_chars += len(text)

--- a/backend/services/chat_message_projections.py
+++ b/backend/services/chat_message_projections.py
@@ -1,0 +1,187 @@
+"""Lean chat message projections for hot-path conversation reads.
+
+The chat_messages row can contain very large JSONB tool results. Hot-path jobs that
+only need transcript text or tool names should not SELECT the full ORM row.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@dataclass(frozen=True)
+class PromptMessageProjection:
+    """Minimal message shape needed for summary/title prompt formatting."""
+
+    role: str
+    content_blocks: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class RecentUserTextProjection:
+    """Minimal user-message shape needed for embedding text construction."""
+
+    block_text: str
+    legacy_content: str | None
+
+
+_PROMPT_MESSAGES_SQL = """
+SELECT
+    role,
+    COALESCE(
+        (
+            SELECT jsonb_agg(projected.block ORDER BY projected.ordinality)
+            FROM (
+                SELECT
+                    block_items.ordinality,
+                    CASE
+                        WHEN block_items.block ->> 'type' = 'text' THEN
+                            jsonb_build_object(
+                                'type', 'text',
+                                'text', left(COALESCE(block_items.block ->> 'text', ''), :text_limit)
+                            )
+                        WHEN block_items.block ->> 'type' = 'tool_use' THEN
+                            jsonb_build_object(
+                                'type', 'tool_use',
+                                'name', COALESCE(block_items.block ->> 'name', 'unknown')
+                            )
+                        ELSE NULL
+                    END AS block
+                FROM jsonb_array_elements(COALESCE(content_blocks, '[]'::jsonb))
+                    WITH ORDINALITY AS block_items(block, ordinality)
+                WHERE block_items.block ->> 'type' IN ('text', 'tool_use')
+            ) AS projected
+            WHERE projected.block IS NOT NULL
+        ),
+        '[]'::jsonb
+    ) AS content_blocks
+FROM chat_messages
+WHERE conversation_id = :conversation_id
+ORDER BY created_at DESC
+LIMIT :limit
+"""
+
+_RECENT_USER_TEXT_SQL = """
+SELECT
+    COALESCE(
+        (
+            SELECT string_agg(projected.part, ' ' ORDER BY projected.ordinality)
+            FROM (
+                SELECT
+                    block_items.ordinality,
+                    CASE
+                        WHEN block_items.block ->> 'type' = 'text' THEN
+                            COALESCE(block_items.block ->> 'text', '')
+                        WHEN block_items.block ->> 'type' = 'tool_use' THEN
+                            '[' || COALESCE(block_items.block ->> 'name', 'unknown') || ']'
+                        ELSE NULL
+                    END AS part
+                FROM jsonb_array_elements(COALESCE(content_blocks, '[]'::jsonb))
+                    WITH ORDINALITY AS block_items(block, ordinality)
+                WHERE block_items.block ->> 'type' IN ('text', 'tool_use')
+            ) AS projected
+            WHERE projected.part IS NOT NULL AND projected.part <> ''
+        ),
+        ''
+    ) AS block_text,
+    content AS legacy_content
+FROM chat_messages
+WHERE conversation_id = :conversation_id
+  AND role = 'user'
+ORDER BY created_at DESC
+LIMIT :limit
+"""
+
+_SEMANTIC_WORD_COUNT_SQL = """
+SELECT COALESCE(SUM(
+    CASE
+        WHEN length(trim(block_items.block ->> 'text')) = 0 THEN 0
+        ELSE array_length(regexp_split_to_array(trim(block_items.block ->> 'text'), '\\s+'), 1)
+    END
+), 0)::integer AS semantic_words
+FROM chat_messages
+CROSS JOIN LATERAL jsonb_array_elements(COALESCE(content_blocks, '[]'::jsonb)) AS block_items(block)
+WHERE conversation_id = :conversation_id
+  AND block_items.block ->> 'type' = 'text'
+"""
+
+
+def _coerce_blocks(value: Any) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = json.loads(value)
+    if not isinstance(value, list):
+        return []
+    return [block for block in value if isinstance(block, dict)]
+
+
+async def fetch_prompt_message_projections(
+    session: AsyncSession,
+    conversation_id: uuid.UUID,
+    *,
+    limit: int,
+    text_limit: int = 2_000,
+) -> list[PromptMessageProjection]:
+    """Fetch recent messages without hydrating full chat_messages rows.
+
+    The JSONB projection intentionally keeps only text and tool names. It omits
+    tool inputs/results and unrelated blocks so summary/title generation avoids
+    repeatedly transferring large tool-result payloads.
+    """
+    result = await session.execute(
+        text(_PROMPT_MESSAGES_SQL),
+        {
+            "conversation_id": conversation_id,
+            "limit": limit,
+            "text_limit": text_limit,
+        },
+    )
+    return [
+        PromptMessageProjection(
+            role=str(row.role),
+            content_blocks=_coerce_blocks(row.content_blocks),
+        )
+        for row in result
+    ]
+
+
+async def fetch_recent_user_text_projections(
+    session: AsyncSession,
+    conversation_id: uuid.UUID,
+    *,
+    limit: int,
+) -> list[RecentUserTextProjection]:
+    """Fetch recent user text for embeddings without full message hydration."""
+    result = await session.execute(
+        text(_RECENT_USER_TEXT_SQL),
+        {
+            "conversation_id": conversation_id,
+            "limit": limit,
+        },
+    )
+    return [
+        RecentUserTextProjection(
+            block_text=str(row.block_text or ""),
+            legacy_content=row.legacy_content,
+        )
+        for row in result
+    ]
+
+
+async def count_semantic_words_projection(
+    session: AsyncSession,
+    conversation_id: uuid.UUID,
+) -> int:
+    """Count text-block words in SQL without returning content_blocks JSONB."""
+    result = await session.execute(
+        text(_SEMANTIC_WORD_COUNT_SQL),
+        {"conversation_id": conversation_id},
+    )
+    return int(result.scalar_one() or 0)

--- a/backend/services/conversation_embeddings.py
+++ b/backend/services/conversation_embeddings.py
@@ -9,39 +9,18 @@ conversation_post_completion.run_post_completion() after this returns.
 """
 
 import logging
-from typing import Any
-
 from models.conversation import Conversation
-from models.chat_message import ChatMessage as ChatMessageModel
 from models.database import get_session
-from sqlalchemy import select, update
+from sqlalchemy import update
 
 from services.embeddings import get_embedding_service
+from services.chat_message_projections import fetch_recent_user_text_projections
 
 logger = logging.getLogger(__name__)
 
 _STALENESS_THRESHOLD = 2
 _MAX_RECENT_CHARS = 12_000
 _MAX_MESSAGES_FOR_RECENT = 50
-
-
-def _extract_text_from_blocks(blocks: list[dict[str, Any]] | None) -> str:
-    """Extract concatenated text from content_blocks (text and tool_use names only)."""
-    if not blocks:
-        return ""
-    parts: list[str] = []
-    for block in blocks:
-        if not isinstance(block, dict):
-            continue
-        if block.get("type") == "text":
-            text = block.get("text")
-            if text:
-                parts.append(str(text))
-        elif block.get("type") == "tool_use":
-            name = block.get("name")
-            if name:
-                parts.append(f"[{name}]")
-    return " ".join(parts)
 
 
 def build_embedding_text(
@@ -103,21 +82,16 @@ async def update_conversation_embedding(
 
             summary_text = (conv.summary or "").strip() or None
 
-            result = await session.execute(
-                select(ChatMessageModel)
-                .where(
-                    ChatMessageModel.conversation_id == conv.id,
-                    ChatMessageModel.role == "user",
-                )
-                .order_by(ChatMessageModel.created_at.desc())
-                .limit(_MAX_MESSAGES_FOR_RECENT)
+            user_messages = await fetch_recent_user_text_projections(
+                session,
+                conv.id,
+                limit=_MAX_MESSAGES_FOR_RECENT,
             )
-            user_messages = list(result.scalars().all())
             total_chars = 0
             for msg in reversed(user_messages):
-                text = _extract_text_from_blocks(msg.content_blocks)
-                if not text and msg.content:
-                    text = msg.content
+                text = msg.block_text
+                if not text and msg.legacy_content:
+                    text = msg.legacy_content
                 if text:
                     recent_texts.append(text)
                     total_chars += len(text)

--- a/backend/services/conversation_summary.py
+++ b/backend/services/conversation_summary.py
@@ -16,13 +16,17 @@ from datetime import datetime, timezone
 from typing import Any
 
 from config import settings
-from models.chat_message import ChatMessage as ChatMessageModel
 from models.conversation import Conversation
-from models.database import get_admin_session, get_session
+from models.database import get_admin_session
 from models.user import User
 from sqlalchemy import select, update
 
 from services.anthropic_health import report_anthropic_call_failure, report_anthropic_call_success
+from services.chat_message_projections import (
+    PromptMessageProjection,
+    count_semantic_words_projection,
+    fetch_prompt_message_projections,
+)
 from services.llm_provider import resolve_llm_config, get_adapter
 
 logger = logging.getLogger(__name__)
@@ -84,16 +88,7 @@ async def count_semantic_words_for_conversation(
     conversation_id: uuid.UUID,
 ) -> int:
     """Sum semantic word counts across all messages in the conversation."""
-    result = await session.execute(
-        select(ChatMessageModel.content_blocks).where(
-            ChatMessageModel.conversation_id == conversation_id
-        )
-    )
-    total: int = 0
-    for row in result:
-        blocks: list[dict[str, Any]] | None = row[0]
-        total += _semantic_word_count_from_blocks(blocks)
-    return total
+    return await count_semantic_words_projection(session, conversation_id)
 
 
 def _should_regenerate_summary(
@@ -110,7 +105,7 @@ def _should_regenerate_summary(
     return (semantic_words - summary_word_count_at_generation) >= _SEMANTIC_REGEN_WORD_DELTA
 
 
-def _format_messages(messages: list[ChatMessageModel]) -> str:
+def _format_messages(messages: list[PromptMessageProjection]) -> str:
     """Format messages into a compact text representation for the prompt."""
     lines: list[str] = []
     for msg in messages:
@@ -215,13 +210,15 @@ async def generate_conversation_summary(
             ):
                 return None
 
-            result = await session.execute(
-                select(ChatMessageModel)
-                .where(ChatMessageModel.conversation_id == conv.id)
-                .order_by(ChatMessageModel.created_at.desc())
-                .limit(_MAX_MESSAGES_FOR_PROMPT)
+            messages = list(
+                reversed(
+                    await fetch_prompt_message_projections(
+                        session,
+                        conv.id,
+                        limit=_MAX_MESSAGES_FOR_PROMPT,
+                    )
+                )
             )
-            messages: list[ChatMessageModel] = list(reversed(result.scalars().all()))
             if len(messages) < 1:
                 return None
 
@@ -325,13 +322,15 @@ async def generate_conversation_title(
             if semantic_words < _TITLE_MIN_WORDS:
                 return None
 
-            result = await session.execute(
-                select(ChatMessageModel)
-                .where(ChatMessageModel.conversation_id == conv.id)
-                .order_by(ChatMessageModel.created_at.desc())
-                .limit(_MAX_MESSAGES_FOR_PROMPT)
+            messages = list(
+                reversed(
+                    await fetch_prompt_message_projections(
+                        session,
+                        conv.id,
+                        limit=_MAX_MESSAGES_FOR_PROMPT,
+                    )
+                )
             )
-            messages: list[ChatMessageModel] = list(reversed(result.scalars().all()))
             if not messages:
                 return None
             formatted = _format_messages(messages)

--- a/backend/tests/test_chat_message_projections.py
+++ b/backend/tests/test_chat_message_projections.py
@@ -1,0 +1,69 @@
+import json
+
+from services.chat_message_projections import (
+    PromptMessageProjection,
+    _PROMPT_MESSAGES_SQL,
+    _RECENT_USER_TEXT_SQL,
+    _SEMANTIC_WORD_COUNT_SQL,
+    _coerce_blocks,
+)
+from services.conversation_summary import _format_messages
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.lower().split())
+
+
+def test_prompt_projection_sql_omits_tool_payload_fields() -> None:
+    sql = _normalized(_PROMPT_MESSAGES_SQL)
+
+    assert "select *" not in sql
+    assert "jsonb_build_object" in sql
+    assert "'name'" in sql
+    assert "->> 'input'" not in sql
+    assert "-> 'input'" not in sql
+    assert "->> 'result'" not in sql
+    assert "-> 'result'" not in sql
+
+
+def test_recent_user_text_projection_returns_text_not_full_jsonb() -> None:
+    sql = _normalized(_RECENT_USER_TEXT_SQL)
+
+    assert "select *" not in sql
+    assert "as content_blocks" not in sql
+    assert "string_agg" in sql
+    assert "legacy_content" in sql
+
+
+def test_semantic_count_sql_returns_count_not_jsonb() -> None:
+    sql = _normalized(_SEMANTIC_WORD_COUNT_SQL)
+
+    assert "select *" not in sql
+    assert "as semantic_words" in sql
+    assert "as content_blocks" not in sql
+
+
+def test_coerce_blocks_accepts_driver_json_strings() -> None:
+    blocks = [
+        {"type": "text", "text": "hello"},
+        "bad",
+        {"type": "tool_use", "name": "lookup"},
+    ]
+
+    assert _coerce_blocks(json.dumps(blocks)) == [blocks[0], blocks[2]]
+
+
+def test_summary_formatter_uses_projected_tool_names_only() -> None:
+    formatted = _format_messages(
+        [
+            PromptMessageProjection(
+                role="assistant",
+                content_blocks=[
+                    {"type": "text", "text": "Checking"},
+                    {"type": "tool_use", "name": "big_query"},
+                ],
+            )
+        ]
+    )
+
+    assert formatted == "ASSISTANT: Checking [Tool call: big_query]"


### PR DESCRIPTION
### Motivation
- Hot paths repeatedly SELECT full `chat_messages` rows (including `content_blocks` with large tool-result JSONB), causing excessive data transfer for summary/title generation and embedding updates. 
- The current behavior (e.g. `_MAX_MESSAGES_FOR_PROMPT = 50`) made background LLM & embedding jobs scan/transfer the full row shape on every assistant reply.

### Description
- Add `services/chat_message_projections.py` with three lean SQL projections: `fetch_prompt_message_projections` (role + truncated text/tool-name blocks), `fetch_recent_user_text_projections` (aggregated recent user text), and `count_semantic_words_projection` (scalar word count), to avoid returning full JSONB payloads.
- Update `services/conversation_summary.py` to use the prompt projection and SQL word-count projection for summary/title generation instead of loading full `ChatMessage` ORM rows.
- Update `services/conversation_embeddings.py` and `scripts/backfill_conversation_embeddings.py` to use the recent-user-text projection for embeddings instead of hydrating full message rows.
- Reduce ORM hydration in hot orchestrator paths by applying `load_only` to history and tool-result lookups, change assistant-message persistence to a targeted `UPDATE` (avoiding read-then-mutate of large JSONB), and narrow post-send message ID lookup to `select(ChatMessage.id, ChatMessage.role)`.
- Add `backend/tests/test_chat_message_projections.py` to assert SQL projection shapes and ensure the prompt formatter still behaves correctly with projected blocks.

### Testing
- Ran unit tests: `pytest -q backend/tests/test_chat_message_projections.py backend/tests/test_tool_progress_dedup.py` (all tests passed; aggregate run reported 6–7 tests passing depending on selection).
- Static/bytecode checks: `python -m compileall` succeeded for modified modules, and code was formatted with `black` during the rollout (no remaining formatting issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe8c20915483218f8e2d954ad1ba77)