### PR TITLE
Add semantic_word_count, lightweight chat message projections, and DB-optimized tool progress updates

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -21,7 +21,7 @@ from uuid import UUID, uuid4
 
 from anthropic import APIStatusError as AnthropicAPIStatusError
 from openai import APIStatusError as OpenAIAPIStatusError
-from sqlalchemy import select, update
+from sqlalchemy import select, text, update
 
 from agents.registry import format_tool_status
 from agents.tools import execute_tool, get_tools, get_tool_defs_for_context
@@ -230,93 +230,108 @@ def _should_include_cross_conversation_history(user_message: str) -> bool:
 async def update_tool_result(
     conversation_id: str,
     tool_id: str,
-    result: dict[str, Any],
+    result: Any,
     status: str = "running",
     organization_id: str | None = None,
     user_id: str | None = None,
 ) -> bool:
-    """
-    Update a tool call's result in an existing conversation message.
-    
-    This enables long-running tools (like foreach) to report progress
-    that the frontend can poll for and display.
-    
-    Args:
-        conversation_id: The conversation containing the tool call
-        tool_id: The tool_use block ID to update
-        result: The new result dict (can be partial progress or final)
-        status: "running" for progress updates, "complete" when done
-        organization_id: Organization ID for RLS context
-        user_id: User ID for RLS visibility context
-        
-    Returns:
-        True if update succeeded, False otherwise
+    """Update a tool result block without fetching the fat chat_messages row.
+
+    Tool progress ticks can happen many times per assistant reply. Keep this as a
+    single JSONB UPDATE/RETURNING statement so the database rewrites the changed
+    JSONB value, but the app server does not repeatedly pull content_blocks (and
+    other chat_messages columns) over the wire just to patch one tool block.
     """
     logger.info(
-        "[update_tool_result] Called: conv=%s, tool=%s, status=%s",
-        conversation_id[:8] if conversation_id else None,
+        "[update_tool_result] Updating tool %s in conversation %s with status=%s",
         tool_id[:8] if tool_id else None,
+        conversation_id,
         status,
     )
     try:
+        result_json = json.dumps(result)
         async with get_session(organization_id=organization_id, user_id=user_id) as session:
-            # Find the latest assistant message in this conversation
-            query = (
-                select(ChatMessage)
-                .where(ChatMessage.conversation_id == UUID(conversation_id))
-                .where(ChatMessage.role == "assistant")
-                .order_by(ChatMessage.created_at.desc())
-                .limit(1)
+            update_stmt = text(
+                """
+                WITH latest_assistant AS (
+                    SELECT id
+                    FROM chat_messages
+                    WHERE conversation_id = CAST(:conversation_id AS uuid)
+                      AND role = 'assistant'
+                      AND content_blocks IS NOT NULL
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                ), matched_tool AS (
+                    SELECT
+                        cm.id,
+                        block.elem ->> 'name' AS tool_name,
+                        block.elem ->> 'status' AS previous_status,
+                        block.elem -> 'result' AS previous_result
+                    FROM chat_messages cm
+                    JOIN latest_assistant la ON la.id = cm.id
+                    CROSS JOIN LATERAL jsonb_array_elements(cm.content_blocks) AS block(elem)
+                    WHERE block.elem ->> 'type' = 'tool_use'
+                      AND block.elem ->> 'id' = :tool_id
+                    LIMIT 1
+                )
+                UPDATE chat_messages cm
+                SET content_blocks = (
+                    SELECT jsonb_agg(
+                        CASE
+                            WHEN block.elem ->> 'type' = 'tool_use'
+                             AND block.elem ->> 'id' = :tool_id
+                            THEN jsonb_set(
+                                jsonb_set(block.elem, '{result}', CAST(:result_json AS jsonb), true),
+                                '{status}',
+                                to_jsonb(CAST(:status AS text)),
+                                true
+                            )
+                            ELSE block.elem
+                        END
+                        ORDER BY block.ordinality
+                    )
+                    FROM jsonb_array_elements(cm.content_blocks) WITH ORDINALITY AS block(elem, ordinality)
+                )
+                FROM matched_tool mt
+                WHERE cm.id = mt.id
+                  AND NOT (
+                      mt.previous_status IS NOT DISTINCT FROM :status
+                      AND mt.previous_result IS NOT DISTINCT FROM CAST(:result_json AS jsonb)
+                  )
+                RETURNING COALESCE(mt.tool_name, 'unknown') AS tool_name
+                """
             )
-            db_result = await session.execute(query)
-            message = db_result.scalar_one_or_none()
-            
-            if not message or not message.content_blocks:
-                logger.warning(f"[update_tool_result] No message found for conversation {conversation_id}")
+            db_result = await session.execute(
+                update_stmt,
+                {
+                    "conversation_id": conversation_id,
+                    "tool_id": tool_id,
+                    "result_json": result_json,
+                    "status": status,
+                },
+            )
+            row = db_result.first()
+            if row is None:
+                logger.info(
+                    "[update_tool_result] No non-duplicate tool update applied for tool=%s status=%s",
+                    tool_id[:8] if tool_id else None,
+                    status,
+                )
                 return False
-            
-            # Find and update the tool_use block
-            # IMPORTANT: Deep-copy blocks to avoid in-place mutation of the original
-            # dicts. SQLAlchemy JSONB columns compare old vs new by value; if we mutate
-            # in-place the old value changes too, so SQLAlchemy sees no diff and skips
-            # the UPDATE statement entirely.
-            import copy
-            updated = False
-            new_blocks: list[dict[str, Any]] = copy.deepcopy(message.content_blocks)
-            
-            for block in new_blocks:
-                if block.get("type") == "tool_use" and block.get("id") == tool_id:
-                    if block.get("status") == status and block.get("result") == result:
-                        logger.info(
-                            "[update_tool_result] Skipping duplicate tool update for tool=%s status=%s",
-                            tool_id[:8] if tool_id else None,
-                            status,
-                        )
-                        return False
-                    block["result"] = result
-                    block["status"] = status
-                    updated = True
-                    logger.info("[update_tool_result] Found and updating tool block")
-            
-            if not updated:
-                logger.warning(f"[update_tool_result] Tool {tool_id} not found in message")
-                return False
-            
-            # Save updated blocks — new list with new dicts ensures SQLAlchemy detects the change
-            message.content_blocks = new_blocks
+
             await session.commit()
-            
-            logger.info(f"[update_tool_result] SUCCESS: Updated tool {tool_id[:8]} with status={status}")
-            
+            tool_name: str = str(row.tool_name or "unknown")
+
+            logger.info(
+                "[update_tool_result] SUCCESS: Updated tool %s with status=%s",
+                tool_id[:8] if tool_id else None,
+                status,
+            )
+
             # Broadcast progress to connected websockets
             if organization_id:
                 from api.websockets import broadcast_tool_progress
-                # Get tool name from the block
-                tool_name: str = "unknown"
-                for block in new_blocks:
-                    if block.get("id") == tool_id:
-                        tool_name = block.get("name", "unknown")
-                        break
+
                 await broadcast_tool_progress(
                     organization_id=organization_id,
                     conversation_id=conversation_id,
@@ -325,9 +340,9 @@ async def update_tool_result(
                     result=result,
                     status=status,
                 )
-            
+
             return True
-            
+
     except Exception as e:
         logger.error(f"[update_tool_result] Error: {e}")
         return False
@@ -2254,17 +2269,38 @@ class ChatOrchestrator:
 
         async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
             result = await session.execute(
-                select(ChatMessage)
+                select(
+                    ChatMessage.id,
+                    ChatMessage.conversation_id,
+                    ChatMessage.role,
+                    ChatMessage.content,
+                    ChatMessage.content_blocks,
+                    ChatMessage.tool_calls,
+                )
                 .where(ChatMessage.conversation_id == UUID(self.conversation_id))
                 .order_by(ChatMessage.created_at.desc())
                 .limit(limit)
             )
-            messages = result.scalars().all()
+            messages = result.all()
 
             history: list[dict[str, Any]] = []
             for msg in reversed(messages):
-                # Get content blocks (new format or convert from legacy)
-                blocks = msg.content_blocks if msg.content_blocks else msg._legacy_to_blocks()
+                # Get content blocks (new format or convert from legacy fields)
+                blocks = msg.content_blocks
+                if not blocks:
+                    blocks = []
+                    if msg.content and str(msg.content).strip():
+                        blocks.append({"type": "text", "text": msg.content})
+                    if msg.tool_calls:
+                        for tool_call in msg.tool_calls:
+                            blocks.append({
+                                "type": "tool_use",
+                                "id": tool_call.get("id", ""),
+                                "name": tool_call.get("name", ""),
+                                "input": tool_call.get("input", {}),
+                                "result": tool_call.get("result"),
+                                "status": "complete",
+                            })
                 
                 if msg.role == "user":
                     # User messages: preserve attachment metadata + reload bytes for multimodal context
@@ -2563,13 +2599,13 @@ class ChatOrchestrator:
                 # Using the exact ID avoids the old bug where "find latest assistant
                 # message" would match a *previous* turn's row and overwrite it.
                 result = await session.execute(
-                    select(ChatMessage).where(ChatMessage.id == self._current_message_id)
+                    update(ChatMessage)
+                    .where(ChatMessage.id == self._current_message_id)
+                    .values(content_blocks=assistant_blocks)
                 )
-                message: ChatMessage | None = result.scalar_one_or_none()
 
-                if message:
-                    logger.info("[Orchestrator] UPDATE assistant message %s", message.id)
-                    message.content_blocks = assistant_blocks
+                if result.rowcount:
+                    logger.info("[Orchestrator] UPDATE assistant message %s", self._current_message_id)
                 else:
                     # Early INSERT may not have committed yet — insert with the same ID
                     logger.info("[Orchestrator] Early INSERT not found, INSERT msg_id=%s", self._current_message_id)

--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -1578,20 +1578,20 @@ async def send_message(
 
         # Get the message IDs from the database
         result = await session.execute(
-            select(ChatMessage)
+            select(ChatMessage.id, ChatMessage.role)
             .where(ChatMessage.conversation_id == conv_uuid)
             .order_by(ChatMessage.created_at.desc())
             .limit(2)
         )
-        recent_messages = result.scalars().all()
+        recent_messages = result.all()
 
         user_msg_id = ""
         assistant_msg_id = ""
-        for msg in recent_messages:
-            if msg.role == "user":
-                user_msg_id = str(msg.id)
-            elif msg.role == "assistant":
-                assistant_msg_id = str(msg.id)
+        for msg_id, role in recent_messages:
+            if role == "user":
+                user_msg_id = str(msg_id)
+            elif role == "assistant":
+                assistant_msg_id = str(msg_id)
 
         return SendMessageResponse(
             conversation_id=str(conv_uuid),

--- a/backend/db/migrations/versions/142_chat_messages_semantic_word_count.py
+++ b/backend/db/migrations/versions/142_chat_messages_semantic_word_count.py
@@ -1,0 +1,46 @@
+"""Add semantic_word_count to chat_messages.
+
+Denormalizes per-message word count of text-type content blocks so that
+``services.conversation_summary.count_semantic_words_for_conversation`` can
+become ``SELECT sum(semantic_word_count) WHERE conversation_id = $1`` instead
+of streaming every row's full ``content_blocks`` JSONB back to Python on every
+assistant reply.
+
+Revision ID: 142_chat_msg_swc
+Revises: 141_conv_delete
+Create Date: 2026-05-08
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "142_chat_msg_swc"
+down_revision: Union[str, None] = "141_conv_delete"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Adding a column with a non-volatile default is a metadata-only operation
+    # in PG 11+, so this is fast even on very large tables.
+    op.add_column(
+        "chat_messages",
+        sa.Column(
+            "semantic_word_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    # Backfill is intentionally NOT run here — see
+    # ``backend/scripts/backfill_chat_message_semantic_word_count.py`` for an
+    # operator-controlled batched backfill. New writes are kept correct by the
+    # SQLAlchemy ``before_insert`` / ``before_update`` event listener on the
+    # ``ChatMessage`` model.
+
+
+def downgrade() -> None:
+    op.drop_column("chat_messages", "semantic_word_count")

--- a/backend/models/chat_message.py
+++ b/backend/models/chat_message.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Optional, TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, event
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -19,6 +19,27 @@ from models.database import Base
 
 if TYPE_CHECKING:
     from models.conversation import Conversation
+
+
+def semantic_word_count_from_blocks(blocks: list[dict[str, Any]] | None) -> int:
+    """Count words in text-type content blocks only.
+
+    Tool-use, tool-result, and attachment blocks are excluded — they hold
+    structured payloads, not user-facing prose, and we don't want a foreach
+    over 10k records to count as 10k "words" for summary-staleness gating.
+    """
+    if not blocks:
+        return 0
+    total: int = 0
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "text":
+            continue
+        text_val: str = str(block.get("text") or "").strip()
+        if text_val:
+            total += len(text_val.split())
+    return total
 
 
 class ChatMessage(Base):
@@ -53,7 +74,15 @@ class ChatMessage(Base):
     content_blocks: Mapped[Optional[list[dict[str, Any]]]] = mapped_column(
         JSONB, nullable=True
     )
-    
+
+    # Denormalized count of words across text-type content blocks only.
+    # Kept in sync by the before_insert / before_update event listener below
+    # so that conversation-summary staleness checks can SUM this column instead
+    # of streaming every row's content_blocks JSONB back to Python.
+    semantic_word_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+
     # Legacy fields - kept for backwards compatibility during migration
     content: Mapped[str] = mapped_column(Text, nullable=False, default="")
     tool_calls: Mapped[Optional[list[dict[str, Any]]]] = mapped_column(
@@ -118,5 +147,18 @@ class ChatMessage(Base):
                     "result": tc.get("result"),
                     "status": "complete",
                 })
-        
+
         return blocks
+
+
+def _sync_semantic_word_count(_mapper, _connection, target: ChatMessage) -> None:
+    """Recompute ``semantic_word_count`` from ``content_blocks`` on every write.
+
+    Centralized here so all 6+ ChatMessage writer sites stay in sync without
+    each having to remember to update the column.
+    """
+    target.semantic_word_count = semantic_word_count_from_blocks(target.content_blocks)
+
+
+event.listen(ChatMessage, "before_insert", _sync_semantic_word_count)
+event.listen(ChatMessage, "before_update", _sync_semantic_word_count)

--- a/backend/scripts/backfill_chat_message_semantic_word_count.py
+++ b/backend/scripts/backfill_chat_message_semantic_word_count.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Backfill ``chat_messages.semantic_word_count`` for rows written before the
+denormalization landed (migration 142).
+
+The column was added with ``DEFAULT 0`` so existing rows have a wrong (always
+zero) value until this script runs. New writes are kept correct by the
+``before_insert`` / ``before_update`` event listener on the ChatMessage model.
+
+Strategy: batched, online, idempotent. Picks rows with
+``semantic_word_count = 0`` that also contain at least one non-blank text block,
+then recomputes from ``content_blocks``. Tool-only and attachment-only rows are
+already correctly represented by 0 and are skipped, which keeps the loop from
+getting stuck on true-zero rows. Use ``--once`` to do a single pass and exit;
+default loops until no candidate rows match.
+
+Usage:
+    cd backend && python scripts/backfill_chat_message_semantic_word_count.py
+    cd backend && python scripts/backfill_chat_message_semantic_word_count.py --batch 5000 --delay 0.5 --once
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import text
+
+from models.chat_message import semantic_word_count_from_blocks
+from models.database import get_admin_session
+
+
+def _log(msg: str) -> None:
+    print(f"[{datetime.now().strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+async def _backfill_batch(batch: int) -> int:
+    """Update one batch. Returns the number of rows updated."""
+    # Pick the oldest un-backfilled rows that have at least one non-blank text
+    # block. True-zero rows (tool-only / attachment-only / blank text) already
+    # have the correct default value of 0, so skipping them avoids an endless
+    # loop where every later pass keeps locking the same rows.
+    select_sql = text(
+        """
+        SELECT id, content_blocks
+        FROM chat_messages
+        WHERE semantic_word_count = 0
+          AND content_blocks IS NOT NULL
+          AND EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements(content_blocks) AS block(elem)
+              WHERE block.elem ->> 'type' = 'text'
+                AND btrim(COALESCE(block.elem ->> 'text', '')) <> ''
+          )
+        ORDER BY created_at ASC NULLS LAST
+        LIMIT :batch
+        FOR UPDATE SKIP LOCKED
+        """
+    )
+
+    async with get_admin_session() as session:
+        rows = (await session.execute(select_sql, {"batch": batch})).all()
+        if not rows:
+            return 0
+
+        # Compute new values in Python (cheap; saves a server-side jsonb walk).
+        # Group rows by computed count so the UPDATE fires once per distinct
+        # value rather than once per row — most messages share the count of 0
+        # (tool-only / attachment-only) so this collapses dramatically.
+        by_count: dict[int, list[Any]] = {}
+        for row_id, blocks in rows:
+            count = semantic_word_count_from_blocks(blocks)
+            by_count.setdefault(count, []).append(row_id)
+
+        updated = 0
+        for count, ids in by_count.items():
+            # The SQL prefilter should exclude true-zero rows, but keep this
+            # guard to avoid no-op writes if malformed JSON sneaks through.
+            if count == 0:
+                continue
+            res = await session.execute(
+                text(
+                    """
+                    UPDATE chat_messages
+                    SET semantic_word_count = :count
+                    WHERE id = ANY(:ids)
+                    """
+                ),
+                {"count": count, "ids": ids},
+            )
+            updated += int(res.rowcount or 0)
+
+        await session.commit()
+        return updated
+
+
+async def backfill(batch: int, delay: float, once: bool) -> None:
+    total_updated = 0
+    started = time.monotonic()
+    pass_index = 0
+
+    while True:
+        pass_index += 1
+        try:
+            updated = await _backfill_batch(batch)
+        except Exception as exc:
+            _log(f"ERROR in batch {pass_index}: {exc}")
+            await asyncio.sleep(max(delay * 5, 2.0))
+            continue
+
+        total_updated += updated
+        elapsed = time.monotonic() - started
+        rate = total_updated / elapsed if elapsed > 0 else 0.0
+        _log(
+            f"batch {pass_index}: updated={updated} total={total_updated} "
+            f"elapsed={elapsed:.1f}s rate={rate:.0f}/s"
+        )
+
+        if updated == 0:
+            _log("no more rows to backfill — done")
+            return
+        if once:
+            return
+        await asyncio.sleep(delay)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batch", type=int, default=2000, help="Rows per batch (default: 2000)")
+    parser.add_argument("--delay", type=float, default=0.25, help="Sleep between batches in seconds (default: 0.25)")
+    parser.add_argument("--once", action="store_true", help="Run a single batch and exit")
+    args = parser.parse_args()
+
+    asyncio.run(backfill(args.batch, args.delay, args.once))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/backfill_conversation_embeddings.py
+++ b/backend/scripts/backfill_conversation_embeddings.py
@@ -23,32 +23,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from sqlalchemy import select
 
 from models.conversation import Conversation
-from models.chat_message import ChatMessage as ChatMessageModel
 from models.database import get_admin_session, get_session
 from services.conversation_embeddings import (
     _MAX_RECENT_CHARS,
     _MAX_MESSAGES_FOR_RECENT,
     build_embedding_text,
 )
+from services.chat_message_projections import fetch_recent_user_text_projections
 from services.embeddings import get_embedding_service
-
-
-def _extract_text_from_blocks(blocks: list | None) -> str:
-    if not blocks:
-        return ""
-    parts: list[str] = []
-    for block in blocks:
-        if not isinstance(block, dict):
-            continue
-        if block.get("type") == "text":
-            text = block.get("text")
-            if text:
-                parts.append(str(text))
-        elif block.get("type") == "tool_use":
-            name = block.get("name")
-            if name:
-                parts.append(f"[{name}]")
-    return " ".join(parts)
 
 
 async def backfill(
@@ -107,23 +89,18 @@ async def backfill(
             summary_overall: str | None = (conv.summary or "").strip() or None
 
             async with get_session(organization_id=oid) as session:
-                result = await session.execute(
-                    select(ChatMessageModel)
-                    .where(
-                        ChatMessageModel.conversation_id == conv.id,
-                        ChatMessageModel.role == "user",
-                    )
-                    .order_by(ChatMessageModel.created_at.desc())
-                    .limit(_MAX_MESSAGES_FOR_RECENT)
+                user_messages = await fetch_recent_user_text_projections(
+                    session,
+                    conv.id,
+                    limit=_MAX_MESSAGES_FOR_RECENT,
                 )
-                user_messages = list(result.scalars().all())
 
             recent_texts: list[str] = []
             total_chars = 0
             for msg in reversed(user_messages):
-                text = _extract_text_from_blocks(msg.content_blocks)
-                if not text and getattr(msg, "content", None):
-                    text = msg.content or ""
+                text = msg.block_text
+                if not text and msg.legacy_content:
+                    text = msg.legacy_content
                 if text:
                     recent_texts.append(text)
                     total_chars += len(text)

--- a/backend/services/chat_message_projections.py
+++ b/backend/services/chat_message_projections.py
@@ -1,0 +1,182 @@
+"""Lean chat message projections for hot-path conversation reads.
+
+The ``chat_messages`` row can contain very large JSONB tool inputs/results. Hot
+paths that only need transcript text, tool names, or semantic counts should not
+hydrate full ORM rows or return full ``content_blocks`` payloads to Python.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@dataclass(frozen=True)
+class PromptMessageProjection:
+    """Minimal message shape needed for summary/title prompt formatting."""
+
+    role: str
+    content_blocks: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class RecentUserTextProjection:
+    """Minimal user-message shape needed for embedding text construction."""
+
+    block_text: str
+    legacy_content: str | None
+
+
+_PROMPT_MESSAGES_SQL = """
+SELECT
+    role,
+    COALESCE(
+        (
+            SELECT jsonb_agg(projected.block ORDER BY projected.ordinality)
+            FROM (
+                SELECT
+                    block_items.ordinality,
+                    CASE
+                        WHEN block_items.block ->> 'type' = 'text' THEN
+                            jsonb_build_object(
+                                'type', 'text',
+                                'text', left(COALESCE(block_items.block ->> 'text', ''), :text_limit)
+                            )
+                        WHEN block_items.block ->> 'type' = 'tool_use' THEN
+                            jsonb_build_object(
+                                'type', 'tool_use',
+                                'name', COALESCE(block_items.block ->> 'name', 'unknown')
+                            )
+                        ELSE NULL
+                    END AS block
+                FROM jsonb_array_elements(COALESCE(content_blocks, '[]'::jsonb))
+                    WITH ORDINALITY AS block_items(block, ordinality)
+                WHERE block_items.block ->> 'type' IN ('text', 'tool_use')
+            ) AS projected
+            WHERE projected.block IS NOT NULL
+        ),
+        '[]'::jsonb
+    ) AS content_blocks
+FROM chat_messages
+WHERE conversation_id = :conversation_id
+ORDER BY created_at DESC
+LIMIT :limit
+"""
+
+_RECENT_USER_TEXT_SQL = """
+SELECT
+    COALESCE(
+        (
+            SELECT string_agg(projected.part, ' ' ORDER BY projected.ordinality)
+            FROM (
+                SELECT
+                    block_items.ordinality,
+                    CASE
+                        WHEN block_items.block ->> 'type' = 'text' THEN
+                            COALESCE(block_items.block ->> 'text', '')
+                        WHEN block_items.block ->> 'type' = 'tool_use' THEN
+                            '[' || COALESCE(block_items.block ->> 'name', 'unknown') || ']'
+                        ELSE NULL
+                    END AS part
+                FROM jsonb_array_elements(COALESCE(content_blocks, '[]'::jsonb))
+                    WITH ORDINALITY AS block_items(block, ordinality)
+                WHERE block_items.block ->> 'type' IN ('text', 'tool_use')
+            ) AS projected
+            WHERE projected.part IS NOT NULL AND projected.part <> ''
+        ),
+        ''
+    ) AS block_text,
+    content AS legacy_content
+FROM chat_messages
+WHERE conversation_id = :conversation_id
+  AND role = 'user'
+ORDER BY created_at DESC
+LIMIT :limit
+"""
+
+_SEMANTIC_WORD_COUNT_SQL = """
+SELECT COALESCE(SUM(semantic_word_count), 0)::integer AS semantic_words
+FROM chat_messages
+WHERE conversation_id = :conversation_id
+"""
+
+
+def _coerce_blocks(value: Any) -> list[dict[str, Any]]:
+    """Normalize driver-returned JSONB values into a list of block dicts."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = json.loads(value)
+    if not isinstance(value, list):
+        return []
+    return [block for block in value if isinstance(block, dict)]
+
+
+async def fetch_prompt_message_projections(
+    session: AsyncSession,
+    conversation_id: uuid.UUID,
+    *,
+    limit: int,
+    text_limit: int = 2_000,
+) -> list[PromptMessageProjection]:
+    """Fetch recent messages without hydrating full ``chat_messages`` rows.
+
+    The JSONB projection intentionally keeps only text and tool names. It omits
+    tool inputs/results and unrelated blocks so summary/title generation avoids
+    transferring large tool payloads.
+    """
+    result = await session.execute(
+        text(_PROMPT_MESSAGES_SQL),
+        {
+            "conversation_id": conversation_id,
+            "limit": limit,
+            "text_limit": text_limit,
+        },
+    )
+    return [
+        PromptMessageProjection(
+            role=str(row.role),
+            content_blocks=_coerce_blocks(row.content_blocks),
+        )
+        for row in result
+    ]
+
+
+async def fetch_recent_user_text_projections(
+    session: AsyncSession,
+    conversation_id: uuid.UUID,
+    *,
+    limit: int,
+) -> list[RecentUserTextProjection]:
+    """Fetch recent user text for embeddings without full message hydration."""
+    result = await session.execute(
+        text(_RECENT_USER_TEXT_SQL),
+        {
+            "conversation_id": conversation_id,
+            "limit": limit,
+        },
+    )
+    return [
+        RecentUserTextProjection(
+            block_text=str(row.block_text or ""),
+            legacy_content=row.legacy_content,
+        )
+        for row in result
+    ]
+
+
+async def count_semantic_words_projection(
+    session: AsyncSession,
+    conversation_id: uuid.UUID,
+) -> int:
+    """Count semantic words via the denormalized integer column."""
+    result = await session.execute(
+        text(_SEMANTIC_WORD_COUNT_SQL),
+        {"conversation_id": conversation_id},
+    )
+    return int(result.scalar_one() or 0)

--- a/backend/services/conversation_embeddings.py
+++ b/backend/services/conversation_embeddings.py
@@ -9,13 +9,12 @@ conversation_post_completion.run_post_completion() after this returns.
 """
 
 import logging
-from typing import Any
 
 from models.conversation import Conversation
-from models.chat_message import ChatMessage as ChatMessageModel
 from models.database import get_session
-from sqlalchemy import select, update
+from sqlalchemy import update
 
+from services.chat_message_projections import fetch_recent_user_text_projections
 from services.embeddings import get_embedding_service
 
 logger = logging.getLogger(__name__)
@@ -23,25 +22,6 @@ logger = logging.getLogger(__name__)
 _STALENESS_THRESHOLD = 2
 _MAX_RECENT_CHARS = 12_000
 _MAX_MESSAGES_FOR_RECENT = 50
-
-
-def _extract_text_from_blocks(blocks: list[dict[str, Any]] | None) -> str:
-    """Extract concatenated text from content_blocks (text and tool_use names only)."""
-    if not blocks:
-        return ""
-    parts: list[str] = []
-    for block in blocks:
-        if not isinstance(block, dict):
-            continue
-        if block.get("type") == "text":
-            text = block.get("text")
-            if text:
-                parts.append(str(text))
-        elif block.get("type") == "tool_use":
-            name = block.get("name")
-            if name:
-                parts.append(f"[{name}]")
-    return " ".join(parts)
 
 
 def build_embedding_text(
@@ -103,21 +83,16 @@ async def update_conversation_embedding(
 
             summary_text = (conv.summary or "").strip() or None
 
-            result = await session.execute(
-                select(ChatMessageModel)
-                .where(
-                    ChatMessageModel.conversation_id == conv.id,
-                    ChatMessageModel.role == "user",
-                )
-                .order_by(ChatMessageModel.created_at.desc())
-                .limit(_MAX_MESSAGES_FOR_RECENT)
+            user_messages = await fetch_recent_user_text_projections(
+                session,
+                conv.id,
+                limit=_MAX_MESSAGES_FOR_RECENT,
             )
-            user_messages = list(result.scalars().all())
             total_chars = 0
             for msg in reversed(user_messages):
-                text = _extract_text_from_blocks(msg.content_blocks)
-                if not text and msg.content:
-                    text = msg.content
+                text = msg.block_text
+                if not text and msg.legacy_content:
+                    text = msg.legacy_content
                 if text:
                     recent_texts.append(text)
                     total_chars += len(text)

--- a/backend/services/conversation_summary.py
+++ b/backend/services/conversation_summary.py
@@ -16,13 +16,17 @@ from datetime import datetime, timezone
 from typing import Any
 
 from config import settings
-from models.chat_message import ChatMessage as ChatMessageModel
 from models.conversation import Conversation
 from models.database import get_admin_session, get_session
 from models.user import User
 from sqlalchemy import select, update
 
 from services.anthropic_health import report_anthropic_call_failure, report_anthropic_call_success
+from services.chat_message_projections import (
+    PromptMessageProjection,
+    count_semantic_words_projection,
+    fetch_prompt_message_projections,
+)
 from services.llm_provider import resolve_llm_config, get_adapter
 
 logger = logging.getLogger(__name__)
@@ -63,37 +67,17 @@ _TITLE_SYSTEM_PROMPT = (
 )
 
 
-def _semantic_word_count_from_blocks(blocks: list[dict[str, Any]] | None) -> int:
-    """Count words in text-type content blocks only (exclude tool_use, attachments, etc.)."""
-    if not blocks:
-        return 0
-    total: int = 0
-    for block in blocks:
-        if not isinstance(block, dict):
-            continue
-        if block.get("type") != "text":
-            continue
-        text_val: str = str(block.get("text") or "").strip()
-        if text_val:
-            total += len(text_val.split())
-    return total
-
-
 async def count_semantic_words_for_conversation(
     session: Any,
     conversation_id: uuid.UUID,
 ) -> int:
-    """Sum semantic word counts across all messages in the conversation."""
-    result = await session.execute(
-        select(ChatMessageModel.content_blocks).where(
-            ChatMessageModel.conversation_id == conversation_id
-        )
-    )
-    total: int = 0
-    for row in result:
-        blocks: list[dict[str, Any]] | None = row[0]
-        total += _semantic_word_count_from_blocks(blocks)
-    return total
+    """Sum semantic word counts across all messages in the conversation.
+
+    Reads the denormalized ``chat_messages.semantic_word_count`` column rather
+    than streaming every row's ``content_blocks`` JSONB back to Python. The
+    column is kept in sync by an event listener on the ChatMessage model.
+    """
+    return await count_semantic_words_projection(session, conversation_id)
 
 
 def _should_regenerate_summary(
@@ -110,8 +94,12 @@ def _should_regenerate_summary(
     return (semantic_words - summary_word_count_at_generation) >= _SEMANTIC_REGEN_WORD_DELTA
 
 
-def _format_messages(messages: list[ChatMessageModel]) -> str:
-    """Format messages into a compact text representation for the prompt."""
+def _format_messages(messages: list[PromptMessageProjection]) -> str:
+    """Format messages into a compact text representation for the prompt.
+
+    Accepts anything with ``.role`` and ``.content_blocks`` attributes —
+    typically SQLAlchemy ``Row`` tuples from a projected select.
+    """
     lines: list[str] = []
     for msg in messages:
         role: str = str(msg.role).upper()
@@ -215,13 +203,15 @@ async def generate_conversation_summary(
             ):
                 return None
 
-            result = await session.execute(
-                select(ChatMessageModel)
-                .where(ChatMessageModel.conversation_id == conv.id)
-                .order_by(ChatMessageModel.created_at.desc())
-                .limit(_MAX_MESSAGES_FOR_PROMPT)
+            messages = list(
+                reversed(
+                    await fetch_prompt_message_projections(
+                        session,
+                        conv.id,
+                        limit=_MAX_MESSAGES_FOR_PROMPT,
+                    )
+                )
             )
-            messages: list[ChatMessageModel] = list(reversed(result.scalars().all()))
             if len(messages) < 1:
                 return None
 
@@ -325,13 +315,15 @@ async def generate_conversation_title(
             if semantic_words < _TITLE_MIN_WORDS:
                 return None
 
-            result = await session.execute(
-                select(ChatMessageModel)
-                .where(ChatMessageModel.conversation_id == conv.id)
-                .order_by(ChatMessageModel.created_at.desc())
-                .limit(_MAX_MESSAGES_FOR_PROMPT)
+            messages = list(
+                reversed(
+                    await fetch_prompt_message_projections(
+                        session,
+                        conv.id,
+                        limit=_MAX_MESSAGES_FOR_PROMPT,
+                    )
+                )
             )
-            messages: list[ChatMessageModel] = list(reversed(result.scalars().all()))
             if not messages:
                 return None
             formatted = _format_messages(messages)

--- a/backend/tests/test_chat_message_projections.py
+++ b/backend/tests/test_chat_message_projections.py
@@ -1,0 +1,70 @@
+import json
+
+from services.chat_message_projections import (
+    PromptMessageProjection,
+    _PROMPT_MESSAGES_SQL,
+    _RECENT_USER_TEXT_SQL,
+    _SEMANTIC_WORD_COUNT_SQL,
+    _coerce_blocks,
+)
+from services.conversation_summary import _format_messages
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.lower().split())
+
+
+def test_prompt_projection_sql_omits_tool_payload_fields() -> None:
+    sql = _normalized(_PROMPT_MESSAGES_SQL)
+
+    assert "select *" not in sql
+    assert "jsonb_build_object" in sql
+    assert "'name'" in sql
+    assert "->> 'input'" not in sql
+    assert "-> 'input'" not in sql
+    assert "->> 'result'" not in sql
+    assert "-> 'result'" not in sql
+
+
+def test_recent_user_text_projection_returns_text_not_full_jsonb() -> None:
+    sql = _normalized(_RECENT_USER_TEXT_SQL)
+
+    assert "select *" not in sql
+    assert "as content_blocks" not in sql
+    assert "string_agg" in sql
+    assert "legacy_content" in sql
+
+
+def test_semantic_count_sql_uses_denormalized_column_not_jsonb() -> None:
+    sql = _normalized(_SEMANTIC_WORD_COUNT_SQL)
+
+    assert "select *" not in sql
+    assert "semantic_word_count" in sql
+    assert "jsonb_array_elements" not in sql
+    assert "content_blocks" not in sql
+
+
+def test_coerce_blocks_accepts_driver_json_strings() -> None:
+    blocks = [
+        {"type": "text", "text": "hello"},
+        "bad",
+        {"type": "tool_use", "name": "lookup"},
+    ]
+
+    assert _coerce_blocks(json.dumps(blocks)) == [blocks[0], blocks[2]]
+
+
+def test_summary_formatter_uses_projected_tool_names_only() -> None:
+    formatted = _format_messages(
+        [
+            PromptMessageProjection(
+                role="assistant",
+                content_blocks=[
+                    {"type": "text", "text": "Checking"},
+                    {"type": "tool_use", "name": "big_query"},
+                ],
+            )
+        ]
+    )
+
+    assert formatted == "ASSISTANT: Checking [Tool call: big_query]"

--- a/backend/tests/test_chat_message_semantic_word_count.py
+++ b/backend/tests/test_chat_message_semantic_word_count.py
@@ -1,0 +1,161 @@
+"""Tests for the chat_messages.semantic_word_count denormalization.
+
+Covers:
+  - The pure helper that counts text-block words (excludes tool_use, attachment, etc.)
+  - The before_insert / before_update event listener that keeps the column in sync
+  - The SUM-based ``count_semantic_words_for_conversation`` query path
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+from models.chat_message import (
+    ChatMessage,
+    _sync_semantic_word_count,
+    semantic_word_count_from_blocks,
+)
+from services.conversation_summary import count_semantic_words_for_conversation
+
+
+# ---------- semantic_word_count_from_blocks (pure helper) -------------------
+
+
+def test_word_count_handles_none_and_empty() -> None:
+    assert semantic_word_count_from_blocks(None) == 0
+    assert semantic_word_count_from_blocks([]) == 0
+
+
+def test_word_count_only_counts_text_blocks() -> None:
+    blocks = [
+        {"type": "text", "text": "hello world from the user"},
+        {"type": "tool_use", "id": "t1", "name": "search", "input": {"q": "ignored"}, "result": {"a": "ignored too"}},
+        {"type": "attachment", "id": "att-1"},
+        {"type": "text", "text": "and a follow up"},
+    ]
+    # 5 + 4 = 9 words; tool_use input/result and attachment are excluded.
+    assert semantic_word_count_from_blocks(blocks) == 9
+
+
+def test_word_count_skips_non_dict_entries_and_blank_text() -> None:
+    blocks = [
+        "not a dict",
+        {"type": "text"},                # missing text key
+        {"type": "text", "text": ""},    # empty
+        {"type": "text", "text": "   "}, # whitespace only
+        {"type": "text", "text": "three real words"},
+    ]
+    assert semantic_word_count_from_blocks(blocks) == 3
+
+
+def test_word_count_collapses_runs_of_whitespace_via_split() -> None:
+    blocks = [{"type": "text", "text": "   one\t two\nthree    four "}]
+    assert semantic_word_count_from_blocks(blocks) == 4
+
+
+# ---------- ChatMessage event listener --------------------------------------
+
+
+def test_event_listener_sets_count_on_insert() -> None:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        role="user",
+        content_blocks=[{"type": "text", "text": "hi there friend"}],
+    )
+    # before_insert fires this synchronously; simulate it directly so the test
+    # doesn't need a DB.
+    _sync_semantic_word_count(None, None, msg)
+    assert msg.semantic_word_count == 3
+
+
+def test_event_listener_recomputes_on_update() -> None:
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        role="assistant",
+        content_blocks=[{"type": "text", "text": "first reply with five words"}],
+        semantic_word_count=5,
+    )
+    msg.content_blocks = [
+        {"type": "text", "text": "first reply with five words"},
+        {"type": "tool_use", "id": "t1", "name": "noop", "input": {}, "result": {}},
+        {"type": "text", "text": "and one more"},
+    ]
+    _sync_semantic_word_count(None, None, msg)
+    # Tool use ignored; 5 + 3 = 8.
+    assert msg.semantic_word_count == 8
+
+
+def test_event_listener_drops_to_zero_when_blocks_cleared() -> None:
+    msg = ChatMessage(id=uuid.uuid4(), role="user", semantic_word_count=42)
+    msg.content_blocks = None
+    _sync_semantic_word_count(None, None, msg)
+    assert msg.semantic_word_count == 0
+
+
+def test_event_listener_handles_tool_only_message() -> None:
+    """A tool-only message has no semantic words and must store 0 — important
+    so that a foreach over thousands of records doesn't push a conversation
+    over the summary-regeneration threshold."""
+    msg = ChatMessage(
+        id=uuid.uuid4(),
+        role="assistant",
+        content_blocks=[
+            {"type": "tool_use", "id": "t1", "name": "foreach", "input": {"items": list(range(1000))}, "result": {}}
+            for _ in range(20)
+        ],
+    )
+    _sync_semantic_word_count(None, None, msg)
+    assert msg.semantic_word_count == 0
+
+
+# ---------- count_semantic_words_for_conversation (SUM path) ----------------
+
+
+class _FakeResult:
+    def __init__(self, value: int) -> None:
+        self._value = value
+
+    def scalar_one(self) -> int:
+        return self._value
+
+
+class _CapturingSession:
+    """Minimal fake that records the executed statement and returns a scalar."""
+
+    def __init__(self, return_value: int) -> None:
+        self.return_value = return_value
+        self.executed: list[Any] = []
+
+    async def execute(self, stmt: Any, _params: dict[str, Any] | None = None) -> _FakeResult:
+        self.executed.append(stmt)
+        return _FakeResult(self.return_value)
+
+
+def test_count_semantic_words_uses_sum_query_not_content_blocks() -> None:
+    """Smoke-test that the SUM path is used.
+
+    Critical: this function used to ``select(content_blocks)`` with no LIMIT,
+    streaming every row's JSONB back to Python on every assistant reply
+    (~14 TB scanned in the prod pg_stat_statements snapshot). It now must SUM
+    a denormalized integer column.
+    """
+    session = _CapturingSession(return_value=137)
+    conv_id = uuid.uuid4()
+
+    result = asyncio.run(count_semantic_words_for_conversation(session, conv_id))
+
+    assert result == 137
+    assert len(session.executed) == 1
+    rendered = str(session.executed[0]).lower()
+    # The new query must SUM the denormalized column, not stream content_blocks.
+    assert "sum" in rendered
+    assert "semantic_word_count" in rendered
+    assert "content_blocks" not in rendered
+
+
+def test_count_semantic_words_returns_zero_when_sum_is_null() -> None:
+    """A conversation with no rows yields SUM=NULL; helper must return 0."""
+    session = _CapturingSession(return_value=0)
+    result = asyncio.run(count_semantic_words_for_conversation(session, uuid.uuid4()))
+    assert result == 0

--- a/backend/tests/test_tool_progress_dedup.py
+++ b/backend/tests/test_tool_progress_dedup.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import sys
 import types
 from types import SimpleNamespace
@@ -20,10 +21,10 @@ from agents import orchestrator
 
 
 class _FakeExecuteResult:
-    def __init__(self, row: object) -> None:
+    def __init__(self, row: object | None) -> None:
         self._row = row
 
-    def scalar_one_or_none(self) -> object:
+    def first(self) -> object | None:
         return self._row
 
 
@@ -31,9 +32,21 @@ class _FakeSession:
     def __init__(self, message: object) -> None:
         self._message = message
         self.commit_calls = 0
+        self.executed_queries: list[str] = []
 
-    async def execute(self, _query: object) -> _FakeExecuteResult:
-        return _FakeExecuteResult(self._message)
+    async def execute(self, query: object, params: dict[str, object] | None = None) -> _FakeExecuteResult:
+        query_text = str(query)
+        self.executed_queries.append(query_text)
+        params = params or {}
+        result_payload = json.loads(str(params.get("result_json", "null")))
+        for block in self._message.content_blocks:
+            if block.get("type") == "tool_use" and block.get("id") == params.get("tool_id"):
+                if block.get("status") == params.get("status") and block.get("result") == result_payload:
+                    return _FakeExecuteResult(None)
+                block["status"] = params.get("status")
+                block["result"] = result_payload
+                return _FakeExecuteResult(SimpleNamespace(tool_name=block.get("name", "unknown")))
+        return _FakeExecuteResult(None)
 
     async def commit(self) -> None:
         self.commit_calls += 1
@@ -95,6 +108,9 @@ def test_update_tool_result_skips_duplicate_progress_updates(monkeypatch) -> Non
     assert fake_session.commit_calls == 0
     assert broadcasts == []
     assert message.content_blocks[0]["result"] == {"message": "Writing to Linear"}
+    assert len(fake_session.executed_queries) == 1
+    assert "UPDATE chat_messages" in fake_session.executed_queries[0]
+    assert "SELECT *" not in fake_session.executed_queries[0]
 
 
 def test_update_tool_result_allows_status_change_with_same_result(monkeypatch) -> None:
@@ -142,6 +158,9 @@ def test_update_tool_result_allows_status_change_with_same_result(monkeypatch) -
     assert updated is True
     assert fake_session.commit_calls == 1
     assert message.content_blocks[0]["status"] == "complete"
+    assert len(fake_session.executed_queries) == 1
+    assert "UPDATE chat_messages" in fake_session.executed_queries[0]
+    assert "SELECT *" not in fake_session.executed_queries[0]
     assert broadcasts == [
         {
             "organization_id": organization_id,


### PR DESCRIPTION
### Motivation

- Reduce expensive JSONB streaming of `chat_messages.content_blocks` on hot paths by denormalizing a per-message word count and providing lightweight SQL projections.
- Make tool-progress updates cheap and idempotent by performing a single server-side JSONB `UPDATE`/`RETURNING` instead of loading and mutating full ORM rows repeatedly.
- Improve embedding/summary pipelines to avoid transferring large tool payloads and to allow efficient SUM-based staleness checks.

### Description

- Add `semantic_word_count` integer column to the `ChatMessage` model with a `before_insert` / `before_update` event listener and a new Alembic migration `142_chat_messages_semantic_word_count.py`. 
- Introduce `services.chat_message_projections` with SQL projections and helper functions: `fetch_prompt_message_projections`, `fetch_recent_user_text_projections`, and `count_semantic_words_projection` to read only the minimal fields needed for summaries and embeddings. 
- Replace hot-path selects that hydrated full `ChatMessage` ORM objects with projection-based reads in `services.conversation_summary`, `services.conversation_embeddings`, and `orchestrator._load_history` to avoid transferring large JSONB blobs. 
- Rewrite `agents.orchestrator.update_tool_result` to use a single parameterized `UPDATE ... RETURNING` SQL statement updating the matching `tool_use` JSONB block inline and skipping duplicate/no-op updates, and adjusted related code paths to broadcast progress without reloading full rows. 
- Add a backfill script `backend/scripts/backfill_chat_message_semantic_word_count.py` to idempotently populate `semantic_word_count` for existing rows, and adapt the conversation embeddings backfill to use the new projections. 
- Add unit tests for projections and denormalized counts in `backend/tests/test_chat_message_projections.py`, `backend/tests/test_chat_message_semantic_word_count.py`, and update `backend/tests/test_tool_progress_dedup.py` to exercise the new DB-update behavior.

### Testing

- Ran unit tests `backend/tests/test_chat_message_projections.py`, `backend/tests/test_chat_message_semantic_word_count.py`, and `backend/tests/test_tool_progress_dedup.py`, and they succeeded.
- Verified the new migration file `142_chat_messages_semantic_word_count.py` and the backfill script `scripts/backfill_chat_message_semantic_word_count.py` for idempotent, batched backfill behavior locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe948ac4308321917ff5b93b3086a4)