### PR TITLE
Fix connector sharing visibility update

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -27,8 +27,9 @@ from fastapi.responses import RedirectResponse
 
 from api.auth_middleware import AuthContext, get_current_auth, require_global_admin
 from pydantic import BaseModel, Field
-from sqlalchemy import and_, func, or_, select, text
+from sqlalchemy import and_, bindparam, func, or_, select, text
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 
 from config import (
     BUILTIN_CONNECTORS,
@@ -3488,8 +3489,8 @@ async def _propagate_integration_synced_data_visibility(
                 "UPDATE meetings "
                 "SET visibility = :vis, "
                 "owner_user_id = CASE "
-                "WHEN :vis = 'owner_only' AND :owner_user_id IS NOT NULL "
-                "THEN :owner_user_id "
+                "WHEN :vis = 'owner_only' AND CAST(:owner_user_id AS uuid) IS NOT NULL "
+                "THEN CAST(:owner_user_id AS uuid) "
                 "ELSE owner_user_id "
                 "END "
                 "WHERE integration_id = :iid "
@@ -3497,10 +3498,13 @@ async def _propagate_integration_synced_data_visibility(
                 "visibility IS DISTINCT FROM :vis "
                 "OR ("
                 ":vis = 'owner_only' "
-                "AND :owner_user_id IS NOT NULL "
-                "AND owner_user_id IS DISTINCT FROM :owner_user_id"
+                "AND CAST(:owner_user_id AS uuid) IS NOT NULL "
+                "AND owner_user_id IS DISTINCT FROM CAST(:owner_user_id AS uuid)"
                 ")"
                 ")"
+            ).bindparams(
+                bindparam("owner_user_id", type_=PG_UUID(as_uuid=True)),
+                bindparam("iid", type_=PG_UUID(as_uuid=True)),
             ),
             {
                 "vis": new_visibility,

--- a/backend/tests/test_integration_sharing_visibility.py
+++ b/backend/tests/test_integration_sharing_visibility.py
@@ -56,7 +56,8 @@ def test_sharing_visibility_propagates_to_activities_and_meetings(monkeypatch):
     assert "UPDATE meetings" in session.executed[1][0]
     assert "visibility IS DISTINCT FROM" in session.executed[1][0]
     assert "owner_user_id = CASE" in session.executed[1][0]
-    assert "owner_user_id IS DISTINCT FROM" in session.executed[1][0]
+    assert "CAST(:owner_user_id AS uuid) IS NOT NULL" in session.executed[1][0]
+    assert "owner_user_id IS DISTINCT FROM CAST(:owner_user_id AS uuid)" in session.executed[1][0]
     assert session.executed[1][1] == {
         "vis": "owner_only",
         "iid": integration_id,
@@ -81,3 +82,26 @@ def test_sharing_visibility_propagates_team_visibility(monkeypatch):
 
     assert [params["vis"] for _query, params in session.executed] == ["team", "team"]
     assert session.executed[1][1]["owner_user_id"] == owner_user_id
+
+
+def test_meeting_visibility_update_casts_owner_user_id_for_asyncpg(monkeypatch):
+    integration_id = UUID("33333333-3333-3333-3333-333333333333")
+    owner_user_id = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+    session = _FakeSession()
+
+    monkeypatch.setattr(auth, "get_admin_session", lambda: _FakeSessionContext(session))
+
+    asyncio.run(
+        auth._propagate_integration_synced_data_visibility(
+            integration_id,
+            share_synced_data=True,
+            owner_user_id=owner_user_id,
+        )
+    )
+
+    meeting_query, meeting_params = session.executed[1]
+
+    assert "CAST(:owner_user_id AS uuid) IS NOT NULL" in meeting_query
+    assert "THEN CAST(:owner_user_id AS uuid)" in meeting_query
+    assert "owner_user_id IS DISTINCT FROM CAST(:owner_user_id AS uuid)" in meeting_query
+    assert meeting_params["owner_user_id"] == owner_user_id


### PR DESCRIPTION
### Motivation
- Toggling connector sharing could raise asyncpg `AmbiguousParameterError` because the same bind parameter was used multiple times without an explicit type for UUID parameters in the meeting-update SQL. 
- The change ensures the `owner_user_id` and `integration_id` parameters are treated as PostgreSQL UUIDs so visibility propagation runs reliably under asyncpg.

### Description
- Updated `_propagate_integration_synced_data_visibility` to cast occurrences of `:owner_user_id` in the `UPDATE meetings` SQL to `CAST(:owner_user_id AS uuid)` and compare against `CAST(:owner_user_id AS uuid)`. 
- Bound `owner_user_id` and `iid` with explicit PostgreSQL UUID types using `.bindparams(bindparam(..., type_=PG_UUID(as_uuid=True)))` and added the `PG_UUID` import. 
- Added a regression test `test_meeting_visibility_update_casts_owner_user_id_for_asyncpg` and adjusted expectations in `tests/test_integration_sharing_visibility.py` to assert the new casts are present while preserving existing propagation behavior.

### Testing
- Ran `cd backend && python -m pytest tests/test_integration_sharing_visibility.py -q` and observed all tests in that file passed (`3 passed`).
- Ran a syntax check with `cd backend && python -m py_compile api/routes/auth.py tests/test_integration_sharing_visibility.py` which completed without errors.
- The new regression test verifies the meeting visibility update SQL includes `CAST(:owner_user_id AS uuid)` and that the bound parameter value is preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fec27c3ed0832197a31de949351f98)