### PR TITLE
Fix sidebar jump on new conversation; default web convs to Direct

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -901,6 +901,7 @@ async def create_conversation(
             participating_user_ids=[auth.user_id],
             title=request.title,
             scope=scope,
+            source=_WEB_PLATFORM_SLUG,
         )
         session.add(conversation)
         # Capture values before commit (model defaults are set on instantiation)
@@ -942,6 +943,9 @@ async def create_conversation(
             scope=conv_scope,
             agent_responding=True,
             participants=participants,
+            source=_WEB_PLATFORM_SLUG,
+            group_bucket_type="direct",
+            group_bucket_key="direct",
         )
 
 

--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -1007,6 +1007,7 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                             participating_user_ids=[UUID(user_id_str)],
                             title=title,
                             scope=conv_scope,
+                            source="web",
                         )
                         session.add(conversation)
                         await session.commit()
@@ -1018,6 +1019,9 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                         "conversation_id": conversation_id,
                         "title": title,
                         "scope": conv_scope,
+                        "source": "web",
+                        "group_bucket_type": "direct",
+                        "group_bucket_key": "direct",
                     }))
 
                 mentions: list[dict] | None = data.get("mentions")

--- a/backend/tests/test_web_conversation_sidebar_behavior.py
+++ b/backend/tests/test_web_conversation_sidebar_behavior.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_web_conversation_buckets_are_direct() -> None:
+    from api.routes.chat import _derive_bucket
+
+    assert _derive_bucket(source="web", scope="shared", normalized_channel_id=None) == (
+        "direct",
+        "direct",
+    )
+
+
+def test_frontend_add_conversation_preserves_sidebar_list_and_defaults_direct() -> None:
+    store_source = (
+        Path(__file__).resolve().parents[2]
+        / "frontend/src/store/chatStore.ts"
+    ).read_text(encoding="utf-8")
+
+    assert "...recentChats.slice(0, 9)" not in store_source
+    assert "...recentChats," in store_source
+    assert 'groupBucketType: metadata.groupBucketType ?? "direct"' in store_source
+    assert 'groupBucketKey: metadata.groupBucketKey ?? "direct"' in store_source

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -106,6 +106,9 @@ interface WsConversationCreated {
   conversation_id: string;
   title?: string;
   scope?: 'private' | 'shared';
+  source?: string | null;
+  group_bucket_type?: 'direct' | 'channel' | 'uncategorized';
+  group_bucket_key?: string | null;
 }
 
 interface WsCatchup {
@@ -1261,7 +1264,11 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
           const title = created.title || 'New Chat';
           const scope: 'private' | 'shared' =
             created.scope === 'private' ? 'private' : 'shared';
-          addConversation(created.conversation_id, title, scope);
+          addConversation(created.conversation_id, title, scope, {
+            source: created.source ?? 'web',
+            groupBucketType: created.group_bucket_type ?? 'direct',
+            groupBucketKey: created.group_bucket_key ?? 'direct',
+          });
           if (source === 'ws') {
             // Only update currentChatId when on new chat (null) - we're waiting for the backend
             // to assign an ID. Don't overwrite when user has selected an existing conversation.

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -120,6 +120,10 @@ export interface ChatState {
     id: string,
     title: string,
     scope?: "private" | "shared",
+    metadata?: Pick<
+      ChatSummary,
+      "source" | "groupBucketType" | "groupBucketKey" | "participants"
+    >,
   ) => void;
   fetchConversations: () => Promise<void>;
   deleteConversation: (id: string) => Promise<void>;
@@ -259,7 +263,7 @@ export const useChatStore = create<ChatState>()(
     setPendingChatAutoSend: (pendingChatAutoSend) =>
       set({ pendingChatAutoSend }),
 
-    addConversation: (id, title, scope?: "private" | "shared") => {
+    addConversation: (id, title, scope?: "private" | "shared", metadata = {}) => {
       const { recentChats } = get();
       if (recentChats.some((chat) => chat.id === id)) {
         return;
@@ -274,8 +278,12 @@ export const useChatStore = create<ChatState>()(
             previewText: "",
             scope: scope ?? "shared",
             userId: creatorId,
+            source: metadata.source ?? "web",
+            groupBucketType: metadata.groupBucketType ?? "direct",
+            groupBucketKey: metadata.groupBucketKey ?? "direct",
+            participants: metadata.participants,
           },
-          ...recentChats.slice(0, 9),
+          ...recentChats,
         ],
       });
     },


### PR DESCRIPTION
### Motivation
- Creating a new conversation from the web client caused the left nav to ‘jump’ because the local insertion truncated the existing `recentChats` list. 
- Web-created conversations were appearing under `Uncategorized` briefly which is confusing; they should appear in the Direct bucket until server state arrives. 

### Description
- Stop truncating the sidebar list by changing `addConversation` in `frontend/src/store/chatStore.ts` to accept optional `metadata` and prepend the new conversation without slicing the existing list. 
- Default newly-added local web conversations to `source: 'web'` and `groupBucketType/groupBucketKey: 'direct'` in the store so they show under Direct immediately. 
- Propagate `source` and bucket metadata from backend creation paths by returning `source`, `group_bucket_type`, and `group_bucket_key` from `backend/api/routes/chat.py` and broadcasting them in `backend/api/websockets.py`. 
- Consume the extended websocket payload in `frontend/src/components/AppLayout.tsx` and call `addConversation(..., metadata)` with safe `direct` fallbacks. 
- Add a regression test `backend/tests/test_web_conversation_sidebar_behavior.py` that verifies `_derive_bucket` for web and checks the frontend store source defaults and list-preservation change. 

### Testing
- Ran `npm run build` for the frontend and the production build completed successfully. 
- Ran the new pytest file with `pytest tests/test_web_conversation_sidebar_behavior.py` and both added tests passed (`2 passed`). 
- Ran `git diff --check` and there were no whitespace/patch issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fec1c1ba2483219f8a78a110d38ce1)