### PR TITLE
Restore shared connector pills

### DIFF
--- a/backend/tests/test_connector_sharing_pill.py
+++ b/backend/tests/test_connector_sharing_pill.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+DATASOURCES = Path(__file__).resolve().parents[2] / "frontend" / "src" / "components" / "DataSources.tsx"
+
+
+def test_shared_with_team_pill_renders_in_connector_rows() -> None:
+    source = DATASOURCES.read_text()
+
+    assert "const renderSharedWithTeamPill = (integration: DisplayIntegration)" in source
+    assert "if (!isSharedWithTeam(integration)) return null;" in source
+    assert "{renderSharedWithTeamPill(integration)}" in source
+
+
+def test_shared_with_team_pill_uses_any_sharing_flag() -> None:
+    source = DATASOURCES.read_text()
+
+    assert "const isSharedWithTeam = (sharing:" in source
+    assert "sharing.shareSyncedData || sharing.shareQueryAccess || sharing.shareWriteAccess" in source
+    assert "const sharedPill = renderSharedWithTeamPill(integration);" in source

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -1560,16 +1560,20 @@ export function DataSources(): JSX.Element {
           ? 'org-connected'
           : 'team-only';
 
+  const renderSharedWithTeamPill = (integration: DisplayIntegration): JSX.Element | null => {
+    if (!isSharedWithTeam(integration)) return null;
+    return (
+      <span className="inline-flex shrink-0 items-center gap-1 rounded px-2 py-0.5 text-xs bg-primary-500/20 text-primary-400">
+        <HiShare className="h-3 w-3" />
+        Shared with team
+      </span>
+    );
+  };
+
   const renderSharingBadgeBlock = (integration: DisplayIntegration, state: TileState): JSX.Element | null => {
+    const sharedPill = renderSharedWithTeamPill(integration);
+    if (sharedPill) return sharedPill;
     if (state !== 'connected') return null;
-    if (isSharedWithTeam(integration)) {
-      return (
-        <span className="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs bg-primary-500/20 text-primary-400">
-          <HiShare className="h-3 w-3" />
-          Shared with team
-        </span>
-      );
-    }
     return (
       <span className="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs bg-surface-700 text-surface-400">
         <HiLockClosed className="h-3 w-3" />
@@ -1862,6 +1866,7 @@ export function DataSources(): JSX.Element {
                   Team
                 </span>
               )}
+              {renderSharedWithTeamPill(integration)}
               {(state === 'connected' || state === 'org-connected') &&
                 integration.lastError &&
                 !isSyncing && (


### PR DESCRIPTION
### Motivation
- Connector rows no longer showed the quick “Shared with team” pill, reducing discoverability of connectors that have any sharing enabled (synced data, query access, or write access).
- Reintroduce a compact, reusable pill so users can see at-a-glance which connectors are shared without opening the detail drawer.

### Description
- Add `renderSharedWithTeamPill` (frontend/src/components/DataSources.tsx) that returns a compact "Shared with team" pill when any sharing flag is set, driven by the existing `isSharedWithTeam` predicate.
- Rewire `renderSharingBadgeBlock` to reuse the new pill and avoid duplicating the sharing predicate.
- Render the shared pill directly in connector rows so shared connectors are visible in the list view as well as in the detail drawer (frontend/src/components/DataSources.tsx).  
- Add a regression test `backend/tests/test_connector_sharing_pill.py` that verifies the pill helper exists, is used in rows, and that the any-flag sharing predicate remains present.

### Testing
- Ran the new unit checks with `pytest backend/tests/test_connector_sharing_pill.py` and they passed (2 tests, 0 failures).  
- Built the frontend with `npm --prefix frontend run build`, which completed successfully.  
- Ran the frontend linter with `npm --prefix frontend run lint`, which completed without reported errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fec2c1740883218555cb7113143b45)