### PR TITLE
Apply monochrome filter to Granola connector icon

### DIFF
--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -34,6 +34,7 @@ import {
   DEFAULT_CONNECTOR_ICON as DEFAULT_ICON,
   DEFAULT_CONNECTOR_COLOR as DEFAULT_COLOR,
   isImageIcon,
+  getImageIconFilterClass,
   getConnectorColorClass as getColorClass,
 } from './shared/ConnectorIcons';
 
@@ -1524,7 +1525,7 @@ export function DataSources(): JSX.Element {
 
   const renderIcon = (iconId: string): JSX.Element => {
     if (isImageIcon(iconId)) {
-      return <img src={iconId} alt="" className="w-full h-full rounded-xl object-cover" />;
+      return <img src={iconId} alt="" className={`w-full h-full rounded-xl object-cover ${getImageIconFilterClass(iconId)}`} />;
     }
     const IconComponent = ICON_MAP[iconId] ?? HiGlobeAlt;
     return <IconComponent className="w-8 h-8" />;
@@ -1532,7 +1533,7 @@ export function DataSources(): JSX.Element {
 
   const renderIconCompact = (iconId: string): JSX.Element => {
     if (isImageIcon(iconId)) {
-      return <img src={iconId} alt="" className="h-6 w-6 rounded-md object-cover" />;
+      return <img src={iconId} alt="" className={`h-6 w-6 rounded-md object-cover ${getImageIconFilterClass(iconId)}`} />;
     }
     const IconComponent = ICON_MAP[iconId] ?? HiGlobeAlt;
     return <IconComponent className="h-5 w-5 text-surface-400" />;
@@ -2625,7 +2626,7 @@ export function DataSources(): JSX.Element {
                     }`}
                   >
                     {isImageIcon(d.icon) ? (
-                      <img src={d.icon} alt="" className="h-full w-full object-cover" />
+                      <img src={d.icon} alt="" className={`h-full w-full object-cover ${getImageIconFilterClass(d.icon)}`} />
                     ) : (
                       renderIcon(d.icon)
                     )}

--- a/frontend/src/components/shared/ConnectorIcons.tsx
+++ b/frontend/src/components/shared/ConnectorIcons.tsx
@@ -148,6 +148,10 @@ export function isImageIcon(iconId: string): boolean {
   return iconId.startsWith("/") || iconId.startsWith("http");
 }
 
+export function getImageIconFilterClass(iconId: string): string {
+  return iconId.includes("/connector-icons/granola.png") ? "grayscale saturate-0" : "";
+}
+
 export function getConnectorColorClass(color: string): string {
   const colorMap: Record<string, string> = {
     "from-orange-500 to-orange-600": "bg-orange-500",
@@ -178,7 +182,7 @@ export function getConnectorColorClass(color: string): string {
 
 export function renderConnectorIcon(iconId: string, sizeClass: string): JSX.Element {
   if (isImageIcon(iconId)) {
-    return <img src={iconId} alt="" className={`${sizeClass} rounded object-cover`} />;
+    return <img src={iconId} alt="" className={`${sizeClass} rounded object-cover ${getImageIconFilterClass(iconId)}`} />;
   }
   const IconComponent = CONNECTOR_ICON_MAP[iconId] ?? HiGlobeAlt;
   return <IconComponent className={sizeClass} />;


### PR DESCRIPTION
### Motivation
- The connectors list should display the Granola icon in monochrome to match design requirements when rendering image-based connector icons.

### Description
- Added `getImageIconFilterClass` helper in `frontend/src/components/shared/ConnectorIcons.tsx` that returns `grayscale saturate-0` for the Granola image path and an empty string otherwise.
- Applied the helper to image rendering paths: `renderConnectorIcon` in `ConnectorIcons.tsx`, `renderIcon` and `renderIconCompact` in `frontend/src/components/DataSources.tsx`, and the connector detail panel image rendering so the Granola image appears monochrome everywhere it is used.
- Updated imports in `DataSources.tsx` to use the new helper and preserved non-image icon rendering.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm run build` and it completed successfully (build emitted chunk-size warnings but finished without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fec587dfc083218373d359412aacf3)