### PR TITLE
Make Granola connector icon monochrome

### DIFF
--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -1530,9 +1530,20 @@ export function DataSources(): JSX.Element {
     return <IconComponent className="w-8 h-8" />;
   };
 
+  const isGranolaImageIcon = (iconId: string): boolean =>
+    iconId.includes('/connector-icons/granola.png');
+
   const renderIconCompact = (iconId: string): JSX.Element => {
     if (isImageIcon(iconId)) {
-      return <img src={iconId} alt="" className="h-6 w-6 rounded-md object-cover" />;
+      return (
+        <img
+          src={iconId}
+          alt=""
+          className={`h-6 w-6 rounded-md object-cover ${
+            isGranolaImageIcon(iconId) ? 'grayscale' : ''
+          }`}
+        />
+      );
     }
     const IconComponent = ICON_MAP[iconId] ?? HiGlobeAlt;
     return <IconComponent className="h-5 w-5 text-surface-400" />;


### PR DESCRIPTION
### Motivation
- Apply a monochrome/grayscale filter specifically to the Granola connector icon in the connectors list so the compact icon matches design intent without affecting other connectors.

### Description
- Added an `isGranolaImageIcon` helper and conditionally applied Tailwind's `grayscale` class to the compact image rendering path in `renderIconCompact` within `frontend/src/components/DataSources.tsx` so only `/connector-icons/granola.png` gets the filter.

### Testing
- Ran `npm run lint` and it completed successfully. 
- Ran `npm run build` (Vite production build) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fec587dfc083218373d359412aacf3)