### PR TITLE
Fix connector sharing pill labels

### DIFF
--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -1637,18 +1637,22 @@ export function DataSources(): JSX.Element {
           ? 'org-connected'
           : 'team-only';
 
-  const renderSharedWithTeamPill = (integration: DisplayIntegration): JSX.Element | null => {
-    if (!isSharedWithTeam(integration)) return null;
+  const renderSharedWithTeamPill = (
+    integration: DisplayIntegration,
+    state: TileState,
+  ): JSX.Element | null => {
+    if (state === 'org-connected' || !isSharedWithTeam(integration)) return null;
+    const label = state === 'team-only' ? 'Shared with you' : 'Shared with team';
     return (
       <span className="inline-flex shrink-0 items-center gap-1 rounded px-2 py-0.5 text-xs bg-primary-500/20 text-primary-400">
         <HiShare className="h-3 w-3" />
-        Shared with team
+        {label}
       </span>
     );
   };
 
   const renderSharingBadgeBlock = (integration: DisplayIntegration, state: TileState): JSX.Element | null => {
-    const sharedPill = renderSharedWithTeamPill(integration);
+    const sharedPill = renderSharedWithTeamPill(integration, state);
     if (sharedPill) return sharedPill;
     if (state !== 'connected') return null;
     return (
@@ -1943,7 +1947,7 @@ export function DataSources(): JSX.Element {
                   Team
                 </span>
               )}
-              {renderSharedWithTeamPill(integration)}
+              {renderSharedWithTeamPill(integration, state)}
               {(state === 'connected' || state === 'org-connected') &&
                 integration.lastError &&
                 !isSyncing && (


### PR DESCRIPTION
### Motivation
- Suppress the "Shared with team" pill for org-scoped `Team connectors` and show a clearer label (`Shared with you`) for user-scoped connectors that were connected by teammates (the "From your team" section). This makes the connectors page and detail drawer accurately reflect sharing context.

### Description
- Change `renderSharedWithTeamPill` in `frontend/src/components/DataSources.tsx` to accept the connector `state: TileState` and return nothing for `org-connected` entries, and to use the label `Shared with you` when `state === 'team-only'`.
- Update all call sites in the connector row and detail drawer to pass the current `state` into the pill renderer so the row and drawer are consistent.
- No backend/API changes; the change is limited to `frontend/src/components/DataSources.tsx`.

### Testing
- Ran the frontend build with `npm run build`, which completed successfully.
- Ran linting with `npm run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fec7cb3ba883219e9676c1e839f5e0)