### PR TITLE
Add DeepSeek (deepseek-4.7) provider and one-million outbound token support

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -35,6 +35,7 @@ from services.llm_adapter import (
 )
 from services.llm_provider import resolve_llm_config
 from services.llm_provider import (
+    get_model_output_token_limit,
     get_model_provider_map,
     provider_for_model,
     resolve_api_key_for_provider,
@@ -1689,13 +1690,21 @@ class ChatOrchestrator:
                         attempt + 1,
                     )
 
+                    output_token_limit = get_model_output_token_limit(model_name)
+                    if output_token_limit != 32_768:
+                        logger.info(
+                            "[Orchestrator] Using model-specific outbound token limit model=%s output_token_limit=%d",
+                            model_name,
+                            output_token_limit,
+                        )
+
                     async for event in adapter.stream(
                         model=model_name,
                         system=system_prompt,
                         messages=api_messages,
                         tools=tool_defs,
                         thinking=True,
-                        max_tokens=32768,
+                        max_tokens=output_token_limit,
                     ):
                         if event.type == "thinking_start":
                             is_thinking_block = True

--- a/backend/config.py
+++ b/backend/config.py
@@ -80,6 +80,9 @@ class Settings(BaseSettings):
     # Qwen / DashScope (OpenAI-compatible LLM provider)
     QWEN_API_KEY: Optional[str] = None
 
+    # DeepSeek (OpenAI-compatible LLM provider)
+    DEEPSEEK_API_KEY: Optional[str] = None
+
     # Google Gemini (OpenAI-compatible LLM provider)
     GEMINI_API_KEY: Optional[str] = None
 

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -25,12 +25,13 @@ logger = logging.getLogger(__name__)
 # Common types
 # ---------------------------------------------------------------------------
 
-LLMProvider = Literal["anthropic", "minimax", "openai", "gemini", "qwen"]
+LLMProvider = Literal["anthropic", "minimax", "openai", "gemini", "qwen", "deepseek"]
 
 PROVIDER_BASE_URLS: dict[str, str] = {
     "minimax": "https://api.minimax.io/anthropic",
     "gemini": "https://generativelanguage.googleapis.com/v1beta/openai/",
     "qwen": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    "deepseek": "https://api.deepseek.com",
 }
 
 PROVIDER_DEFAULT_MODELS: dict[str, dict[str, str]] = {
@@ -39,6 +40,7 @@ PROVIDER_DEFAULT_MODELS: dict[str, dict[str, str]] = {
     "openai": {"primary": "gpt-5.5", "cheap": "gpt-5.5-mini"},
     "gemini": {"primary": "gemini-2.5-pro", "cheap": "gemini-2.5-flash"},
     "qwen": {"primary": "qwen3.6-plus", "cheap": "qwen3-30b-a3b-instruct-2507"},
+    "deepseek": {"primary": "deepseek-4.7", "cheap": "deepseek-4.7"},
 }
 
 
@@ -810,6 +812,7 @@ _PROVIDERS_WITHOUT_DOCUMENT_BLOCKS: frozenset[str] = frozenset({
     "openai",
     "gemini",
     "qwen",
+    "deepseek",
 })
 _PROVIDER_ALIASES: dict[str, str] = {
     "alibaba": "qwen",
@@ -829,7 +832,7 @@ def get_adapter(config: LLMConfig) -> AnthropicAdapter | OpenAIAdapter:
             supports_document_blocks=supports_docs,
         )
 
-    if provider in ("openai", "gemini", "qwen"):
+    if provider in ("openai", "gemini", "qwen", "deepseek"):
         base_url = config.base_url or PROVIDER_BASE_URLS.get(provider)
         supports_docs: bool = provider not in _PROVIDERS_WITHOUT_DOCUMENT_BLOCKS
         return OpenAIAdapter(

--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -3,7 +3,7 @@ Resolve per-org LLM configuration from database + environment variables.
 
 Resolution order for API keys:
 1. LLM_KEY__<org_handle> environment variable (org-specific)
-2. Global provider key (ANTHROPIC_API_KEY, MINIMAX_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, QWEN_API_KEY)
+2. Global provider key (ANTHROPIC_API_KEY, MINIMAX_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, QWEN_API_KEY, DEEPSEEK_API_KEY)
 
 Provider/model resolution:
 1. Organization.llm_provider / llm_primary_model / llm_cheap_model / llm_workflow_model (DB)
@@ -34,6 +34,7 @@ _GLOBAL_PROVIDER_KEYS: dict[str, str | None] = {
     "openai": settings.OPENAI_API_KEY,
     "gemini": getattr(settings, "GEMINI_API_KEY", None),
     "qwen": getattr(settings, "QWEN_API_KEY", None),
+    "deepseek": getattr(settings, "DEEPSEEK_API_KEY", None),
 }
 
 _DEFAULT_PROVIDER: LLMProvider = "anthropic"
@@ -246,6 +247,8 @@ def _infer_provider_from_model_name(model: str) -> str | None:
         return "gemini"
     if normalized.startswith(("qwen", "qwq")):
         return "qwen"
+    if normalized.startswith("deepseek"):
+        return "deepseek"
     if normalized.startswith("minimax"):
         return "minimax"
     return None
@@ -314,11 +317,21 @@ def get_model_max_tokens_map(default_max_tokens: int = 200_000) -> dict[str, int
         "gpt-5.5": 1_000_000,
         "gpt5.5": 1_000_000,
         "qwen3.6-plus": 1_000_000,
+        "deepseek-4.7": 1_000_000,
     }
     return {
         model_name: explicit_windows.get(model_name, default_max_tokens)
         for model_name in raw_model_map
     }
+
+
+def get_model_output_token_limit(model: str, default_max_tokens: int = 32_768) -> int:
+    """Return outbound generation-token limit for models with explicit output windows."""
+    normalized: str = model.strip().lower()
+    explicit_output_limits: dict[str, int] = {
+        "deepseek-4.7": 1_000_000,
+    }
+    return explicit_output_limits.get(normalized, default_max_tokens)
 
 
 def get_allowed_models() -> list[str]:

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -5,7 +5,7 @@ import httpx
 import pytest
 from openai import APIStatusError
 
-from services.llm_adapter import OpenAIAdapter
+from services.llm_adapter import LLMConfig, OpenAIAdapter, PROVIDER_BASE_URLS, get_adapter
 
 
 class _EmptyAsyncIterator:
@@ -227,3 +227,26 @@ async def test_openai_complete_falls_back_when_gpt5_not_found():
     assert create_mock.await_count == 2
     assert create_mock.await_args_list[0].kwargs["model"] == "gpt-5.5"
     assert create_mock.await_args_list[1].kwargs["model"] == "gpt-5"
+
+
+def test_deepseek_adapter_uses_openai_compatible_base_url():
+    adapter = get_adapter(
+        LLMConfig(
+            provider="deepseek",
+            primary_model="deepseek-4.7",
+            cheap_model="deepseek-4.7",
+            workflow_model="deepseek-4.7",
+            api_key="test-key",
+        )
+    )
+
+    assert isinstance(adapter, OpenAIAdapter)
+    assert PROVIDER_BASE_URLS["deepseek"] == "https://api.deepseek.com"
+
+
+def test_deepseek_uses_max_tokens_parameter():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    assert adapter._build_token_limit_kwargs(model="deepseek-4.7", max_tokens=1_000_000) == {
+        "max_tokens": 1_000_000
+    }

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -2,6 +2,7 @@ import asyncio
 
 from services.llm_provider import (
     _infer_provider_from_model_name,
+    get_model_output_token_limit,
     is_model_allowed,
     provider_for_model,
     resolve_api_key_for_provider,
@@ -16,6 +17,7 @@ def test_infer_provider_from_model_name() -> None:
     assert _infer_provider_from_model_name("MiniMax-M2.7-highspeed") == "minimax"
     assert _infer_provider_from_model_name("qwen3-max") == "qwen"
     assert _infer_provider_from_model_name("qwq-plus") == "qwen"
+    assert _infer_provider_from_model_name("deepseek-4.7") == "deepseek"
     assert _infer_provider_from_model_name("some-unknown-model") is None
 
 
@@ -143,7 +145,7 @@ def test_get_model_max_tokens_map_uses_explicit_windows_and_defaults(monkeypatch
     monkeypatch.setattr(
         llm_provider.settings,
         "ALL_MODEL_STRINGS",
-        "claude-opus-4-6:anthropic,gpt-5.5:openai,qwen3.6-plus:alibaba,random-model:openai",
+        "claude-opus-4-6:anthropic,gpt-5.5:openai,qwen3.6-plus:alibaba,deepseek-4.7:deepseek,random-model:openai",
     )
 
     max_tokens_map = llm_provider.get_model_max_tokens_map(default_max_tokens=200_000)
@@ -151,4 +153,39 @@ def test_get_model_max_tokens_map_uses_explicit_windows_and_defaults(monkeypatch
     assert max_tokens_map["claude-opus-4-6"] == 1_000_000
     assert max_tokens_map["gpt-5.5"] == 1_000_000
     assert max_tokens_map["qwen3.6-plus"] == 1_000_000
+    assert max_tokens_map["deepseek-4.7"] == 1_000_000
     assert max_tokens_map["random-model"] == 200_000
+
+
+def test_deepseek_output_token_limit_is_one_million() -> None:
+    assert get_model_output_token_limit("deepseek-4.7") == 1_000_000
+    assert get_model_output_token_limit("gpt-5.5") == 32_768
+
+
+def test_resolve_llm_config_uses_deepseek_defaults(monkeypatch) -> None:
+    from services import llm_provider
+
+    monkeypatch.setattr(llm_provider, "_DEFAULT_PROVIDER", "anthropic")
+    monkeypatch.setitem(llm_provider._GLOBAL_PROVIDER_KEYS, "deepseek", "test-deepseek-key")
+    monkeypatch.setattr(llm_provider.settings, "DEFAULT_PRIMARY_MODEL", "")
+    monkeypatch.setattr(llm_provider.settings, "DEFAULT_CHEAP_MODEL", "")
+    monkeypatch.setattr(llm_provider.settings, "ALL_MODEL_STRINGS", "deepseek-4.7:deepseek")
+
+    class _Org:
+        handle = "acme"
+        llm_provider = None
+        llm_primary_model = "deepseek-4.7"
+        llm_cheap_model = None
+        llm_workflow_model = None
+
+    async def _fake_load_org(_organization_id):
+        return _Org()
+
+    monkeypatch.setattr(llm_provider, "_load_organization_for_llm", _fake_load_org)
+
+    config = asyncio.run(resolve_llm_config("00000000-0000-0000-0000-000000000001"))
+
+    assert config.provider == "deepseek"
+    assert config.primary_model == "deepseek-4.7"
+    assert config.cheap_model == "deepseek-4.7"
+    assert config.api_key == "test-deepseek-key"

--- a/env.example
+++ b/env.example
@@ -15,7 +15,7 @@ DEFAULT_PRIMARY_MODEL=claude-opus-4-6
 DEFAULT_CHEAP_MODEL=claude-haiku-4-5-20251001
 # Comma-separated allowlist of model names for the org settings UI.
 # Empty = no restriction (free-text input). When set, the frontend shows dropdowns.
-# ALL_MODEL_STRINGS=claude-opus-4-6,claude-haiku-4-5-20251001,gpt-5.5,gpt-5.5-mini,gemini-2.5-pro,gemini-2.5-flash,MiniMax-M2.7,MiniMax-M2.7-highspeed,qwen3.6-plus,qwen3-30b-a3b-instruct-2507
+# ALL_MODEL_STRINGS=claude-opus-4-6,claude-haiku-4-5-20251001,gpt-5.5,gpt-5.5-mini,gemini-2.5-pro,gemini-2.5-flash,MiniMax-M2.7,MiniMax-M2.7-highspeed,qwen3.6-plus,qwen3-30b-a3b-instruct-2507,deepseek-4.7:deepseek
 
 # LLM provider API keys
 ANTHROPIC_API_KEY=your_anthropic_api_key
@@ -23,6 +23,7 @@ OPENAI_API_KEY=your_openai_api_key
 # MINIMAX_API_KEY=your_minimax_api_key
 # GEMINI_API_KEY=your_gemini_api_key
 # QWEN_API_KEY=your_qwen_api_key
+# DEEPSEEK_API_KEY=your_deepseek_api_key
 
 # OpenAI research model (embeddings + web search fallback, separate from org LLM config)
 OPENAI_RESEARCH_MODEL=gpt-5.5

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -106,7 +106,7 @@ interface ToolApprovalState {
 }
 
 const DEFAULT_MODEL_MAX_TOKENS = 200_000;
-const ONE_MILLION_TOKEN_MODELS = new Set<string>(['claude-opus-4-6', 'gpt-5.5', 'gpt5.5', 'qwen3.6-plus']);
+const ONE_MILLION_TOKEN_MODELS = new Set<string>(['claude-opus-4-6', 'gpt-5.5', 'gpt5.5', 'qwen3.6-plus', 'deepseek-4.7']);
 
 /**
  * Slack-like message thread typography & layout.

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -136,6 +136,7 @@ const MODEL_FAMILY_DEFAULTS: Record<string, { primary: string; fast: string }> =
   openai: { primary: 'gpt-5.5', fast: 'gpt-5.5-mini' },
   gemini: { primary: 'gemini-2.5-pro', fast: 'gemini-2.5-flash' },
   alibaba: { primary: 'qwen3.6-plus', fast: 'qwen3-30b-a3b-instruct-2507' },
+  deepseek: { primary: 'deepseek-4.7', fast: 'deepseek-4.7' },
 };
 
 const isFastModelCandidate = (modelName: string): boolean => {
@@ -700,6 +701,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
       if (normalized.startsWith('minimax')) return 'minimax';
       if (normalized.startsWith('gemini')) return 'gemini';
       if (normalized.startsWith('qwen') || normalized.startsWith('qwq')) return 'alibaba';
+      if (normalized.startsWith('deepseek')) return 'deepseek';
       if (normalized.startsWith('gpt') || normalized.startsWith('o1') || normalized.startsWith('o3') || normalized.startsWith('o4')) return 'openai';
       return null;
     };


### PR DESCRIPTION
### Motivation
- Introduce a new single-model family `deepseek-4.7` following existing Quen/Opus patterns so DeepSeek can be selected as an LLM provider and have correct defaults.
- Ensure DeepSeek is treated as OpenAI-compatible (base URL + adapter routing) and that the UI and server honor its 1,000,000 outbound generation-token window.

### Description
- Added `DEEPSEEK_API_KEY` to `backend/config.py` and an example entry to `env.example` for global API-key configuration.
- Registered `deepseek` in the adapter/provider mapping by extending `LLMProvider` and `PROVIDER_BASE_URLS` with `"https://api.deepseek.com"`, and added `"deepseek": { primary: "deepseek-4.7", cheap: "deepseek-4.7" }` in `PROVIDER_DEFAULT_MODELS` in `backend/services/llm_adapter.py` so `get_adapter` returns an `OpenAIAdapter` for DeepSeek.
- Implemented provider inference and allowlist support for `deepseek-4.7` in `backend/services/llm_provider.py` and added `get_model_output_token_limit()` which returns a 1,000,000 outbound-token limit for `deepseek-4.7`.
- Wired the outbound token limit into the orchestrator streaming call by calling `get_model_output_token_limit()` and passing the returned value as `max_tokens` in `backend/agents/orchestrator.py`, with a log line when a non-default limit is used.
- Updated frontend model metadata and family defaults so the UI recognizes DeepSeek: `frontend/src/components/OrganizationPanel.tsx` adds the `deepseek` family defaults and model-family inference, and `frontend/src/components/Chat.tsx` adds `deepseek-4.7` to the one-million-token model set for client-side display/behavior.
- Added/updated tests in `backend/tests/test_llm_provider.py` and `backend/tests/test_llm_adapter_openai_token_params.py` to cover provider inference, model-window mapping, adapter routing for DeepSeek, and correct token-parameter behavior.

### Testing
- Ran `pytest backend/tests/test_llm_provider.py backend/tests/test_llm_adapter_openai_token_params.py` and all tests passed (`25 passed`).
- Verified model-window / UI mapping code paths exercise the new `deepseek-4.7` explicit 1,000,000 window and that orchestrator uses `get_model_output_token_limit()` to set `max_tokens` for streaming (tests covering token-parameter selection passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00afc6a0908321b59773b5f48c6903)