### PR TITLE
Replace DeepSeek model name `deepseek-4.7` with `deepseek-v4-pro`

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -40,7 +40,7 @@ PROVIDER_DEFAULT_MODELS: dict[str, dict[str, str]] = {
     "openai": {"primary": "gpt-5.5", "cheap": "gpt-5.5-mini"},
     "gemini": {"primary": "gemini-2.5-pro", "cheap": "gemini-2.5-flash"},
     "qwen": {"primary": "qwen3.6-plus", "cheap": "qwen3-30b-a3b-instruct-2507"},
-    "deepseek": {"primary": "deepseek-4.7", "cheap": "deepseek-4.7"},
+    "deepseek": {"primary": "deepseek-v4-pro", "cheap": "deepseek-v4-pro"},
 }
 
 

--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -317,7 +317,7 @@ def get_model_max_tokens_map(default_max_tokens: int = 200_000) -> dict[str, int
         "gpt-5.5": 1_000_000,
         "gpt5.5": 1_000_000,
         "qwen3.6-plus": 1_000_000,
-        "deepseek-4.7": 1_000_000,
+        "deepseek-v4-pro": 1_000_000,
     }
     return {
         model_name: explicit_windows.get(model_name, default_max_tokens)
@@ -329,7 +329,7 @@ def get_model_output_token_limit(model: str, default_max_tokens: int = 32_768) -
     """Return outbound generation-token limit for models with explicit output windows."""
     normalized: str = model.strip().lower()
     explicit_output_limits: dict[str, int] = {
-        "deepseek-4.7": 1_000_000,
+        "deepseek-v4-pro": 1_000_000,
     }
     return explicit_output_limits.get(normalized, default_max_tokens)
 

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -233,9 +233,9 @@ def test_deepseek_adapter_uses_openai_compatible_base_url():
     adapter = get_adapter(
         LLMConfig(
             provider="deepseek",
-            primary_model="deepseek-4.7",
-            cheap_model="deepseek-4.7",
-            workflow_model="deepseek-4.7",
+            primary_model="deepseek-v4-pro",
+            cheap_model="deepseek-v4-pro",
+            workflow_model="deepseek-v4-pro",
             api_key="test-key",
         )
     )
@@ -247,6 +247,6 @@ def test_deepseek_adapter_uses_openai_compatible_base_url():
 def test_deepseek_uses_max_tokens_parameter():
     adapter = OpenAIAdapter(api_key="test-key")
 
-    assert adapter._build_token_limit_kwargs(model="deepseek-4.7", max_tokens=1_000_000) == {
+    assert adapter._build_token_limit_kwargs(model="deepseek-v4-pro", max_tokens=1_000_000) == {
         "max_tokens": 1_000_000
     }

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -17,7 +17,7 @@ def test_infer_provider_from_model_name() -> None:
     assert _infer_provider_from_model_name("MiniMax-M2.7-highspeed") == "minimax"
     assert _infer_provider_from_model_name("qwen3-max") == "qwen"
     assert _infer_provider_from_model_name("qwq-plus") == "qwen"
-    assert _infer_provider_from_model_name("deepseek-4.7") == "deepseek"
+    assert _infer_provider_from_model_name("deepseek-v4-pro") == "deepseek"
     assert _infer_provider_from_model_name("some-unknown-model") is None
 
 
@@ -145,7 +145,7 @@ def test_get_model_max_tokens_map_uses_explicit_windows_and_defaults(monkeypatch
     monkeypatch.setattr(
         llm_provider.settings,
         "ALL_MODEL_STRINGS",
-        "claude-opus-4-6:anthropic,gpt-5.5:openai,qwen3.6-plus:alibaba,deepseek-4.7:deepseek,random-model:openai",
+        "claude-opus-4-6:anthropic,gpt-5.5:openai,qwen3.6-plus:alibaba,deepseek-v4-pro:deepseek,random-model:openai",
     )
 
     max_tokens_map = llm_provider.get_model_max_tokens_map(default_max_tokens=200_000)
@@ -153,12 +153,12 @@ def test_get_model_max_tokens_map_uses_explicit_windows_and_defaults(monkeypatch
     assert max_tokens_map["claude-opus-4-6"] == 1_000_000
     assert max_tokens_map["gpt-5.5"] == 1_000_000
     assert max_tokens_map["qwen3.6-plus"] == 1_000_000
-    assert max_tokens_map["deepseek-4.7"] == 1_000_000
+    assert max_tokens_map["deepseek-v4-pro"] == 1_000_000
     assert max_tokens_map["random-model"] == 200_000
 
 
 def test_deepseek_output_token_limit_is_one_million() -> None:
-    assert get_model_output_token_limit("deepseek-4.7") == 1_000_000
+    assert get_model_output_token_limit("deepseek-v4-pro") == 1_000_000
     assert get_model_output_token_limit("gpt-5.5") == 32_768
 
 
@@ -169,12 +169,12 @@ def test_resolve_llm_config_uses_deepseek_defaults(monkeypatch) -> None:
     monkeypatch.setitem(llm_provider._GLOBAL_PROVIDER_KEYS, "deepseek", "test-deepseek-key")
     monkeypatch.setattr(llm_provider.settings, "DEFAULT_PRIMARY_MODEL", "")
     monkeypatch.setattr(llm_provider.settings, "DEFAULT_CHEAP_MODEL", "")
-    monkeypatch.setattr(llm_provider.settings, "ALL_MODEL_STRINGS", "deepseek-4.7:deepseek")
+    monkeypatch.setattr(llm_provider.settings, "ALL_MODEL_STRINGS", "deepseek-v4-pro:deepseek")
 
     class _Org:
         handle = "acme"
         llm_provider = None
-        llm_primary_model = "deepseek-4.7"
+        llm_primary_model = "deepseek-v4-pro"
         llm_cheap_model = None
         llm_workflow_model = None
 
@@ -186,6 +186,6 @@ def test_resolve_llm_config_uses_deepseek_defaults(monkeypatch) -> None:
     config = asyncio.run(resolve_llm_config("00000000-0000-0000-0000-000000000001"))
 
     assert config.provider == "deepseek"
-    assert config.primary_model == "deepseek-4.7"
-    assert config.cheap_model == "deepseek-4.7"
+    assert config.primary_model == "deepseek-v4-pro"
+    assert config.cheap_model == "deepseek-v4-pro"
     assert config.api_key == "test-deepseek-key"

--- a/env.example
+++ b/env.example
@@ -15,7 +15,7 @@ DEFAULT_PRIMARY_MODEL=claude-opus-4-6
 DEFAULT_CHEAP_MODEL=claude-haiku-4-5-20251001
 # Comma-separated allowlist of model names for the org settings UI.
 # Empty = no restriction (free-text input). When set, the frontend shows dropdowns.
-# ALL_MODEL_STRINGS=claude-opus-4-6,claude-haiku-4-5-20251001,gpt-5.5,gpt-5.5-mini,gemini-2.5-pro,gemini-2.5-flash,MiniMax-M2.7,MiniMax-M2.7-highspeed,qwen3.6-plus,qwen3-30b-a3b-instruct-2507,deepseek-4.7:deepseek
+# ALL_MODEL_STRINGS=claude-opus-4-6,claude-haiku-4-5-20251001,gpt-5.5,gpt-5.5-mini,gemini-2.5-pro,gemini-2.5-flash,MiniMax-M2.7,MiniMax-M2.7-highspeed,qwen3.6-plus,qwen3-30b-a3b-instruct-2507,deepseek-v4-pro:deepseek
 
 # LLM provider API keys
 ANTHROPIC_API_KEY=your_anthropic_api_key

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -106,7 +106,7 @@ interface ToolApprovalState {
 }
 
 const DEFAULT_MODEL_MAX_TOKENS = 200_000;
-const ONE_MILLION_TOKEN_MODELS = new Set<string>(['claude-opus-4-6', 'gpt-5.5', 'gpt5.5', 'qwen3.6-plus', 'deepseek-4.7']);
+const ONE_MILLION_TOKEN_MODELS = new Set<string>(['claude-opus-4-6', 'gpt-5.5', 'gpt5.5', 'qwen3.6-plus', 'deepseek-v4-pro']);
 
 /**
  * Slack-like message thread typography & layout.

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -136,7 +136,7 @@ const MODEL_FAMILY_DEFAULTS: Record<string, { primary: string; fast: string }> =
   openai: { primary: 'gpt-5.5', fast: 'gpt-5.5-mini' },
   gemini: { primary: 'gemini-2.5-pro', fast: 'gemini-2.5-flash' },
   alibaba: { primary: 'qwen3.6-plus', fast: 'qwen3-30b-a3b-instruct-2507' },
-  deepseek: { primary: 'deepseek-4.7', fast: 'deepseek-4.7' },
+  deepseek: { primary: 'deepseek-v4-pro', fast: 'deepseek-v4-pro' },
 };
 
 const isFastModelCandidate = (modelName: string): boolean => {


### PR DESCRIPTION
### Motivation
- Standardize the DeepSeek model identifier across the codebase to the new name `deepseek-v4-pro`.
- Ensure model defaults and explicit token/window limits remain correct after the rename so UI and backend behavior are consistent.

### Description
- Updated provider default models in `backend/services/llm_adapter.py` to use `deepseek-v4-pro` instead of `deepseek-4.7`.
- Updated explicit max-token and output-token mappings in `backend/services/llm_provider.py` to reference `deepseek-v4-pro`.
- Updated frontend references in `frontend/src/components/Chat.tsx` and `frontend/src/components/OrganizationPanel.tsx` to include `deepseek-v4-pro` in the one-million-token set and family defaults.
- Updated `env.example` and adjusted backend tests in `backend/tests/test_llm_provider.py` and `backend/tests/test_llm_adapter_openai_token_params.py` to assert the new model name.

### Testing
- Ran `python -m pytest backend/tests/test_llm_provider.py backend/tests/test_llm_adapter_openai_token_params.py` and all tests passed (25 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0128af3fd88321b3e5afed03b2e0e5)