### PR TITLE
fix(attio): catch record updates + stop UI clearing spinner before sync starts

### DIFF
--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -842,34 +842,53 @@ async def _ensure_org_admin_can_sync_all(organization_id: str, auth: AuthContext
 
 
 async def _execute_sync_all_integrations(organization_id: str) -> SyncAllResponse:
-    """Enqueue Celery sync for every active integration that supports SYNC."""
+    """Enqueue Celery sync for every active integration that supports SYNC.
+
+    Synchronously stamps ``sync_started_at`` on each integration before
+    enqueuing so the immediate ``/status`` poll from the UI reports
+    "syncing" — see the matching note in ``trigger_sync``.
+    """
+    from sqlalchemy.orm.attributes import flag_modified
+
     try:
         customer_uuid = UUID(organization_id)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid customer ID")
 
+    sync_started_iso: str = datetime.utcnow().isoformat()
     async with get_session(organization_id=organization_id) as session:
         result = await session.execute(
-            select(Integration.connector, Integration.user_id).where(
+            select(Integration).where(
                 Integration.organization_id == customer_uuid,
                 Integration.is_active == True,  # noqa: E712
             )
         )
-        integrations: list[tuple[str, UUID | None]] = list(result.all())
+        integrations: list[Integration] = list(result.scalars().all())
 
-    if not integrations:
-        raise HTTPException(status_code=404, detail="No active integrations found")
+        if not integrations:
+            raise HTTPException(status_code=404, detail="No active integrations found")
+
+        provider_user_pairs: list[tuple[str, UUID | None]] = []
+        for integration in integrations:
+            connector_cls = CONNECTORS.get(integration.connector)
+            if connector_cls is None or Capability.SYNC not in connector_cls.meta.capabilities:
+                continue
+            provider_user_pairs.append((integration.connector, integration.user_id))
+            stats: dict[str, Any] = dict(integration.sync_stats or {})
+            stats["sync_started_at"] = sync_started_iso
+            integration.sync_stats = stats
+            flag_modified(integration, "sync_stats")
+            integration.last_error = None
+        await session.commit()
 
     from workers.tasks.sync import sync_integration
 
     syncing_providers: list[str] = []
-    for prov, integration_user_id in integrations:
-        connector_cls = CONNECTORS.get(prov)
-        if connector_cls is not None and Capability.SYNC in connector_cls.meta.capabilities:
-            if prov not in syncing_providers:
-                syncing_providers.append(prov)
-            uid: str | None = str(integration_user_id) if integration_user_id else None
-            sync_integration.delay(organization_id, prov, uid)
+    for prov, integration_user_id in provider_user_pairs:
+        if prov not in syncing_providers:
+            syncing_providers.append(prov)
+        uid: str | None = str(integration_user_id) if integration_user_id else None
+        sync_integration.delay(organization_id, prov, uid)
 
     return SyncAllResponse(
         status="queued",
@@ -925,22 +944,42 @@ async def trigger_sync(
             detail=f"Provider {provider} does not support sync (query-only connector).",
         )
 
-    # Fetch *all* active integrations for this provider (may be per-user)
+    # Fetch *all* active integrations for this provider (may be per-user) and
+    # synchronously mark them as syncing. Doing the mark in the API process
+    # before enqueuing the Celery task closes a race with the immediate
+    # ``/status`` poll the frontend issues right after this trigger: without
+    # this, the worker hasn't yet called ``mark_sync_started``, so the status
+    # endpoint sees ``last_sync_at`` from the previous run and replies
+    # "completed" — which causes the UI to clear its spinner and stop polling
+    # before the actual sync finishes.
+    from sqlalchemy.orm.attributes import flag_modified
+
+    sync_started_iso: str = datetime.utcnow().isoformat()
     async with get_session(organization_id=organization_id) as session:
         result = await session.execute(
-            select(Integration.user_id).where(
+            select(Integration).where(
                 Integration.organization_id == customer_uuid,
                 Integration.connector == provider,
                 Integration.is_active == True,  # noqa: E712
             )
         )
-        integration_user_ids: list[UUID | None] = list(result.scalars().all())
+        integrations: list[Integration] = list(result.scalars().all())
 
-        if not integration_user_ids:
+        if not integrations:
             raise HTTPException(
                 status_code=404,
                 detail=f"No active {provider} integration found",
             )
+
+        integration_user_ids: list[UUID | None] = []
+        for integration in integrations:
+            integration_user_ids.append(integration.user_id)
+            stats: dict[str, Any] = dict(integration.sync_stats or {})
+            stats["sync_started_at"] = sync_started_iso
+            integration.sync_stats = stats
+            flag_modified(integration, "sync_stats")
+            integration.last_error = None
+        await session.commit()
 
     sync_since_override: datetime | None = parse_sync_since_param(since)
     since_iso: str | None = (

--- a/backend/connectors/attio.py
+++ b/backend/connectors/attio.py
@@ -488,17 +488,35 @@ After connecting and syncing, query SQL on `contacts`, `accounts`, `deals`, `act
         assert last_exc is not None
         raise last_exc
 
-    def _incremental_record_filter(self) -> dict[str, Any] | None:
-        """Incremental filter for record queries (sync_since).
+    # Object types where Attio's `last_interaction` system attribute is
+    # available. `last_interaction` aggregates email + calendar interactions
+    # and is updated whenever the record is touched, so filtering on it lets
+    # us catch records that were *updated* (not just created) since last sync.
+    # Per Attio v2 docs, this is supported on people and companies. Deals do
+    # not expose a queryable "last modified" timestamp; we fall back to
+    # `created_at` only for those (see ``_incremental_record_filter_for``).
+    _OBJECTS_WITH_LAST_INTERACTION: frozenset[str] = frozenset({"people", "companies"})
 
-        Use only ``created_at`` — attributes like ``last_email_interaction`` are
-        not on every object (e.g. companies/deals) and may be absent in some
-        workspaces, which makes Attio return 400 ``Unknown attribute slug``.
+    def _incremental_record_filter_for(
+        self, object_slug: str
+    ) -> dict[str, Any] | None:
+        """Incremental filter for a specific object type.
+
+        Catches records *created* AND *updated/interacted with* since the last
+        successful sync, where Attio supports it. Object types differ in which
+        timestamps are filterable; emitting an unknown slug returns
+        ``400 Unknown attribute slug``, so we whitelist per object type.
         """
         if self.sync_since is None:
             return None
         iso: str = _iso_utc_z(self.sync_since)
-        return {"created_at": {"$gte": iso}}
+        created_clause: dict[str, Any] = {"created_at": {"$gte": iso}}
+        if object_slug not in self._OBJECTS_WITH_LAST_INTERACTION:
+            return created_clause
+        last_interaction_clause: dict[str, Any] = {
+            "last_interaction": {"interacted_at": {"$gte": iso}}
+        }
+        return {"$or": [created_clause, last_interaction_clause]}
 
     async def _paginate_object_records(
         self,
@@ -506,7 +524,9 @@ After connecting and syncing, query SQL on `contacts`, `accounts`, `deals`, `act
         *,
         extra_filter: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
-        base_filter: dict[str, Any] | None = self._incremental_record_filter()
+        base_filter: dict[str, Any] | None = self._incremental_record_filter_for(
+            object_slug
+        )
         merged_filter: dict[str, Any] | None
         if base_filter and extra_filter:
             merged_filter = {"$and": [base_filter, extra_filter]}
@@ -517,6 +537,7 @@ After connecting and syncing, query SQL on `contacts`, `accounts`, `deals`, `act
 
         out: list[dict[str, Any]] = []
         offset: int = 0
+        attempted_fallback: bool = False
         while True:
             body: dict[str, Any] = {
                 "limit": DEFAULT_PAGE_LIMIT_RECORDS,
@@ -525,11 +546,42 @@ After connecting and syncing, query SQL on `contacts`, `accounts`, `deals`, `act
             if merged_filter:
                 body["filter"] = merged_filter
 
-            data: dict[str, Any] = await self._make_request(
-                "POST",
-                f"/v2/objects/{object_slug}/records/query",
-                json_body=body,
-            )
+            try:
+                data: dict[str, Any] = await self._make_request(
+                    "POST",
+                    f"/v2/objects/{object_slug}/records/query",
+                    json_body=body,
+                )
+            except httpx.HTTPStatusError as exc:
+                # Defensive fallback: if Attio rejects an attribute slug we
+                # assumed was supported (e.g. workspace customization disabled
+                # `last_interaction`), retry once with `created_at` only so the
+                # sync still picks up newly-created records instead of failing.
+                response: httpx.Response | None = exc.response
+                status_code: int | None = (
+                    response.status_code if response is not None else None
+                )
+                if (
+                    status_code == 400
+                    and not attempted_fallback
+                    and base_filter is not None
+                    and "Unknown attribute slug" in str(exc)
+                ):
+                    logger.warning(
+                        "Attio %s incremental filter rejected (%s); "
+                        "falling back to created_at-only filter",
+                        object_slug,
+                        exc,
+                    )
+                    iso_fallback: str = _iso_utc_z(self.sync_since) if self.sync_since else ""
+                    created_only: dict[str, Any] = {"created_at": {"$gte": iso_fallback}}
+                    if extra_filter is not None:
+                        merged_filter = {"$and": [created_only, extra_filter]}
+                    else:
+                        merged_filter = created_only
+                    attempted_fallback = True
+                    continue
+                raise
             rows: Any = data.get("data", [])
             if not isinstance(rows, list):
                 break

--- a/backend/tests/test_attio_connector.py
+++ b/backend/tests/test_attio_connector.py
@@ -477,3 +477,139 @@ async def test_execute_action_unknown_raises() -> None:
     c = _connector()
     with pytest.raises(ValueError, match="Unknown Attio action"):
         await c.execute_action("not_real", {})
+
+
+def test_incremental_filter_returns_none_when_no_sync_since() -> None:
+    c = _connector()
+    assert c._incremental_record_filter_for("people") is None
+    assert c._incremental_record_filter_for("companies") is None
+    assert c._incremental_record_filter_for("deals") is None
+
+
+def test_incremental_filter_includes_last_interaction_for_people_and_companies() -> None:
+    c = _connector()
+    cutoff: datetime = datetime(2026, 1, 1, 0, 0, 0)
+    c._sync_since_override = cutoff
+    iso: str = "2026-01-01T00:00:00.000Z"
+
+    expected_or: dict[str, Any] = {
+        "$or": [
+            {"created_at": {"$gte": iso}},
+            {"last_interaction": {"interacted_at": {"$gte": iso}}},
+        ]
+    }
+    assert c._incremental_record_filter_for("people") == expected_or
+    assert c._incremental_record_filter_for("companies") == expected_or
+
+
+def test_incremental_filter_uses_created_at_only_for_deals() -> None:
+    c = _connector()
+    cutoff: datetime = datetime(2026, 1, 1, 0, 0, 0)
+    c._sync_since_override = cutoff
+    iso: str = "2026-01-01T00:00:00.000Z"
+
+    assert c._incremental_record_filter_for("deals") == {"created_at": {"$gte": iso}}
+
+
+@pytest.mark.asyncio
+async def test_paginate_object_records_uses_per_object_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    c = _connector()
+    cutoff: datetime = datetime(2026, 1, 1, 0, 0, 0)
+    c._sync_since_override = cutoff
+    iso: str = "2026-01-01T00:00:00.000Z"
+
+    captured: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    async def fake_make_request(
+        self: AttioConnector,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        captured.append((method, endpoint, json_body))
+        return {"data": []}
+
+    monkeypatch.setattr(AttioConnector, "_make_request", fake_make_request)
+    monkeypatch.setattr(AttioConnector, "ensure_sync_active", _noop_ensure_sync_active)
+
+    await c.sync_contacts()
+    await c.sync_deals()
+
+    assert len(captured) == 2
+
+    people_body: dict[str, Any] | None = captured[0][2]
+    assert people_body is not None
+    assert people_body.get("filter") == {
+        "$or": [
+            {"created_at": {"$gte": iso}},
+            {"last_interaction": {"interacted_at": {"$gte": iso}}},
+        ]
+    }
+
+    deals_body: dict[str, Any] | None = captured[1][2]
+    assert deals_body is not None
+    assert deals_body.get("filter") == {"created_at": {"$gte": iso}}
+
+
+@pytest.mark.asyncio
+async def test_paginate_falls_back_to_created_at_on_unknown_attribute_slug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If Attio rejects ``last_interaction`` with 400, we must retry once with
+    ``created_at`` only so a workspace where the attribute is missing still
+    syncs newly-created records instead of failing the whole sync."""
+    import httpx
+
+    c = _connector()
+    cutoff: datetime = datetime(2026, 1, 1, 0, 0, 0)
+    c._sync_since_override = cutoff
+    iso: str = "2026-01-01T00:00:00.000Z"
+
+    bodies_seen: list[dict[str, Any] | None] = []
+    call_count: dict[str, int] = {"n": 0}
+
+    async def fake_make_request(
+        self: AttioConnector,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        bodies_seen.append(json_body)
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            request: httpx.Request = httpx.Request(method, f"https://api.attio.com{endpoint}")
+            response: httpx.Response = httpx.Response(
+                400,
+                request=request,
+                json={"message": "Unknown attribute slug: last_interaction"},
+            )
+            raise httpx.HTTPStatusError(
+                "Attio API error (400): Unknown attribute slug: last_interaction",
+                request=request,
+                response=response,
+            )
+        return {"data": [{"id": {"record_id": "p-1"}, "values": {}}]}
+
+    monkeypatch.setattr(AttioConnector, "_make_request", fake_make_request)
+    monkeypatch.setattr(AttioConnector, "ensure_sync_active", _noop_ensure_sync_active)
+
+    rows: list[dict[str, Any]] = await c._paginate_object_records("people")
+
+    assert len(bodies_seen) == 2
+    assert bodies_seen[0] is not None
+    assert bodies_seen[0].get("filter") == {
+        "$or": [
+            {"created_at": {"$gte": iso}},
+            {"last_interaction": {"interacted_at": {"$gte": iso}}},
+        ]
+    }
+    assert bodies_seen[1] is not None
+    assert bodies_seen[1].get("filter") == {"created_at": {"$gte": iso}}
+    assert len(rows) == 1
+    assert rows[0]["id"]["record_id"] == "p-1"


### PR DESCRIPTION
## Summary

Resolves two bugs that surfaced together as *"Attio sync hangs in production"*:

### 1. Incremental sync only matched newly-*created* records

`backend/connectors/attio.py` filtered every object-type query with `created_at >= last_sync_at`, so edits to existing people / companies / deals in Attio were silently dropped.

- New per-object-type filter (`_incremental_record_filter_for`) also matches `last_interaction.interacted_at` for `people` and `companies` (Attio's universal *last-touched* timestamp).
- Keeps `created_at`-only for `deals` (Attio doesn't expose a queryable last-modified there).
- Defensive fallback: on `400 Unknown attribute slug`, retry once with `created_at`-only so workspaces that disabled `last_interaction` still partially sync instead of failing the whole run.

### 2. UI cleared its sync spinner before the worker even started

`POST /api/sync/{organization_id}/{provider}` enqueued the Celery task with `sync_integration.delay(...)` without stamping `sync_started_at` first. The frontend polls `/status` every 2s right after the trigger; if the first poll happened before the worker called `mark_sync_started`, the endpoint saw `last_sync_at` from the previous run and returned `"completed"` — so the spinner cleared and polling stopped while the actual sync was still queued.

`trigger_sync` and `_execute_sync_all_integrations` now stamp `sync_started_at` synchronously **before** enqueuing, so the immediate `/status` poll correctly returns `"syncing"` and the UI keeps polling until the run actually finishes.

Production logs from the affected org confirmed the diagnosis: the worker task `succeeded in 9.5s` with `{accounts:0, deals:0, contacts:0, activities:0}` (correct incremental result given no recent creates), but the UI saw only one status poll after the trigger.

## Test plan

- [x] `pytest -q tests` — 782 passed
- [x] `npm run build` (frontend) — passed
- [x] New tests in `backend/tests/test_attio_connector.py` (5 cases): per-object filter shape, deals fallback, `last_interaction` for people/companies, end-to-end pagination filter, and 400 fallback to `created_at`-only.
- [ ] Verify in staging: trigger Attio sync, confirm spinner stays up for the full ~10s run and clears to a fresh `last_sync_at` afterwards.
- [ ] Edit a deal/contact in Attio, trigger sync, and confirm the change flows through (records were touched recently → caught by `last_interaction` filter for people/companies).

Made with [Cursor](https://cursor.com)