### PR TITLE
feat(attio): add delete operations for people/companies/deals/notes

### DIFF
--- a/backend/connectors/attio.py
+++ b/backend/connectors/attio.py
@@ -324,6 +324,38 @@ class AttioConnector(BaseConnector):
                     {"name": "format", "type": "string", "required": False, "description": "plaintext or markdown"},
                 ],
             ),
+            WriteOperation(
+                name="delete_person",
+                entity_type="contact",
+                description="Permanently delete an Attio person record by record_id",
+                parameters=[
+                    {"name": "id", "type": "string", "required": True, "description": "Attio person record_id"},
+                ],
+            ),
+            WriteOperation(
+                name="delete_company",
+                entity_type="company",
+                description="Permanently delete an Attio company record by record_id",
+                parameters=[
+                    {"name": "id", "type": "string", "required": True, "description": "Attio company record_id"},
+                ],
+            ),
+            WriteOperation(
+                name="delete_deal",
+                entity_type="deal",
+                description="Permanently delete an Attio deal record by record_id",
+                parameters=[
+                    {"name": "id", "type": "string", "required": True, "description": "Attio deal record_id"},
+                ],
+            ),
+            WriteOperation(
+                name="delete_note",
+                entity_type="note",
+                description="Permanently delete an Attio note by note_id",
+                parameters=[
+                    {"name": "id", "type": "string", "required": True, "description": "Attio note_id"},
+                ],
+            ),
         ],
         actions=[
             ConnectorAction(
@@ -411,6 +443,8 @@ After connecting and syncing, query SQL on `contacts`, `accounts`, `deals`, `act
 - **create_deal** — Required: `name`, `stage` (must match a configured pipeline status **title** or **status UUID**), and **either** `owner_email` **or** `owner_workspace_member_id`. Call **`list_statuses`** first (default: deals + stage) to see exact titles/IDs for this workspace—do not guess. Optional: `value`, `currency`, `company_id`. **Custom attributes:** pass Attio attribute **api_slug** as extra top-level keys (e.g. `pipeline_type`) or grouped under optional `values` — each value is sent as-is in `data.values` per [Attio deals API](https://docs.attio.com/rest-api/endpoint-reference/deals/create-a-deal-record).
 - **update_deal** — Required: `id`. Optional: `name`, `stage`, `owner_email`, `owner_workspace_member_id`, `value`, `currency`, `company_id`. Same **custom attributes** rules as `create_deal`.
 - **create_note** — Required: `parent_object`, `parent_record_id`, `title`, `content`. Optional: `format` (`plaintext`|`markdown`).
+- **delete_person** / **delete_company** / **delete_deal** — Required: `id` (Attio `record_id`). Permanently deletes the record in Attio (irreversible). Use to clean up duplicates or unwanted records.
+- **delete_note** — Required: `id` (Attio `note_id`). Permanently deletes the note (irreversible).
 
 ## Actions (`run_on_connector`)
 
@@ -1112,22 +1146,58 @@ After connecting and syncing, query SQL on `contacts`, `accounts`, `deals`, `act
                     },
                 },
             )
+        if operation in ("delete_person", "delete_company", "delete_deal"):
+            object_slug: str = {
+                "delete_person": "people",
+                "delete_company": "companies",
+                "delete_deal": "deals",
+            }[operation]
+            id_key: str = {
+                "delete_person": "person_id",
+                "delete_company": "company_id",
+                "delete_deal": "deal_id",
+            }[operation]
+            rid: str = str(d.pop(id_key, None) or d.pop("id", "") or "").strip()
+            if not rid:
+                raise ValueError(f"{operation} requires id")
+            await self._make_request(
+                "DELETE",
+                f"/v2/objects/{object_slug}/records/{rid}",
+            )
+            return {"deleted": True, "id": rid, "object": object_slug}
+        if operation == "delete_note":
+            nid: str = str(d.pop("note_id", None) or d.pop("id", "") or "").strip()
+            if not nid:
+                raise ValueError("delete_note requires id")
+            await self._make_request("DELETE", f"/v2/notes/{nid}")
+            return {"deleted": True, "id": nid, "object": "notes"}
         raise ValueError(f"Unknown Attio write operation: {operation}")
 
     async def capture_before_state(self, operation: str, data: dict[str, Any]) -> dict[str, Any] | None:
+        # Mapping of operations that target a specific record to the (object_slug, id_key)
+        # used to fetch the current record state for the action ledger. Captures
+        # both update_* (so we can show the diff) and delete_* (so the deletion
+        # is recoverable / auditable).
+        record_lookups: dict[str, tuple[str, str]] = {
+            "update_person": ("people", "person_id"),
+            "update_company": ("companies", "company_id"),
+            "update_deal": ("deals", "deal_id"),
+            "delete_person": ("people", "person_id"),
+            "delete_company": ("companies", "company_id"),
+            "delete_deal": ("deals", "deal_id"),
+        }
         try:
-            if operation == "update_person":
-                rid: str = str(data.get("id") or data.get("person_id") or "").strip()
+            if operation in record_lookups:
+                object_slug, id_key = record_lookups[operation]
+                rid: str = str(data.get("id") or data.get(id_key) or "").strip()
                 if rid:
-                    return await self._make_request("GET", f"/v2/objects/people/records/{rid}")
-            if operation == "update_company":
-                rid2: str = str(data.get("id") or data.get("company_id") or "").strip()
-                if rid2:
-                    return await self._make_request("GET", f"/v2/objects/companies/records/{rid2}")
-            if operation == "update_deal":
-                rid3: str = str(data.get("id") or data.get("deal_id") or "").strip()
-                if rid3:
-                    return await self._make_request("GET", f"/v2/objects/deals/records/{rid3}")
+                    return await self._make_request(
+                        "GET", f"/v2/objects/{object_slug}/records/{rid}"
+                    )
+            if operation == "delete_note":
+                nid: str = str(data.get("id") or data.get("note_id") or "").strip()
+                if nid:
+                    return await self._make_request("GET", f"/v2/notes/{nid}")
         except Exception:
             return None
         return None

--- a/backend/tests/test_attio_connector.py
+++ b/backend/tests/test_attio_connector.py
@@ -556,6 +556,146 @@ async def test_paginate_object_records_uses_per_object_filter(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "operation,object_slug,id_key",
+    [
+        ("delete_person", "people", "person_id"),
+        ("delete_company", "companies", "company_id"),
+        ("delete_deal", "deals", "deal_id"),
+    ],
+)
+async def test_write_delete_record_dispatches_to_object_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    object_slug: str,
+    id_key: str,
+) -> None:
+    c = _connector()
+    recorded: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    async def fake_make_request(
+        self: AttioConnector,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        recorded.append((method, endpoint, json_body))
+        return {}
+
+    async def fake_token(self: AttioConnector) -> tuple[str, str]:
+        return ("tok", "")
+
+    monkeypatch.setattr(AttioConnector, "_make_request", fake_make_request)
+    monkeypatch.setattr(AttioConnector, "get_oauth_token", fake_token)
+
+    rid: str = "abc123-record-id"
+    result_by_id: dict[str, Any] = await c.write(operation, {"id": rid})
+    assert result_by_id == {"deleted": True, "id": rid, "object": object_slug}
+    assert recorded[-1] == ("DELETE", f"/v2/objects/{object_slug}/records/{rid}", None)
+
+    rid2: str = "xyz789-record-id"
+    result_by_typed: dict[str, Any] = await c.write(operation, {id_key: rid2})
+    assert result_by_typed == {"deleted": True, "id": rid2, "object": object_slug}
+    assert recorded[-1] == ("DELETE", f"/v2/objects/{object_slug}/records/{rid2}", None)
+
+
+@pytest.mark.asyncio
+async def test_write_delete_note_uses_notes_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    c = _connector()
+    recorded: list[tuple[str, str]] = []
+
+    async def fake_make_request(
+        self: AttioConnector,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        recorded.append((method, endpoint))
+        return {}
+
+    async def fake_token(self: AttioConnector) -> tuple[str, str]:
+        return ("tok", "")
+
+    monkeypatch.setattr(AttioConnector, "_make_request", fake_make_request)
+    monkeypatch.setattr(AttioConnector, "get_oauth_token", fake_token)
+
+    nid: str = "note-uuid-1"
+    result: dict[str, Any] = await c.write("delete_note", {"id": nid})
+    assert result == {"deleted": True, "id": nid, "object": "notes"}
+    assert recorded == [("DELETE", f"/v2/notes/{nid}")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "operation",
+    ["delete_person", "delete_company", "delete_deal", "delete_note"],
+)
+async def test_write_delete_requires_id(operation: str) -> None:
+    c = _connector()
+    with pytest.raises(ValueError, match="requires id"):
+        await c.write(operation, {})
+
+
+@pytest.mark.asyncio
+async def test_capture_before_state_for_delete_operations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """capture_before_state must fetch the existing record for delete_* ops so
+    the action ledger preserves an auditable copy of what was destroyed."""
+    c = _connector()
+    fetched: list[tuple[str, str]] = []
+
+    async def fake_make_request(
+        self: AttioConnector,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        fetched.append((method, endpoint))
+        return {"data": {"id": {"record_id": "rec-1"}, "values": {"name": "Old"}}}
+
+    async def fake_token(self: AttioConnector) -> tuple[str, str]:
+        return ("tok", "")
+
+    monkeypatch.setattr(AttioConnector, "_make_request", fake_make_request)
+    monkeypatch.setattr(AttioConnector, "get_oauth_token", fake_token)
+
+    snap_person: dict[str, Any] | None = await c.capture_before_state(
+        "delete_person", {"id": "p-1"}
+    )
+    snap_company: dict[str, Any] | None = await c.capture_before_state(
+        "delete_company", {"id": "c-1"}
+    )
+    snap_deal: dict[str, Any] | None = await c.capture_before_state(
+        "delete_deal", {"id": "d-1"}
+    )
+    snap_note: dict[str, Any] | None = await c.capture_before_state(
+        "delete_note", {"id": "n-1"}
+    )
+
+    assert snap_person is not None and snap_company is not None
+    assert snap_deal is not None and snap_note is not None
+    assert fetched == [
+        ("GET", "/v2/objects/people/records/p-1"),
+        ("GET", "/v2/objects/companies/records/c-1"),
+        ("GET", "/v2/objects/deals/records/d-1"),
+        ("GET", "/v2/notes/n-1"),
+    ]
+
+
+def test_meta_includes_delete_write_operations() -> None:
+    c = _connector()
+    op_names: set[str] = {op.name for op in c.meta.write_operations}
+    assert {"delete_person", "delete_company", "delete_deal", "delete_note"} <= op_names
+
+
+@pytest.mark.asyncio
 async def test_paginate_falls_back_to_created_at_on_unknown_attribute_slug(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

The Attio connector previously exposed only `create_*` and `update_*`, so the agent couldn't clean up duplicates or unwanted records (e.g. the duplicate Gilead and Cro Metrics deals it had to flag manually). Adds four new `WriteOperation`s:

- **`delete_person`** → `DELETE /v2/objects/people/records/{id}`
- **`delete_company`** → `DELETE /v2/objects/companies/records/{id}`
- **`delete_deal`** → `DELETE /v2/objects/deals/records/{id}`
- **`delete_note`** → `DELETE /v2/notes/{id}`

Each returns `{"deleted": true, "id": ..., "object": ...}`. Both `id` and the typed alias (`person_id` / `company_id` / `deal_id` / `note_id`) are accepted.

`capture_before_state` is extended to fetch the existing record before each delete, so the action ledger preserves an auditable copy of what was destroyed (delete is irreversible in Attio).

The existing `record_permission:read-write` OAuth scope already grants delete permission, so no scope changes are required.

## Out of scope

- Local DB cleanup of synced rows after a remote delete. Today the next sync will not re-fetch the deleted record but won't remove the local copy either; that's a separate concern (incremental sync only signals creates/updates, not deletes).

## Test plan

- [x] `pytest -q tests/test_attio_connector.py` — 28 passed (10 new tests covering dispatch, id/alias acceptance, validation, before-state capture, and meta exposure)
- [x] `pytest -q tests` — 784 passed
- [x] `npm run build` (frontend) — passed
- [ ] Verify in product: ask the agent to delete a duplicate deal in Attio and confirm both the action ledger contains the before-state and the record is gone in Attio.

Made with [Cursor](https://cursor.com)