### PR TITLE
Support DeepSeek thinking-mode `reasoning_content` in OpenAI adapter and orchestrator

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1664,6 +1664,8 @@ class ChatOrchestrator:
         # Prepare messages for the target provider's API format
         tool_defs = get_tool_defs_for_context(self.workflow_context)
 
+        has_deepseek_tool_turn = False
+
         while True:
             # Track state for this streaming response
             current_text = ""
@@ -1887,6 +1889,17 @@ class ChatOrchestrator:
             
             # If no tool calls, we're done
             if not tool_uses:
+                # A final answer after one or more DeepSeek tool sub-turns can
+                # include additional reasoning_content. Persist it with the saved
+                # turn so future history reloads can replay the full DeepSeek
+                # reasoning_content contract for tool-using turns.
+                if (
+                    has_deepseek_tool_turn
+                    and is_deepseek_model(model_name)
+                    and current_thinking_text.strip()
+                ):
+                    content_blocks.append({"type": "thinking", "thinking": current_thinking_text})
+
                 # Save text to content_blocks
                 if current_text.strip():
                     content_blocks.append({"type": "text", "text": current_text})
@@ -1899,10 +1912,13 @@ class ChatOrchestrator:
 
                 break
 
+            is_deepseek_tool_turn = is_deepseek_model(model_name)
+            has_deepseek_tool_turn = has_deepseek_tool_turn or is_deepseek_tool_turn
+
             # Persist DeepSeek thinking before tool calls so later turns can
             # replay it as reasoning_content. Other provider thinking blocks are
             # deliberately not stored here because their replay contracts differ.
-            if is_deepseek_model(model_name) and current_thinking_text.strip():
+            if is_deepseek_tool_turn and current_thinking_text.strip():
                 content_blocks.append({"type": "thinking", "thinking": current_thinking_text})
 
             # Flush current text to content_blocks before processing tools
@@ -2382,34 +2398,40 @@ class ChatOrchestrator:
                     tool_uses = [b for b in blocks if b.get("type") == "tool_use"]
                     
                     if tool_uses:
-                        # Need to reconstruct the conversation properly:
-                        # 1. assistant: [pre-tool text + tool_use]
-                        # 2. user: [tool_result]
-                        # 3. assistant: [post-tool text] (if any)
-                        
-                        # Collect blocks before and after tool use
-                        pre_tool_thinking: list[str] = []
-                        pre_tool_text: list[str] = []
-                        post_tool_text: list[str] = []
-                        current_tool_uses: list[dict[str, Any]] = []
+                        # Reconstruct saved tool turns as provider-agnostic
+                        # assistant/tool-result sub-turns. DeepSeek thinking-mode
+                        # can produce reasoning before each chained tool call (and
+                        # again before the final answer), so keep thinking blocks
+                        # with the assistant sub-turn that immediately follows them
+                        # when explicitly requested by the selected model path.
+                        assistant_blocks: list[dict[str, Any]] = []
                         tool_results: list[dict[str, Any]] = []
-                        seen_tool = False
-                        
+
+                        def flush_tool_subturn() -> None:
+                            nonlocal assistant_blocks, tool_results
+                            if assistant_blocks:
+                                history.append({"role": "assistant", "content": assistant_blocks})
+                            if tool_results:
+                                history.append({"role": "user", "content": tool_results})
+                            assistant_blocks = []
+                            tool_results = []
+
                         for block in blocks:
-                            if block.get("type") == "thinking":
+                            block_type = block.get("type")
+                            if block_type == "thinking":
+                                if tool_results:
+                                    flush_tool_subturn()
                                 thinking = block.get("thinking", "").strip()
-                                if include_thinking_blocks and thinking and not seen_tool:
-                                    pre_tool_thinking.append(thinking)
-                            elif block.get("type") == "text":
+                                if include_thinking_blocks and thinking:
+                                    assistant_blocks.append({"type": "thinking", "thinking": thinking})
+                            elif block_type == "text":
+                                if tool_results:
+                                    flush_tool_subturn()
                                 text = block.get("text", "").strip()
                                 if text:
-                                    if not seen_tool:
-                                        pre_tool_text.append(text)
-                                    else:
-                                        post_tool_text.append(text)
-                            elif block.get("type") == "tool_use":
-                                seen_tool = True
-                                tool_id = block.get("id", f"tool_{len(current_tool_uses)}")
+                                    assistant_blocks.append({"type": "text", "text": text})
+                            elif block_type == "tool_use":
+                                tool_id = block.get("id", f"tool_{len(tool_results)}")
                                 tool_name = block.get("name", "unknown")
                                 tool_result = block.get("result")
                                 
@@ -2420,7 +2442,7 @@ class ChatOrchestrator:
                                     str(tool_result)[:200] if tool_result else "NO RESULT"
                                 )
                                 
-                                current_tool_uses.append({
+                                assistant_blocks.append({
                                     "type": "tool_use",
                                     "id": tool_id,
                                     "name": tool_name,
@@ -2441,37 +2463,26 @@ class ChatOrchestrator:
                                         "tool_use_id": tool_id,
                                         "content": json.dumps({"error": "Result not available - tool execution may have failed"}),
                                     })
-                        
-                        # Build assistant message with pre-tool thinking + text + tool_use
-                        claude_blocks: list[dict[str, Any]] = []
-                        for thinking in pre_tool_thinking:
-                            claude_blocks.append({"type": "thinking", "thinking": thinking})
-                        for text in pre_tool_text:
-                            claude_blocks.append({"type": "text", "text": text})
-                        claude_blocks.extend(current_tool_uses)
-                        
-                        if claude_blocks:
-                            history.append({"role": "assistant", "content": claude_blocks})
-                        
-                        # Add tool_result as user message
+
                         if tool_results:
-                            history.append({"role": "user", "content": tool_results})
-                        
-                        # Add post-tool text as assistant continuation
-                        # Must have an assistant message after tool_result to avoid consecutive user messages
-                        if post_tool_text:
-                            history.append({"role": "assistant", "content": " ".join(post_tool_text)})
-                        else:
-                            # Build a summary of tool results to help Claude understand context
+                            flush_tool_subturn()
+                        elif assistant_blocks:
+                            history.append({"role": "assistant", "content": assistant_blocks})
+
+                        # Preserve the existing invariant that a reconstructed
+                        # saved tool turn does not leave history ending with a
+                        # tool-result user message when no final assistant text
+                        # was saved after the tool completed.
+                        if history and history[-1].get("role") == "user":
                             result_summaries: list[str] = []
-                            for tr in tool_results:
+                            for tr in history[-1].get("content", []):
                                 try:
                                     content = json.loads(tr.get("content", "{}"))
                                     if "rows" in content:
                                         result_summaries.append(f"{content.get('row_count', len(content['rows']))} rows returned")
                                     elif "error" in content:
                                         result_summaries.append(f"error: {content['error'][:50]}")
-                                except:
+                                except Exception:
                                     pass
                             summary = ", ".join(result_summaries) if result_summaries else "results processed"
                             history.append({"role": "assistant", "content": f"Tool results: {summary}. I'll analyze these results."})

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -32,6 +32,7 @@ from services.llm_adapter import (
     OpenAIAdapter,
     StreamEvent,
     get_adapter,
+    is_deepseek_model,
 )
 from services.llm_provider import resolve_llm_config
 from services.llm_provider import (
@@ -2095,10 +2096,11 @@ class ChatOrchestrator:
                 break
 
             # Build assistant history from tracked state (provider-agnostic).
-            # Preserve thinking so DeepSeek thinking-mode tool turns can be replayed
-            # with reasoning_content in subsequent API calls.
+            # Only DeepSeek-family models need streamed thinking replayed as
+            # reasoning_content on tool turns; other providers (for example
+            # Anthropic) have provider-specific requirements for thinking blocks.
             assistant_content: list[dict[str, Any]] = []
-            if current_thinking_text.strip():
+            if is_deepseek_model(model_name) and current_thinking_text.strip():
                 assistant_content.append({"type": "thinking", "thinking": current_thinking_text})
             if current_text.strip():
                 assistant_content.append({"type": "text", "text": current_text})

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1659,6 +1659,7 @@ class ChatOrchestrator:
         while True:
             # Track state for this streaming response
             current_text = ""
+            current_thinking_text = ""
             tool_uses: list[dict[str, Any]] = []
             current_tool: dict[str, Any] | None = None
             current_tool_input_json = ""
@@ -1676,6 +1677,7 @@ class ChatOrchestrator:
                 try:
                     # Reset state on retry
                     current_text = ""
+                    current_thinking_text = ""
                     tool_uses = []
                     current_tool = None
                     current_tool_input_json = ""
@@ -1711,6 +1713,8 @@ class ChatOrchestrator:
                             yield _json_dumps({"type": "thinking_start"})
 
                         elif event.type == "thinking_delta":
+                            thinking_chunk = event.text or ""
+                            current_thinking_text += thinking_chunk
                             yield _json_dumps({
                                 "type": "thinking_delta",
                                 "text": event.text,
@@ -2091,9 +2095,11 @@ class ChatOrchestrator:
                 break
 
             # Build assistant history from tracked state (provider-agnostic).
-            # For Anthropic-family: thinking blocks are preserved for reasoning continuity.
-            # For OpenAI-family: only text + tool_use blocks.
+            # Preserve thinking so DeepSeek thinking-mode tool turns can be replayed
+            # with reasoning_content in subsequent API calls.
             assistant_content: list[dict[str, Any]] = []
+            if current_thinking_text.strip():
+                assistant_content.append({"type": "thinking", "thinking": current_thinking_text})
             if current_text.strip():
                 assistant_content.append({"type": "text", "text": current_text})
             for tu in tool_uses:

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1246,27 +1246,12 @@ class ChatOrchestrator:
             meta_ids: list[str] = [str(m["attachment_id"]) for m in attachment_meta]
             text_for_model = user_message + _linear_attachment_tool_hint(meta_ids)
 
-        # Skip history DB call for new conversations (zero messages to load).
-        if skip_history:
-            history: list[dict[str, Any]] = []
-            logger.info("[Orchestrator] Skipped history load (new conversation)")
-        else:
-            history = await self._load_history(limit=20)
-            logger.info("[Orchestrator] Loaded %d history messages", len(history))
-
-        # Build user content — may include attachment blocks (images, PDFs, text)
-        user_content: str | list[dict[str, Any]] = self._build_user_content(
-            text_for_model, attachment_ids,
-        )
-
-        # Add user message to context for Claude
-        messages: list[dict[str, Any]] = history + [
-            {"role": "user", "content": user_content}
-        ]
         cross_conversation_context_message: str | None = None
         slack_recent_channel_context_message: str | None = None
 
-        # Resolve per-org LLM provider/model/key
+        # Resolve per-org LLM provider/model/key before loading history so
+        # provider-specific persisted blocks can be included only when the
+        # selected model understands them.
         self._llm_config = await resolve_llm_config(self.organization_id)
         is_workflow_run: bool = bool((self.workflow_context or {}).get("is_workflow"))
         workflow_model_override = (self.workflow_context or {}).get("workflow_model_override")
@@ -1315,6 +1300,28 @@ class ChatOrchestrator:
             "provider": self._llm_config.provider,
             "is_workflow": is_workflow_run,
         })
+
+        # Skip history DB call for new conversations (zero messages to load).
+        include_deepseek_thinking_history = is_deepseek_model(selected_model)
+        if skip_history:
+            history: list[dict[str, Any]] = []
+            logger.info("[Orchestrator] Skipped history load (new conversation)")
+        else:
+            history = await self._load_history(
+                limit=20,
+                include_thinking_blocks=include_deepseek_thinking_history,
+            )
+            logger.info("[Orchestrator] Loaded %d history messages", len(history))
+
+        # Build user content — may include attachment blocks (images, PDFs, text)
+        user_content: str | list[dict[str, Any]] = self._build_user_content(
+            text_for_model, attachment_ids,
+        )
+
+        # Add user message to context for Claude
+        messages: list[dict[str, Any]] = history + [
+            {"role": "user", "content": user_content}
+        ]
 
         # Keep track of content blocks for saving (preserves interleaving order)
         content_blocks: list[dict[str, Any]] = []
@@ -1892,6 +1899,12 @@ class ChatOrchestrator:
 
                 break
 
+            # Persist DeepSeek thinking before tool calls so later turns can
+            # replay it as reasoning_content. Other provider thinking blocks are
+            # deliberately not stored here because their replay contracts differ.
+            if is_deepseek_model(model_name) and current_thinking_text.strip():
+                content_blocks.append({"type": "thinking", "thinking": current_thinking_text})
+
             # Flush current text to content_blocks before processing tools
             if current_text.strip():
                 content_blocks.append({"type": "text", "text": current_text})
@@ -2260,7 +2273,12 @@ class ChatOrchestrator:
             await session.commit()
             return conv_id
 
-    async def _load_history(self, limit: int = 20) -> list[dict[str, Any]]:
+    async def _load_history(
+        self,
+        limit: int = 20,
+        *,
+        include_thinking_blocks: bool = False,
+    ) -> list[dict[str, Any]]:
         """Load recent chat history from the current conversation.
         
         Reconstructs proper Claude message format:
@@ -2370,6 +2388,7 @@ class ChatOrchestrator:
                         # 3. assistant: [post-tool text] (if any)
                         
                         # Collect blocks before and after tool use
+                        pre_tool_thinking: list[str] = []
                         pre_tool_text: list[str] = []
                         post_tool_text: list[str] = []
                         current_tool_uses: list[dict[str, Any]] = []
@@ -2377,7 +2396,11 @@ class ChatOrchestrator:
                         seen_tool = False
                         
                         for block in blocks:
-                            if block.get("type") == "text":
+                            if block.get("type") == "thinking":
+                                thinking = block.get("thinking", "").strip()
+                                if include_thinking_blocks and thinking and not seen_tool:
+                                    pre_tool_thinking.append(thinking)
+                            elif block.get("type") == "text":
                                 text = block.get("text", "").strip()
                                 if text:
                                     if not seen_tool:
@@ -2419,8 +2442,10 @@ class ChatOrchestrator:
                                         "content": json.dumps({"error": "Result not available - tool execution may have failed"}),
                                     })
                         
-                        # Build assistant message with pre-tool text + tool_use
+                        # Build assistant message with pre-tool thinking + text + tool_use
                         claude_blocks: list[dict[str, Any]] = []
+                        for thinking in pre_tool_thinking:
+                            claude_blocks.append({"type": "thinking", "thinking": thinking})
                         for text in pre_tool_text:
                             claude_blocks.append({"type": "text", "text": text})
                         claude_blocks.extend(current_tool_uses)

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -538,6 +538,7 @@ class OpenAIAdapter:
         current_thinking_started: bool = False
 
         stream: Any = None
+        active_model: str = model
         model_candidates: list[str] = [model, *self._openai_not_found_fallback_models(model)]
         for idx, candidate_model in enumerate(model_candidates):
             candidate_kwargs: dict[str, Any] = {
@@ -548,6 +549,7 @@ class OpenAIAdapter:
             }
             try:
                 stream = await self._client.chat.completions.create(**candidate_kwargs)
+                active_model = candidate_model
                 if idx > 0:
                     logger.info(
                         "[OpenAIAdapter] Stream call succeeded with fallback model=%s requested_model=%s",
@@ -580,7 +582,7 @@ class OpenAIAdapter:
                 continue
 
             reasoning_content = _get_attr_or_item(delta, "reasoning_content")
-            if reasoning_content:
+            if is_deepseek_model(active_model) and reasoning_content:
                 if current_text_started:
                     yield StreamEvent(type="text_stop")
                     current_text_started = False

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -49,6 +49,13 @@ def is_deepseek_model(model: str) -> bool:
     return normalized_model.startswith(DEEPSEEK_MODEL_PREFIXES)
 
 
+def _get_attr_or_item(value: Any, name: str, default: Any = None) -> Any:
+    """Read an SDK object's attribute or a dict key without assuming a shape."""
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
 PROVIDER_DEFAULT_MODELS: dict[str, dict[str, str]] = {
     "anthropic": {"primary": "claude-opus-4-6", "cheap": "claude-haiku-4-5-20251001"},
     "minimax": {"primary": "MiniMax-M2.7", "cheap": "MiniMax-M2.7-highspeed"},
@@ -415,12 +422,14 @@ class OpenAIAdapter:
         api_key: str,
         base_url: str | None = None,
         supports_document_blocks: bool = False,
+        supports_reasoning_content: bool = False,
     ) -> None:
         kwargs: dict[str, Any] = {"api_key": api_key}
         if base_url is not None:
             kwargs["base_url"] = base_url
         self._client: AsyncOpenAI = AsyncOpenAI(**kwargs)
         self._supports_document_blocks: bool = supports_document_blocks
+        self._supports_reasoning_content: bool = supports_reasoning_content
 
     def _build_token_limit_kwargs(self, *, model: str, max_tokens: int) -> dict[str, int]:
         """Map and clamp token-limit parameters based on model requirements."""
@@ -454,6 +463,21 @@ class OpenAIAdapter:
             },
         )
         return {token_param_name: token_limit}
+
+    def _build_thinking_kwargs(self, *, model: str, thinking: bool) -> dict[str, Any]:
+        """Return provider-specific thinking controls for OpenAI-compatible APIs."""
+        if not is_deepseek_model(model):
+            return {}
+
+        thinking_type = "enabled" if thinking else "disabled"
+        logger.debug(
+            "DeepSeek thinking mode controls selected",
+            extra={"model": model, "thinking_type": thinking_type},
+        )
+        return {
+            "reasoning_effort": "high",
+            "extra_body": {"thinking": {"type": thinking_type}},
+        }
 
     def _openai_not_found_fallback_models(self, model: str) -> list[str]:
         """Return same-family model candidates when a model is not found."""
@@ -511,6 +535,7 @@ class OpenAIAdapter:
 
         tool_calls_accum: dict[int, dict[str, str]] = {}
         current_text_started: bool = False
+        current_thinking_started: bool = False
 
         stream: Any = None
         model_candidates: list[str] = [model, *self._openai_not_found_fallback_models(model)]
@@ -519,6 +544,7 @@ class OpenAIAdapter:
                 **api_kwargs,
                 "model": candidate_model,
                 **self._build_token_limit_kwargs(model=candidate_model, max_tokens=max_tokens),
+                **self._build_thinking_kwargs(model=candidate_model, thinking=thinking),
             }
             try:
                 stream = await self._client.chat.completions.create(**candidate_kwargs)
@@ -553,8 +579,21 @@ class OpenAIAdapter:
             if delta is None:
                 continue
 
+            reasoning_content = _get_attr_or_item(delta, "reasoning_content")
+            if reasoning_content:
+                if current_text_started:
+                    yield StreamEvent(type="text_stop")
+                    current_text_started = False
+                if not current_thinking_started:
+                    yield StreamEvent(type="thinking_start")
+                    current_thinking_started = True
+                yield StreamEvent(type="thinking_delta", text=reasoning_content)
+
             # Text content
             if delta.content:
+                if current_thinking_started:
+                    yield StreamEvent(type="thinking_stop")
+                    current_thinking_started = False
                 if not current_text_started:
                     yield StreamEvent(type="text_start")
                     current_text_started = True
@@ -565,6 +604,9 @@ class OpenAIAdapter:
                 for tc_delta in delta.tool_calls:
                     idx: int = tc_delta.index if tc_delta.index is not None else 0
                     if idx not in tool_calls_accum:
+                        if current_thinking_started:
+                            yield StreamEvent(type="thinking_stop")
+                            current_thinking_started = False
                         tool_calls_accum[idx] = {
                             "id": tc_delta.id or f"call_{idx}",
                             "name": "",
@@ -593,6 +635,9 @@ class OpenAIAdapter:
 
             # Finish
             if choice.finish_reason:
+                if current_thinking_started:
+                    yield StreamEvent(type="thinking_stop")
+                    current_thinking_started = False
                 if current_text_started:
                     yield StreamEvent(type="text_stop")
                 for tc_data in tool_calls_accum.values():
@@ -729,11 +774,15 @@ class OpenAIAdapter:
                             "arguments": arguments,
                         },
                     })
-                result.append({
+                msg_dict = {
                     "role": "assistant",
                     "content": _as_text(content),
                     "tool_calls": normalized_tool_calls,
-                })
+                }
+                reasoning_content = _as_text(msg.get("reasoning_content", ""))
+                if self._supports_reasoning_content and reasoning_content:
+                    msg_dict["reasoning_content"] = reasoning_content
+                result.append(msg_dict)
                 continue
 
             if role == "user" and isinstance(content, list):
@@ -776,6 +825,7 @@ class OpenAIAdapter:
 
             if role == "assistant" and isinstance(content, list):
                 text_parts: list[str] = []
+                thinking_parts: list[str] = []
                 tool_calls: list[dict[str, Any]] = []
                 for block in content:
                     if not isinstance(block, dict):
@@ -783,6 +833,10 @@ class OpenAIAdapter:
                     btype = block.get("type", "")
                     if btype == "text":
                         text_parts.append(_as_text(block.get("text", "")))
+                    elif btype == "thinking":
+                        thinking_text = _as_text(block.get("thinking", block.get("text", "")))
+                        if thinking_text:
+                            thinking_parts.append(thinking_text)
                     elif btype == "tool_use":
                         tool_calls.append({
                             "id": block.get("id", ""),
@@ -792,12 +846,13 @@ class OpenAIAdapter:
                                 "arguments": json.dumps(block.get("input", {})),
                             },
                         })
-                    # Skip thinking blocks — OpenAI doesn't use them
 
                 msg_dict: dict[str, Any] = {
                     "role": "assistant",
                     "content": "\n".join(text_parts),
                 }
+                if self._supports_reasoning_content and thinking_parts:
+                    msg_dict["reasoning_content"] = "".join(thinking_parts)
                 if tool_calls:
                     msg_dict["tool_calls"] = tool_calls
                 result.append(msg_dict)
@@ -814,6 +869,9 @@ class OpenAIAdapter:
             return blocks
 
         message = choice.message
+        reasoning_content = _get_attr_or_item(message, "reasoning_content")
+        if reasoning_content:
+            blocks.append(ContentBlock(type="thinking", thinking=reasoning_content))
         if message.content:
             blocks.append(ContentBlock(type="text", text=message.content))
         if message.tool_calls:
@@ -868,6 +926,7 @@ def get_adapter(config: LLMConfig) -> AnthropicAdapter | OpenAIAdapter:
             api_key=config.api_key,
             base_url=base_url,
             supports_document_blocks=supports_docs,
+            supports_reasoning_content=provider == "deepseek",
         )
 
     raise ValueError(f"Unsupported LLM provider: {config.provider}")

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -871,9 +871,6 @@ class OpenAIAdapter:
             return blocks
 
         message = choice.message
-        reasoning_content = _get_attr_or_item(message, "reasoning_content")
-        if reasoning_content:
-            blocks.append(ContentBlock(type="thinking", thinking=reasoning_content))
         if message.content:
             blocks.append(ContentBlock(type="text", text=message.content))
         if message.tool_calls:

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -243,6 +243,27 @@ async def test_openai_complete_falls_back_when_gpt5_not_found():
     assert create_mock.await_args_list[1].kwargs["model"] == "gpt-5"
 
 
+def test_openai_completed_content_keeps_text_first_when_reasoning_content_present():
+    adapter = OpenAIAdapter(api_key="test-key")
+    response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    reasoning_content="hidden reasoning",
+                    content="visible answer",
+                    tool_calls=None,
+                )
+            )
+        ]
+    )
+
+    blocks = adapter.build_completed_content(response)
+
+    assert [(block.type, block.text, block.thinking) for block in blocks] == [
+        ("text", "visible answer", None)
+    ]
+
+
 def test_deepseek_adapter_uses_openai_compatible_base_url():
     adapter = get_adapter(
         LLMConfig(

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -16,6 +16,20 @@ class _EmptyAsyncIterator:
         raise StopAsyncIteration
 
 
+class _ListAsyncIterator:
+    def __init__(self, items):
+        self._items = iter(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._items)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
 def _openai_api_status_error(message: str, status_code: int = 404) -> APIStatusError:
     request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
     response = httpx.Response(status_code=status_code, request=request, headers={"x-request-id": "req_test"})
@@ -261,3 +275,108 @@ def test_deepseek_clamps_max_tokens_to_provider_output_limit():
     assert adapter._build_token_limit_kwargs(model="deepseek/deepseek-v4-flash", max_tokens=500_000) == {
         "max_tokens": 393_216
     }
+
+
+def test_deepseek_thinking_kwargs_use_extra_body_when_enabled():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    assert adapter._build_thinking_kwargs(model="deepseek-v4-pro", thinking=True) == {
+        "reasoning_effort": "high",
+        "extra_body": {"thinking": {"type": "enabled"}},
+    }
+
+
+def test_non_deepseek_thinking_kwargs_are_omitted():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    assert adapter._build_thinking_kwargs(model="gpt-4o-mini", thinking=True) == {}
+
+
+def test_deepseek_format_messages_converts_thinking_block_to_reasoning_content():
+    adapter = OpenAIAdapter(api_key="test-key", supports_reasoning_content=True)
+
+    formatted = adapter.format_messages_for_api(
+        [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "need a tool"},
+                    {"type": "text", "text": "I'll check."},
+                    {"type": "tool_use", "id": "call_1", "name": "lookup", "input": {"q": "x"}},
+                ],
+            }
+        ]
+    )
+
+    assert formatted == [
+        {
+            "role": "assistant",
+            "content": "I'll check.",
+            "reasoning_content": "need a tool",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": '{"q": "x"}'},
+                }
+            ],
+        }
+    ]
+
+
+def test_openai_format_messages_skips_thinking_blocks_without_reasoning_support():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    formatted = adapter.format_messages_for_api(
+        [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "provider-specific reasoning"},
+                    {"type": "text", "text": "Visible answer."},
+                ],
+            }
+        ]
+    )
+
+    assert formatted == [{"role": "assistant", "content": "Visible answer."}]
+
+
+@pytest.mark.asyncio
+async def test_deepseek_stream_emits_reasoning_content_as_thinking_events():
+    adapter = OpenAIAdapter(api_key="test-key")
+    stream = _ListAsyncIterator(
+        [
+            SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(reasoning_content="think", content=None, tool_calls=None), finish_reason=None)]
+            ),
+            SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(reasoning_content=None, content="answer", tool_calls=None), finish_reason="stop")]
+            ),
+        ]
+    )
+    create_mock = AsyncMock(return_value=stream)
+    adapter._client = SimpleNamespace(  # type: ignore[assignment]
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+    )
+
+    events = [
+        event
+        async for event in adapter.stream(
+            model="deepseek-v4-pro",
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            thinking=True,
+            max_tokens=42,
+        )
+    ]
+
+    assert [(event.type, event.text) for event in events] == [
+        ("thinking_start", None),
+        ("thinking_delta", "think"),
+        ("thinking_stop", None),
+        ("text_start", None),
+        ("text_delta", "answer"),
+        ("text_stop", None),
+    ]
+    assert create_mock.await_args.kwargs["extra_body"] == {"thinking": {"type": "enabled"}}

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -380,3 +380,58 @@ async def test_deepseek_stream_emits_reasoning_content_as_thinking_events():
         ("text_stop", None),
     ]
     assert create_mock.await_args.kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
+
+
+@pytest.mark.asyncio
+async def test_non_deepseek_stream_ignores_reasoning_content_delta():
+    adapter = OpenAIAdapter(api_key="test-key")
+    stream = _ListAsyncIterator(
+        [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(
+                            reasoning_content="provider reasoning",
+                            content=None,
+                            tool_calls=None,
+                        ),
+                        finish_reason=None,
+                    )
+                ]
+            ),
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(
+                            reasoning_content=None,
+                            content="answer",
+                            tool_calls=None,
+                        ),
+                        finish_reason="stop",
+                    )
+                ]
+            ),
+        ]
+    )
+    create_mock = AsyncMock(return_value=stream)
+    adapter._client = SimpleNamespace(  # type: ignore[assignment]
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+    )
+
+    events = [
+        event
+        async for event in adapter.stream(
+            model="gpt-4o-mini",
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            thinking=True,
+            max_tokens=42,
+        )
+    ]
+
+    assert [(event.type, event.text) for event in events] == [
+        ("text_start", None),
+        ("text_delta", "answer"),
+        ("text_stop", None),
+    ]
+    assert "extra_body" not in create_mock.await_args.kwargs

--- a/backend/tests/test_orchestrator_slack_cross_user_warning.py
+++ b/backend/tests/test_orchestrator_slack_cross_user_warning.py
@@ -247,3 +247,119 @@ def test_load_history_replays_persisted_thinking_only_when_enabled(monkeypatch) 
         if isinstance(message["content"], list)
         for block in message["content"]
     )
+
+
+class _ThinkingToolThenFinalThinkingAdapter:
+    def __init__(self) -> None:
+        self._calls = 0
+        self.calls: list[dict[str, object]] = []
+
+    async def stream(self, **kwargs):  # type: ignore[no-untyped-def]
+        self._calls += 1
+        self.calls.append(kwargs)
+        if self._calls == 1:
+            yield StreamEvent(type="thinking_start")
+            yield StreamEvent(type="thinking_delta", text="first reasoning")
+            yield StreamEvent(type="thinking_stop")
+            yield StreamEvent(
+                type="tool_use_start",
+                tool_id="tool-1",
+                tool_name="query_on_connector",
+            )
+            yield StreamEvent(
+                type="tool_input_delta",
+                tool_input_json='{"connector":"hubspot","query":"x"}',
+            )
+            yield StreamEvent(type="tool_use_stop")
+            return
+
+        yield StreamEvent(type="thinking_start")
+        yield StreamEvent(type="thinking_delta", text="final reasoning")
+        yield StreamEvent(type="thinking_stop")
+        yield StreamEvent(type="text_delta", text="Final response")
+
+
+def test_stream_with_tools_persists_final_deepseek_thinking_after_tool(monkeypatch) -> None:
+    async def _fake_execute_tool(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return {"status": "success", "result": "ok"}
+
+    monkeypatch.setattr("agents.orchestrator.execute_tool", _fake_execute_tool)
+
+    orchestrator = ChatOrchestrator(
+        user_id="u1",
+        organization_id="org1",
+        source="web",
+    )
+    adapter = _ThinkingToolThenFinalThinkingAdapter()
+    orchestrator._adapter = adapter
+    orchestrator._llm_config = SimpleNamespace(provider="deepseek")
+
+    _, content_blocks = asyncio.run(_collect_stream_for_model(orchestrator, "deepseek-v4-pro"))
+
+    thinking_blocks = [block for block in content_blocks if block["type"] == "thinking"]
+    assert thinking_blocks == [
+        {"type": "thinking", "thinking": "first reasoning"},
+        {"type": "thinking", "thinking": "final reasoning"},
+    ]
+    assert content_blocks[-1] == {"type": "text", "text": "Final response"}
+
+
+def test_load_history_replays_thinking_before_each_deepseek_tool_subturn(monkeypatch) -> None:
+    saved_messages = [
+        SimpleNamespace(
+            role="assistant",
+            content_blocks=[
+                {"type": "thinking", "thinking": "reason for tool one"},
+                {
+                    "type": "tool_use",
+                    "id": "tool-1",
+                    "name": "query_on_connector",
+                    "input": {"connector": "hubspot", "query": "one"},
+                    "result": {"status": "success", "rows": [1]},
+                },
+                {"type": "thinking", "thinking": "reason for tool two"},
+                {
+                    "type": "tool_use",
+                    "id": "tool-2",
+                    "name": "query_on_connector",
+                    "input": {"connector": "hubspot", "query": "two"},
+                    "result": {"status": "success", "rows": [2]},
+                },
+                {"type": "thinking", "thinking": "final reasoning"},
+                {"type": "text", "text": "Final response"},
+            ],
+            _legacy_to_blocks=lambda: [],
+        )
+    ]
+
+    monkeypatch.setattr(
+        "agents.orchestrator.get_session",
+        lambda **_kwargs: _FakeSessionManager(saved_messages),
+    )
+
+    orchestrator = ChatOrchestrator(
+        user_id="00000000-0000-0000-0000-000000000001",
+        organization_id="00000000-0000-0000-0000-000000000002",
+        conversation_id="00000000-0000-0000-0000-000000000003",
+        source="web",
+    )
+
+    history = asyncio.run(orchestrator._load_history(limit=20, include_thinking_blocks=True))
+
+    assert history[0]["role"] == "assistant"
+    assert history[0]["content"][0] == {"type": "thinking", "thinking": "reason for tool one"}
+    assert history[0]["content"][1]["id"] == "tool-1"
+    assert history[1]["role"] == "user"
+    assert history[1]["content"][0]["tool_use_id"] == "tool-1"
+    assert history[2]["role"] == "assistant"
+    assert history[2]["content"][0] == {"type": "thinking", "thinking": "reason for tool two"}
+    assert history[2]["content"][1]["id"] == "tool-2"
+    assert history[3]["role"] == "user"
+    assert history[3]["content"][0]["tool_use_id"] == "tool-2"
+    assert history[4] == {
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": "final reasoning"},
+            {"type": "text", "text": "Final response"},
+        ],
+    }

--- a/backend/tests/test_orchestrator_slack_cross_user_warning.py
+++ b/backend/tests/test_orchestrator_slack_cross_user_warning.py
@@ -75,3 +75,84 @@ def test_stream_with_tools_does_not_emit_warning_for_web(monkeypatch) -> None:
 
     assert "⚠️ Used teammate connector" not in joined
     assert "Final response" in joined
+
+
+class _ThinkingThenToolAdapter:
+    def __init__(self) -> None:
+        self._calls = 0
+        self.calls: list[dict[str, object]] = []
+
+    async def stream(self, **kwargs):  # type: ignore[no-untyped-def]
+        self._calls += 1
+        self.calls.append(kwargs)
+        if self._calls == 1:
+            yield StreamEvent(type="thinking_start")
+            yield StreamEvent(type="thinking_delta", text="need a tool")
+            yield StreamEvent(type="thinking_stop")
+            yield StreamEvent(
+                type="tool_use_start",
+                tool_id="tool-1",
+                tool_name="query_on_connector",
+            )
+            yield StreamEvent(
+                type="tool_input_delta",
+                tool_input_json='{"connector":"hubspot","query":"x"}',
+            )
+            yield StreamEvent(type="tool_use_stop")
+            return
+
+        yield StreamEvent(type="text_delta", text="Final response")
+
+
+async def _collect_stream_for_model(
+    orchestrator: ChatOrchestrator,
+    model_name: str,
+) -> list[str]:
+    messages = [{"role": "user", "content": "hi"}]
+    content_blocks: list[dict[str, object]] = []
+    out: list[str] = []
+    async for chunk in orchestrator._stream_with_tools(
+        messages,
+        "sys",
+        content_blocks,
+        model_name,
+    ):
+        out.append(chunk)
+    return out
+
+
+def test_stream_with_tools_replays_thinking_only_for_deepseek_models(monkeypatch) -> None:
+    async def _fake_execute_tool(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return {"status": "success", "result": "ok"}
+
+    monkeypatch.setattr("agents.orchestrator.execute_tool", _fake_execute_tool)
+
+    non_deepseek_orchestrator = ChatOrchestrator(
+        user_id="u1",
+        organization_id="org1",
+        source="web",
+    )
+    non_deepseek_adapter = _ThinkingThenToolAdapter()
+    non_deepseek_orchestrator._adapter = non_deepseek_adapter
+    non_deepseek_orchestrator._llm_config = SimpleNamespace(provider="anthropic")
+
+    asyncio.run(_collect_stream_for_model(non_deepseek_orchestrator, "claude-opus-4-6"))
+
+    non_deepseek_messages = non_deepseek_adapter.calls[1]["messages"]
+    non_deepseek_assistant_content = non_deepseek_messages[1]["content"]
+    assert all(block["type"] != "thinking" for block in non_deepseek_assistant_content)
+
+    deepseek_orchestrator = ChatOrchestrator(
+        user_id="u1",
+        organization_id="org1",
+        source="web",
+    )
+    deepseek_adapter = _ThinkingThenToolAdapter()
+    deepseek_orchestrator._adapter = deepseek_adapter
+    deepseek_orchestrator._llm_config = SimpleNamespace(provider="deepseek")
+
+    asyncio.run(_collect_stream_for_model(deepseek_orchestrator, "deepseek-v4-pro"))
+
+    deepseek_messages = deepseek_adapter.calls[1]["messages"]
+    deepseek_assistant_content = deepseek_messages[1]["content"]
+    assert deepseek_assistant_content[0] == {"type": "thinking", "thinking": "need a tool"}

--- a/backend/tests/test_orchestrator_slack_cross_user_warning.py
+++ b/backend/tests/test_orchestrator_slack_cross_user_warning.py
@@ -107,7 +107,7 @@ class _ThinkingThenToolAdapter:
 async def _collect_stream_for_model(
     orchestrator: ChatOrchestrator,
     model_name: str,
-) -> list[str]:
+) -> tuple[list[str], list[dict[str, object]]]:
     messages = [{"role": "user", "content": "hi"}]
     content_blocks: list[dict[str, object]] = []
     out: list[str] = []
@@ -118,7 +118,7 @@ async def _collect_stream_for_model(
         model_name,
     ):
         out.append(chunk)
-    return out
+    return out, content_blocks
 
 
 def test_stream_with_tools_replays_thinking_only_for_deepseek_models(monkeypatch) -> None:
@@ -136,11 +136,14 @@ def test_stream_with_tools_replays_thinking_only_for_deepseek_models(monkeypatch
     non_deepseek_orchestrator._adapter = non_deepseek_adapter
     non_deepseek_orchestrator._llm_config = SimpleNamespace(provider="anthropic")
 
-    asyncio.run(_collect_stream_for_model(non_deepseek_orchestrator, "claude-opus-4-6"))
+    _, non_deepseek_content_blocks = asyncio.run(
+        _collect_stream_for_model(non_deepseek_orchestrator, "claude-opus-4-6")
+    )
 
     non_deepseek_messages = non_deepseek_adapter.calls[1]["messages"]
     non_deepseek_assistant_content = non_deepseek_messages[1]["content"]
     assert all(block["type"] != "thinking" for block in non_deepseek_assistant_content)
+    assert all(block["type"] != "thinking" for block in non_deepseek_content_blocks)
 
     deepseek_orchestrator = ChatOrchestrator(
         user_id="u1",
@@ -151,8 +154,96 @@ def test_stream_with_tools_replays_thinking_only_for_deepseek_models(monkeypatch
     deepseek_orchestrator._adapter = deepseek_adapter
     deepseek_orchestrator._llm_config = SimpleNamespace(provider="deepseek")
 
-    asyncio.run(_collect_stream_for_model(deepseek_orchestrator, "deepseek-v4-pro"))
+    _, deepseek_content_blocks = asyncio.run(
+        _collect_stream_for_model(deepseek_orchestrator, "deepseek-v4-pro")
+    )
 
     deepseek_messages = deepseek_adapter.calls[1]["messages"]
     deepseek_assistant_content = deepseek_messages[1]["content"]
     assert deepseek_assistant_content[0] == {"type": "thinking", "thinking": "need a tool"}
+    assert deepseek_content_blocks[0] == {"type": "thinking", "thinking": "need a tool"}
+
+
+class _FakeScalarResult:
+    def __init__(self, messages):  # type: ignore[no-untyped-def]
+        self._messages = messages
+
+    def all(self):  # type: ignore[no-untyped-def]
+        return self._messages
+
+
+class _FakeExecuteResult:
+    def __init__(self, messages):  # type: ignore[no-untyped-def]
+        self._messages = messages
+
+    def scalars(self):  # type: ignore[no-untyped-def]
+        return _FakeScalarResult(self._messages)
+
+
+class _FakeSession:
+    def __init__(self, messages):  # type: ignore[no-untyped-def]
+        self._messages = messages
+
+    async def execute(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return _FakeExecuteResult(self._messages)
+
+
+class _FakeSessionManager:
+    def __init__(self, messages):  # type: ignore[no-untyped-def]
+        self._messages = messages
+
+    async def __aenter__(self):  # type: ignore[no-untyped-def]
+        return _FakeSession(self._messages)
+
+    async def __aexit__(self, *_args):  # type: ignore[no-untyped-def]
+        return False
+
+
+def test_load_history_replays_persisted_thinking_only_when_enabled(monkeypatch) -> None:
+    saved_messages = [
+        SimpleNamespace(
+            role="assistant",
+            content_blocks=[
+                {"type": "thinking", "thinking": "need a tool"},
+                {"type": "text", "text": "I'll check."},
+                {
+                    "type": "tool_use",
+                    "id": "tool-1",
+                    "name": "query_on_connector",
+                    "input": {"connector": "hubspot", "query": "x"},
+                    "result": {"status": "success"},
+                },
+            ],
+            _legacy_to_blocks=lambda: [],
+        )
+    ]
+
+    monkeypatch.setattr(
+        "agents.orchestrator.get_session",
+        lambda **_kwargs: _FakeSessionManager(saved_messages),
+    )
+
+    orchestrator = ChatOrchestrator(
+        user_id="00000000-0000-0000-0000-000000000001",
+        organization_id="00000000-0000-0000-0000-000000000002",
+        conversation_id="00000000-0000-0000-0000-000000000003",
+        source="web",
+    )
+
+    deepseek_history = asyncio.run(
+        orchestrator._load_history(limit=20, include_thinking_blocks=True)
+    )
+    assert deepseek_history[0]["content"][0] == {
+        "type": "thinking",
+        "thinking": "need a tool",
+    }
+
+    non_deepseek_history = asyncio.run(
+        orchestrator._load_history(limit=20, include_thinking_blocks=False)
+    )
+    assert all(
+        block["type"] != "thinking"
+        for message in non_deepseek_history
+        if isinstance(message["content"], list)
+        for block in message["content"]
+    )


### PR DESCRIPTION
### Motivation
- DeepSeek's Thinking Mode requires streamed `reasoning_content` to be passed back on subsequent requests or the API returns a 400 invalid_request_error. 
- The change ensures thinking-mode reasoning is preserved and replayed for DeepSeek so tool-call turns don't fail and the UI can show thinking blocks during streaming.

### Description
- Add DeepSeek-aware controls to the OpenAI-compatible adapter by introducing `OpenAIAdapter._build_thinking_kwargs` which returns `reasoning_effort` and `extra_body: {"thinking": {"type": ...}}` when `is_deepseek_model(model)` is true and `thinking=True`.
- Parse and translate provider `reasoning_content` from stream deltas into provider-agnostic `thinking_start` / `thinking_delta` / `thinking_stop` `StreamEvent`s in `OpenAIAdapter.stream` and ensure stream calls include the extra thinking body.
- Preserve streamed thinking text in the orchestrator (`current_thinking_text`) and emit a `{"type":"thinking"}` content block so subsequent tool-turn requests include `reasoning_content` (so DeepSeek accepts the replayed context).
- Scope formatting to adapters that opt in via a new `supports_reasoning_content` flag (set for `deepseek` in `get_adapter`) and add a small `_get_attr_or_item` helper to safely read SDK attributes or dict keys.
- Files changed: `backend/services/llm_adapter.py`, `backend/agents/orchestrator.py`, and tests in `backend/tests/test_llm_adapter_openai_token_params.py` were added/updated to cover the behavior.

### Testing
- Ran `pytest backend/tests/test_llm_adapter_openai_token_params.py` which exercised the DeepSeek thinking-flow and OpenAI adapter changes; all tests passed (`20 passed`).
- Compiled modules with `python -m compileall` for the modified files without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0228956cbc8321a8fb0234b6a39edc)