### PR TITLE
Fix DeepSeek thinking-mode replay and scoping

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1892,6 +1892,12 @@ class ChatOrchestrator:
 
                 break
 
+            # Persist DeepSeek thinking for tool-call turns so saved history can
+            # replay reasoning_content on later requests. DeepSeek requires this
+            # for all subsequent turns after a thinking-mode tool call.
+            if is_deepseek_model(model_name) and current_thinking.strip():
+                content_blocks.append({"type": "thinking", "thinking": current_thinking})
+
             # Flush current text to content_blocks before processing tools
             if current_text.strip():
                 content_blocks.append({"type": "text", "text": current_text})
@@ -2375,6 +2381,7 @@ class ChatOrchestrator:
                         # 3. assistant: [post-tool text] (if any)
                         
                         # Collect blocks before and after tool use
+                        tool_call_thinking: list[str] = []
                         pre_tool_text: list[str] = []
                         post_tool_text: list[str] = []
                         current_tool_uses: list[dict[str, Any]] = []
@@ -2382,7 +2389,11 @@ class ChatOrchestrator:
                         seen_tool = False
                         
                         for block in blocks:
-                            if block.get("type") == "text":
+                            if block.get("type") == "thinking":
+                                thinking = block.get("thinking", "").strip()
+                                if thinking:
+                                    tool_call_thinking.append(thinking)
+                            elif block.get("type") == "text":
                                 text = block.get("text", "").strip()
                                 if text:
                                     if not seen_tool:
@@ -2424,8 +2435,10 @@ class ChatOrchestrator:
                                         "content": json.dumps({"error": "Result not available - tool execution may have failed"}),
                                     })
                         
-                        # Build assistant message with pre-tool text + tool_use
+                        # Build assistant message with DeepSeek thinking + pre-tool text + tool_use
                         claude_blocks: list[dict[str, Any]] = []
+                        for thinking in tool_call_thinking:
+                            claude_blocks.append({"type": "thinking", "thinking": thinking})
                         for text in pre_tool_text:
                             claude_blocks.append({"type": "text", "text": text})
                         claude_blocks.extend(current_tool_uses)

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -32,6 +32,7 @@ from services.llm_adapter import (
     OpenAIAdapter,
     StreamEvent,
     get_adapter,
+    is_deepseek_model,
 )
 from services.llm_provider import resolve_llm_config
 from services.llm_provider import (
@@ -1659,6 +1660,7 @@ class ChatOrchestrator:
         while True:
             # Track state for this streaming response
             current_text = ""
+            current_thinking = ""
             tool_uses: list[dict[str, Any]] = []
             current_tool: dict[str, Any] | None = None
             current_tool_input_json = ""
@@ -1676,6 +1678,7 @@ class ChatOrchestrator:
                 try:
                     # Reset state on retry
                     current_text = ""
+                    current_thinking = ""
                     tool_uses = []
                     current_tool = None
                     current_tool_input_json = ""
@@ -1711,6 +1714,8 @@ class ChatOrchestrator:
                             yield _json_dumps({"type": "thinking_start"})
 
                         elif event.type == "thinking_delta":
+                            thinking_chunk: str = event.text or ""
+                            current_thinking += thinking_chunk
                             yield _json_dumps({
                                 "type": "thinking_delta",
                                 "text": event.text,
@@ -2097,8 +2102,11 @@ class ChatOrchestrator:
 
             # Build assistant history from tracked state (provider-agnostic).
             # For Anthropic-family: thinking blocks are preserved for reasoning continuity.
-            # For OpenAI-family: only text + tool_use blocks.
+            # For DeepSeek: replay reasoning_content for thinking-mode tool-call turns.
+            # For other OpenAI-family providers: only text + tool_use blocks.
             assistant_content: list[dict[str, Any]] = []
+            if is_deepseek_model(model_name) and current_thinking:
+                assistant_content.append({"type": "thinking", "thinking": current_thinking})
             if current_text.strip():
                 assistant_content.append({"type": "text", "text": current_text})
             for tu in tool_uses:

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -415,12 +415,14 @@ class OpenAIAdapter:
         api_key: str,
         base_url: str | None = None,
         supports_document_blocks: bool = False,
+        supports_reasoning_content: bool = False,
     ) -> None:
         kwargs: dict[str, Any] = {"api_key": api_key}
         if base_url is not None:
             kwargs["base_url"] = base_url
         self._client: AsyncOpenAI = AsyncOpenAI(**kwargs)
         self._supports_document_blocks: bool = supports_document_blocks
+        self._supports_reasoning_content: bool = supports_reasoning_content
 
     def _build_token_limit_kwargs(self, *, model: str, max_tokens: int) -> dict[str, int]:
         """Map and clamp token-limit parameters based on model requirements."""
@@ -511,6 +513,7 @@ class OpenAIAdapter:
 
         tool_calls_accum: dict[int, dict[str, str]] = {}
         current_text_started: bool = False
+        current_thinking_started: bool = False
 
         stream: Any = None
         model_candidates: list[str] = [model, *self._openai_not_found_fallback_models(model)]
@@ -520,6 +523,12 @@ class OpenAIAdapter:
                 "model": candidate_model,
                 **self._build_token_limit_kwargs(model=candidate_model, max_tokens=max_tokens),
             }
+            if thinking and is_deepseek_model(candidate_model):
+                candidate_kwargs["extra_body"] = {"thinking": {"type": "enabled"}}
+                logger.debug(
+                    "[OpenAIAdapter] Enabled DeepSeek thinking mode for streaming request",
+                    extra={"model": candidate_model},
+                )
             try:
                 stream = await self._client.chat.completions.create(**candidate_kwargs)
                 if idx > 0:
@@ -553,8 +562,19 @@ class OpenAIAdapter:
             if delta is None:
                 continue
 
+            if is_deepseek_model(model):
+                reasoning_content: str | None = getattr(delta, "reasoning_content", None)
+                if reasoning_content:
+                    if not current_thinking_started:
+                        yield StreamEvent(type="thinking_start")
+                        current_thinking_started = True
+                    yield StreamEvent(type="thinking_delta", text=reasoning_content)
+
             # Text content
             if delta.content:
+                if current_thinking_started:
+                    yield StreamEvent(type="thinking_stop")
+                    current_thinking_started = False
                 if not current_text_started:
                     yield StreamEvent(type="text_start")
                     current_text_started = True
@@ -565,6 +585,9 @@ class OpenAIAdapter:
                 for tc_delta in delta.tool_calls:
                     idx: int = tc_delta.index if tc_delta.index is not None else 0
                     if idx not in tool_calls_accum:
+                        if current_thinking_started:
+                            yield StreamEvent(type="thinking_stop")
+                            current_thinking_started = False
                         tool_calls_accum[idx] = {
                             "id": tc_delta.id or f"call_{idx}",
                             "name": "",
@@ -593,6 +616,9 @@ class OpenAIAdapter:
 
             # Finish
             if choice.finish_reason:
+                if current_thinking_started:
+                    yield StreamEvent(type="thinking_stop")
+                    current_thinking_started = False
                 if current_text_started:
                     yield StreamEvent(type="text_stop")
                 for tc_data in tool_calls_accum.values():
@@ -776,6 +802,7 @@ class OpenAIAdapter:
 
             if role == "assistant" and isinstance(content, list):
                 text_parts: list[str] = []
+                reasoning_parts: list[str] = []
                 tool_calls: list[dict[str, Any]] = []
                 for block in content:
                     if not isinstance(block, dict):
@@ -783,6 +810,10 @@ class OpenAIAdapter:
                     btype = block.get("type", "")
                     if btype == "text":
                         text_parts.append(_as_text(block.get("text", "")))
+                    elif btype == "thinking":
+                        reasoning_text = _as_text(block.get("thinking", block.get("text", "")))
+                        if reasoning_text:
+                            reasoning_parts.append(reasoning_text)
                     elif btype == "tool_use":
                         tool_calls.append({
                             "id": block.get("id", ""),
@@ -792,12 +823,15 @@ class OpenAIAdapter:
                                 "arguments": json.dumps(block.get("input", {})),
                             },
                         })
-                    # Skip thinking blocks — OpenAI doesn't use them
 
                 msg_dict: dict[str, Any] = {
                     "role": "assistant",
                     "content": "\n".join(text_parts),
                 }
+                if self._supports_reasoning_content and reasoning_parts:
+                    # DeepSeek thinking-mode tool-call turns require this exact
+                    # assistant reasoning field to be replayed on subsequent calls.
+                    msg_dict["reasoning_content"] = "".join(reasoning_parts)
                 if tool_calls:
                     msg_dict["tool_calls"] = tool_calls
                 result.append(msg_dict)
@@ -868,6 +902,7 @@ def get_adapter(config: LLMConfig) -> AnthropicAdapter | OpenAIAdapter:
             api_key=config.api_key,
             base_url=base_url,
             supports_document_blocks=supports_docs,
+            supports_reasoning_content=provider == "deepseek",
         )
 
     raise ValueError(f"Unsupported LLM provider: {config.provider}")

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -261,3 +261,128 @@ def test_deepseek_clamps_max_tokens_to_provider_output_limit():
     assert adapter._build_token_limit_kwargs(model="deepseek/deepseek-v4-flash", max_tokens=500_000) == {
         "max_tokens": 393_216
     }
+
+
+class _SingleChunkAsyncIterator:
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self._idx = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._idx >= len(self._chunks):
+            raise StopAsyncIteration
+        chunk = self._chunks[self._idx]
+        self._idx += 1
+        return chunk
+
+
+def test_deepseek_format_messages_preserves_reasoning_content_when_enabled():
+    adapter = OpenAIAdapter(api_key="test-key", supports_reasoning_content=True)
+
+    formatted = adapter.format_messages_for_api(
+        [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "I should call a tool."},
+                    {"type": "text", "text": "Let me check."},
+                    {"type": "tool_use", "id": "call_1", "name": "lookup", "input": {"q": "x"}},
+                ],
+            }
+        ]
+    )
+
+    assert formatted == [
+        {
+            "role": "assistant",
+            "content": "Let me check.",
+            "reasoning_content": "I should call a tool.",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": '{"q": "x"}'},
+                }
+            ],
+        }
+    ]
+
+
+def test_openai_format_messages_drops_reasoning_content_by_default():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    formatted = adapter.format_messages_for_api(
+        [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "do not pass to non-DeepSeek providers"},
+                    {"type": "tool_use", "id": "call_1", "name": "lookup", "input": {}},
+                ],
+            }
+        ]
+    )
+
+    assert "reasoning_content" not in formatted[0]
+
+
+@pytest.mark.asyncio
+async def test_deepseek_stream_emits_reasoning_and_enables_thinking_mode():
+    adapter = OpenAIAdapter(api_key="test-key", supports_reasoning_content=True)
+    chunks = [
+        SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        reasoning_content="think",
+                        content=None,
+                        tool_calls=None,
+                    ),
+                    finish_reason=None,
+                )
+            ],
+        ),
+        SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        reasoning_content=None,
+                        content="answer",
+                        tool_calls=None,
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+        ),
+    ]
+    create_mock = AsyncMock(return_value=_SingleChunkAsyncIterator(chunks))
+    adapter._client = SimpleNamespace(  # type: ignore[assignment]
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+    )
+
+    events = [
+        event
+        async for event in adapter.stream(
+            model="deepseek-v4-pro",
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            thinking=True,
+            max_tokens=42,
+        )
+    ]
+
+    assert [event.type for event in events] == [
+        "thinking_start",
+        "thinking_delta",
+        "thinking_stop",
+        "text_start",
+        "text_delta",
+        "text_stop",
+    ]
+    assert events[1].text == "think"
+    assert events[4].text == "answer"
+    call_kwargs = create_mock.await_args.kwargs
+    assert call_kwargs["extra_body"] == {"thinking": {"type": "enabled"}}

--- a/backend/tests/test_orchestrator_deepseek_thinking.py
+++ b/backend/tests/test_orchestrator_deepseek_thinking.py
@@ -1,0 +1,90 @@
+import asyncio
+from types import SimpleNamespace
+
+from agents.orchestrator import ChatOrchestrator
+from services.llm_adapter import StreamEvent
+
+
+class _DeepSeekThinkingToolAdapter:
+    def __init__(self) -> None:
+        self._calls = 0
+        self.calls: list[dict[str, object]] = []
+
+    async def stream(self, **kwargs):  # type: ignore[no-untyped-def]
+        self._calls += 1
+        self.calls.append(kwargs)
+        if self._calls == 1:
+            yield StreamEvent(type="thinking_start")
+            yield StreamEvent(type="thinking_delta", text="I should look this up.")
+            yield StreamEvent(type="thinking_stop")
+            yield StreamEvent(type="text_delta", text="Let me check.")
+            yield StreamEvent(type="tool_use_start", tool_id="tool-1", tool_name="query_on_connector")
+            yield StreamEvent(type="tool_input_delta", tool_input_json='{"connector":"hubspot","query":"x"}')
+            yield StreamEvent(type="tool_use_stop")
+            return
+
+        yield StreamEvent(type="text_delta", text="Final response")
+        yield StreamEvent(type="text_stop")
+
+
+async def _collect_deepseek_stream(orchestrator: ChatOrchestrator):  # type: ignore[no-untyped-def]
+    messages = [{"role": "user", "content": "hi"}]
+    content_blocks: list[dict[str, object]] = []
+    chunks: list[str] = []
+    async for chunk in orchestrator._stream_with_tools(
+        messages,
+        "sys",
+        content_blocks,
+        "deepseek-v4-pro",
+    ):
+        chunks.append(chunk)
+    return chunks, content_blocks, messages
+
+
+def test_stream_with_tools_persists_deepseek_thinking_for_tool_turns(monkeypatch) -> None:
+    orchestrator = ChatOrchestrator(
+        user_id="u1",
+        organization_id="org1",
+        source="web",
+    )
+    adapter = _DeepSeekThinkingToolAdapter()
+    orchestrator._adapter = adapter
+    orchestrator._llm_config = SimpleNamespace(provider="deepseek")
+
+    async def _fake_execute_tool(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return {"status": "success", "rows": []}
+
+    monkeypatch.setattr("agents.orchestrator.execute_tool", _fake_execute_tool)
+
+    _chunks, content_blocks, messages = asyncio.run(_collect_deepseek_stream(orchestrator))
+
+    assert content_blocks[:3] == [
+        {"type": "thinking", "thinking": "I should look this up."},
+        {"type": "text", "text": "Let me check."},
+        {
+            "type": "tool_use",
+            "id": "tool-1",
+            "name": "query_on_connector",
+            "input": {"connector": "hubspot", "query": "x"},
+            "result": {"status": "success", "rows": []},
+            "status": "complete",
+        },
+    ]
+    assert {"type": "text", "text": "Final response"} in content_blocks
+
+    assistant_message = messages[1]
+    assert assistant_message == {
+        "role": "assistant",
+        "content": [
+            {"type": "thinking", "thinking": "I should look this up."},
+            {"type": "text", "text": "Let me check."},
+            {
+                "type": "tool_use",
+                "id": "tool-1",
+                "name": "query_on_connector",
+                "input": {"connector": "hubspot", "query": "x"},
+            },
+        ],
+    }
+    second_call_messages = adapter.calls[1]["messages"]
+    assert second_call_messages[1] == assistant_message


### PR DESCRIPTION
### Motivation
- DeepSeek requires streaming "thinking" deltas (`reasoning_content`) to be returned on subsequent tool-call turns, and failing to replay that field caused invalid-request errors. 
- The repository has multiple OpenAI-compatible providers, so DeepSeek-specific behavior must be scoped so other providers are unaffected. 

### Description
- Add a DeepSeek-aware reasoning path to the OpenAI-compatible adapter by introducing `supports_reasoning_content` and enabling DeepSeek thinking-mode on streaming requests via `extra_body` when `thinking=True`. 
- Emit `thinking_start` / `thinking_delta` / `thinking_stop` StreamEvents from the OpenAI adapter when DeepSeek `reasoning_content` deltas are present and ensure thinking is closed before text/tool events. 
- Preserve DeepSeek reasoning in non-streaming assistant history by having `format_messages_for_api` include `reasoning_content` only when `supports_reasoning_content` is enabled, and update the adapter factory to enable this flag for the DeepSeek provider. 
- Update the orchestrator streaming loop to accumulate streamed thinking text into `current_thinking` and append a provider-agnostic `thinking` content block to assistant history only when `is_deepseek_model(model_name)` is true. 
- Add regression tests to `backend/tests/test_llm_adapter_openai_token_params.py` that verify DeepSeek streaming emits reasoning deltas, that the adapter enables the DeepSeek thinking request body, and that reasoning content is only preserved when explicitly enabled.

### Testing
- Ran `pytest backend/tests/test_llm_adapter_openai_token_params.py` and all tests in that file passed (new DeepSeek tests included). 
- Ran `pytest backend/tests/test_llm_adapter_openai_token_params.py backend/tests/test_llm_provider.py` and both test suites passed (full run reported all tests green). 
- Ran `python -m compileall` on the modified modules and compilation succeeded with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02a4644394832191885a95b7eefaaa)