### PR TITLE
Validate pending sandbox participants before granting sandbox access

### DIFF
--- a/backend/connectors/code_sandbox.py
+++ b/backend/connectors/code_sandbox.py
@@ -300,7 +300,14 @@ class CodeSandboxConnector(BaseConnector):
         )
         pending_participant_user_ids: list[str] = _extract_pending_participant_user_ids(params)
         if pending_participant_user_ids:
-            conversation_allowed_user_ids = sorted(set(conversation_allowed_user_ids).union(pending_participant_user_ids))
+            valid_pending_user_ids, validation_error = await _validate_pending_participant_user_ids(
+                pending_participant_user_ids,
+                self.organization_id,
+                conversation_id,
+            )
+            if validation_error:
+                return {"error": validation_error}
+            conversation_allowed_user_ids = sorted(set(conversation_allowed_user_ids).union(valid_pending_user_ids))
         if basebase_user_id not in conversation_allowed_user_ids:
             logger.warning(
                 "[Sandbox] User %s is not allowed for conversation %s",
@@ -518,6 +525,95 @@ def _extract_pending_participant_user_ids(params: dict[str, Any]) -> list[str]:
 
     return sorted(normalized)
 
+
+async def _validate_pending_participant_user_ids(
+    pending_user_ids: list[str],
+    organization_id: str,
+    conversation_id: str,
+) -> tuple[list[str], str | None]:
+    """Validate pending sandbox participants are real users in this organization."""
+    if not pending_user_ids:
+        return [], None
+
+    normalized_pending: set[str] = set()
+    invalid_user_ids: list[str] = []
+    for user_id in pending_user_ids:
+        try:
+            normalized_pending.add(str(UUID(user_id)))
+        except ValueError:
+            invalid_user_ids.append(user_id)
+
+    if invalid_user_ids:
+        logger.warning(
+            "[Sandbox] Rejected malformed pending participant IDs org=%s conversation=%s count=%d",
+            organization_id,
+            conversation_id,
+            len(invalid_user_ids),
+        )
+        return [], "Pending participant user IDs must be valid Basebase user IDs."
+
+    organization_user_ids: set[str] = await _get_organization_user_ids(
+        sorted(normalized_pending),
+        organization_id,
+    )
+    missing_user_ids: list[str] = sorted(normalized_pending - organization_user_ids)
+    if missing_user_ids:
+        logger.warning(
+            "[Sandbox] Rejected pending participant IDs outside organization "
+            "org=%s conversation=%s missing_count=%d",
+            organization_id,
+            conversation_id,
+            len(missing_user_ids),
+        )
+        return [], (
+            "Pending participant user IDs must belong to the current organization before sandbox access is granted."
+        )
+
+    logger.info(
+        "[Sandbox] Validated %d pending participant ID(s) for org=%s conversation=%s",
+        len(normalized_pending),
+        organization_id,
+        conversation_id,
+    )
+    return sorted(normalized_pending), None
+
+
+async def _get_organization_user_ids(user_ids: list[str], organization_id: str) -> set[str]:
+    """Return candidate user IDs that are members or guests of the organization."""
+    if not user_ids:
+        return set()
+
+    from sqlalchemy import and_, or_, select
+    from models.database import get_session
+    from models.org_member import ORG_MEMBER_SCOPING_STATUSES, OrgMember
+    from models.user import User
+
+    user_uuids: list[UUID] = [UUID(user_id) for user_id in user_ids]
+    organization_uuid: UUID = UUID(organization_id)
+
+    async with get_session(organization_id=organization_id) as session:
+        result = await session.execute(
+            select(User.id)
+            .outerjoin(
+                OrgMember,
+                and_(
+                    OrgMember.user_id == User.id,
+                    OrgMember.organization_id == organization_uuid,
+                    OrgMember.status.in_(ORG_MEMBER_SCOPING_STATUSES),
+                ),
+            )
+            .where(User.id.in_(user_uuids))
+            .where(
+                or_(
+                    OrgMember.id.is_not(None),
+                    and_(
+                        User.is_guest.is_(True),
+                        User.guest_organization_id == organization_uuid,
+                    ),
+                )
+            )
+        )
+        return {str(user_id) for user_id in result.scalars().all()}
 
 def _get_sandbox_context_sync(sandbox_id: str) -> dict[str, str]:
     from e2b import Sandbox

--- a/backend/tests/test_code_sandbox_command_policy.py
+++ b/backend/tests/test_code_sandbox_command_policy.py
@@ -178,22 +178,30 @@ def test_extract_pending_participant_user_ids_supports_multiple_param_shapes() -
 
 @pytest.mark.asyncio
 async def test_execute_action_allows_pending_participant_when_about_to_add(monkeypatch) -> None:
-    connector = CodeSandboxConnector(organization_id="org_123")
+    org_id = "11111111-1111-1111-1111-111111111111"
+    existing_user_id = "22222222-2222-2222-2222-222222222222"
+    new_user_id = "33333333-3333-3333-3333-333333333333"
+    connector = CodeSandboxConnector(organization_id=org_id)
     monkeypatch.setattr("connectors.code_sandbox.settings.E2B_API_KEY", "test-key")
 
     async def _fake_allowed_users(conversation_id: str, organization_id: str) -> list[str]:
         assert conversation_id == "conv_123"
-        assert organization_id == "org_123"
-        return ["user_existing"]
+        assert organization_id == org_id
+        return [existing_user_id]
+
+    async def _fake_org_user_ids(user_ids: list[str], organization_id: str) -> set[str]:
+        assert user_ids == [new_user_id]
+        assert organization_id == org_id
+        return {new_user_id}
 
     async def _fake_get_sandbox_id(conversation_id: str, organization_id: str) -> str | None:
         assert conversation_id == "conv_123"
-        assert organization_id == "org_123"
+        assert organization_id == org_id
         return None
 
     async def _fake_save_sandbox_id(conversation_id: str, organization_id: str, sandbox_id: str | None) -> None:
         assert conversation_id == "conv_123"
-        assert organization_id == "org_123"
+        assert organization_id == org_id
         assert sandbox_id == "sbx_new"
 
     def _fake_create_sandbox(
@@ -202,10 +210,10 @@ async def test_execute_action_allows_pending_participant_when_about_to_add(monke
         basebase_user_id: str,
         allowed_user_ids_csv: str,
     ) -> str:
-        assert organization_id == "org_123"
+        assert organization_id == org_id
         assert conversation_id == "conv_123"
-        assert basebase_user_id == "user_new"
-        assert allowed_user_ids_csv == "user_existing,user_new"
+        assert basebase_user_id == new_user_id
+        assert allowed_user_ids_csv == f"{existing_user_id},{new_user_id}"
         return "sbx_new"
 
     def _fake_run_command(sandbox_id: str, command: str) -> dict[str, object]:
@@ -218,6 +226,7 @@ async def test_execute_action_allows_pending_participant_when_about_to_add(monke
         return []
 
     monkeypatch.setattr("connectors.code_sandbox._get_conversation_allowed_user_ids", _fake_allowed_users)
+    monkeypatch.setattr("connectors.code_sandbox._get_organization_user_ids", _fake_org_user_ids)
     monkeypatch.setattr("connectors.code_sandbox._get_sandbox_id_from_db", _fake_get_sandbox_id)
     monkeypatch.setattr("connectors.code_sandbox._save_sandbox_id_to_db", _fake_save_sandbox_id)
     monkeypatch.setattr("connectors.code_sandbox._create_sandbox_sync", _fake_create_sandbox)
@@ -229,12 +238,73 @@ async def test_execute_action_allows_pending_participant_when_about_to_add(monke
         {
             "command": "python3 -c 'print(1)'",
             "conversation_id": "conv_123",
-            "basebase_user_id": "user_new",
-            "about_to_add_user_ids": ["user_new"],
+            "basebase_user_id": new_user_id,
+            "about_to_add_user_ids": [new_user_id],
         },
     )
 
     assert result == {"exit_code": 0, "stdout": "1\n", "stderr": ""}
+
+
+@pytest.mark.asyncio
+async def test_execute_action_rejects_pending_participant_outside_organization(monkeypatch) -> None:
+    org_id = "11111111-1111-1111-1111-111111111111"
+    existing_user_id = "22222222-2222-2222-2222-222222222222"
+    outside_user_id = "44444444-4444-4444-4444-444444444444"
+    connector = CodeSandboxConnector(organization_id=org_id)
+    monkeypatch.setattr("connectors.code_sandbox.settings.E2B_API_KEY", "test-key")
+
+    async def _fake_allowed_users(conversation_id: str, organization_id: str) -> list[str]:
+        assert conversation_id == "conv_123"
+        assert organization_id == org_id
+        return [existing_user_id]
+
+    async def _fake_org_user_ids(user_ids: list[str], organization_id: str) -> set[str]:
+        assert user_ids == [outside_user_id]
+        assert organization_id == org_id
+        return set()
+
+    monkeypatch.setattr("connectors.code_sandbox._get_conversation_allowed_user_ids", _fake_allowed_users)
+    monkeypatch.setattr("connectors.code_sandbox._get_organization_user_ids", _fake_org_user_ids)
+
+    result = await connector.execute_action(
+        "execute_command",
+        {
+            "command": "python3 -c 'print(1)'",
+            "conversation_id": "conv_123",
+            "basebase_user_id": outside_user_id,
+            "about_to_add_user_ids": [outside_user_id],
+        },
+    )
+
+    assert result == {
+        "error": "Pending participant user IDs must belong to the current organization before sandbox access is granted."
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_action_rejects_malformed_pending_participant_id(monkeypatch) -> None:
+    connector = CodeSandboxConnector(organization_id="11111111-1111-1111-1111-111111111111")
+    monkeypatch.setattr("connectors.code_sandbox.settings.E2B_API_KEY", "test-key")
+
+    async def _fake_allowed_users(conversation_id: str, organization_id: str) -> list[str]:
+        assert conversation_id == "conv_123"
+        assert organization_id == "11111111-1111-1111-1111-111111111111"
+        return ["22222222-2222-2222-2222-222222222222"]
+
+    monkeypatch.setattr("connectors.code_sandbox._get_conversation_allowed_user_ids", _fake_allowed_users)
+
+    result = await connector.execute_action(
+        "execute_command",
+        {
+            "command": "python3 -c 'print(1)'",
+            "conversation_id": "conv_123",
+            "basebase_user_id": "not-a-uuid",
+            "about_to_add_user_ids": ["not-a-uuid"],
+        },
+    )
+
+    assert result == {"error": "Pending participant user IDs must be valid Basebase user IDs."}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Prevent extending a sandbox allow-list with arbitrary or malformed user IDs by validating pending/about-to-add participant IDs before creating or reusing a sandbox.
- Ensure any pending participant being temporarily allowed in a conversation is actually a member/guest of the same organization to avoid cross-org access.

### Description
- Update `backend/connectors/code_sandbox.py` to validate pending IDs when merging them into the conversation allow-list by calling a new ` _validate_pending_participant_user_ids` helper before creating/reusing a sandbox.
- Add `async def _validate_pending_participant_user_ids(...)` which canonicalizes UUIDs, rejects malformed IDs, logs warnings, and returns a user-facing error message when validation fails.
- Add `async def _get_organization_user_ids(...)` which queries `users` / `org_members` (including guest orgs and scoping statuses) to confirm membership before admitting pending IDs.
- Update tests in `backend/tests/test_code_sandbox_command_policy.py` to cover the happy path (about-to-add accepted), malformed pending IDs rejection, and out-of-organization rejection, and wire the new org lookup into the test harness.

### Testing
- Ran `pytest backend/tests/test_code_sandbox_command_policy.py backend/tests/test_code_sandbox_db_security.py` and all tests passed (`21 passed`).
- Performed a bytecode/compile check with `python -m compileall` for the modified files and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0353cd547483219c9047e0c38ef23e)