### PR TITLE
Support DeepSeek-V4-Vision and guard DeepSeek v4 text models from image inputs

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -41,12 +41,47 @@ DEEPSEEK_MODEL_PREFIXES: tuple[str, ...] = (
     "deepseek-chat",
     "deepseek-reasoner",
 )
+DEEPSEEK_V4_VISION_MODEL_PREFIX: str = "deepseek-v4-vision"
+DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE: str = (
+    "DeepSeek v4 does not accept image attachments. Please switch to "
+    "DeepSeek-V4-Vision or another vision-capable model, or resend your message without images."
+)
+
+
+def _normalized_model_name(model: str) -> str:
+    """Normalize provider-prefixed model names for local capability checks."""
+    return model.strip().lower().split("/")[-1]
 
 
 def is_deepseek_model(model: str) -> bool:
     """Return whether a model name targets DeepSeek's OpenAI-compatible API."""
-    normalized_model: str = model.strip().lower().split("/")[-1]
-    return normalized_model.startswith(DEEPSEEK_MODEL_PREFIXES)
+    return _normalized_model_name(model).startswith(DEEPSEEK_MODEL_PREFIXES)
+
+
+def is_deepseek_v4_vision_model(model: str) -> bool:
+    """Return whether a DeepSeek v4 model explicitly supports image inputs."""
+    return _normalized_model_name(model).startswith(DEEPSEEK_V4_VISION_MODEL_PREFIX)
+
+
+def deepseek_v4_rejects_images(model: str) -> bool:
+    """Return whether a DeepSeek v4 model is text-only for image inputs."""
+    normalized_model: str = _normalized_model_name(model)
+    return normalized_model.startswith("deepseek-v4") and not is_deepseek_v4_vision_model(model)
+
+
+def messages_contain_images(messages: list[dict[str, Any]]) -> bool:
+    """Detect image content blocks before dispatching to a provider API."""
+    for msg in messages:
+        content: Any = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type: str = str(block.get("type", "")).lower()
+            if block_type in {"image", "image_url"}:
+                return True
+    return False
 
 
 def _get_attr_or_item(value: Any, name: str, default: Any = None) -> Any:
@@ -370,6 +405,19 @@ class AnthropicAdapter:
 
     # -- formatting helpers -------------------------------------------------
 
+    def _guard_model_image_support(
+        self, *, model: str, messages: list[dict[str, Any]]
+    ) -> None:
+        """Fail locally before sending images to text-only model variants."""
+        if not deepseek_v4_rejects_images(model) or not messages_contain_images(messages):
+            return
+
+        logger.info(
+            "Rejected image-bearing request for text-only DeepSeek v4 model",
+            extra={"model": model},
+        )
+        raise ValueError(DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE)
+
     def format_tools(self, tools: list[ToolDef]) -> list[dict[str, Any]]:
         return [
             {"name": t.name, "description": t.description, "input_schema": t.input_schema}
@@ -522,6 +570,7 @@ class OpenAIAdapter:
         thinking: bool = False,
         max_tokens: int = 32768,
     ) -> AsyncIterator[StreamEvent]:
+        self._guard_model_image_support(model=model, messages=messages)
         api_messages: list[dict[str, Any]] = [
             {"role": "system", "content": system}
         ] + self.format_messages_for_api(messages)
@@ -667,6 +716,7 @@ class OpenAIAdapter:
         messages: list[dict[str, Any]],
         max_tokens: int = 1024,
     ) -> CompletedMessage:
+        self._guard_model_image_support(model=model, messages=messages)
         api_messages: list[dict[str, Any]] = [
             {"role": "system", "content": system}
         ] + self.format_messages_for_api(messages)
@@ -710,6 +760,19 @@ class OpenAIAdapter:
         )
 
     # -- formatting helpers -------------------------------------------------
+
+    def _guard_model_image_support(
+        self, *, model: str, messages: list[dict[str, Any]]
+    ) -> None:
+        """Fail locally before sending images to text-only model variants."""
+        if not deepseek_v4_rejects_images(model) or not messages_contain_images(messages):
+            return
+
+        logger.info(
+            "Rejected image-bearing request for text-only DeepSeek v4 model",
+            extra={"model": model},
+        )
+        raise ValueError(DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE)
 
     def format_tools(self, tools: list[ToolDef]) -> list[dict[str, Any]]:
         return [

--- a/backend/services/llm_provider.py
+++ b/backend/services/llm_provider.py
@@ -321,6 +321,7 @@ def get_model_max_tokens_map(default_max_tokens: int = 200_000) -> dict[str, int
         "qwen3.6-plus": 1_000_000,
         "deepseek-v4-flash": DEEPSEEK_CONTEXT_WINDOW_TOKENS,
         "deepseek-v4-pro": DEEPSEEK_CONTEXT_WINDOW_TOKENS,
+        "deepseek-v4-vision": DEEPSEEK_CONTEXT_WINDOW_TOKENS,
         "deepseek-chat": DEEPSEEK_CONTEXT_WINDOW_TOKENS,
         "deepseek-reasoner": DEEPSEEK_CONTEXT_WINDOW_TOKENS,
     }
@@ -336,6 +337,7 @@ def get_model_output_token_limit(model: str, default_max_tokens: int = 32_768) -
     explicit_output_limits: dict[str, int] = {
         "deepseek-v4-flash": DEEPSEEK_MAX_OUTPUT_TOKENS,
         "deepseek-v4-pro": DEEPSEEK_MAX_OUTPUT_TOKENS,
+        "deepseek-v4-vision": DEEPSEEK_MAX_OUTPUT_TOKENS,
         "deepseek-chat": DEEPSEEK_MAX_OUTPUT_TOKENS,
         "deepseek-reasoner": DEEPSEEK_MAX_OUTPUT_TOKENS,
     }

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -456,3 +456,94 @@ async def test_non_deepseek_stream_ignores_reasoning_content_delta():
         ("text_stop", None),
     ]
     assert "extra_body" not in create_mock.await_args.kwargs
+
+
+def _image_message():
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is in this image?"},
+                {
+                    "type": "image",
+                    "source": {
+                        "media_type": "image/png",
+                        "data": "iVBORw0KGgo=",
+                    },
+                },
+            ],
+        }
+    ]
+
+
+def test_deepseek_v4_text_model_rejects_image_messages_before_formatting():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    with pytest.raises(ValueError, match="DeepSeek v4 does not accept image attachments"):
+        adapter._guard_model_image_support(
+            model="deepseek-v4-pro",
+            messages=_image_message(),
+        )
+
+
+def test_deepseek_v4_vision_model_allows_image_messages():
+    adapter = OpenAIAdapter(api_key="test-key")
+
+    adapter._guard_model_image_support(
+        model="deepseek-v4-vision",
+        messages=_image_message(),
+    )
+
+    formatted = adapter.format_messages_for_api(_image_message())
+    assert formatted[0]["content"][1] == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+    }
+
+
+@pytest.mark.asyncio
+async def test_deepseek_v4_stream_rejects_images_without_api_call():
+    adapter = OpenAIAdapter(api_key="test-key")
+    create_mock = AsyncMock(return_value=_EmptyAsyncIterator())
+    adapter._client = SimpleNamespace(  # type: ignore[assignment]
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+    )
+
+    with pytest.raises(ValueError, match="DeepSeek-V4-Vision"):
+        _ = [
+            event
+            async for event in adapter.stream(
+                model="deepseek-v4-pro",
+                system="sys",
+                messages=_image_message(),
+                max_tokens=42,
+            )
+        ]
+
+    create_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_deepseek_v4_vision_stream_sends_images_to_api():
+    adapter = OpenAIAdapter(api_key="test-key")
+    create_mock = AsyncMock(return_value=_EmptyAsyncIterator())
+    adapter._client = SimpleNamespace(  # type: ignore[assignment]
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+    )
+
+    events = [
+        event
+        async for event in adapter.stream(
+            model="deepseek-v4-vision",
+            system="sys",
+            messages=_image_message(),
+            max_tokens=42,
+        )
+    ]
+
+    assert events == []
+    assert create_mock.await_count == 1
+    assert create_mock.await_args.kwargs["messages"][1]["content"][1] == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+    }

--- a/backend/tests/test_llm_provider.py
+++ b/backend/tests/test_llm_provider.py
@@ -145,7 +145,7 @@ def test_get_model_max_tokens_map_uses_explicit_windows_and_defaults(monkeypatch
     monkeypatch.setattr(
         llm_provider.settings,
         "ALL_MODEL_STRINGS",
-        "claude-opus-4-6:anthropic,gpt-5.5:openai,qwen3.6-plus:alibaba,deepseek-v4-flash:deepseek,deepseek-v4-pro:deepseek,deepseek-chat:deepseek,deepseek-reasoner:deepseek,random-model:openai",
+        "claude-opus-4-6:anthropic,gpt-5.5:openai,qwen3.6-plus:alibaba,deepseek-v4-flash:deepseek,deepseek-v4-pro:deepseek,deepseek-v4-vision:deepseek,deepseek-chat:deepseek,deepseek-reasoner:deepseek,random-model:openai",
     )
 
     max_tokens_map = llm_provider.get_model_max_tokens_map(default_max_tokens=200_000)
@@ -155,6 +155,7 @@ def test_get_model_max_tokens_map_uses_explicit_windows_and_defaults(monkeypatch
     assert max_tokens_map["qwen3.6-plus"] == 1_000_000
     assert max_tokens_map["deepseek-v4-flash"] == 1_000_000
     assert max_tokens_map["deepseek-v4-pro"] == 1_000_000
+    assert max_tokens_map["deepseek-v4-vision"] == 1_000_000
     assert max_tokens_map["deepseek-chat"] == 1_000_000
     assert max_tokens_map["deepseek-reasoner"] == 1_000_000
     assert max_tokens_map["random-model"] == 200_000
@@ -163,6 +164,7 @@ def test_get_model_max_tokens_map_uses_explicit_windows_and_defaults(monkeypatch
 def test_deepseek_output_token_limit_matches_provider_max_output() -> None:
     assert get_model_output_token_limit("deepseek-v4-pro") == 393_216
     assert get_model_output_token_limit("deepseek-v4-flash") == 393_216
+    assert get_model_output_token_limit("deepseek-v4-vision") == 393_216
     assert get_model_output_token_limit("deepseek-chat") == 393_216
     assert get_model_output_token_limit("deepseek-reasoner") == 393_216
     assert get_model_output_token_limit("gpt-5.5") == 32_768


### PR DESCRIPTION
### Motivation
- Add explicit support for a DeepSeek v4 vision-capable model variant while preventing accidental image dispatch to DeepSeek v4 text-only models by failing early with a user-friendly message.

### Description
- Added `deepseek-v4-vision` handling and token/window entries to `services/llm_provider.py` so it is treated like other DeepSeek v4 variants for context and output limits.
- Added model-normalization helpers and image-detection helpers plus a local guard `_guard_model_image_support` in `services/llm_adapter.py` that raises a friendly `ValueError` when a DeepSeek v4 text model would be sent image content.
- Plumbed the guard into both streaming (`OpenAIAdapter.stream`) and non-streaming (`OpenAIAdapter.complete`) paths so image-bearing requests are rejected before any provider API call; added the same guard to the Anthropic adapter formatting helpers for consistency.
- Added regression tests in `backend/tests/test_llm_adapter_openai_token_params.py` and updated `backend/tests/test_llm_provider.py` to cover the new `deepseek-v4-vision` token mappings and the image-rejection behavior.

### Testing
- Ran `pytest backend/tests/test_llm_adapter_openai_token_params.py backend/tests/test_llm_provider.py` and all tests passed (`37 passed`).
- Ran repository checks (`git diff --check`) to ensure no whitespace/errors and the modified tests exercised the new guard and model mappings successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03e1bf32888321b0e6dac267192e48)