### PR TITLE
feat(integrations): multi-account OAuth connectors

### DIFF
--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -472,6 +472,9 @@ async def _get_connector_instance(
     user_id: str | None,
     required_capability: str | None = None,
     preferred_integration_user_id: str | None = None,
+    *,
+    integration_id: str | None = None,
+    account_identifier: str | None = None,
 ) -> tuple["BaseConnector | None", str | None]:
     """Resolve a connector by slug, verify active Integration, and instantiate.
 
@@ -507,6 +510,10 @@ async def _get_connector_instance(
                 Integration.user_id == UUID(preferred_integration_user_id),
                 Integration.is_active == True,  # noqa: E712
             ]
+            if integration_id and integration_id.strip():
+                preferred_filters.append(Integration.id == UUID(integration_id.strip()))
+            if account_identifier and account_identifier.strip():
+                preferred_filters.append(Integration.account_identifier == account_identifier.strip())
 
             requester_matches_preferred = bool(user_id) and preferred_integration_user_id == user_id
             if (
@@ -522,25 +529,34 @@ async def _get_connector_instance(
                 preferred_filters.append(preferred_share_flag_map[required_capability] == True)  # noqa: E712
 
             result = await session.execute(
-                select(Integration).where(
-                    *preferred_filters,
-                )
+                select(Integration)
+                .where(*preferred_filters)
+                .order_by(Integration.updated_at.desc().nullslast())
+                .limit(1)
             )
-            integration: Integration | None = result.scalar_one_or_none()
+            integration: Integration | None = result.scalars().first()
         else:
             integration = None
 
         # Next, try to find user's own integration
         if integration is None and user_id:
+            user_filters: list[Any] = [
+                Integration.organization_id == UUID(organization_id),
+                Integration.connector == slug,
+                Integration.user_id == UUID(user_id),
+                Integration.is_active == True,  # noqa: E712
+            ]
+            if integration_id and integration_id.strip():
+                user_filters.append(Integration.id == UUID(integration_id.strip()))
+            if account_identifier and account_identifier.strip():
+                user_filters.append(Integration.account_identifier == account_identifier.strip())
             result = await session.execute(
-                select(Integration).where(
-                    Integration.organization_id == UUID(organization_id),
-                    Integration.connector == slug,
-                    Integration.user_id == UUID(user_id),
-                    Integration.is_active == True,  # noqa: E712
-                )
+                select(Integration)
+                .where(*user_filters)
+                .order_by(Integration.updated_at.desc().nullslast())
+                .limit(1)
             )
-            integration = result.scalar_one_or_none()
+            integration = result.scalars().first()
 
         # If no personal integration, look for shared integrations
         if integration is None:
@@ -606,7 +622,12 @@ async def _get_connector_instance(
         integration_user_id = str(integration.user_id)
 
     # Instantiate connector with the integration owner's user_id
-    instance: BaseConnector = connector_cls(organization_id, user_id=integration_user_id)
+    instance: BaseConnector = connector_cls(
+        organization_id,
+        user_id=integration_user_id,
+        integration_id=integration_id.strip() if integration_id and integration_id.strip() else None,
+        account_identifier=account_identifier.strip() if account_identifier and account_identifier.strip() else None,
+    )
 
     # Dynamic MCP slugs (mcp_deepwiki, etc.) share the McpConnector class whose
     # source_system is "mcp", but the Integration row uses the dynamic slug.
@@ -916,9 +937,13 @@ async def _query_on_connector(
     params: dict[str, Any], organization_id: str, user_id: str | None
 ) -> dict[str, Any]:
     """Dispatch a query to a QUERY-capable connector."""
+    from models.integration import Integration
+
     connector: str = (params.get("connector") or "").strip()
     query: str = (params.get("query") or "").strip()
     info: dict[str, Any] = dict(params.get("info") or {})
+    account_param: str = str(params.get("account") or params.get("account_identifier") or "").strip()
+
     if not connector:
         return {"error": "connector is required"}
     if not query:
@@ -937,36 +962,109 @@ async def _query_on_connector(
     if not dp_result.allowed:
         return {"error": dp_result.deny_reason or "Connector query not allowed"}
 
-    instance, error = await _get_connector_instance(connector, organization_id, user_id, required_capability="query")
-    if error:
-        return {"error": error}
-    assert instance is not None
-
-    cross_user_warning = _build_cross_user_connector_warning(connector, instance, user_id)
-
-    try:
-        if info:
-            logger.info(
-                "[Tools] query_on_connector(%s) info=%s",
-                connector,
-                info,
+    owner_rows: list[Integration] = []
+    if user_id:
+        async with get_session(organization_id=organization_id) as session:
+            stmt = (
+                select(Integration)
+                .where(
+                    Integration.organization_id == UUID(organization_id),
+                    Integration.connector == connector,
+                    Integration.user_id == UUID(user_id),
+                    Integration.is_active == True,  # noqa: E712
+                )
+                .order_by(Integration.updated_at.desc().nullslast())
             )
-        result = await instance.query(query)
-        if info and isinstance(result, dict):
-            result.setdefault("info", info)
-        return _attach_cross_user_connector_warning(result, cross_user_warning)
-    except ExternalConnectionRevokedError as exc:
-        logger.warning("[Tools] query_on_connector(%s) connection revoked: %s", connector, exc)
-        return await _attach_connector_docs(
-            _build_connection_revoked_result(connector, f"Query to {connector}", exc),
-            connector, organization_id,
+            if account_param:
+                stmt = stmt.where(Integration.account_identifier == account_param)
+            owner_rows = list((await session.execute(stmt)).scalars().all())
+
+    multi_account: bool = bool(user_id and len(owner_rows) > 1 and not account_param)
+
+    if not multi_account:
+        pick_id: str | None = str(owner_rows[0].id) if owner_rows else None
+        instance, error = await _get_connector_instance(
+            connector,
+            organization_id,
+            user_id,
+            required_capability="query",
+            integration_id=pick_id,
+            account_identifier=account_param or None,
         )
-    except Exception as exc:
-        logger.error("[Tools] query_on_connector(%s) failed: %s", connector, exc, exc_info=True)
-        return await _attach_connector_docs(
-            {"error": f"Query to {connector} failed: {exc}"},
-            connector, organization_id,
+        if error:
+            return {"error": error}
+        assert instance is not None
+
+        cross_user_warning = _build_cross_user_connector_warning(connector, instance, user_id)
+
+        try:
+            if info:
+                logger.info(
+                    "[Tools] query_on_connector(%s) info=%s",
+                    connector,
+                    info,
+                )
+            result = await instance.query(query)
+            if info and isinstance(result, dict):
+                result.setdefault("info", info)
+            return _attach_cross_user_connector_warning(result, cross_user_warning)
+        except ExternalConnectionRevokedError as exc:
+            logger.warning("[Tools] query_on_connector(%s) connection revoked: %s", connector, exc)
+            return await _attach_connector_docs(
+                _build_connection_revoked_result(connector, f"Query to {connector}", exc),
+                connector, organization_id,
+            )
+        except Exception as exc:
+            logger.error("[Tools] query_on_connector(%s) failed: %s", connector, exc, exc_info=True)
+            return await _attach_connector_docs(
+                {"error": f"Query to {connector} failed: {exc}"},
+                connector, organization_id,
+            )
+
+    async def _run_one(row: Integration) -> dict[str, Any]:
+        label: str = row.account_label or row.account_identifier or str(row.id)
+        inst, err = await _get_connector_instance(
+            connector,
+            organization_id,
+            user_id,
+            required_capability="query",
+            integration_id=str(row.id),
         )
+        if err or inst is None:
+            return {"account": label, "error": err or "no_connector_instance"}
+        try:
+            res = await inst.query(query)
+        except ExternalConnectionRevokedError as exc:
+            return {
+                "account": label,
+                "error": str(exc),
+                "user_guidance": _build_connection_revoked_result(connector, f"Query to {connector}", exc).get(
+                    "user_guidance"
+                ),
+            }
+        except Exception as exc:
+            return {"account": label, "error": str(exc)}
+        if isinstance(res, dict):
+            payload: dict[str, Any] = dict(res)
+        else:
+            payload = {"result": res}
+        payload["account"] = label
+        return payload
+
+    first_inst, _ = await _get_connector_instance(
+        connector,
+        organization_id,
+        user_id,
+        required_capability="query",
+        integration_id=str(owner_rows[0].id),
+    )
+    cross_user_warning = _build_cross_user_connector_warning(connector, first_inst, user_id)
+
+    items: list[dict[str, Any]] = await asyncio.gather(*[_run_one(r) for r in owner_rows])
+    merged: dict[str, Any] = {"multi_account": True, "items": items}
+    if info:
+        merged["info"] = info
+    return _attach_cross_user_connector_warning(merged, cross_user_warning)
 
 
 
@@ -5294,7 +5392,7 @@ async def _trigger_sync(
         return {"error": "Provider is required (e.g., 'hubspot', 'gmail', 'salesforce')."}
     
     # Active integrations (often multiple user-scoped rows per org + connector)
-    owner_ids: list[str | None] = []
+    sync_targets: list[tuple[str | None, str]] = []
     async with get_session(organization_id=organization_id) as session:
         result = await session.execute(
             select(Integration)
@@ -5315,11 +5413,10 @@ async def _trigger_sync(
                 "error": f"No active {provider} integration found.",
                 "suggestion": f"Go to Data Sources and connect {provider}.",
             }
-        # Snapshot scalar identifiers while the rows are still bound to a live
-        # session. Accessing ORM attributes after the session exits can trigger
-        # detached-instance refresh errors.
-        owner_ids = [str(integration.user_id) if integration.user_id else None for integration in integrations]
-    
+        for integration in integrations:
+            owner: str | None = str(integration.user_id) if integration.user_id else None
+            sync_targets.append((owner, str(integration.id)))
+
     dp_ctx = ConnectorContext(
         organization_id=organization_id,
         user_id=None,
@@ -5336,12 +5433,17 @@ async def _trigger_sync(
         task_ids: list[str] = []
         logger.info(
             "[Tools._trigger_sync] Queueing %d sync task(s) for provider=%s org=%s",
-            len(owner_ids),
+            len(sync_targets),
             provider,
             organization_id,
         )
-        for owner_id in owner_ids:
-            task = sync_integration.delay(organization_id, provider, user_id=owner_id)
+        for owner_id, integ_id in sync_targets:
+            task = sync_integration.delay(
+                organization_id,
+                provider,
+                user_id=owner_id,
+                integration_id=integ_id,
+            )
             task_ids.append(task.id)
 
         if len(task_ids) == 1:
@@ -5434,24 +5536,6 @@ async def _initiate_connector(
 
     if not user_id:
         return {"error": "user_id is required for all connector authentication."}
-
-    async with get_session(organization_id=organization_id) as session:
-        result = await session.execute(
-            select(Integration).where(
-                Integration.organization_id == UUID(organization_id),
-                Integration.connector == provider,
-                Integration.user_id == UUID(user_id),
-                Integration.is_active == True,  # noqa: E712
-            )
-        )
-        existing = result.scalar_one_or_none()
-
-        if existing:
-            return {
-                "status": "already_connected",
-                "message": f"{provider} is already connected.",
-                "provider": provider,
-            }
 
     ctx: dict[str, Any] = context or {}
     raw_source: str = str(ctx.get("source") or "web").strip().lower()

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import and_, bindparam, func, or_, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import (
     BUILTIN_CONNECTORS,
@@ -3246,10 +3247,17 @@ async def _probe_account_metadata_for_confirm(
     user_id_str: str,
     nango_connection_id: str,
 ) -> AccountMetadata:
-    """Resolve stable account identifier for a fresh Nango connection (pre-DB row)."""
+    """Resolve stable account identifier for a fresh Nango connection (pre-DB row).
+
+    When the connector cannot resolve a real identity (missing scopes, transient
+    upstream failure, unknown provider), we return ``identifier=None`` so the row
+    stays NULL-keyed. We deliberately do not persist the opaque Nango connection
+    id as ``account_identifier``/``account_label`` because it surfaces as a
+    user-visible UUID in the connectors list.
+    """
     connector_cls: type[BaseConnector] | None = resolve_connector(provider)
     if connector_cls is None:
-        return AccountMetadata(identifier=nango_connection_id, label=None, avatar_url=None)
+        return AccountMetadata(identifier=None, label=None, avatar_url=None)
     probe: BaseConnector = connector_cls(organization_id_str, user_id_str)
     probe._nango_connection_override = nango_connection_id
     try:
@@ -3260,7 +3268,81 @@ async def _probe_account_metadata_for_confirm(
             provider,
             exc,
         )
-        return AccountMetadata(identifier=nango_connection_id, label=None, avatar_url=None)
+        return AccountMetadata(identifier=None, label=None, avatar_url=None)
+
+
+async def _find_existing_integration_for_confirm(
+    session: AsyncSession,
+    *,
+    organization_id: UUID,
+    provider: str,
+    user_id: UUID,
+    account_identifier: str | None,
+    nango_connection_id: str | None,
+) -> Integration | None:
+    """Find an existing integration row to upsert during confirm.
+
+    Order:
+    1. Exact ``account_identifier`` match (only when identifier is known).
+    2. Existing row with the same Nango ``connection_id`` (covers re-confirms
+       and lets us upgrade a row whose ``account_identifier`` was previously
+       written as the Nango UUID before the metadata fetch was fixed).
+    3. Most recent legacy NULL-identifier row for backfill / single-account upgrade.
+    """
+    if account_identifier:
+        match = await session.execute(
+            select(Integration).where(
+                Integration.organization_id == organization_id,
+                Integration.connector == provider,
+                Integration.user_id == user_id,
+                Integration.account_identifier == account_identifier,
+            )
+        )
+        existing: Integration | None = match.scalar_one_or_none()
+        if existing is not None:
+            return existing
+
+    if nango_connection_id:
+        by_connection = await session.execute(
+            select(Integration).where(
+                Integration.organization_id == organization_id,
+                Integration.connector == provider,
+                Integration.user_id == user_id,
+                Integration.nango_connection_id == nango_connection_id,
+            )
+        )
+        by_conn_row: Integration | None = by_connection.scalar_one_or_none()
+        if by_conn_row is not None:
+            return by_conn_row
+
+    legacy = await session.execute(
+        select(Integration)
+        .where(
+            Integration.organization_id == organization_id,
+            Integration.connector == provider,
+            Integration.user_id == user_id,
+            Integration.account_identifier.is_(None),
+        )
+        .order_by(Integration.updated_at.desc().nullslast())
+        .limit(1)
+    )
+    return legacy.scalar_one_or_none()
+
+
+def _apply_account_meta_to_integration(
+    integration: Integration,
+    account_meta: AccountMetadata,
+) -> None:
+    """Persist account identity onto an Integration row.
+
+    When ``identifier`` is ``None`` we leave ``account_identifier``/``account_label``
+    untouched so the row stays NULL-keyed and the connectors UI does not surface
+    a placeholder (e.g. a Nango UUID) as the account label.
+    """
+    if account_meta.identifier is None:
+        return
+    integration.account_identifier = account_meta.identifier
+    integration.account_label = account_meta.label or account_meta.identifier
 
 
 @router.post("/integrations/confirm")
@@ -3448,29 +3530,14 @@ async def confirm_integration(
             {"org_id": str(org_uuid)}
         )
 
-        match_result = await session.execute(
-            select(Integration).where(
-                Integration.organization_id == org_uuid,
-                Integration.connector == request.provider,
-                Integration.user_id == user_uuid,
-                Integration.account_identifier == account_meta.identifier,
-            )
+        existing_row: Integration | None = await _find_existing_integration_for_confirm(
+            session,
+            organization_id=org_uuid,
+            provider=request.provider,
+            user_id=user_uuid,
+            account_identifier=account_meta.identifier,
+            nango_connection_id=nango_connection_id,
         )
-        existing_row: Integration | None = match_result.scalar_one_or_none()
-
-        if existing_row is None:
-            legacy_match = await session.execute(
-                select(Integration)
-                .where(
-                    Integration.organization_id == org_uuid,
-                    Integration.connector == request.provider,
-                    Integration.user_id == user_uuid,
-                    Integration.account_identifier.is_(None),
-                )
-                .order_by(Integration.updated_at.desc().nullslast())
-                .limit(1)
-            )
-            existing_row = legacy_match.scalar_one_or_none()
 
         if existing_row is not None:
             existing_row.nango_connection_id = nango_connection_id
@@ -3481,8 +3548,7 @@ async def confirm_integration(
             existing_row.share_synced_data = sharing_defaults.share_synced_data
             existing_row.share_query_access = sharing_defaults.share_query_access
             existing_row.share_write_access = sharing_defaults.share_write_access
-            existing_row.account_identifier = account_meta.identifier
-            existing_row.account_label = account_meta.label or account_meta.identifier
+            _apply_account_meta_to_integration(existing_row, account_meta)
             if merged_extra is not None:
                 existing_row.extra_data = merged_extra
             integration_id = str(existing_row.id)
@@ -3501,7 +3567,11 @@ async def confirm_integration(
                 share_write_access=sharing_defaults.share_write_access,
                 pending_sharing_config=False,
                 account_identifier=account_meta.identifier,
-                account_label=account_meta.label or account_meta.identifier,
+                account_label=(
+                    (account_meta.label or account_meta.identifier)
+                    if account_meta.identifier
+                    else None
+                ),
             )
             session.add(new_integration)
             await session.flush()
@@ -4231,29 +4301,14 @@ async def nango_callback(
             if await _get_org_membership(guard_cb, user_uuid, org_uuid) is None:
                 raise HTTPException(status_code=403, detail="User not authorized")
 
-        match_result = await session.execute(
-            select(Integration).where(
-                Integration.organization_id == org_uuid,
-                Integration.connector == provider,
-                Integration.user_id == user_uuid,
-                Integration.account_identifier == account_meta.identifier,
-            )
+        existing: Integration | None = await _find_existing_integration_for_confirm(
+            session,
+            organization_id=org_uuid,
+            provider=provider,
+            user_id=user_uuid,
+            account_identifier=account_meta.identifier,
+            nango_connection_id=connection_id,
         )
-        existing: Integration | None = match_result.scalar_one_or_none()
-
-        if existing is None:
-            legacy_match = await session.execute(
-                select(Integration)
-                .where(
-                    Integration.organization_id == org_uuid,
-                    Integration.connector == provider,
-                    Integration.user_id == user_uuid,
-                    Integration.account_identifier.is_(None),
-                )
-                .order_by(Integration.updated_at.desc().nullslast())
-                .limit(1)
-            )
-            existing = legacy_match.scalar_one_or_none()
 
         if existing is not None:
             existing.is_active = True
@@ -4261,8 +4316,7 @@ async def nango_callback(
             existing.nango_connection_id = connection_id
             existing.updated_at = datetime.utcnow()
             existing.pending_sharing_config = True
-            existing.account_identifier = account_meta.identifier
-            existing.account_label = account_meta.label or account_meta.identifier
+            _apply_account_meta_to_integration(existing, account_meta)
             if merged_extra is not None:
                 existing.extra_data = merged_extra
             integration_id = str(existing.id)
@@ -4281,7 +4335,11 @@ async def nango_callback(
                 share_write_access=sharing_defaults.share_write_access,
                 pending_sharing_config=True,
                 account_identifier=account_meta.identifier,
-                account_label=account_meta.label or account_meta.identifier,
+                account_label=(
+                    (account_meta.label or account_meta.identifier)
+                    if account_meta.identifier
+                    else None
+                ),
             )
             session.add(new_integration)
             await session.flush()
@@ -4532,7 +4590,7 @@ async def disconnect_integration(
             detail="user_id is required to disconnect an integration"
         )
 
-    async with get_session() as db_session:
+    async with get_session(organization_id=str(org_uuid)) as db_session:
         await db_session.execute(
             text("SELECT set_config('app.current_org_id', :org_id, true)"),
             {"org_id": str(org_uuid)}

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -43,6 +43,7 @@ from config import (
 from connectors.account_metadata import AccountMetadata
 from connectors.base import BaseConnector
 from connectors.registry import resolve_connector
+from models.database import get_admin_session, get_session
 from models.integration import Integration, merge_account_avatar_into_extra_data
 from models.user import User
 from models.organization import Organization

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -22,6 +22,8 @@ import logging
 from typing import Any, Final, Optional
 from uuid import UUID
 
+import uuid as uuid_stdlib
+
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
 
@@ -38,8 +40,10 @@ from config import (
     get_provider_sharing_defaults,
     PROVIDER_SHARING_DEFAULTS,
 )
-from models.database import get_admin_session, get_session
-from models.integration import Integration
+from connectors.account_metadata import AccountMetadata
+from connectors.base import BaseConnector
+from connectors.registry import resolve_connector
+from models.integration import Integration, merge_account_avatar_into_extra_data
 from models.user import User
 from models.organization import Organization
 from services.favicon import update_org_logo_from_website
@@ -125,7 +129,12 @@ def _enqueue_google_drive_login_sync(organization_id: UUID, user_id: UUID, integ
     try:
         from workers.tasks.sync import sync_integration
 
-        task = sync_integration.delay(str(organization_id), "google_drive", str(user_id))
+        task = sync_integration.delay(
+            str(organization_id),
+            "google_drive",
+            str(user_id),
+            integration_id=str(integration.id),
+        )
         logger.info(
             "Queued login-triggered Google Drive sync org=%s user=%s task_id=%s",
             organization_id,
@@ -491,6 +500,9 @@ class IntegrationResponse(BaseModel):
     sync_stats: Optional[dict[str, int | str]] = None
     # Optional display name override (e.g. user-provided name for MCP connectors)
     display_name: Optional[str] = None
+    account_identifier: Optional[str] = None
+    account_label: Optional[str] = None
+    account_avatar_url: Optional[str] = None
 
 
 class IntegrationsListResponse(BaseModel):
@@ -3103,8 +3115,8 @@ async def get_connect_session(
     except ValueError:
         raise HTTPException(status_code=400, detail=f"Unknown provider: {provider}")
 
-    # All connections are user-scoped
-    connection_id = f"{org_id_str}:user:{user_id_str}"
+    # All connections are user-scoped; suffix keeps Nango connections distinct per account.
+    connection_id = f"{org_id_str}:user:{user_id_str}:{uuid_stdlib.uuid4().hex}"
 
     org_name: str | None = None
     async with get_session(organization_id=org_id_str) as db_session:
@@ -3227,6 +3239,29 @@ async def _notify_connector_connected_in_conversation(
         )
 
 
+async def _probe_account_metadata_for_confirm(
+    provider: str,
+    organization_id_str: str,
+    user_id_str: str,
+    nango_connection_id: str,
+) -> AccountMetadata:
+    """Resolve stable account identifier for a fresh Nango connection (pre-DB row)."""
+    connector_cls: type[BaseConnector] | None = resolve_connector(provider)
+    if connector_cls is None:
+        return AccountMetadata(identifier=nango_connection_id, label=None, avatar_url=None)
+    probe: BaseConnector = connector_cls(organization_id_str, user_id_str)
+    probe._nango_connection_override = nango_connection_id
+    try:
+        return await probe.fetch_account_metadata()
+    except Exception as exc:
+        logger.warning(
+            "[Confirm] fetch_account_metadata fallback provider=%s err=%s",
+            provider,
+            exc,
+        )
+        return AccountMetadata(identifier=nango_connection_id, label=None, avatar_url=None)
+
+
 @router.post("/integrations/confirm")
 async def confirm_integration(
     request: ConfirmConnectionRequest,
@@ -3338,54 +3373,6 @@ async def confirm_integration(
                     "[Confirm] Could not resolve Attio workspace_id for connection_id=%s",
                     nango_connection_id,
                 )
-        # Prevent an org from connecting two different Slack workspaces.
-        if request.provider == "slack":
-            _incoming_team_id: str | None = (connection_metadata or {}).get("team_id")
-            if _incoming_team_id:
-                async with get_session(organization_id=str(org_uuid)) as _check_session:
-                    _existing_slack_rows = await _check_session.execute(
-                        select(Integration.extra_data).where(
-                            Integration.organization_id == org_uuid,
-                            Integration.connector == "slack",
-                            Integration.is_active.is_(True),
-                        )
-                    )
-                    for (_extra_data_row,) in _existing_slack_rows:
-                        _existing_team: str | None = (_extra_data_row or {}).get("team_id")
-                        if _existing_team and _existing_team != _incoming_team_id:
-                            raise HTTPException(
-                                status_code=409,
-                                detail=(
-                                    "This organization is already connected to a different Slack workspace. "
-                                    "All team members must connect to the same workspace."
-                                ),
-                            )
-
-        # Prevent an org from connecting two different Attio workspaces.
-        if request.provider == "attio":
-            _incoming_attio_workspace: str | None = (connection_metadata or {}).get("workspace_id")
-            if isinstance(_incoming_attio_workspace, str):
-                _incoming_attio_workspace = _incoming_attio_workspace.strip() or None
-            if _incoming_attio_workspace:
-                async with get_session(organization_id=str(org_uuid)) as _attio_check_session:
-                    _existing_attio_rows = await _attio_check_session.execute(
-                        select(Integration.extra_data).where(
-                            Integration.organization_id == org_uuid,
-                            Integration.connector == "attio",
-                            Integration.is_active.is_(True),
-                        )
-                    )
-                    for (_attio_extra,) in _existing_attio_rows:
-                        _existing_attio_wid: str | None = (_attio_extra or {}).get("workspace_id")
-                        if _existing_attio_wid and _existing_attio_wid != _incoming_attio_workspace:
-                            raise HTTPException(
-                                status_code=409,
-                                detail=(
-                                    "This organization is already connected to a different Attio workspace. "
-                                    "All team members must connect to the same workspace."
-                                ),
-                            )
-
         # For Slack, extract the bot token from Nango and upsert into
         # messenger_bot_installs so event-handling paths can look it up by team_id.
         # With bot scopes configured in Nango, the top-level access_token is
@@ -3442,6 +3429,17 @@ async def confirm_integration(
     # Get default sharing settings for this provider
     sharing_defaults = get_provider_sharing_defaults(request.provider)
 
+    account_meta: AccountMetadata = await _probe_account_metadata_for_confirm(
+        request.provider,
+        str(org_uuid),
+        str(user_uuid),
+        nango_connection_id,
+    )
+    merged_extra: dict[str, Any] | None = merge_account_avatar_into_extra_data(
+        connection_metadata,
+        account_meta.avatar_url,
+    )
+
     integration_id: str = ""
     async with get_session(organization_id=str(org_uuid)) as session:
         await session.execute(
@@ -3449,29 +3447,44 @@ async def confirm_integration(
             {"org_id": str(org_uuid)}
         )
 
-        # Check for existing integration for this user
-        result = await session.execute(
+        match_result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == org_uuid,
                 Integration.connector == request.provider,
                 Integration.user_id == user_uuid,
+                Integration.account_identifier == account_meta.identifier,
             )
         )
+        existing_row: Integration | None = match_result.scalar_one_or_none()
 
-        existing = result.scalar_one_or_none()
+        if existing_row is None:
+            legacy_match = await session.execute(
+                select(Integration)
+                .where(
+                    Integration.organization_id == org_uuid,
+                    Integration.connector == request.provider,
+                    Integration.user_id == user_uuid,
+                    Integration.account_identifier.is_(None),
+                )
+                .order_by(Integration.updated_at.desc().nullslast())
+                .limit(1)
+            )
+            existing_row = legacy_match.scalar_one_or_none()
 
-        if existing:
-            existing.nango_connection_id = nango_connection_id
-            existing.is_active = True
-            existing.last_error = None
-            existing.updated_at = datetime.utcnow()
-            existing.pending_sharing_config = False
-            existing.share_synced_data = sharing_defaults.share_synced_data
-            existing.share_query_access = sharing_defaults.share_query_access
-            existing.share_write_access = sharing_defaults.share_write_access
-            if connection_metadata:
-                existing.extra_data = connection_metadata
-            integration_id = str(existing.id)
+        if existing_row is not None:
+            existing_row.nango_connection_id = nango_connection_id
+            existing_row.is_active = True
+            existing_row.last_error = None
+            existing_row.updated_at = datetime.utcnow()
+            existing_row.pending_sharing_config = False
+            existing_row.share_synced_data = sharing_defaults.share_synced_data
+            existing_row.share_query_access = sharing_defaults.share_query_access
+            existing_row.share_write_access = sharing_defaults.share_write_access
+            existing_row.account_identifier = account_meta.identifier
+            existing_row.account_label = account_meta.label or account_meta.identifier
+            if merged_extra is not None:
+                existing_row.extra_data = merged_extra
+            integration_id = str(existing_row.id)
         else:
             new_integration = Integration(
                 organization_id=org_uuid,
@@ -3481,11 +3494,13 @@ async def confirm_integration(
                 nango_connection_id=nango_connection_id,
                 connected_by_user_id=user_uuid,
                 is_active=True,
-                extra_data=connection_metadata,
+                extra_data=merged_extra,
                 share_synced_data=sharing_defaults.share_synced_data,
                 share_query_access=sharing_defaults.share_query_access,
                 share_write_access=sharing_defaults.share_write_access,
                 pending_sharing_config=False,
+                account_identifier=account_meta.identifier,
+                account_label=account_meta.label or account_meta.identifier,
             )
             session.add(new_integration)
             await session.flush()
@@ -3502,6 +3517,7 @@ async def confirm_integration(
             str(org_uuid),
             request.provider,
             user_id_str,
+            integration_id,
         )
 
     if request.provider == "slack" and user_uuid:
@@ -4187,8 +4203,21 @@ async def nango_callback(
 
     sharing_defaults = get_provider_sharing_defaults(provider)
 
+    connection_metadata: dict[str, Any] | None = extract_connection_metadata(connection)
+
+    account_meta: AccountMetadata = await _probe_account_metadata_for_confirm(
+        provider,
+        str(org_uuid),
+        str(user_uuid),
+        connection_id,
+    )
+    merged_extra: dict[str, Any] | None = merge_account_avatar_into_extra_data(
+        connection_metadata,
+        account_meta.avatar_url,
+    )
+
     integration_id: str = ""
-    async with get_session() as session:
+    async with get_session(organization_id=str(org_uuid)) as session:
         await session.execute(
             text("SELECT set_config('app.current_org_id', :org_id, true)"),
             {"org_id": str(org_uuid)}
@@ -4201,21 +4230,40 @@ async def nango_callback(
             if await _get_org_membership(guard_cb, user_uuid, org_uuid) is None:
                 raise HTTPException(status_code=403, detail="User not authorized")
 
-        result = await session.execute(
+        match_result = await session.execute(
             select(Integration).where(
                 Integration.organization_id == org_uuid,
                 Integration.connector == provider,
                 Integration.user_id == user_uuid,
+                Integration.account_identifier == account_meta.identifier,
             )
         )
-        existing = result.scalar_one_or_none()
+        existing: Integration | None = match_result.scalar_one_or_none()
 
-        if existing:
+        if existing is None:
+            legacy_match = await session.execute(
+                select(Integration)
+                .where(
+                    Integration.organization_id == org_uuid,
+                    Integration.connector == provider,
+                    Integration.user_id == user_uuid,
+                    Integration.account_identifier.is_(None),
+                )
+                .order_by(Integration.updated_at.desc().nullslast())
+                .limit(1)
+            )
+            existing = legacy_match.scalar_one_or_none()
+
+        if existing is not None:
             existing.is_active = True
             existing.last_error = None
             existing.nango_connection_id = connection_id
             existing.updated_at = datetime.utcnow()
             existing.pending_sharing_config = True
+            existing.account_identifier = account_meta.identifier
+            existing.account_label = account_meta.label or account_meta.identifier
+            if merged_extra is not None:
+                existing.extra_data = merged_extra
             integration_id = str(existing.id)
         else:
             new_integration = Integration(
@@ -4226,11 +4274,13 @@ async def nango_callback(
                 nango_connection_id=connection_id,
                 connected_by_user_id=user_uuid,
                 is_active=True,
-                extra_data=connection.get("metadata"),
+                extra_data=merged_extra,
                 share_synced_data=sharing_defaults.share_synced_data,
                 share_query_access=sharing_defaults.share_query_access,
                 share_write_access=sharing_defaults.share_write_access,
                 pending_sharing_config=True,
+                account_identifier=account_meta.identifier,
+                account_label=account_meta.label or account_meta.identifier,
             )
             session.add(new_integration)
             await session.flush()
@@ -4256,10 +4306,11 @@ async def list_integrations(
     user_id: Optional[str] = None,
     organization_id: Optional[str] = None,
 ) -> IntegrationsListResponse:
-    """List all integrations for a user's organization.
+    """List integrations for the active organization.
 
-    Returns integrations grouped by provider, showing the current user's
-    integration (if any), team connections, and connector scope.
+    Returns one row per integration owned by the authenticated user (multi-account),
+    plus a placeholder row per registered provider when the user has not connected
+    that provider yet. Each row includes optional account display fields.
     """
     if user_id is not None and user_id != auth.user_id_str:
         raise HTTPException(
@@ -4313,21 +4364,20 @@ async def list_integrations(
         team_members: dict[UUID, User] = {u.id: u for u in team_result.scalars().all()}
         team_total = len(team_members)
 
+        from models.integration import read_account_avatar_url
+
         response_integrations: list[IntegrationResponse] = []
 
-        # Include all known providers (from PROVIDER_SHARING_DEFAULTS)
         all_providers = set(integrations_by_provider.keys()) | set(PROVIDER_SHARING_DEFAULTS.keys())
+
+        my_by_provider: dict[str, list[Integration]] = {}
+        for row in all_integrations:
+            if row.user_id == current_user_uuid:
+                my_by_provider.setdefault(row.connector, []).append(row)
 
         for provider in sorted(all_providers):
             integrations_for_provider = integrations_by_provider.get(provider, [])
 
-            # Find current user's integration
-            current_user_integration = next(
-                (i for i in integrations_for_provider if i.user_id == current_user_uuid),
-                None
-            )
-
-            # Build team connections list (excluding current user)
             team_connections: list[TeamConnection] = []
             for integration in integrations_for_provider:
                 if integration.user_id and integration.user_id in team_members:
@@ -4337,59 +4387,82 @@ async def list_integrations(
                         user_name=user_obj.name or user_obj.email,
                     ))
 
-            # Use current user's integration for display, or the one with most recent sync
-            # (sync may update a different integration when multiple exist)
-            if current_user_integration:
-                ref_integration = current_user_integration
-            elif integrations_for_provider:
-                ref_integration = max(
-                    integrations_for_provider,
-                    key=lambda i: (i.last_sync_at or datetime.min),
+            mine: list[Integration] = my_by_provider.get(provider, [])
+            if mine:
+                mine_sorted = sorted(
+                    mine,
+                    key=lambda row: (row.account_identifier or "", str(row.id)),
                 )
+                for ref_integration in mine_sorted:
+                    connected_by_name: str | None = None
+                    if ref_integration.user_id in team_members:
+                        owner = team_members[ref_integration.user_id]
+                        connected_by_name = owner.name or owner.email
+
+                    mcp_display_name: str | None = None
+                    if provider.startswith("mcp_") and ref_integration.extra_data:
+                        mcp_display_name = ref_integration.extra_data.get("display_name")
+
+                    avatar_url: str | None = read_account_avatar_url(ref_integration.extra_data)
+
+                    response_integrations.append(IntegrationResponse(
+                        id=str(ref_integration.id),
+                        provider=provider,
+                        is_active=ref_integration.is_active,
+                        last_sync_at=(
+                            f"{ref_integration.last_sync_at.isoformat()}Z"
+                            if ref_integration.last_sync_at else None
+                        ),
+                        last_error=ref_integration.last_error,
+                        connected_at=(
+                            f"{ref_integration.created_at.isoformat()}Z"
+                            if ref_integration.created_at else None
+                        ),
+                        scope=scope_by_provider.get(provider, ConnectorScope.USER.value),
+                        user_id=str(ref_integration.user_id) if ref_integration.user_id else None,
+                        connected_by=connected_by_name,
+                        share_synced_data=ref_integration.share_synced_data,
+                        share_query_access=ref_integration.share_query_access,
+                        share_write_access=ref_integration.share_write_access,
+                        pending_sharing_config=ref_integration.pending_sharing_config,
+                        is_owner=(
+                            current_user_uuid is not None
+                            and ref_integration.user_id == current_user_uuid
+                        ),
+                        current_user_connected=True,
+                        team_connections=team_connections,
+                        team_total=team_total,
+                        sync_stats=ref_integration.sync_stats,
+                        display_name=mcp_display_name,
+                        account_identifier=ref_integration.account_identifier,
+                        account_label=ref_integration.account_label,
+                        account_avatar_url=avatar_url,
+                    ))
             else:
-                ref_integration = None
-
-            # Get owner name
-            connected_by_name: str | None = None
-            if ref_integration and ref_integration.user_id in team_members:
-                owner = team_members[ref_integration.user_id]
-                connected_by_name = owner.name or owner.email
-
-            mcp_display_name: str | None = None
-            if provider.startswith("mcp_") and ref_integration and ref_integration.extra_data:
-                mcp_display_name = ref_integration.extra_data.get("display_name")
-
-            response_integrations.append(IntegrationResponse(
-                id=str(ref_integration.id) if ref_integration else f"pending-{provider}",
-                provider=provider,
-                is_active=ref_integration.is_active if ref_integration else False,
-                last_sync_at=(
-                    f"{ref_integration.last_sync_at.isoformat()}Z"
-                    if ref_integration and ref_integration.last_sync_at else None
-                ),
-                last_error=ref_integration.last_error if ref_integration else None,
-                connected_at=(
-                    f"{ref_integration.created_at.isoformat()}Z"
-                    if ref_integration and ref_integration.created_at else None
-                ),
-                scope=scope_by_provider.get(provider, ConnectorScope.USER.value),
-                user_id=str(ref_integration.user_id) if ref_integration else None,
-                connected_by=connected_by_name,
-                share_synced_data=ref_integration.share_synced_data if ref_integration else False,
-                share_query_access=ref_integration.share_query_access if ref_integration else False,
-                share_write_access=ref_integration.share_write_access if ref_integration else False,
-                pending_sharing_config=ref_integration.pending_sharing_config if ref_integration else False,
-                is_owner=(
-                    current_user_uuid is not None
-                    and ref_integration is not None
-                    and ref_integration.user_id == current_user_uuid
-                ),
-                current_user_connected=current_user_integration is not None,
-                team_connections=team_connections,
-                team_total=team_total,
-                sync_stats=ref_integration.sync_stats if ref_integration else None,
-                display_name=mcp_display_name,
-            ))
+                response_integrations.append(IntegrationResponse(
+                    id=f"pending-{provider}",
+                    provider=provider,
+                    is_active=False,
+                    last_sync_at=None,
+                    last_error=None,
+                    connected_at=None,
+                    scope=scope_by_provider.get(provider, ConnectorScope.USER.value),
+                    user_id=None,
+                    connected_by=None,
+                    share_synced_data=False,
+                    share_query_access=False,
+                    share_write_access=False,
+                    pending_sharing_config=False,
+                    is_owner=False,
+                    current_user_connected=False,
+                    team_connections=team_connections,
+                    team_total=team_total,
+                    sync_stats=None,
+                    display_name=None,
+                    account_identifier=None,
+                    account_label=None,
+                    account_avatar_url=None,
+                ))
 
         return IntegrationsListResponse(integrations=response_integrations)
 
@@ -4399,6 +4472,7 @@ async def disconnect_integration(
     provider: str,
     user_id: Optional[str] = None,
     organization_id: Optional[str] = None,
+    integration_id: Optional[str] = None,
     delete_data: bool = False,
 ) -> dict[str, Any]:
     """Disconnect an integration.
@@ -4410,6 +4484,7 @@ async def disconnect_integration(
         provider: The integration provider to disconnect
         user_id: User ID (required for user-scoped integrations)
         organization_id: Organization ID
+        integration_id: When set, disconnect only this integration row (multi-account)
         delete_data: If True, also deletes all synced data (activities, contacts, accounts, deals, pipelines, orphaned meetings)
     """
     org_uuid: Optional[UUID] = None
@@ -4462,17 +4537,37 @@ async def disconnect_integration(
             {"org_id": str(org_uuid)}
         )
 
-        # Find integration for this user
-        integration: Integration | None = None
+        # Find integration for this user (specific row when integration_id is set)
+        integration_id_uuid: UUID | None = None
+        if integration_id and integration_id.strip():
+            try:
+                integration_id_uuid = UUID(integration_id.strip())
+            except ValueError:
+                raise HTTPException(status_code=400, detail="Invalid integration_id")
 
-        result = await db_session.execute(
-            select(Integration).where(
-                Integration.organization_id == org_uuid,
-                Integration.connector == provider,
-                Integration.user_id == current_user_uuid,
+        integration = None
+        if integration_id_uuid is not None:
+            result = await db_session.execute(
+                select(Integration).where(
+                    Integration.organization_id == org_uuid,
+                    Integration.connector == provider,
+                    Integration.user_id == current_user_uuid,
+                    Integration.id == integration_id_uuid,
+                )
             )
-        )
-        integration = result.scalar_one_or_none()
+            integration = result.scalar_one_or_none()
+        else:
+            result = await db_session.execute(
+                select(Integration)
+                .where(
+                    Integration.organization_id == org_uuid,
+                    Integration.connector == provider,
+                    Integration.user_id == current_user_uuid,
+                )
+                .order_by(Integration.updated_at.desc().nullslast())
+                .limit(1)
+            )
+            integration = result.scalars().first()
 
         # Fallback: check by nango_connection_id for old records
         if not integration:
@@ -4927,6 +5022,7 @@ async def run_initial_sync(
     organization_id: str,
     provider: str,
     user_id: Optional[str] = None,
+    integration_id: Optional[str] = None,
 ) -> None:
     """
     Run initial data sync after OAuth connection.
@@ -4954,6 +5050,7 @@ async def run_initial_sync(
         provider,
         user_id=owner_user_id,
         sync_since_override_iso=None,
+        integration_id=integration_id.strip() if integration_id and integration_id.strip() else None,
     )
     status: str = str(result.get("status", "unknown"))
     if status == "completed":

--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -916,12 +916,20 @@ async def trigger_sync(
         default=None,
         description="ISO8601 UTC start time for manual resync (overrides last_sync_at for this run)",
     ),
+    integration_id: str | None = Query(
+        default=None,
+        description=(
+            "Specific integration row UUID to sync. When omitted, syncs every "
+            "active row of this provider for the org (multi-account fan-out)."
+        ),
+    ),
 ) -> SyncTriggerResponse:
     """Trigger a sync for a specific integration.
 
     Per-user integrations (Gmail, Calendar, etc.) may have multiple rows per
-    provider.  We sync each one individually so every connected user gets
-    updated.
+    provider.  When ``integration_id`` is supplied we sync only that row;
+    otherwise we sync each active row for this provider in the org (legacy
+    "Sync all of provider" behavior).
 
     Optional ``since`` (ISO8601) temporarily overrides the incremental window
     for this run only (e.g. resync last 7 days).
@@ -931,6 +939,13 @@ async def trigger_sync(
         customer_uuid = UUID(organization_id)
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid customer ID")
+
+    integration_uuid: UUID | None = None
+    if integration_id is not None and integration_id.strip():
+        try:
+            integration_uuid = UUID(integration_id.strip())
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid integration_id")
 
     connector_cls = CONNECTORS.get(provider)
     if not connector_cls:
@@ -944,31 +959,34 @@ async def trigger_sync(
             detail=f"Provider {provider} does not support sync (query-only connector).",
         )
 
-    # Fetch *all* active integrations for this provider (may be per-user) and
-    # synchronously mark them as syncing. Doing the mark in the API process
-    # before enqueuing the Celery task closes a race with the immediate
-    # ``/status`` poll the frontend issues right after this trigger: without
-    # this, the worker hasn't yet called ``mark_sync_started``, so the status
-    # endpoint sees ``last_sync_at`` from the previous run and replies
-    # "completed" — which causes the UI to clear its spinner and stop polling
-    # before the actual sync finishes.
+    # Fetch *all* matching active integrations and synchronously mark them as
+    # syncing. Doing the mark in the API process before enqueuing the Celery
+    # task closes a race with the immediate ``/status`` poll the frontend issues
+    # right after this trigger: without this, the worker hasn't yet called
+    # ``mark_sync_started``, so the status endpoint sees ``last_sync_at`` from
+    # the previous run and replies "completed" — which causes the UI to clear
+    # its spinner and stop polling before the actual sync finishes.
     from sqlalchemy.orm.attributes import flag_modified
 
     sync_started_iso: str = datetime.utcnow().isoformat()
     async with get_session(organization_id=organization_id) as session:
-        result = await session.execute(
-            select(Integration).where(
-                Integration.organization_id == customer_uuid,
-                Integration.connector == provider,
-                Integration.is_active == True,  # noqa: E712
-            )
+        stmt = select(Integration).where(
+            Integration.organization_id == customer_uuid,
+            Integration.connector == provider,
+            Integration.is_active == True,  # noqa: E712
         )
+        if integration_uuid is not None:
+            stmt = stmt.where(Integration.id == integration_uuid)
+        result = await session.execute(stmt)
         integrations: list[Integration] = list(result.scalars().all())
 
         if not integrations:
+            detail_suffix: str = (
+                f" with id={integration_uuid}" if integration_uuid is not None else ""
+            )
             raise HTTPException(
                 status_code=404,
-                detail=f"No active {provider} integration found",
+                detail=f"No active {provider} integration found{detail_suffix}",
             )
 
         sync_pairs: list[tuple[UUID | None, UUID]] = []

--- a/backend/api/routes/sync.py
+++ b/backend/api/routes/sync.py
@@ -868,12 +868,12 @@ async def _execute_sync_all_integrations(organization_id: str) -> SyncAllRespons
         if not integrations:
             raise HTTPException(status_code=404, detail="No active integrations found")
 
-        provider_user_pairs: list[tuple[str, UUID | None]] = []
+        sync_jobs: list[tuple[str, UUID | None, UUID]] = []
         for integration in integrations:
             connector_cls = CONNECTORS.get(integration.connector)
             if connector_cls is None or Capability.SYNC not in connector_cls.meta.capabilities:
                 continue
-            provider_user_pairs.append((integration.connector, integration.user_id))
+            sync_jobs.append((integration.connector, integration.user_id, integration.id))
             stats: dict[str, Any] = dict(integration.sync_stats or {})
             stats["sync_started_at"] = sync_started_iso
             integration.sync_stats = stats
@@ -884,11 +884,11 @@ async def _execute_sync_all_integrations(organization_id: str) -> SyncAllRespons
     from workers.tasks.sync import sync_integration
 
     syncing_providers: list[str] = []
-    for prov, integration_user_id in provider_user_pairs:
+    for prov, integration_user_id, integ_id in sync_jobs:
         if prov not in syncing_providers:
             syncing_providers.append(prov)
         uid: str | None = str(integration_user_id) if integration_user_id else None
-        sync_integration.delay(organization_id, prov, uid)
+        sync_integration.delay(organization_id, prov, uid, integration_id=str(integ_id))
 
     return SyncAllResponse(
         status="queued",
@@ -971,9 +971,9 @@ async def trigger_sync(
                 detail=f"No active {provider} integration found",
             )
 
-        integration_user_ids: list[UUID | None] = []
+        sync_pairs: list[tuple[UUID | None, UUID]] = []
         for integration in integrations:
-            integration_user_ids.append(integration.user_id)
+            sync_pairs.append((integration.user_id, integration.id))
             stats: dict[str, Any] = dict(integration.sync_stats or {})
             stats["sync_started_at"] = sync_started_iso
             integration.sync_stats = stats
@@ -988,13 +988,14 @@ async def trigger_sync(
 
     from workers.tasks.sync import sync_integration
 
-    for integration_user_id in integration_user_ids:
+    for integration_user_id, integ_uuid in sync_pairs:
         user_id: str | None = str(integration_user_id) if integration_user_id else None
         sync_integration.delay(
             organization_id,
             provider,
             user_id,
             sync_since_override_iso=since_iso,
+            integration_id=str(integ_uuid),
         )
 
     return SyncTriggerResponse(
@@ -1019,7 +1020,8 @@ async def get_sync_status(
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid customer ID")
 
-    # DB is the primary source of truth — check sync_started_at first
+    # DB is the primary source of truth — aggregate across all integration rows
+    # for this provider (multi-account) so status reflects any in-flight sync.
     async with get_session(organization_id=organization_id) as session:
         result = await session.execute(
             select(
@@ -1031,54 +1033,69 @@ async def get_sync_status(
                 Integration.connector == provider,
             )
         )
-        integration_row: tuple[dict[str, Any] | None, str | None, datetime | None] | None = (
-            result.first()
+        integration_rows: list[tuple[dict[str, Any] | None, str | None, datetime | None]] = list(
+            result.all()
         )
 
-    if integration_row:
-        stats, last_err, last_sync_at = integration_row
+    stale_cutoff: timedelta = timedelta(hours=2)
+    now_utc: datetime = datetime.utcnow()
+
+    earliest_syncing_started: datetime | None = None
+    for stats, _le, _lsa in integration_rows:
         sync_started_raw: str | None = (
             stats.get("sync_started_at") if isinstance(stats, dict) else None
         )
+        if not sync_started_raw:
+            continue
+        try:
+            sync_started: datetime = datetime.fromisoformat(sync_started_raw)
+        except (ValueError, TypeError):
+            continue
+        if now_utc - sync_started < stale_cutoff:
+            if earliest_syncing_started is None or sync_started < earliest_syncing_started:
+                earliest_syncing_started = sync_started
 
-        if sync_started_raw:
-            try:
-                sync_started: datetime = datetime.fromisoformat(sync_started_raw)
-                stale_cutoff: timedelta = timedelta(hours=2)
-                if datetime.utcnow() - sync_started < stale_cutoff:
-                    return SyncStatusResponse(
-                        organization_id=organization_id,
-                        provider=provider,
-                        status="syncing",
-                        started_at=f"{sync_started.isoformat()}Z",
-                        completed_at=None,
-                        error=None,
-                        counts=None,
-                    )
-            except (ValueError, TypeError):
-                pass
+    if earliest_syncing_started is not None:
+        return SyncStatusResponse(
+            organization_id=organization_id,
+            provider=provider,
+            status="syncing",
+            started_at=f"{earliest_syncing_started.isoformat()}Z",
+            completed_at=None,
+            error=None,
+            counts=None,
+        )
 
-        if last_err and last_err.strip():
-            completed_at: str | None = None
-            if last_sync_at:
-                completed_at = f"{last_sync_at.isoformat()}Z"
-            return SyncStatusResponse(
-                organization_id=organization_id,
-                provider=provider,
-                status="failed",
-                started_at=None,
-                completed_at=completed_at,
-                error=last_err,
-                counts=None,
-            )
+    any_error: str | None = None
+    latest_completed: datetime | None = None
+    for _stats, last_err, last_sync_at in integration_rows:
+        if last_err and str(last_err).strip():
+            any_error = str(last_err).strip()
+        if last_sync_at is not None:
+            if latest_completed is None or last_sync_at > latest_completed:
+                latest_completed = last_sync_at
 
-    if integration_row and integration_row[2]:
+    if any_error:
+        completed_at_err: str | None = None
+        if latest_completed:
+            completed_at_err = f"{latest_completed.isoformat()}Z"
+        return SyncStatusResponse(
+            organization_id=organization_id,
+            provider=provider,
+            status="failed",
+            started_at=None,
+            completed_at=completed_at_err,
+            error=any_error,
+            counts=None,
+        )
+
+    if latest_completed is not None:
         return SyncStatusResponse(
             organization_id=organization_id,
             provider=provider,
             status="completed",
             started_at=None,
-            completed_at=f"{integration_row[2].isoformat()}Z",
+            completed_at=f"{latest_completed.isoformat()}Z",
             error=None,
             counts=None,
         )

--- a/backend/api/websockets.py
+++ b/backend/api/websockets.py
@@ -128,18 +128,22 @@ async def broadcast_sync_progress(
     count: int,
     status: str = "syncing",
     step: Optional[str] = None,
+    integration_id: Optional[str] = None,
 ) -> None:
     """
     Broadcast sync progress to all connected clients for an organization.
-    
+
     Called from connectors during sync to update the UI in real-time.
-    
+
     Args:
         organization_id: The organization UUID
         provider: The provider name (e.g., "google_calendar")
         count: Current count of synced items
         status: "syncing" or "completed"
         step: Current sync phase (e.g., "accounts", "deals", "contacts", "activities")
+        integration_id: Specific integration row UUID this event targets. When
+            present, the UI scopes its "syncing" indicator to that row only
+            (multi-account: one provider can have multiple connected accounts).
     """
     data: dict[str, str | int] = {
         "provider": provider,
@@ -148,6 +152,8 @@ async def broadcast_sync_progress(
     }
     if step is not None:
         data["step"] = step
+    if integration_id is not None and integration_id.strip():
+        data["integration_id"] = integration_id.strip()
     await sync_broadcaster.broadcast(
         organization_id=organization_id,
         event_type="sync_progress",

--- a/backend/connectors/account_metadata.py
+++ b/backend/connectors/account_metadata.py
@@ -7,8 +7,14 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class AccountMetadata:
-    """Stable account identity plus optional UI fields."""
+    """Stable account identity plus optional UI fields.
 
-    identifier: str
+    ``identifier`` is the canonical provider-side account id (e.g. email,
+    workspace id, portal id). It may be ``None`` when the connector cannot
+    resolve a real identity – callers must treat that as the legacy
+    single-account / NULL-keyed row and never persist a placeholder UUID.
+    """
+
+    identifier: str | None
     label: str | None = None
     avatar_url: str | None = None

--- a/backend/connectors/account_metadata.py
+++ b/backend/connectors/account_metadata.py
@@ -1,0 +1,14 @@
+"""Account identity metadata returned after OAuth (multi-account integrations)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AccountMetadata:
+    """Stable account identity plus optional UI fields."""
+
+    identifier: str
+    label: str | None = None
+    avatar_url: str | None = None

--- a/backend/connectors/attio.py
+++ b/backend/connectors/attio.py
@@ -17,6 +17,7 @@ from typing import Any, Final
 
 import httpx
 
+from connectors.account_metadata import AccountMetadata
 from connectors.base import BaseConnector
 from connectors.models import AccountRecord, ActivityRecord, ContactRecord, DealRecord
 from connectors.registry import (
@@ -456,6 +457,40 @@ After connecting and syncing, query SQL on `contacts`, `accounts`, `deals`, `act
 - **list_statuses** — Optional `object` (default `deals`), optional `attribute` (default `stage`). Returns workspace-specific status titles/UUIDs; **use before create_deal** so `stage` matches Attio.
 """,
     )
+
+    async def fetch_account_metadata(self) -> AccountMetadata:
+        token, _ = await self.get_oauth_token()
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response: httpx.Response = await client.get(
+                f"{ATTIO_API_BASE}/v2/self",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/json",
+                },
+            )
+            response.raise_for_status()
+            payload: Any = response.json()
+        inner: dict[str, Any] = payload if isinstance(payload, dict) else {}
+        data_obj: Any = inner.get("data")
+        if isinstance(data_obj, dict):
+            inner = data_obj
+        wid_raw: Any = inner.get("workspace_id") or inner.get("workspaceId")
+        workspace_id: str = str(wid_raw).strip() if wid_raw else ""
+        if not workspace_id:
+            ws_obj: Any = inner.get("workspace") or inner.get("active_workspace") or inner.get("activeWorkspace")
+            if isinstance(ws_obj, dict):
+                for k in ("workspace_id", "workspaceId", "id"):
+                    v: Any = ws_obj.get(k)
+                    if isinstance(v, str) and v.strip():
+                        workspace_id = v.strip()
+                        break
+        if not workspace_id:
+            raise ValueError("Attio /v2/self missing workspace id")
+        name_raw: Any = inner.get("workspace_name") or inner.get("name")
+        label: str = (
+            str(name_raw).strip() if isinstance(name_raw, str) and name_raw.strip() else workspace_id
+        )
+        return AccountMetadata(identifier=workspace_id, label=label, avatar_url=None)
 
     async def _get_headers(self) -> dict[str, str]:
         token: str

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -193,6 +193,20 @@ class BaseConnector(ABC):
         self._nango_connection_override: str | None = None
 
     @property
+    def current_integration_id(self) -> str | None:
+        """UUID of the integration row this connector instance is bound to, if known.
+
+        Set after ``_select_integration`` (e.g. via ``get_oauth_token`` or
+        ``mark_sync_started``). Connectors include it in WebSocket sync events
+        so the UI can scope the "Syncing…" indicator to the correct row when a
+        user has multiple accounts connected for the same provider.
+        """
+        integration: Integration | None = self._integration
+        if integration is None or integration.id is None:
+            return None
+        return str(integration.id)
+
+    @property
     def sync_since(self) -> datetime | None:
         """Return the cutoff time for incremental sync, or None for first sync.
 
@@ -514,8 +528,16 @@ class BaseConnector(ABC):
     async def fetch_account_metadata(self) -> AccountMetadata:
         """Return stable account identity after OAuth.
 
-        OAuth subclasses should override with provider-specific calls. Built-in
-        non-Nango connectors return a slug-based placeholder.
+        Non-OAuth connectors (API key / bearer / custom) have a single connection
+        per (org, user, connector), so the slug is a perfectly stable identifier
+        and we use it directly.
+
+        OAuth subclasses MUST override this to call the provider's "who am I"
+        endpoint and return the real account email / workspace id / portal id.
+        We deliberately raise here instead of synthesizing one from the Nango
+        connection id because that id is opaque and surfaces as a UUID in the UI.
+        The confirm flow catches this exception and leaves
+        ``account_identifier``/``account_label`` NULL.
         """
         from connectors.account_metadata import AccountMetadata
         from connectors.registry import AuthType
@@ -526,14 +548,10 @@ class BaseConnector(ABC):
             label: str = self.meta.name if hasattr(self, "meta") else slug
             return AccountMetadata(identifier=slug, label=label, avatar_url=None)
 
-        await self.get_oauth_token()
-        cid_raw: str | None = self._nango_connection_override
-        if not cid_raw and self._integration is not None:
-            cid_raw = self._integration.nango_connection_id
-        cid: str = (cid_raw or "").strip()
-        if not cid:
-            raise ValueError("Missing Nango connection id for account metadata")
-        return AccountMetadata(identifier=cid, label=None, avatar_url=None)
+        raise NotImplementedError(
+            f"{self.source_system}: OAuth connectors must override "
+            "fetch_account_metadata() to return a real account identifier"
+        )
 
     @abstractmethod
     async def sync_deals(self) -> int:

--- a/backend/connectors/base.py
+++ b/backend/connectors/base.py
@@ -49,6 +49,7 @@ from uuid import UUID
 from sqlalchemy import case, select, update
 
 from config import get_nango_integration_id
+from connectors.account_metadata import AccountMetadata
 from connectors.registry import ConnectorMeta  # noqa: F401 – re-export for convenience
 from models.database import get_session
 from models.integration import Integration
@@ -163,6 +164,8 @@ class BaseConnector(ABC):
         user_id: str | None = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         """
         Initialize the connector.
@@ -172,6 +175,8 @@ class BaseConnector(ABC):
             user_id: UUID of the user who owns this integration (required for all connectors)
             sync_since_override: When set (e.g. manual "resync from"), used as incremental
                 cutoff instead of ``last_sync_at``. Naive UTC recommended.
+            integration_id: When set, DB lookups target this integration row only (multi-account).
+            account_identifier: When set, DB lookups filter to this account (multi-account).
         """
         self.organization_id = organization_id
         self.user_id = user_id
@@ -179,6 +184,13 @@ class BaseConnector(ABC):
         self._credentials: dict[str, Any] | None = None
         self._integration: Integration | None = None
         self._sync_since_override: datetime | None = sync_since_override
+        self._integration_id_filter: UUID | None = (
+            UUID(integration_id.strip()) if integration_id and integration_id.strip() else None
+        )
+        aid: str | None = account_identifier.strip() if account_identifier and account_identifier.strip() else None
+        self._account_identifier_filter: str | None = aid
+        # Ephemeral Nango connection id (OAuth confirm before DB row exists).
+        self._nango_connection_override: str | None = None
 
     @property
     def sync_since(self) -> datetime | None:
@@ -422,6 +434,10 @@ class BaseConnector(ABC):
             conditions.append(Integration.is_active == True)  # noqa: E712
         if self.user_id:
             conditions.append(Integration.user_id == UUID(self.user_id))
+        if self._integration_id_filter is not None:
+            conditions.append(Integration.id == self._integration_id_filter)
+        if self._account_identifier_filter is not None:
+            conditions.append(Integration.account_identifier == self._account_identifier_filter)
 
         order_clauses: list[Any] = []
         if not self.user_id:
@@ -455,6 +471,70 @@ class BaseConnector(ABC):
             session.expunge(selected)
         return selected
 
+    async def _select_all_integrations(
+        self,
+        session: Any,
+        *,
+        require_active: bool = False,
+    ) -> list[Integration]:
+        """Return every matching integration row (multi-account fan-out)."""
+        conditions: list[Any] = [
+            Integration.organization_id == UUID(self.organization_id),
+            Integration.connector == self.source_system,
+        ]
+        if require_active:
+            conditions.append(Integration.is_active == True)  # noqa: E712
+        if self.user_id:
+            conditions.append(Integration.user_id == UUID(self.user_id))
+        if self._integration_id_filter is not None:
+            conditions.append(Integration.id == self._integration_id_filter)
+        if self._account_identifier_filter is not None:
+            conditions.append(Integration.account_identifier == self._account_identifier_filter)
+
+        order_clauses: list[Any] = []
+        if not self.user_id:
+            order_clauses.append(
+                case((Integration.user_id.is_(None), 0), else_=1)
+            )
+        order_clauses.extend([
+            Integration.updated_at.desc().nullslast(),
+            Integration.created_at.desc().nullslast(),
+        ])
+
+        result = await session.execute(
+            select(Integration)
+            .where(*conditions)
+            .order_by(*order_clauses)
+        )
+        rows: list[Integration] = list(result.scalars().all())
+        for row in rows:
+            session.expunge(row)
+        return rows
+
+    async def fetch_account_metadata(self) -> AccountMetadata:
+        """Return stable account identity after OAuth.
+
+        OAuth subclasses should override with provider-specific calls. Built-in
+        non-Nango connectors return a slug-based placeholder.
+        """
+        from connectors.account_metadata import AccountMetadata
+        from connectors.registry import AuthType
+
+        auth_type = getattr(self.meta, "auth_type", None)
+        if auth_type in (AuthType.API_KEY, AuthType.CUSTOM, AuthType.BEARER_TOKEN):
+            slug: str = self.source_system
+            label: str = self.meta.name if hasattr(self, "meta") else slug
+            return AccountMetadata(identifier=slug, label=label, avatar_url=None)
+
+        await self.get_oauth_token()
+        cid_raw: str | None = self._nango_connection_override
+        if not cid_raw and self._integration is not None:
+            cid_raw = self._integration.nango_connection_id
+        cid: str = (cid_raw or "").strip()
+        if not cid:
+            raise ValueError("Missing Nango connection id for account metadata")
+        return AccountMetadata(identifier=cid, label=None, avatar_url=None)
+
     @abstractmethod
     async def sync_deals(self) -> int:
         """Fetch and normalize deals, return count synced."""
@@ -464,8 +544,6 @@ class BaseConnector(ABC):
     async def sync_accounts(self) -> int:
         """Fetch and normalize accounts, return count synced."""
         pass
-
-    @abstractmethod
     async def sync_contacts(self) -> int:
         """Fetch and normalize contacts, return count synced."""
         pass
@@ -560,24 +638,39 @@ class BaseConnector(ABC):
         if self._token:
             return self._token, ""
 
-        # Verify we have an active integration for this user
-        async with get_session(organization_id=self.organization_id) as session:
-            integration = await self._select_integration(session, require_active=True)
+        override_id: str | None = (
+            self._nango_connection_override.strip()
+            if self._nango_connection_override and self._nango_connection_override.strip()
+            else None
+        )
 
-            if not integration:
-                user_msg = f" for user {self.user_id}" if self.user_id else ""
-                raise ValueError(
-                    f"No active {self.source_system} integration{user_msg} for organization: {self.organization_id}"
-                )
+        if override_id:
+            uid: UUID | None = UUID(self.user_id) if self.user_id else None
+            self._integration = Integration(
+                organization_id=UUID(self.organization_id),
+                connector=self.source_system,
+                provider=self.source_system,
+                user_id=uid,
+                nango_connection_id=override_id,
+                is_active=True,
+            )
+        else:
+            async with get_session(organization_id=self.organization_id) as session:
+                integration = await self._select_integration(session, require_active=True)
 
-            self._integration = integration
+                if not integration:
+                    user_msg = f" for user {self.user_id}" if self.user_id else ""
+                    raise ValueError(
+                        f"No active {self.source_system} integration{user_msg} "
+                        f"for organization: {self.organization_id}"
+                    )
 
-        # Get token from Nango
+                self._integration = integration
+
         nango = get_nango_client()
         nango_integration_id = get_nango_integration_id(self.source_system)
 
-        # Use the actual Nango connection ID from the integration record
-        connection_id = self._integration.nango_connection_id
+        connection_id = self._integration.nango_connection_id if self._integration else None
         if not connection_id:
             raise ValueError(
                 f"No Nango connection ID stored for {self.source_system} integration"
@@ -626,7 +719,7 @@ class BaseConnector(ABC):
 
         # Ensure integration is loaded
         if not self._integration:
-            await self.get_token()
+            await self.get_oauth_token()
 
         nango = get_nango_client()
         nango_integration_id = get_nango_integration_id(self.source_system)

--- a/backend/connectors/fireflies.py
+++ b/backend/connectors/fireflies.py
@@ -231,8 +231,9 @@ class FirefliesConnector(BaseConnector):
             provider=self.source_system,
             count=0,
             status="syncing",
+            integration_id=self.current_integration_id,
         )
-        
+
         transcripts: list[dict[str, Any]] = await self.get_transcripts(limit=50)
         logger.info("Fetched %d transcripts for org %s", len(transcripts), self.organization_id)
 
@@ -314,6 +315,7 @@ class FirefliesConnector(BaseConnector):
                         provider=self.source_system,
                         count=count,
                         status="syncing",
+                        integration_id=self.current_integration_id,
                     )
 
                     logger.debug(
@@ -444,6 +446,7 @@ class FirefliesConnector(BaseConnector):
                 provider=self.source_system,
                 count=0,
                 status="failed",
+                integration_id=self.current_integration_id,
             )
             raise
 
@@ -452,6 +455,7 @@ class FirefliesConnector(BaseConnector):
             provider=self.source_system,
             count=activities_count,
             status="completed",
+            integration_id=self.current_integration_id,
         )
 
         return {

--- a/backend/connectors/github.py
+++ b/backend/connectors/github.py
@@ -21,6 +21,7 @@ import httpx
 from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
+from connectors.account_metadata import AccountMetadata
 from connectors.base import BaseConnector
 from connectors.registry import (
     AuthType, Capability, ConnectorMeta, ConnectorScope, WriteOperation,
@@ -214,9 +215,15 @@ Use `run_sql_query` on `github_repositories`, `github_commits`, `github_pull_req
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         super().__init__(
-            organization_id, user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
         # Cache: GitHub login → internal user UUID (or None)
         self._login_cache: dict[str, UUID | None] = {}
@@ -241,6 +248,9 @@ Use `run_sql_query` on `github_repositories`, `github_commits`, `github_pull_req
         if self._token:
             return self._token, ""
 
+        if self._nango_connection_override:
+            return await super().get_oauth_token()
+
         async with get_session(organization_id=self.organization_id) as session:
             conditions: list[Any] = [
                 Integration.organization_id == UUID(self.organization_id),
@@ -249,6 +259,10 @@ Use `run_sql_query` on `github_repositories`, `github_commits`, `github_pull_req
             ]
             if self.user_id:
                 conditions.append(Integration.user_id == UUID(self.user_id))
+            if self._integration_id_filter is not None:
+                conditions.append(Integration.id == self._integration_id_filter)
+            if self._account_identifier_filter is not None:
+                conditions.append(Integration.account_identifier == self._account_identifier_filter)
 
             result = await session.execute(
                 select(
@@ -290,6 +304,21 @@ Use `run_sql_query` on `github_repositories`, `github_commits`, `github_pull_req
             self._nango_connection_id,
         )
         return self._token, ""
+
+    async def fetch_account_metadata(self) -> AccountMetadata:
+
+        data: dict[str, Any] = await self._gh_get("/user")
+        login_raw: Any = data.get("login")
+        login: str = str(login_raw).strip() if login_raw else ""
+        if not login:
+            raise ValueError("GitHub /user missing login")
+        name_raw: Any = data.get("name")
+        label: str = str(name_raw).strip() if isinstance(name_raw, str) and name_raw.strip() else login
+        avatar_raw: Any = data.get("avatar_url")
+        avatar: str | None = (
+            str(avatar_raw).strip() if isinstance(avatar_raw, str) and avatar_raw.strip() else None
+        )
+        return AccountMetadata(identifier=login.lower(), label=label, avatar_url=avatar)
 
     # ── HTTP helpers ─────────────────────────────────────────────────────
 

--- a/backend/connectors/gmail.py
+++ b/backend/connectors/gmail.py
@@ -9,8 +9,10 @@ Responsibilities:
 """
 
 import base64
+import re
 import uuid
 from datetime import datetime, timedelta
+from html import unescape
 from typing import Any, Optional
 
 import httpx
@@ -25,6 +27,13 @@ from models.database import get_session
 from services.automated_agent_footer import ensure_automated_agent_footer
 
 GMAIL_API_BASE = "https://gmail.googleapis.com/gmail/v1"
+
+# Max characters returned for `message:<id>` live body text (QUERY).
+_BODY_TEXT_MAX_CHARS: int = 20_000
+
+# Default / upper bound for list + thread QUERY result sizes.
+_QUERY_DEFAULT_MAX_MESSAGES: int = 10
+_QUERY_MAX_MESSAGES_CAP: int = 25
 
 
 class GmailConnector(BaseConnector):
@@ -52,7 +61,17 @@ class GmailConnector(BaseConnector):
             ),
         ],
         nango_integration_id="gmail",
-        description="Gmail – email sync and send",
+        description="Gmail – email sync, live search, and send",
+        query_description=(
+            "Live Gmail search via `query_on_connector(connector='gmail', query=...)` using Gmail's `q` syntax.\n"
+            "- **Search / list (snippets):** pass a Gmail search string, e.g. `from:alice@example.com newer_than:2d`, "
+            "`subject:\"proposal\"`, `has:attachment`. Append ` max:N` (default 10, max 25) to limit hits.\n"
+            "- **One message (full body):** `message:<gmail_message_id>` — returns decoded plain text (or stripped HTML) "
+            f"in `body_text`, truncated to {_BODY_TEXT_MAX_CHARS:,} characters.\n"
+            "- **Thread:** `thread:<thread_id>` — all messages in the thread with snippets; the **latest** message "
+            "also includes `body_text`.\n"
+            "See Google: Gmail search operators."
+        ),
         usage_guide="""# Gmail Usage Guide
 
 ## send_email action
@@ -81,7 +100,9 @@ Send an email via the user's connected Gmail account. Emails are sent from the a
 {"to": "client@example.com", "subject": "Proposal", "body": "Please find attached...", "cc": ["manager@company.com"]}
 ```
 
-**Querying email data:** Synced emails appear in the `activities` table. Use `run_sql_query` with `WHERE source_system = 'gmail'` to search by subject, description, or date.
+**Live search (on-demand):** Use `query_on_connector(connector='gmail', query='<Gmail q string>')` for up-to-the-minute results (see connector `query_description` for `message:` and `thread:` forms). Do **not** rely on sync alone for \"did someone reply yet?\".
+
+**Synced warehouse:** Emails also sync into the `activities` table. Use `run_sql_query` with `WHERE source_system = 'gmail'` for bulk/historical analytics on already-synced rows.
 """,
     )
 
@@ -195,6 +216,219 @@ Send an email via the user's connected Gmail account. Emails are sent from the a
         """Get full message details."""
         params = {"format": "metadata", "metadataHeaders": ["From", "To", "Cc", "Subject", "Date"]}
         return await self._make_request("GET", f"/users/me/messages/{message_id}", params=params)
+
+    async def _get_message_summary(self, message_id: str) -> dict[str, Any]:
+        """Fetch one message with metadata headers (cheap; used by live QUERY)."""
+        return await self._get_message_detail(message_id)
+
+    async def _get_message_full(self, message_id: str) -> dict[str, Any]:
+        """Fetch one message with full MIME payload (for body extraction)."""
+        return await self._make_request(
+            "GET",
+            f"/users/me/messages/{message_id}",
+            params={"format": "full"},
+        )
+
+    @staticmethod
+    def _strip_max_suffix(raw: str) -> tuple[str, int]:
+        """Strip trailing `` max:N`` from a list-style query; return (query, max_messages)."""
+        stripped: str = raw.strip()
+        match: re.Match[str] | None = re.search(r"\s+max:(\d+)\s*$", stripped, flags=re.IGNORECASE)
+        if not match:
+            return stripped, _QUERY_DEFAULT_MAX_MESSAGES
+        q_part: str = stripped[: match.start()].strip()
+        try:
+            n: int = int(match.group(1))
+        except ValueError:
+            return q_part, _QUERY_DEFAULT_MAX_MESSAGES
+        capped: int = max(1, min(n, _QUERY_MAX_MESSAGES_CAP))
+        return q_part, capped
+
+    @staticmethod
+    def _b64url_decode(data: str) -> bytes:
+        """Decode a Gmail API base64url ``body.data`` string."""
+        padded: str = data + "=" * ((4 - len(data) % 4) % 4)
+        return base64.urlsafe_b64decode(padded.encode("ascii"))
+
+    @staticmethod
+    def _strip_html_to_text(html: str) -> str:
+        """Best-effort HTML → plain text for QUERY results."""
+        without_blocks: str = re.sub(
+            r"(?is)<(script|style)[^>]*>.*?</\1>",
+            "",
+            html,
+        )
+        without_tags: str = re.sub(r"<[^>]+>", " ", without_blocks)
+        collapsed: str = re.sub(r"\s+", " ", without_tags).strip()
+        return unescape(collapsed)
+
+    def _extract_body_text(self, payload: dict[str, Any]) -> str:
+        """Walk a Gmail ``payload`` tree; prefer ``text/plain``, else stripped ``text/html``."""
+        plain_parts: list[str] = []
+        html_parts: list[str] = []
+
+        def walk(part: dict[str, Any]) -> None:
+            mime_type: str = str(part.get("mimeType") or "")
+            body: dict[str, Any] = part.get("body") or {}
+            raw_data: Any = body.get("data")
+            if isinstance(raw_data, str) and raw_data:
+                try:
+                    decoded: str = self._b64url_decode(raw_data).decode("utf-8", errors="replace")
+                except Exception:
+                    decoded = ""
+                if mime_type == "text/plain" and decoded:
+                    plain_parts.append(decoded)
+                elif mime_type == "text/html" and decoded:
+                    html_parts.append(decoded)
+            for sub in part.get("parts") or []:
+                if isinstance(sub, dict):
+                    walk(sub)
+
+        walk(payload)
+        if plain_parts:
+            text: str = "\n\n".join(plain_parts).strip()
+        elif html_parts:
+            text = self._strip_html_to_text("\n\n".join(html_parts))
+        else:
+            text = ""
+        if len(text) > _BODY_TEXT_MAX_CHARS:
+            text = text[:_BODY_TEXT_MAX_CHARS] + f"\n\n[Truncated — first {_BODY_TEXT_MAX_CHARS:,} characters]"
+        return text
+
+    def _gmail_message_to_query_row(
+        self,
+        gmail_msg: dict[str, Any],
+        *,
+        body_text: str | None = None,
+    ) -> dict[str, Any]:
+        """Shape a Gmail API message dict for ``query()`` JSON (not persisted)."""
+        activity: Optional[Activity] = self._normalize_message(gmail_msg)
+        if activity is None:
+            return {}
+        cf: dict[str, Any] = dict(activity.custom_fields or {})
+        date_val: str | None = None
+        if activity.activity_date is not None:
+            date_val = activity.activity_date.isoformat()
+        row: dict[str, Any] = {
+            "id": activity.source_id or "",
+            "thread_id": cf.get("thread_id"),
+            "subject": activity.subject,
+            "from": cf.get("from_email"),
+            "from_name": cf.get("from_name"),
+            "to": list(cf.get("to_emails") or []),
+            "cc": list(cf.get("cc_emails") or []),
+            "date": date_val,
+            "snippet": (gmail_msg.get("snippet") or "")[:2000],
+            "labels": list(cf.get("labels") or []),
+            "is_unread": bool(cf.get("is_unread")),
+            "is_sent": bool(cf.get("is_sent")),
+        }
+        if body_text is not None:
+            row["body_text"] = body_text
+        return row
+
+    async def query(self, request: str) -> dict[str, Any]:
+        """Live search / read Gmail on demand (QUERY capability)."""
+        stripped: str = request.strip()
+        if not stripped:
+            return {"error": "Empty query"}
+
+        lower: str = stripped.lower()
+        if lower.startswith("message:"):
+            raw_id: str = stripped[len("message:") :].strip()
+            if not raw_id:
+                return {"error": "message_id is required after 'message:'"}
+            full_msg: dict[str, Any] = await self._get_message_full(raw_id)
+            body_text: str = self._extract_body_text(full_msg.get("payload") or {})
+            row: dict[str, Any] = self._gmail_message_to_query_row(full_msg, body_text=body_text)
+            if not row:
+                return {"error": f"Could not normalize message: {raw_id}"}
+            return {"query": stripped, "count": 1, "messages": [row]}
+
+        if lower.startswith("thread:"):
+            thread_id: str = stripped[len("thread:") :].strip()
+            if not thread_id:
+                return {"error": "thread_id is required after 'thread:'"}
+            meta_params: dict[str, Any] = {
+                "format": "metadata",
+                "metadataHeaders": ["From", "To", "Cc", "Subject", "Date"],
+            }
+            thread_data: dict[str, Any] = await self._make_request(
+                "GET",
+                f"/users/me/threads/{thread_id}",
+                params=meta_params,
+            )
+            raw_messages: list[Any] = list(thread_data.get("messages") or [])
+            typed_messages: list[dict[str, Any]] = [m for m in raw_messages if isinstance(m, dict)]
+
+            def _internal_ms(msg: dict[str, Any]) -> int:
+                raw: Any = msg.get("internalDate")
+                try:
+                    return int(raw) if raw is not None else 0
+                except (TypeError, ValueError):
+                    return 0
+
+            typed_messages.sort(key=_internal_ms)
+            rows: list[dict[str, Any]] = []
+            last_id: str | None = None
+            for m in typed_messages:
+                mid_any = m.get("id")
+                if isinstance(mid_any, str) and mid_any:
+                    last_id = mid_any
+
+            for m in typed_messages:
+                mid_any = m.get("id")
+                if not isinstance(mid_any, str) or not mid_any:
+                    continue
+                body_for_row: str | None = None
+                if last_id is not None and mid_any == last_id:
+                    full_last: dict[str, Any] = await self._get_message_full(mid_any)
+                    body_for_row = self._extract_body_text(full_last.get("payload") or {})
+                    row_t = self._gmail_message_to_query_row(full_last, body_text=body_for_row)
+                else:
+                    summary: dict[str, Any] = await self._get_message_summary(mid_any)
+                    row_t = self._gmail_message_to_query_row(summary)
+                if row_t:
+                    rows.append(row_t)
+
+            return {
+                "query": stripped,
+                "thread_id": thread_id,
+                "count": len(rows),
+                "messages": rows,
+            }
+
+        q_raw: str
+        max_messages: int
+        q_raw, max_messages = self._strip_max_suffix(stripped)
+        if not q_raw:
+            return {"error": "Empty query after removing max: suffix"}
+
+        list_params: dict[str, Any] = {
+            "q": q_raw,
+            "maxResults": min(100, max_messages),
+        }
+        list_data: dict[str, Any] = await self._make_request("GET", "/users/me/messages", params=list_params)
+        refs: list[Any] = list(list_data.get("messages") or [])
+        out_rows: list[dict[str, Any]] = []
+        for ref in refs:
+            if len(out_rows) >= max_messages:
+                break
+            if not isinstance(ref, dict):
+                continue
+            mid: Any = ref.get("id")
+            if not isinstance(mid, str) or not mid:
+                continue
+            detail: dict[str, Any] = await self._get_message_summary(mid)
+            r = self._gmail_message_to_query_row(detail)
+            if r:
+                out_rows.append(r)
+
+        return {
+            "query": stripped,
+            "count": len(out_rows),
+            "messages": out_rows,
+        }
 
     async def sync_deals(self) -> int:
         """Gmail doesn't have deals - return 0."""

--- a/backend/connectors/gmail.py
+++ b/backend/connectors/gmail.py
@@ -18,6 +18,7 @@ from typing import Any, Optional
 import httpx
 
 from api.websockets import broadcast_sync_progress
+from connectors.account_metadata import AccountMetadata
 from connectors.base import BaseConnector
 from connectors.registry import (
     AuthType, Capability, ConnectorAction, ConnectorMeta, ConnectorScope,
@@ -57,6 +58,12 @@ class GmailConnector(BaseConnector):
                     {"name": "body", "type": "string", "required": True, "description": "Email body (plain text)"},
                     {"name": "cc", "type": "array", "required": False, "description": "CC recipients"},
                     {"name": "bcc", "type": "array", "required": False, "description": "BCC recipients"},
+                    {
+                        "name": "account",
+                        "type": "string",
+                        "required": False,
+                        "description": "Connected Gmail address to send from (defaults to primary / most recent).",
+                    },
                 ],
             ),
         ],
@@ -687,8 +694,15 @@ Send an email via the user's connected Gmail account. Emails are sent from the a
                 bcc=params.get("bcc"),
                 reply_to=params.get("reply_to"),
                 thread_id=params.get("thread_id"),
+                account=params.get("account"),
             )
         raise ValueError(f"Unknown action: {action}")
+
+    async def fetch_account_metadata(self) -> AccountMetadata:
+        from connectors.google_userinfo import fetch_google_account_metadata
+
+        token, _ = await self.get_oauth_token()
+        return await fetch_google_account_metadata(token)
 
     async def send_email(
         self,
@@ -699,6 +713,7 @@ Send an email via the user's connected Gmail account. Emails are sent from the a
         bcc: Optional[list[str]] = None,
         reply_to: Optional[str] = None,
         thread_id: Optional[str] = None,
+        account: Optional[str] = None,
     ) -> dict[str, Any]:
         """
         Send an email via the user's Gmail account.
@@ -711,71 +726,83 @@ Send an email via the user's connected Gmail account. Emails are sent from the a
             bcc: Optional BCC recipients
             reply_to: Optional reply-to address
             thread_id: Optional thread ID to reply in thread
+            account: Optional connected account email (lowercased) to send from
             
         Returns:
             Dict with id, threadId on success, or error on failure
         """
-        import email.mime.text
-        import email.mime.multipart
-        
-        # Build recipients list
-        to_list = [to] if isinstance(to, str) else to
-        body_with_footer: str = ensure_automated_agent_footer(body)
-        if body_with_footer != body:
-            print(f"[GmailConnector] Applied automated-agent footer before send to {to_list}")
-        
-        # Create message
-        message = email.mime.multipart.MIMEMultipart()
-        message["To"] = ", ".join(to_list)
-        message["Subject"] = subject
-        
-        if cc:
-            message["Cc"] = ", ".join(cc)
-        if bcc:
-            message["Bcc"] = ", ".join(bcc)
-        if reply_to:
-            message["Reply-To"] = reply_to
-        
-        # Attach body
-        message.attach(email.mime.text.MIMEText(body_with_footer, "plain"))
-        
-        # Encode to base64url
-        raw_message = base64.urlsafe_b64encode(message.as_bytes()).decode("utf-8")
-        
-        # Build request body
-        request_body: dict[str, Any] = {"raw": raw_message}
-        if thread_id:
-            request_body["threadId"] = thread_id
-        
-        headers = await self._get_headers()
-        url = f"{GMAIL_API_BASE}/users/me/messages/send"
-        
-        async with httpx.AsyncClient() as client:
-            try:
-                response = await client.post(
-                    url,
-                    headers=headers,
-                    json=request_body,
-                    timeout=30.0,
-                )
-                response.raise_for_status()
-                data = response.json()
-                
-                return {
-                    "success": True,
-                    "id": data.get("id"),
-                    "threadId": data.get("threadId"),
-                    "labelIds": data.get("labelIds", []),
-                }
-                
-            except httpx.HTTPStatusError as e:
-                error_msg = e.response.text if e.response else str(e)
-                return {
-                    "success": False,
-                    "error": f"Gmail API error: {error_msg}",
-                }
-            except Exception as e:
-                return {
-                    "success": False,
-                    "error": str(e),
-                }
+        prev_filter: str | None = self._account_identifier_filter
+        prev_token: str | None = self._token
+        try:
+            acct: str | None = account.strip().lower() if isinstance(account, str) and account.strip() else None
+            if acct:
+                self._account_identifier_filter = acct
+                self._token = None
+
+            import email.mime.text
+            import email.mime.multipart
+
+            # Build recipients list
+            to_list = [to] if isinstance(to, str) else to
+            body_with_footer: str = ensure_automated_agent_footer(body)
+            if body_with_footer != body:
+                print(f"[GmailConnector] Applied automated-agent footer before send to {to_list}")
+
+            # Create message
+            message = email.mime.multipart.MIMEMultipart()
+            message["To"] = ", ".join(to_list)
+            message["Subject"] = subject
+
+            if cc:
+                message["Cc"] = ", ".join(cc)
+            if bcc:
+                message["Bcc"] = ", ".join(bcc)
+            if reply_to:
+                message["Reply-To"] = reply_to
+
+            # Attach body
+            message.attach(email.mime.text.MIMEText(body_with_footer, "plain"))
+
+            # Encode to base64url
+            raw_message = base64.urlsafe_b64encode(message.as_bytes()).decode("utf-8")
+
+            # Build request body
+            request_body: dict[str, Any] = {"raw": raw_message}
+            if thread_id:
+                request_body["threadId"] = thread_id
+
+            headers = await self._get_headers()
+            url = f"{GMAIL_API_BASE}/users/me/messages/send"
+
+            async with httpx.AsyncClient() as client:
+                try:
+                    response = await client.post(
+                        url,
+                        headers=headers,
+                        json=request_body,
+                        timeout=30.0,
+                    )
+                    response.raise_for_status()
+                    data = response.json()
+
+                    return {
+                        "success": True,
+                        "id": data.get("id"),
+                        "threadId": data.get("threadId"),
+                        "labelIds": data.get("labelIds", []),
+                    }
+
+                except httpx.HTTPStatusError as e:
+                    error_msg = e.response.text if e.response else str(e)
+                    return {
+                        "success": False,
+                        "error": f"Gmail API error: {error_msg}",
+                    }
+                except Exception as e:
+                    return {
+                        "success": False,
+                        "error": str(e),
+                    }
+        finally:
+            self._account_identifier_filter = prev_filter
+            self._token = prev_token

--- a/backend/connectors/gmail.py
+++ b/backend/connectors/gmail.py
@@ -175,6 +175,7 @@ Send an email via the user's connected Gmail account. Emails are sent from the a
             provider=self.source_system,
             count=0,
             status="syncing",
+            integration_id=self.current_integration_id,
         )
 
         while len(messages) < max_results:
@@ -209,6 +210,7 @@ Send an email via the user's connected Gmail account. Emails are sent from the a
                                 provider=self.source_system,
                                 count=len(messages),
                                 status="syncing",
+                                integration_id=self.current_integration_id,
                             )
                     except Exception as e:
                         print(f"Failed to fetch message {msg_id}: {e}")
@@ -670,6 +672,7 @@ Send an email via the user's connected Gmail account. Emails are sent from the a
             provider=self.source_system,
             count=activities_count,
             status="completed",
+            integration_id=self.current_integration_id,
         )
 
         return {
@@ -702,7 +705,9 @@ Send an email via the user's connected Gmail account. Emails are sent from the a
         from connectors.google_userinfo import fetch_google_account_metadata
 
         token, _ = await self.get_oauth_token()
-        return await fetch_google_account_metadata(token)
+        # Gmail scope is always granted here; userinfo is a best-effort fallback
+        # in case the integration is also configured with email/profile scopes.
+        return await fetch_google_account_metadata(token, sources=("gmail", "userinfo"))
 
     async def send_email(
         self,

--- a/backend/connectors/google_calendar.py
+++ b/backend/connectors/google_calendar.py
@@ -17,6 +17,7 @@ from zoneinfo import ZoneInfo
 
 import httpx
 
+from connectors.account_metadata import AccountMetadata
 from connectors.base import BaseConnector
 from connectors.registry import AuthType, Capability, ConnectorAction, ConnectorMeta, ConnectorScope
 from models.activity import Activity
@@ -137,6 +138,12 @@ class GoogleCalendarConnector(BaseConnector):
             "https://www.googleapis.com/auth/calendar.events",
         ],
     )
+
+    async def fetch_account_metadata(self) -> AccountMetadata:
+        from connectors.google_userinfo import fetch_google_account_metadata
+
+        token, _ = await self.get_oauth_token()
+        return await fetch_google_account_metadata(token)
 
     async def _get_headers(self) -> dict[str, str]:
         """Get authorization headers for Google Calendar API."""

--- a/backend/connectors/google_calendar.py
+++ b/backend/connectors/google_calendar.py
@@ -143,7 +143,7 @@ class GoogleCalendarConnector(BaseConnector):
         from connectors.google_userinfo import fetch_google_account_metadata
 
         token, _ = await self.get_oauth_token()
-        return await fetch_google_account_metadata(token)
+        return await fetch_google_account_metadata(token, sources=("calendar", "userinfo"))
 
     async def _get_headers(self) -> dict[str, str]:
         """Get authorization headers for Google Calendar API."""
@@ -307,6 +307,7 @@ class GoogleCalendarConnector(BaseConnector):
             provider=self.source_system,
             count=0,
             status="syncing",
+            integration_id=self.current_integration_id,
         )
 
         # Build resolver from existing CRM data in the database
@@ -481,6 +482,7 @@ class GoogleCalendarConnector(BaseConnector):
                                 provider=self.source_system,
                                 count=count,
                                 status="syncing",
+                                integration_id=self.current_integration_id,
                             )
 
                         if meeting is not None:
@@ -569,6 +571,7 @@ class GoogleCalendarConnector(BaseConnector):
             provider=self.source_system,
             count=count,
             status="completed",
+            integration_id=self.current_integration_id,
         )
         
         print(f"[GCal Sync] Successfully synced {count} activities")

--- a/backend/connectors/google_drive.py
+++ b/backend/connectors/google_drive.py
@@ -29,6 +29,7 @@ from sqlalchemy import select, and_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from config import settings, get_nango_integration_id
+from connectors.account_metadata import AccountMetadata
 from connectors.base import BaseConnector
 from connectors.registry import (
     AuthType, Capability, ConnectorAction, ConnectorMeta, ConnectorScope,
@@ -586,9 +587,15 @@ Call via `run_on_connector(connector='google_drive', action='edit_file', params=
         user_id: str,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         super().__init__(
-            organization_id, user_id=user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id=user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
         self._integration_last_sync_at: datetime | None = None
         self._nango_connection_id: str | None = None
@@ -612,16 +619,26 @@ Call via `run_on_connector(connector='google_drive', action='edit_file', params=
         if self._token:
             return self._token, ""
 
+        if self._nango_connection_override:
+            return await super().get_oauth_token()
+
         async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
-            connection_id: str = f"{self.organization_id}:user:{self.user_id}"
-            result = await session.execute(
-                select(Integration.nango_connection_id, Integration.last_sync_at).where(
+            legacy_connection_id: str = f"{self.organization_id}:user:{self.user_id}"
+            stmt = (
+                select(Integration.nango_connection_id, Integration.last_sync_at)
+                .where(
                     Integration.organization_id == UUID(self.organization_id),
                     Integration.connector == "google_drive",
                     Integration.user_id == UUID(self.user_id),
                 )
+                .order_by(Integration.updated_at.desc().nullslast())
             )
-            integration_row = result.one_or_none()
+            if self._integration_id_filter is not None:
+                stmt = stmt.where(Integration.id == self._integration_id_filter)
+            if self._account_identifier_filter is not None:
+                stmt = stmt.where(Integration.account_identifier == self._account_identifier_filter)
+            stmt = stmt.limit(1)
+            integration_row = (await session.execute(stmt)).one_or_none()
 
             if integration_row is None:
                 raise ValueError(
@@ -636,9 +653,15 @@ Call via `run_on_connector(connector='google_drive', action='edit_file', params=
 
         self._token = await nango.get_token(
             nango_integration_id,
-            self._nango_connection_id or connection_id,
+            self._nango_connection_id or legacy_connection_id,
         )
         return self._token, ""
+
+    async def fetch_account_metadata(self) -> AccountMetadata:
+        from connectors.google_userinfo import fetch_google_account_metadata
+
+        token, _ = await self.get_oauth_token()
+        return await fetch_google_account_metadata(token)
 
     def _get_headers(self) -> dict[str, str]:
         """Build request headers with OAuth token."""

--- a/backend/connectors/google_drive.py
+++ b/backend/connectors/google_drive.py
@@ -661,7 +661,7 @@ Call via `run_on_connector(connector='google_drive', action='edit_file', params=
         from connectors.google_userinfo import fetch_google_account_metadata
 
         token, _ = await self.get_oauth_token()
-        return await fetch_google_account_metadata(token)
+        return await fetch_google_account_metadata(token, sources=("drive", "userinfo"))
 
     def _get_headers(self) -> dict[str, str]:
         """Build request headers with OAuth token."""

--- a/backend/connectors/google_userinfo.py
+++ b/backend/connectors/google_userinfo.py
@@ -1,4 +1,19 @@
-"""Shared Google OAuth userinfo for account_identifier / label / avatar."""
+"""Shared Google account-identity helpers for account_identifier / label / avatar.
+
+Different Google connectors are granted different OAuth scopes, so a single
+shared endpoint (e.g. ``/oauth2/v2/userinfo``) is not always reachable. Each
+service exposes its own "who am I" endpoint that requires only the service's
+own scope:
+
+- Gmail:    ``GET gmail/v1/users/me/profile`` (gmail.readonly / gmail.metadata)
+- Drive:    ``GET drive/v3/about?fields=user(emailAddress,displayName,photoLink)``
+- Calendar: ``GET calendar/v3/users/me/calendarList`` (look for ``primary=true``)
+- userinfo: ``GET oauth2/v2/userinfo`` (requires ``email`` / ``profile`` scopes)
+
+``fetch_google_account_metadata`` tries the configured ``sources`` in order and
+returns the first successful identity. Connectors pass their own service first
+so we only fall back when truly necessary.
+"""
 
 from __future__ import annotations
 
@@ -12,22 +27,140 @@ from connectors.account_metadata import AccountMetadata
 logger = logging.getLogger(__name__)
 
 GOOGLE_USERINFO_URL: str = "https://www.googleapis.com/oauth2/v2/userinfo"
+GMAIL_PROFILE_URL: str = "https://gmail.googleapis.com/gmail/v1/users/me/profile"
+DRIVE_ABOUT_URL: str = "https://www.googleapis.com/drive/v3/about"
+CALENDAR_LIST_URL: str = "https://www.googleapis.com/calendar/v3/users/me/calendarList"
+
+_DEFAULT_SOURCES: tuple[str, ...] = ("userinfo", "gmail", "drive", "calendar")
 
 
-async def fetch_google_account_metadata(access_token: str) -> AccountMetadata:
-    """Resolve Google account email (identifier) and optional name / picture."""
-    headers: dict[str, str] = {"Authorization": f"Bearer {access_token}"}
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.get(GOOGLE_USERINFO_URL, headers=headers)
-        response.raise_for_status()
-        data: dict[str, Any] = response.json()
-
+async def _from_userinfo(client: httpx.AsyncClient, headers: dict[str, str]) -> AccountMetadata:
+    response = await client.get(GOOGLE_USERINFO_URL, headers=headers)
+    response.raise_for_status()
+    data: dict[str, Any] = response.json() or {}
     email_raw: Any = data.get("email") or data.get("id")
     if not email_raw:
         raise ValueError("Google userinfo response missing email/id")
     identifier: str = str(email_raw).strip().lower()
     name_raw: Any = data.get("name")
-    label: str | None = str(name_raw).strip() if isinstance(name_raw, str) and name_raw.strip() else identifier
+    label: str | None = (
+        str(name_raw).strip() if isinstance(name_raw, str) and name_raw.strip() else identifier
+    )
     pic_raw: Any = data.get("picture")
-    avatar: str | None = str(pic_raw).strip() if isinstance(pic_raw, str) and pic_raw.strip() else None
+    avatar: str | None = (
+        str(pic_raw).strip() if isinstance(pic_raw, str) and pic_raw.strip() else None
+    )
     return AccountMetadata(identifier=identifier, label=label, avatar_url=avatar)
+
+
+async def _from_gmail_profile(
+    client: httpx.AsyncClient, headers: dict[str, str]
+) -> AccountMetadata:
+    response = await client.get(GMAIL_PROFILE_URL, headers=headers)
+    response.raise_for_status()
+    data: dict[str, Any] = response.json() or {}
+    email_raw: Any = data.get("emailAddress")
+    if not email_raw:
+        raise ValueError("Gmail profile response missing emailAddress")
+    identifier: str = str(email_raw).strip().lower()
+    return AccountMetadata(identifier=identifier, label=identifier, avatar_url=None)
+
+
+async def _from_drive_about(
+    client: httpx.AsyncClient, headers: dict[str, str]
+) -> AccountMetadata:
+    response = await client.get(
+        DRIVE_ABOUT_URL,
+        headers=headers,
+        params={"fields": "user(emailAddress,displayName,photoLink)"},
+    )
+    response.raise_for_status()
+    body: dict[str, Any] = response.json() or {}
+    user: dict[str, Any] = body.get("user") or {}
+    email_raw: Any = user.get("emailAddress")
+    if not email_raw:
+        raise ValueError("Drive about response missing user.emailAddress")
+    identifier: str = str(email_raw).strip().lower()
+    name_raw: Any = user.get("displayName")
+    label: str | None = (
+        str(name_raw).strip() if isinstance(name_raw, str) and name_raw.strip() else identifier
+    )
+    pic_raw: Any = user.get("photoLink")
+    avatar: str | None = (
+        str(pic_raw).strip() if isinstance(pic_raw, str) and pic_raw.strip() else None
+    )
+    return AccountMetadata(identifier=identifier, label=label, avatar_url=avatar)
+
+
+async def _from_calendar_list(
+    client: httpx.AsyncClient, headers: dict[str, str]
+) -> AccountMetadata:
+    response = await client.get(
+        CALENDAR_LIST_URL,
+        headers=headers,
+        params={"maxResults": 250},
+    )
+    response.raise_for_status()
+    body: dict[str, Any] = response.json() or {}
+    items_raw: Any = body.get("items")
+    items: list[dict[str, Any]] = items_raw if isinstance(items_raw, list) else []
+    primary: dict[str, Any] | None = next(
+        (c for c in items if isinstance(c, dict) and c.get("primary")),
+        None,
+    )
+    if primary is None and items:
+        primary = items[0] if isinstance(items[0], dict) else None
+    if primary is None:
+        raise ValueError("Calendar list response empty")
+    email_raw: Any = primary.get("id")
+    if not email_raw:
+        raise ValueError("Calendar list missing primary id")
+    identifier: str = str(email_raw).strip().lower()
+    summary_raw: Any = primary.get("summary")
+    label: str | None = (
+        str(summary_raw).strip() if isinstance(summary_raw, str) and summary_raw.strip() else identifier
+    )
+    return AccountMetadata(identifier=identifier, label=label, avatar_url=None)
+
+
+async def fetch_google_account_metadata(
+    access_token: str,
+    *,
+    sources: tuple[str, ...] | list[str] | None = None,
+) -> AccountMetadata:
+    """Resolve a Google account's email / label / avatar using the first source that works.
+
+    Args:
+        access_token: OAuth access token.
+        sources: Ordered list of identity sources to try. Each connector should
+            pass its own service first (e.g. ``("gmail", "userinfo")`` for the
+            Gmail connector) to avoid wasted 401s on scopes it does not own.
+    """
+    chosen: tuple[str, ...] = tuple(sources) if sources else _DEFAULT_SOURCES
+    headers: dict[str, str] = {"Authorization": f"Bearer {access_token}"}
+    last_error: Exception | None = None
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        for source in chosen:
+            try:
+                if source == "userinfo":
+                    return await _from_userinfo(client, headers)
+                if source == "gmail":
+                    return await _from_gmail_profile(client, headers)
+                if source == "drive":
+                    return await _from_drive_about(client, headers)
+                if source == "calendar":
+                    return await _from_calendar_list(client, headers)
+                logger.warning(
+                    "Unknown Google identity source requested",
+                    extra={"source": source},
+                )
+            except Exception as exc:
+                last_error = exc
+                logger.info(
+                    "Google account metadata source failed; trying next",
+                    extra={"source": source, "error": str(exc)},
+                )
+                continue
+    if last_error is not None:
+        raise last_error
+    raise ValueError("No Google account metadata source produced a result")

--- a/backend/connectors/google_userinfo.py
+++ b/backend/connectors/google_userinfo.py
@@ -1,0 +1,33 @@
+"""Shared Google OAuth userinfo for account_identifier / label / avatar."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from connectors.account_metadata import AccountMetadata
+
+logger = logging.getLogger(__name__)
+
+GOOGLE_USERINFO_URL: str = "https://www.googleapis.com/oauth2/v2/userinfo"
+
+
+async def fetch_google_account_metadata(access_token: str) -> AccountMetadata:
+    """Resolve Google account email (identifier) and optional name / picture."""
+    headers: dict[str, str] = {"Authorization": f"Bearer {access_token}"}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(GOOGLE_USERINFO_URL, headers=headers)
+        response.raise_for_status()
+        data: dict[str, Any] = response.json()
+
+    email_raw: Any = data.get("email") or data.get("id")
+    if not email_raw:
+        raise ValueError("Google userinfo response missing email/id")
+    identifier: str = str(email_raw).strip().lower()
+    name_raw: Any = data.get("name")
+    label: str | None = str(name_raw).strip() if isinstance(name_raw, str) and name_raw.strip() else identifier
+    pic_raw: Any = data.get("picture")
+    avatar: str | None = str(pic_raw).strip() if isinstance(pic_raw, str) and pic_raw.strip() else None
+    return AccountMetadata(identifier=identifier, label=label, avatar_url=avatar)

--- a/backend/connectors/granola.py
+++ b/backend/connectors/granola.py
@@ -412,6 +412,7 @@ class GranolaConnector(BaseConnector):
             provider=self.source_system,
             count=0,
             status="syncing",
+            integration_id=self.current_integration_id,
         )
 
         mcp: GranolaMcpClient = await self._get_mcp_client()
@@ -539,6 +540,7 @@ class GranolaConnector(BaseConnector):
                         provider=self.source_system,
                         count=count,
                         status="syncing",
+                        integration_id=self.current_integration_id,
                     )
                     logger.debug(
                         "Synced Granola meeting %s -> meeting %s",
@@ -564,6 +566,7 @@ class GranolaConnector(BaseConnector):
                 provider=self.source_system,
                 count=0,
                 status="failed",
+                integration_id=self.current_integration_id,
             )
             raise
 
@@ -572,6 +575,7 @@ class GranolaConnector(BaseConnector):
             provider=self.source_system,
             count=activities_count,
             status="completed",
+            integration_id=self.current_integration_id,
         )
 
         return {

--- a/backend/connectors/hubspot.py
+++ b/backend/connectors/hubspot.py
@@ -630,6 +630,7 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
             count=0,
             status="syncing",
             step="preparing",
+            integration_id=self.current_integration_id,
         )
 
         # Call parent sync_all
@@ -644,6 +645,7 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
             provider=self.source_system,
             count=total,
             status="completed",
+            integration_id=self.current_integration_id,
         )
         
         return result
@@ -968,6 +970,7 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
             count=0,
             status="syncing",
             step="fetching deals",
+            integration_id=self.current_integration_id,
         )
         properties = [
             "dealname",
@@ -1074,6 +1077,7 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
                     count=count,
                     status="syncing",
                     step="deals",
+                    integration_id=self.current_integration_id,
                 )
                 print(f"[HubSpot] Deals: {count}/{len(rows)}")
         print(f"[HubSpot] Committed {len(rows)} deals")
@@ -1175,6 +1179,7 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
             count=0,
             status="syncing",
             step="fetching accounts",
+            integration_id=self.current_integration_id,
         )
         properties = [
             "name",
@@ -1245,6 +1250,7 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
                     count=count,
                     status="syncing",
                     step="accounts",
+                    integration_id=self.current_integration_id,
                 )
                 print(f"[HubSpot] Accounts: {count}/{len(rows)}")
         print(f"[HubSpot] Committed {len(rows)} accounts")
@@ -1302,6 +1308,7 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
             count=0,
             status="syncing",
             step="fetching contacts",
+            integration_id=self.current_integration_id,
         )
         # Only request standard properties that exist in all HubSpot instances
         # Removed 'company' as it's a custom/optional text field
@@ -1410,6 +1417,7 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
                     count=count,
                     status="syncing",
                     step="contacts",
+                    integration_id=self.current_integration_id,
                 )
                 print(f"[HubSpot] Contacts: {count}/{len(rows)}")
         print(f"[HubSpot] Committed {len(rows)} contacts")
@@ -1630,6 +1638,7 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
                             count=count,
                             status="syncing",
                             step="activities",
+                            integration_id=self.current_integration_id,
                         )
                         print(f"[HubSpot] Activities ({engagement_type}): {count}/{len(rows)}")
                 total_count += len(rows)
@@ -1743,6 +1752,7 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
             count=0,
             status="syncing",
             step="fetching goals",
+            integration_id=self.current_integration_id,
         )
 
         # Discover the correct owner/assignee property for goal_targets
@@ -1868,6 +1878,7 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
                     count=count,
                     status="syncing",
                     step="goals",
+                    integration_id=self.current_integration_id,
                 )
                 print(f"[HubSpot] Goals: {count}/{len(rows)}")
         print(f"[HubSpot] Committed {len(rows)} goals")

--- a/backend/connectors/hubspot.py
+++ b/backend/connectors/hubspot.py
@@ -22,6 +22,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 
 from api.websockets import broadcast_sync_progress
+from connectors.account_metadata import AccountMetadata
 from connectors.base import BaseConnector
 from connectors.registry import (
     AuthType,
@@ -577,10 +578,16 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         """Initialize connector with owner and pipeline caches."""
         super().__init__(
-            organization_id, user_id=user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id=user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
         # Cache for HubSpot owner ID -> internal user ID mapping
         self._owner_cache: dict[str, Optional[uuid.UUID]] = {}
@@ -593,6 +600,26 @@ Notes are activities attached to deals (or contacts/companies). Use HubSpot **so
         # HubSpot owner ID -> full owner dict (email, firstName, lastName) for proactive user creation
         self._owner_detail_cache: dict[str, dict[str, Any]] = {}
         self._owner_email_cache_loaded: bool = False
+
+    async def fetch_account_metadata(self) -> AccountMetadata:
+        from connectors.account_metadata import AccountMetadata
+
+        token, _ = await self.get_oauth_token()
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(
+                f"{HUBSPOT_API_BASE}/account-info/v3/details",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            response.raise_for_status()
+            payload: dict[str, Any] = response.json()
+        portal_raw: Any = payload.get("portalId")
+        portal_id: str = str(portal_raw).strip() if portal_raw is not None else ""
+        if not portal_id:
+            raise ValueError("HubSpot account-info missing portalId")
+        name_raw: Any = payload.get("name") or payload.get("accountName") or payload.get("companyCurrency")
+        name: str = str(name_raw).strip() if isinstance(name_raw, str) and name_raw.strip() else ""
+        label: str = f"{name} ({portal_id})" if name else f"HubSpot {portal_id}"
+        return AccountMetadata(identifier=portal_id, label=label, avatar_url=None)
 
     async def sync_all(self) -> dict[str, int]:
         """Run all sync operations with progress broadcasting."""

--- a/backend/connectors/microsoft_calendar.py
+++ b/backend/connectors/microsoft_calendar.py
@@ -16,6 +16,7 @@ from typing import Any, Optional
 
 import httpx
 
+from connectors.account_metadata import AccountMetadata
 from connectors.base import BaseConnector
 from connectors.registry import AuthType, Capability, ConnectorMeta, ConnectorScope
 from models.activity import Activity
@@ -56,6 +57,23 @@ class MicrosoftCalendarConnector(BaseConnector):
         nango_integration_id="microsoft-calendar",
         description="Microsoft Outlook Calendar – event sync",
     )
+
+    async def fetch_account_metadata(self) -> AccountMetadata:
+        token, _ = await self.get_oauth_token()
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(
+                f"{MICROSOFT_GRAPH_API_BASE}/me",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+        mail_raw: Any = data.get("mail") or data.get("userPrincipalName")
+        ident: str = str(mail_raw).strip().lower() if mail_raw else ""
+        if not ident:
+            raise ValueError("Microsoft Graph /me missing mail")
+        name_raw: Any = data.get("displayName")
+        label: str = str(name_raw).strip() if isinstance(name_raw, str) and name_raw.strip() else ident
+        return AccountMetadata(identifier=ident, label=label, avatar_url=None)
 
     async def _get_headers(self) -> dict[str, str]:
         """Get authorization headers for Microsoft Graph API."""

--- a/backend/connectors/microsoft_mail.py
+++ b/backend/connectors/microsoft_mail.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 
 import httpx
 
+from connectors.account_metadata import AccountMetadata
 from connectors.base import BaseConnector
 from connectors.registry import (
     AuthType, Capability, ConnectorAction, ConnectorMeta, ConnectorScope,
@@ -46,12 +47,35 @@ class MicrosoftMailConnector(BaseConnector):
                     {"name": "body", "type": "string", "required": True, "description": "Email body (plain text)"},
                     {"name": "cc", "type": "array", "required": False, "description": "CC recipients"},
                     {"name": "bcc", "type": "array", "required": False, "description": "BCC recipients"},
+                    {
+                        "name": "account",
+                        "type": "string",
+                        "required": False,
+                        "description": "Connected mailbox to send from (defaults to primary).",
+                    },
                 ],
             ),
         ],
         nango_integration_id="microsoft-mail",
         description="Microsoft Outlook Mail – email sync and send",
     )
+
+    async def fetch_account_metadata(self) -> AccountMetadata:
+        token, _ = await self.get_oauth_token()
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(
+                f"{MICROSOFT_GRAPH_API_BASE}/me",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+        mail_raw: Any = data.get("mail") or data.get("userPrincipalName")
+        ident: str = str(mail_raw).strip().lower() if mail_raw else ""
+        if not ident:
+            raise ValueError("Microsoft Graph /me missing mail")
+        name_raw: Any = data.get("displayName")
+        label: str = str(name_raw).strip() if isinstance(name_raw, str) and name_raw.strip() else ident
+        return AccountMetadata(identifier=ident, label=label, avatar_url=None)
 
     async def _get_headers(self) -> dict[str, str]:
         """Get authorization headers for Microsoft Graph API."""
@@ -292,6 +316,7 @@ class MicrosoftMailConnector(BaseConnector):
                 bcc=params.get("bcc"),
                 reply_to=params.get("reply_to"),
                 save_to_sent=params.get("save_to_sent", True),
+                account=params.get("account"),
             )
         raise ValueError(f"Unknown action: {action}")
 
@@ -304,6 +329,7 @@ class MicrosoftMailConnector(BaseConnector):
         bcc: Optional[list[str]] = None,
         reply_to: Optional[str] = None,
         save_to_sent: bool = True,
+        account: Optional[str] = None,
     ) -> dict[str, Any]:
         """
         Send an email via the user's Microsoft/Outlook account.
@@ -316,86 +342,98 @@ class MicrosoftMailConnector(BaseConnector):
             bcc: Optional BCC recipients
             reply_to: Optional reply-to address
             save_to_sent: Whether to save to Sent Items (default True)
+            account: Optional connected mailbox address to send from
             
         Returns:
             Dict with success status and message details
         """
-        # Build recipients list
-        to_list = [to] if isinstance(to, str) else to
-        body_with_footer: str = ensure_automated_agent_footer(body)
-        if body_with_footer != body:
-            print(f"[MicrosoftMailConnector] Applied automated-agent footer before send to {to_list}")
-        
-        # Build recipient objects
-        to_recipients = [
-            {"emailAddress": {"address": addr}} for addr in to_list
-        ]
-        
-        cc_recipients = []
-        if cc:
-            cc_recipients = [{"emailAddress": {"address": addr}} for addr in cc]
-        
-        bcc_recipients = []
-        if bcc:
-            bcc_recipients = [{"emailAddress": {"address": addr}} for addr in bcc]
-        
-        # Build message payload
-        message_payload: dict[str, Any] = {
-            "message": {
-                "subject": subject,
-                "body": {
-                    "contentType": "Text",
-                    "content": body_with_footer,
-                },
-                "toRecipients": to_recipients,
-            },
-            "saveToSentItems": save_to_sent,
-        }
-        
-        if cc_recipients:
-            message_payload["message"]["ccRecipients"] = cc_recipients
-        if bcc_recipients:
-            message_payload["message"]["bccRecipients"] = bcc_recipients
-        if reply_to:
-            message_payload["message"]["replyTo"] = [
-                {"emailAddress": {"address": reply_to}}
+        prev_filter: str | None = self._account_identifier_filter
+        prev_token: str | None = self._token
+        try:
+            acct: str | None = account.strip().lower() if isinstance(account, str) and account.strip() else None
+            if acct:
+                self._account_identifier_filter = acct
+                self._token = None
+
+            # Build recipients list
+            to_list = [to] if isinstance(to, str) else to
+            body_with_footer: str = ensure_automated_agent_footer(body)
+            if body_with_footer != body:
+                print(f"[MicrosoftMailConnector] Applied automated-agent footer before send to {to_list}")
+
+            # Build recipient objects
+            to_recipients = [
+                {"emailAddress": {"address": addr}} for addr in to_list
             ]
-        
-        headers = await self._get_headers()
-        url = f"{MICROSOFT_GRAPH_API_BASE}/me/sendMail"
-        
-        async with httpx.AsyncClient() as client:
-            try:
-                response = await client.post(
-                    url,
-                    headers=headers,
-                    json=message_payload,
-                    timeout=30.0,
-                )
-                
-                # Microsoft returns 202 Accepted on success (no body)
-                if response.status_code == 202:
+
+            cc_recipients = []
+            if cc:
+                cc_recipients = [{"emailAddress": {"address": addr}} for addr in cc]
+
+            bcc_recipients = []
+            if bcc:
+                bcc_recipients = [{"emailAddress": {"address": addr}} for addr in bcc]
+
+            # Build message payload
+            message_payload: dict[str, Any] = {
+                "message": {
+                    "subject": subject,
+                    "body": {
+                        "contentType": "Text",
+                        "content": body_with_footer,
+                    },
+                    "toRecipients": to_recipients,
+                },
+                "saveToSentItems": save_to_sent,
+            }
+
+            if cc_recipients:
+                message_payload["message"]["ccRecipients"] = cc_recipients
+            if bcc_recipients:
+                message_payload["message"]["bccRecipients"] = bcc_recipients
+            if reply_to:
+                message_payload["message"]["replyTo"] = [
+                    {"emailAddress": {"address": reply_to}}
+                ]
+
+            headers = await self._get_headers()
+            url = f"{MICROSOFT_GRAPH_API_BASE}/me/sendMail"
+
+            async with httpx.AsyncClient() as client:
+                try:
+                    response = await client.post(
+                        url,
+                        headers=headers,
+                        json=message_payload,
+                        timeout=30.0,
+                    )
+
+                    # Microsoft returns 202 Accepted on success (no body)
+                    if response.status_code == 202:
+                        return {
+                            "success": True,
+                            "status": "sent",
+                            "to": to_list,
+                        }
+
+                    response.raise_for_status()
                     return {
                         "success": True,
                         "status": "sent",
                         "to": to_list,
                     }
-                
-                response.raise_for_status()
-                return {
-                    "success": True,
-                    "status": "sent",
-                    "to": to_list,
-                }
-                
-            except httpx.HTTPStatusError as e:
-                error_msg = e.response.text if e.response else str(e)
-                return {
-                    "success": False,
-                    "error": f"Microsoft Graph API error: {error_msg}",
-                }
-            except Exception as e:
-                return {
-                    "success": False,
-                    "error": str(e),
-                }
+
+                except httpx.HTTPStatusError as e:
+                    error_msg = e.response.text if e.response else str(e)
+                    return {
+                        "success": False,
+                        "error": f"Microsoft Graph API error: {error_msg}",
+                    }
+                except Exception as e:
+                    return {
+                        "success": False,
+                        "error": str(e),
+                    }
+        finally:
+            self._account_identifier_filter = prev_filter
+            self._token = prev_token

--- a/backend/connectors/registry.py
+++ b/backend/connectors/registry.py
@@ -135,7 +135,7 @@ class ConnectorMeta:
 # Discovery
 # ---------------------------------------------------------------------------
 
-_SKIP_MODULES = frozenset({"base", "resolution", "registry", "models", "persistence", "_template"})
+_SKIP_MODULES = frozenset({"base", "resolution", "registry", "models", "persistence", "_template", "account_metadata", "google_userinfo"})
 
 
 def discover_connectors() -> dict[str, type[BaseConnector]]:

--- a/backend/connectors/salesforce.py
+++ b/backend/connectors/salesforce.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 import httpx
 from sqlalchemy import and_, or_, select
 
+from connectors.account_metadata import AccountMetadata
 from connectors.base import BaseConnector
 from connectors.registry import AuthType, Capability, ConnectorMeta, ConnectorScope
 from models.account import Account
@@ -53,10 +54,16 @@ class SalesforceConnector(BaseConnector):
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         """Initialize the connector."""
         super().__init__(
-            organization_id, user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
         self._instance_url: Optional[str] = None
 
@@ -73,6 +80,29 @@ class SalesforceConnector(BaseConnector):
 
         self._instance_url = instance_url.rstrip("/")
         return self._instance_url
+
+    async def fetch_account_metadata(self) -> AccountMetadata:
+        token, _ = await self.get_oauth_token()
+        instance_url: str = await self._get_instance_url()
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(
+                f"{instance_url}/services/oauth2/userinfo",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            response.raise_for_status()
+            payload: dict[str, Any] = response.json()
+        org_raw: Any = payload.get("organization_id") or payload.get("organizationId")
+        identifier: str = str(org_raw).strip() if org_raw else ""
+        if not identifier:
+            sub_raw: Any = payload.get("sub")
+            identifier = str(sub_raw).strip() if sub_raw else ""
+        if not identifier:
+            raise ValueError("Salesforce userinfo missing organization_id/sub")
+        name_raw: Any = payload.get("name") or payload.get("preferred_username")
+        label: str = (
+            str(name_raw).strip() if isinstance(name_raw, str) and name_raw.strip() else identifier
+        )
+        return AccountMetadata(identifier=identifier, label=label, avatar_url=None)
 
     async def _get_headers(self) -> dict[str, str]:
         """Get authorization headers for Salesforce API."""

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -970,6 +970,7 @@ Returns normalized messages for one channel since a cutoff (does not write to th
             provider=self.source_system,
             count=0,
             status="syncing",
+            integration_id=self.current_integration_id,
         )
 
         all_channels: list[dict[str, Any]] = await self.get_channels()
@@ -1287,6 +1288,7 @@ Returns normalized messages for one channel since a cutoff (does not write to th
             provider=self.source_system,
             count=joined_count,
             status="completed",
+            integration_id=self.current_integration_id,
         )
 
         return {

--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -197,6 +197,7 @@ def _extract_fallback_text_from_blocks(blocks: list[dict[str, Any]]) -> str:
     return fallback
 
 from api.websockets import broadcast_sync_progress
+from connectors.account_metadata import AccountMetadata
 from connectors.base import BaseConnector, ExternalConnectionRevokedError, build_connection_removed_message
 from connectors.registry import (
     AuthType, Capability, ConnectorAction, ConnectorMeta, ConnectorScope,
@@ -253,6 +254,12 @@ class SlackConnector(BaseConnector):
                     {"name": "user_id", "type": "string", "required": False, "description": "Slack user ID (e.g. 'U123'). If provided without channel, Basebase opens a DM to this user and sends the message."},
                     {"name": "text", "type": "string", "required": True, "description": "Message text in Slack mrkdwn format"},
                     {"name": "thread_ts", "type": "string", "required": False, "description": "Thread timestamp to reply in-thread (when channel is provided)"},
+                    {
+                        "name": "account",
+                        "type": "string",
+                        "required": False,
+                        "description": "Slack workspace team id when multiple workspaces are connected (defaults to primary).",
+                    },
                 ],
             ),
             ConnectorAction(
@@ -352,6 +359,8 @@ Returns normalized messages for one channel since a cutoff (does not write to th
         team_id: str | None = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         """Initialize Slack connector.
 
@@ -366,6 +375,8 @@ Returns normalized messages for one channel since a cutoff (does not write to th
             organization_id=organization_id,
             user_id=user_id,
             sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
         self.team_id = (team_id or "").strip() or None
         self._user_info_cache: dict[str, dict[str, Any]] = {}
@@ -392,6 +403,10 @@ Returns normalized messages for one channel since a cutoff (does not write to th
             Integration.connector == self.source_system,
             Integration.extra_data["team_id"].astext == self.team_id,
         ]
+        if self._integration_id_filter is not None:
+            conditions.append(Integration.id == self._integration_id_filter)
+        if self._account_identifier_filter is not None:
+            conditions.append(Integration.account_identifier == self._account_identifier_filter)
         if require_active:
             conditions.append(Integration.is_active == True)  # noqa: E712
         if self.user_id:
@@ -474,6 +489,25 @@ Returns normalized messages for one channel since a cutoff (does not write to th
                     return self._token, ""
 
         return await super().get_oauth_token()
+
+    async def fetch_account_metadata(self) -> AccountMetadata:
+        token, _ = await self.get_oauth_token()
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                "https://slack.com/api/auth.test",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            response.raise_for_status()
+            data: dict[str, Any] = response.json()
+        if not data.get("ok"):
+            raise ValueError(str(data.get("error") or "slack_auth_test_failed"))
+        tid_raw: Any = data.get("team_id")
+        tid: str = str(tid_raw).strip() if tid_raw else ""
+        if not tid:
+            raise ValueError("Slack auth.test missing team_id")
+        team_raw: Any = data.get("team")
+        label: str = str(team_raw).strip() if isinstance(team_raw, str) and team_raw.strip() else tid
+        return AccountMetadata(identifier=tid, label=label, avatar_url=None)
 
     async def _get_headers(self) -> dict[str, str]:
         """Get authorization headers for Slack API."""
@@ -1584,12 +1618,13 @@ Returns normalized messages for one channel since a cutoff (does not write to th
             user_id: str | None = params.get("user_id")
             text: str = params.get("text") or params.get("message") or ""
             thread_ts: str | None = params.get("thread_ts")
+            account: str | None = params.get("account")
             if not str(text).strip():
                 raise ValueError("send_message requires non-empty text")
             if user_id and not channel:
                 return await self.send_direct_message(user_id, text)
             if channel:
-                return await self.post_message(channel, text, thread_ts=thread_ts)
+                return await self.post_message(channel, text, thread_ts=thread_ts, account=account)
             raise ValueError("send_message requires 'channel' or 'user_id' and non-empty text")
         if action == "fetch_channel_history":
             ch: str | None = (
@@ -1644,6 +1679,7 @@ Returns normalized messages for one channel since a cutoff (does not write to th
         text: str,
         thread_ts: Optional[str] = None,
         blocks: Optional[list[dict[str, Any]]] = None,
+        account: Optional[str] = None,
     ) -> dict[str, Any]:
         """
         Post a message to a Slack channel.
@@ -1653,10 +1689,31 @@ Returns normalized messages for one channel since a cutoff (does not write to th
             text: Message text (used as fallback if blocks provided)
             thread_ts: Optional thread timestamp to reply in thread
             blocks: Optional Block Kit blocks for rich formatting
+            account: Optional Slack team/workspace id when multiple workspaces are connected
         
         Returns:
             Response with channel, ts (timestamp), and message details
         """
+        prev_filter: str | None = self._account_identifier_filter
+        prev_token: str | None = self._token
+        try:
+            acct: str | None = account.strip() if isinstance(account, str) and account.strip() else None
+            if acct:
+                self._account_identifier_filter = acct
+                self._token = None
+
+            return await self._post_message_impl(channel, text, thread_ts=thread_ts, blocks=blocks)
+        finally:
+            self._account_identifier_filter = prev_filter
+            self._token = prev_token
+
+    async def _post_message_impl(
+        self,
+        channel: str,
+        text: str,
+        thread_ts: Optional[str] = None,
+        blocks: Optional[list[dict[str, Any]]] = None,
+    ) -> dict[str, Any]:
         channel = await self._resolve_channel_for_post(channel)
 
         # When blocks are provided, text is already mrkdwn from the caller. Otherwise convert.

--- a/backend/db/migrations/versions/143_integration_account_identifier.py
+++ b/backend/db/migrations/versions/143_integration_account_identifier.py
@@ -32,10 +32,8 @@ def upgrade() -> None:
         sa.Column("account_label", sa.String(length=512), nullable=True),
     )
 
-    op.drop_constraint(
-        "uq_integration_org_connector_user",
-        "integrations",
-        type_="unique",
+    op.execute(
+        'ALTER TABLE integrations DROP CONSTRAINT IF EXISTS "uq_integration_org_connector_user"'
     )
 
     op.create_index(

--- a/backend/db/migrations/versions/143_integration_account_identifier.py
+++ b/backend/db/migrations/versions/143_integration_account_identifier.py
@@ -1,0 +1,69 @@
+"""Add account_identifier/account_label for multi-account integrations.
+
+Allows multiple OAuth connections per (organization_id, connector, user_id)
+when each row has a distinct account_identifier (e.g. Gmail email, HubSpot
+portal id). Legacy rows keep account_identifier NULL until backfilled; a
+partial unique index permits at most one NULL row per (org, connector, user).
+
+Revision ID: 143_int_acct_id
+Revises: 142_chat_msg_swc
+Create Date: 2026-05-13
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "143_int_acct_id"
+down_revision: Union[str, None] = "142_chat_msg_swc"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "integrations",
+        sa.Column("account_identifier", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "integrations",
+        sa.Column("account_label", sa.String(length=512), nullable=True),
+    )
+
+    op.drop_constraint(
+        "uq_integration_org_connector_user",
+        "integrations",
+        type_="unique",
+    )
+
+    op.create_index(
+        "uq_integration_org_connector_user_single",
+        "integrations",
+        ["organization_id", "connector", "user_id"],
+        unique=True,
+        postgresql_where=sa.text("account_identifier IS NULL"),
+    )
+    op.create_index(
+        "uq_integration_org_connector_user_account",
+        "integrations",
+        ["organization_id", "connector", "user_id", "account_identifier"],
+        unique=True,
+        postgresql_where=sa.text("account_identifier IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    # Partial unique indexes: use raw SQL for reliable drops across Alembic/SQLAlchemy versions.
+    op.execute("DROP INDEX IF EXISTS uq_integration_org_connector_user_account")
+    op.execute("DROP INDEX IF EXISTS uq_integration_org_connector_user_single")
+
+    op.create_unique_constraint(
+        "uq_integration_org_connector_user",
+        "integrations",
+        ["organization_id", "connector", "user_id"],
+    )
+
+    op.drop_column("integrations", "account_label")
+    op.drop_column("integrations", "account_identifier")

--- a/backend/models/integration.py
+++ b/backend/models/integration.py
@@ -14,13 +14,39 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Final
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, String, Text, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from models.database import Base
+
+# Stored in ``extra_data`` JSONB (no dedicated column).
+INTEGRATION_ACCOUNT_AVATAR_EXTRA_KEY: Final[str] = "account_avatar_url"
+
+
+def read_account_avatar_url(extra_data: dict[str, Any] | None) -> str | None:
+    """Return avatar URL from integration ``extra_data``, if set."""
+    if not extra_data:
+        return None
+    raw: Any = extra_data.get(INTEGRATION_ACCOUNT_AVATAR_EXTRA_KEY)
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return None
+
+
+def merge_account_avatar_into_extra_data(
+    extra_data: dict[str, Any] | None,
+    avatar_url: str | None,
+) -> dict[str, Any] | None:
+    """Return a copy of ``extra_data`` with ``account_avatar_url`` set or cleared."""
+    merged: dict[str, Any] = dict(extra_data) if extra_data else {}
+    if avatar_url and avatar_url.strip():
+        merged[INTEGRATION_ACCOUNT_AVATAR_EXTRA_KEY] = avatar_url.strip()
+    else:
+        merged.pop(INTEGRATION_ACCOUNT_AVATAR_EXTRA_KEY, None)
+    return merged or None
 
 
 class Integration(Base):  # type: ignore[misc]
@@ -45,9 +71,22 @@ class Integration(Base):  # type: ignore[misc]
 
     __tablename__ = "integrations"
     __table_args__ = (
-        UniqueConstraint(
-            "organization_id", "connector", "user_id",
-            name="uq_integration_org_connector_user"
+        Index(
+            "uq_integration_org_connector_user_single",
+            "organization_id",
+            "connector",
+            "user_id",
+            unique=True,
+            postgresql_where=text("account_identifier IS NULL"),
+        ),
+        Index(
+            "uq_integration_org_connector_user_account",
+            "organization_id",
+            "connector",
+            "user_id",
+            "account_identifier",
+            unique=True,
+            postgresql_where=text("account_identifier IS NOT NULL"),
         ),
     )
 
@@ -83,10 +122,18 @@ class Integration(Base):  # type: ignore[misc]
     # True until user configures sharing preferences after OAuth
     pending_sharing_config: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
-    # Nango connection ID - always user-scoped format: "{org_id}:user:{user_id}"
+    # Nango connection ID — legacy "{org_id}:user:{user_id}" or suffixed with
+    # ":{uuid}" for multi-account rows.
     nango_connection_id: Mapped[str | None] = mapped_column(
         String(255), nullable=True
     )
+
+    # Stable per-provider account id (email, portal id, team id, etc.). NULL
+    # until backfilled; at most one NULL row per (org, connector, user).
+    account_identifier: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # Human-readable label for UI (e.g. display name, workspace name).
+    account_label: Mapped[str | None] = mapped_column(String(512), nullable=True)
 
     # User who connected this integration (same as user_id, kept for audit trail)
     connected_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
@@ -114,12 +161,16 @@ class Integration(Base):  # type: ignore[misc]
 
     def to_dict(self, include_sharing: bool = False) -> dict[str, Any]:
         """Convert to dictionary for API responses."""
+        avatar_url: str | None = read_account_avatar_url(self.extra_data)
         result: dict[str, Any] = {
             "id": str(self.id),
             "organization_id": str(self.organization_id),
             "connector": self.connector,
             "provider": self.connector,  # Deprecated alias for connector; remove after frontend migration
             "user_id": str(self.user_id),
+            "account_identifier": self.account_identifier,
+            "account_label": self.account_label,
+            "account_avatar_url": avatar_url,
             "is_active": self.is_active,
             "last_sync_at": f"{self.last_sync_at.isoformat()}Z" if self.last_sync_at else None,
             "last_error": self.last_error,

--- a/backend/tests/test_artifacts_connector_query.py
+++ b/backend/tests/test_artifacts_connector_query.py
@@ -93,6 +93,24 @@ def test_query_on_connector_fetches_artifact_payload(monkeypatch):
     async def _fake_get_connector_instance(*_args, **_kwargs):
         return _FakeArtifactsConnector(), None
 
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        """_query_on_connector loads Integration rows when user_id is set; avoid real DB in tests."""
+
+        class _ExecResult:
+            def scalars(self) -> "_ExecResult":
+                return self
+
+            def all(self) -> list[object]:
+                return []
+
+        class _Sess:
+            async def execute(self, _stmt: object) -> _ExecResult:
+                return _ExecResult()
+
+        yield _Sess()
+
+    monkeypatch.setattr(tools, "get_session", _fake_get_session)
     monkeypatch.setattr(tools, "check_connector_call", _allow_connector_call)
     monkeypatch.setattr(tools, "_get_connector_instance", _fake_get_connector_instance)
 

--- a/backend/tests/test_gmail_connector_query.py
+++ b/backend/tests/test_gmail_connector_query.py
@@ -1,0 +1,154 @@
+"""Tests for GmailConnector live QUERY (``query_on_connector``)."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from typing import Any, Optional
+
+import pytest
+
+from connectors.gmail import GmailConnector
+
+
+@pytest.fixture
+def connector(monkeypatch: pytest.MonkeyPatch) -> GmailConnector:
+    c = GmailConnector(
+        organization_id="00000000-0000-0000-0000-000000000001",
+        user_id="00000000-0000-0000-0000-000000000002",
+    )
+
+    async def _fake_get_oauth_token(*args: Any, **kwargs: Any) -> tuple[str, str]:
+        return "fake-token", ""
+
+    monkeypatch.setattr(c, "get_oauth_token", _fake_get_oauth_token)
+    return c
+
+
+def test_query_empty_returns_error(connector: GmailConnector) -> None:
+    result: dict[str, Any] = asyncio.run(connector.query("   "))
+    assert result.get("error") == "Empty query"
+
+
+def test_query_passes_through_gmail_search_operators(
+    connector: GmailConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def _fake_make_request(
+        method: str,
+        endpoint: str,
+        params: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        p: dict[str, Any] = dict(params or {})
+        calls.append((endpoint, p))
+        if endpoint == "/users/me/messages" and p.get("q") is not None:
+            assert p["q"] == "from:dan@example.com newer_than:1d"
+            assert p.get("maxResults") == 10
+            return {"messages": [{"id": "m1"}]}
+        if endpoint == "/users/me/messages/m1":
+            assert p.get("format") == "metadata"
+            return {
+                "id": "m1",
+                "threadId": "t1",
+                "snippet": "snippet text",
+                "internalDate": "1700000000000",
+                "labelIds": ["INBOX", "UNREAD"],
+                "payload": {
+                    "headers": [
+                        {"name": "Subject", "value": "Re: venture"},
+                        {"name": "From", "value": "Dan <dan@example.com>"},
+                        {"name": "To", "value": "you@example.com"},
+                    ],
+                    "parts": [],
+                },
+            }
+        raise AssertionError(f"unexpected endpoint {endpoint} params={p}")
+
+    monkeypatch.setattr(connector, "_make_request", _fake_make_request)
+
+    result: dict[str, Any] = asyncio.run(
+        connector.query("from:dan@example.com newer_than:1d")
+    )
+    assert result["count"] == 1
+    msgs: list[dict[str, Any]] = result["messages"]
+    assert len(msgs) == 1
+    assert msgs[0]["id"] == "m1"
+    assert msgs[0]["subject"] == "Re: venture"
+    assert msgs[0]["from"] == "dan@example.com"
+    assert len(calls) == 2
+
+
+def test_query_max_clamp(connector: GmailConnector, monkeypatch: pytest.MonkeyPatch) -> None:
+    list_params_captured: dict[str, Any] = {}
+
+    async def _fake_make_request(
+        method: str,
+        endpoint: str,
+        params: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        p: dict[str, Any] = dict(params or {})
+        if endpoint == "/users/me/messages" and p.get("q") is not None:
+            list_params_captured.clear()
+            list_params_captured.update(p)
+            return {"messages": [{"id": f"m{i}"} for i in range(30)]}
+        if endpoint.startswith("/users/me/messages/m"):
+            return {
+                "id": p.get("id", endpoint.rsplit("/", 1)[-1]),
+                "threadId": "t",
+                "snippet": "s",
+                "internalDate": "1700000000000",
+                "labelIds": [],
+                "payload": {
+                    "headers": [
+                        {"name": "Subject", "value": "S"},
+                        {"name": "From", "value": "x@y.com"},
+                    ],
+                    "parts": [],
+                },
+            }
+        raise AssertionError(endpoint)
+
+    monkeypatch.setattr(connector, "_make_request", _fake_make_request)
+
+    asyncio.run(connector.query("from:x max:500"))
+    assert list_params_captured["q"] == "from:x"
+    assert list_params_captured["maxResults"] == 25
+
+
+def test_query_message_prefix_returns_body_text(
+    connector: GmailConnector, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plain: bytes = b"Hello decoded body"
+    b64: str = base64.urlsafe_b64encode(plain).decode("ascii").rstrip("=")
+
+    async def _fake_make_request(
+        method: str,
+        endpoint: str,
+        params: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        p: dict[str, Any] = dict(params or {})
+        if endpoint == "/users/me/messages/abc123" and p.get("format") == "full":
+            return {
+                "id": "abc123",
+                "threadId": "th1",
+                "snippet": "snip",
+                "internalDate": "1700000000000",
+                "labelIds": ["SENT"],
+                "payload": {
+                    "mimeType": "text/plain",
+                    "headers": [
+                        {"name": "Subject", "value": "Hi"},
+                        {"name": "From", "value": "me@example.com"},
+                    ],
+                    "body": {"data": b64},
+                },
+            }
+        raise AssertionError(f"{endpoint} {p}")
+
+    monkeypatch.setattr(connector, "_make_request", _fake_make_request)
+
+    result: dict[str, Any] = asyncio.run(connector.query("message:abc123"))
+    assert result["count"] == 1
+    body: str = result["messages"][0].get("body_text", "")
+    assert "Hello decoded body" in body

--- a/backend/tests/test_integration_multi_account.py
+++ b/backend/tests/test_integration_multi_account.py
@@ -1,0 +1,117 @@
+"""Multi-account integration behavior (query fan-out, Gmail send account filter)."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from agents import tools as tools_mod
+
+
+@pytest.mark.asyncio
+async def test_query_on_connector_fanout_tags_accounts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When a user has two active rows for a connector, query runs per row and tags results."""
+    org: str = "00000000-0000-0000-0000-0000000000bb"
+    uid: str = "00000000-0000-0000-0000-0000000000aa"
+    id1: UUID = uuid4()
+    id2: UUID = uuid4()
+    row1 = SimpleNamespace(id=id1, account_label="Work", account_identifier="w@w.com")
+    row2 = SimpleNamespace(id=id2, account_label="Home", account_identifier="h@h.com")
+
+    class _FakeResult:
+        def scalars(self) -> "_FakeResult":
+            return self
+
+        def all(self) -> list[SimpleNamespace]:
+            return [row1, row2]
+
+    class _FakeSession:
+        async def execute(self, _stmt: Any) -> _FakeResult:
+            return _FakeResult()
+
+    @asynccontextmanager
+    async def _fake_get_session(*_a: Any, **_kw: Any):
+        yield _FakeSession()
+
+    async def _fake_check_connector_call(*_a: Any, **_kw: Any) -> SimpleNamespace:
+        return SimpleNamespace(allowed=True, deny_reason=None)
+
+    integration_ids: list[str | None] = []
+
+    async def _fake_get_connector_instance(
+        _connector: str,
+        _organization_id: str,
+        _user_id: str | None,
+        *,
+        required_capability: str | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
+    ) -> tuple[Any, str | None]:
+        integration_ids.append(integration_id)
+
+        class _FakeInst:
+            user_id: str | None = _user_id
+
+            async def query(self, q: str) -> dict[str, Any]:
+                return {"ok": True, "integration_id": integration_id, "q": q}
+
+        return _FakeInst(), None
+
+    monkeypatch.setattr(tools_mod, "get_session", _fake_get_session)
+    monkeypatch.setattr(tools_mod, "check_connector_call", _fake_check_connector_call)
+    monkeypatch.setattr(tools_mod, "_get_connector_instance", _fake_get_connector_instance)
+
+    out: dict[str, Any] = await tools_mod._query_on_connector(
+        {"connector": "gmail", "query": "in:inbox"},
+        organization_id=org,
+        user_id=uid,
+    )
+    assert out.get("multi_account") is True
+    items: list[dict[str, Any]] = out.get("items", [])
+    assert len(items) == 2
+    labels: set[str] = {str(i.get("account")) for i in items}
+    assert labels == {"Work", "Home"}
+    seen_ids: set[str] = {str(i.get("integration_id")) for i in items if i.get("integration_id")}
+    assert seen_ids == {str(id1), str(id2)}
+    assert str(id1) in integration_ids and str(id2) in integration_ids
+
+
+@pytest.mark.asyncio
+async def test_gmail_send_email_restores_account_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    from connectors.gmail import GmailConnector
+
+    c = GmailConnector(
+        organization_id="00000000-0000-0000-0000-000000000001",
+        user_id="00000000-0000-0000-0000-000000000002",
+    )
+    c._account_identifier_filter = "keep@example.com"
+
+    monkeypatch.setattr(c, "get_oauth_token", AsyncMock(return_value=("tok", "")))
+    monkeypatch.setattr(c, "_get_headers", AsyncMock(return_value={"Authorization": "Bearer tok"}))
+
+    class _FakeResp:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {"id": "m1", "threadId": "t1", "labelIds": []}
+
+    class _FakeClient:
+        async def __aenter__(self) -> "_FakeClient":
+            return self
+
+        async def __aexit__(self, *_a: Any) -> None:
+            return None
+
+        async def post(self, *_a: Any, **_kw: Any) -> _FakeResp:
+            return _FakeResp()
+
+    monkeypatch.setattr("connectors.gmail.httpx.AsyncClient", _FakeClient)
+
+    await c.send_email(to="t@t.com", subject="s", body="body", account="other@o.com")
+    assert c._account_identifier_filter == "keep@example.com"

--- a/backend/tests/test_slack_connector_actions.py
+++ b/backend/tests/test_slack_connector_actions.py
@@ -573,7 +573,13 @@ def test_execute_action_send_message_accepts_legacy_message_param(monkeypatch) -
     connector = SlackConnector(organization_id="00000000-0000-0000-0000-000000000001")
     captured: dict[str, str] = {}
 
-    async def _fake_post_message(channel: str, text: str, thread_ts: str | None = None):
+    async def _fake_post_message(
+        channel: str,
+        text: str,
+        thread_ts: str | None = None,
+        blocks: object | None = None,
+        account: str | None = None,
+    ):
         captured["channel"] = channel
         captured["text"] = text
         captured["thread_ts"] = thread_ts or ""
@@ -626,7 +632,13 @@ def test_send_direct_message_falls_back_to_user_channel_on_missing_scope(monkeyp
 
     captured: dict[str, str] = {}
 
-    async def _fake_post_message(channel: str, text: str, thread_ts: str | None = None):
+    async def _fake_post_message(
+        channel: str,
+        text: str,
+        thread_ts: str | None = None,
+        blocks: object | None = None,
+        account: str | None = None,
+    ):
         captured["channel"] = channel
         captured["text"] = text
         captured["thread_ts"] = thread_ts or ""

--- a/backend/tests/test_sync_cancellation.py
+++ b/backend/tests/test_sync_cancellation.py
@@ -13,6 +13,8 @@ class CancelledConnector:
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        **_: Any,
     ) -> None:
         self.organization_id = organization_id
         self.user_id = user_id

--- a/backend/tests/test_sync_failure_logging.py
+++ b/backend/tests/test_sync_failure_logging.py
@@ -13,6 +13,8 @@ class FailingConnector:
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        **_: Any,
     ) -> None:
         self.organization_id = organization_id
         self.user_id = user_id
@@ -99,6 +101,8 @@ class EmptyTimeoutConnector:
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        **_: Any,
     ) -> None:
         self.organization_id = organization_id
         self.user_id = user_id

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -140,6 +140,7 @@ async def _broadcast_worker_sync_progress(
     count: int = 0,
     status: str = "syncing",
     step: str | None = None,
+    integration_id: str | None = None,
 ) -> None:
     """Broadcast worker-level sync lifecycle events without failing the sync."""
     try:
@@ -151,12 +152,14 @@ async def _broadcast_worker_sync_progress(
             count=count,
             status=status,
             step=step,
+            integration_id=integration_id,
         )
     except Exception as exc:
         logger.debug(
-            "Failed to broadcast sync progress provider=%s org=%s status=%s: %s",
+            "Failed to broadcast sync progress provider=%s org=%s integration=%s status=%s: %s",
             provider,
             organization_id,
+            integration_id,
             status,
             exc,
         )
@@ -275,12 +278,21 @@ async def _sync_integration(
         await _clear_last_errors_for_integration(organization_id, provider, user_id, integration_id)
 
         await connector.mark_sync_started()
+        # After mark_sync_started, ``connector._integration`` is bound to the row
+        # actually being synced (multi-account safe). Prefer it over the caller-
+        # supplied ``integration_id`` so the UI scopes the spinner to one row.
+        resolved_integration_id: str | None = (
+            str(connector._integration.id)
+            if getattr(connector, "_integration", None) is not None
+            else (integration_id.strip() if integration_id and integration_id.strip() else None)
+        )
         await _broadcast_worker_sync_progress(
             organization_id,
             provider,
             count=0,
             status="syncing",
             step="starting",
+            integration_id=resolved_integration_id,
         )
         counts = await connector.sync_all()
         await connector.update_last_sync(counts)
@@ -290,6 +302,7 @@ async def _sync_integration(
             count=_sum_sync_counts(counts),
             status="completed",
             step="completed",
+            integration_id=resolved_integration_id,
         )
 
         # Generate embeddings for newly synced activities
@@ -328,12 +341,18 @@ async def _sync_integration(
                 await connector.clear_sync_started()
         except Exception:
             pass
+        cancelled_integration_id: str | None = (
+            str(connector._integration.id)
+            if connector is not None and getattr(connector, "_integration", None) is not None
+            else (integration_id.strip() if integration_id and integration_id.strip() else None)
+        )
         await _broadcast_worker_sync_progress(
             organization_id,
             provider,
             count=0,
             status="failed",
             step="cancelled",
+            integration_id=cancelled_integration_id,
         )
         try:
             await emit_event(
@@ -413,12 +432,18 @@ async def _sync_integration(
         except Exception:
             pass
 
+        failed_integration_id: str | None = (
+            str(connector._integration.id)
+            if connector is not None and getattr(connector, "_integration", None) is not None
+            else (integration_id.strip() if integration_id and integration_id.strip() else None)
+        )
         await _broadcast_worker_sync_progress(
             organization_id,
             provider,
             count=0,
             status="failed",
             step="failed",
+            integration_id=failed_integration_id,
         )
 
         # Emit sync failed event

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -166,6 +166,7 @@ async def _clear_last_errors_for_integration(
     organization_id: str,
     provider: str,
     user_id: str | None,
+    integration_id: str | None = None,
 ) -> None:
     """Clear integration.last_error for matching rows (matches API trigger_sync behavior)."""
     from sqlalchemy import select
@@ -184,6 +185,8 @@ async def _clear_last_errors_for_integration(
             stmt = stmt.where(Integration.user_id == UUID(user_id))
         else:
             stmt = stmt.where(Integration.user_id.is_(None))
+        if integration_id is not None and integration_id.strip():
+            stmt = stmt.where(Integration.id == UUID(integration_id.strip()))
         result = await session.execute(stmt)
         rows: list[Integration] = list(result.scalars().all())
         changed: bool = False
@@ -200,6 +203,7 @@ async def _sync_integration(
     provider: str,
     user_id: str | None = None,
     sync_since_override_iso: str | None = None,
+    integration_id: str | None = None,
 ) -> dict[str, Any]:
     """
     Internal async function to sync a single integration.
@@ -242,11 +246,13 @@ async def _sync_integration(
 
     try:
         user_label: str = f" user={user_id}" if user_id else ""
-        logger.info(f"Starting sync for {provider} in org {organization_id}{user_label}")
+        integ_label: str = f" integration={integration_id}" if integration_id else ""
+        logger.info(f"Starting sync for {provider} in org {organization_id}{user_label}{integ_label}")
         connector = connector_class(
             organization_id,
             user_id=user_id,
             sync_since_override=sync_since_dt,
+            integration_id=integration_id.strip() if integration_id and integration_id.strip() else None,
         )
 
         from access_control import ConnectorContext, check_connector_call
@@ -266,7 +272,7 @@ async def _sync_integration(
                 "error": dp_result.deny_reason or "Connector sync not allowed",
             }
 
-        await _clear_last_errors_for_integration(organization_id, provider, user_id)
+        await _clear_last_errors_for_integration(organization_id, provider, user_id, integration_id)
 
         await connector.mark_sync_started()
         await _broadcast_worker_sync_progress(
@@ -449,6 +455,7 @@ async def _get_all_active_integrations() -> list[dict[str, str | None]]:
         
         return [
             {
+                "id": str(i.id),
                 "organization_id": str(i.organization_id),
                 "connector": i.connector,
                 "user_id": str(i.user_id) if i.user_id else None,
@@ -515,6 +522,7 @@ async def _get_org_integrations(organization_id: str) -> list[dict[str, str | No
         integrations = result.scalars().all()
         return [
             {
+                "id": str(i.id),
                 "connector": i.connector,
                 "user_id": str(i.user_id) if i.user_id else None,
             }
@@ -533,6 +541,7 @@ def sync_integration(
     provider: str,
     user_id: str | None = None,
     sync_since_override_iso: str | None = None,
+    integration_id: str | None = None,
 ) -> dict[str, Any]:
     """
     Celery task to sync a single integration.
@@ -554,6 +563,7 @@ def sync_integration(
             provider,
             user_id=user_id,
             sync_since_override_iso=sync_since_override_iso,
+            integration_id=integration_id,
         )
     )
     if result.get("status") == "failed":
@@ -613,7 +623,8 @@ def sync_organization(self: Any, organization_id: str) -> dict[str, Any]:
                 skipped += 1
                 continue
             uid: str | None = entry["user_id"]
-            async_result = sync_integration.delay(organization_id, provider, uid)
+            integ_id: str | None = entry.get("id")  # type: ignore[assignment]
+            async_result = sync_integration.delay(organization_id, provider, uid, integration_id=integ_id)
             task_ids.append(str(async_result.id))
 
         return {
@@ -1283,7 +1294,8 @@ def sync_all_organizations(self: Any) -> dict[str, Any]:
                 total_skipped_cadence += 1
                 continue
             uid: str | None = entry["user_id"]
-            async_result = sync_integration.delay(org_id, provider, uid)
+            integ_id: str | None = entry.get("id")  # type: ignore[assignment]
+            async_result = sync_integration.delay(org_id, provider, uid, integration_id=integ_id)
             child_task_ids.append(str(async_result.id))
 
         total_elapsed: float = _time.monotonic() - run_start

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "zustand": "^5.0.10"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.2.0",
         "@types/plotly.js": "^2.33.4",
         "@types/react": "^18.2.55",
         "@types/react-dom": "^18.2.19",
@@ -38,10 +39,12 @@
         "eslint": "^8.56.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
+        "jsdom": "^26.0.0",
         "postcss": "^8.5.12",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.3.3",
-        "vite": "^7.3.2"
+        "vite": "^7.3.2",
+        "vitest": "^3.0.5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -55,6 +58,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -308,6 +332,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -714,6 +748,121 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2215,6 +2364,55 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@turf/area": {
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.4.tgz",
@@ -2287,6 +2485,14 @@
         "url": "https://opencollective.com/turf"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2332,6 +2538,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2340,6 +2557,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2734,6 +2958,151 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abs-svg-path": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
@@ -2761,6 +3130,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2850,6 +3229,17 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-bounds": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-bounds/-/array-bounds-1.0.1.tgz",
@@ -2894,6 +3284,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -3132,6 +3532,16 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -3204,6 +3614,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3259,6 +3686,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3584,6 +4021,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -3867,6 +4318,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3884,6 +4349,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -3895,6 +4367,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -3987,6 +4469,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -4088,6 +4578,19 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -4105,6 +4608,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4534,6 +5044,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ext": {
@@ -5444,6 +5964,19 @@
       "integrity": "sha512-08iL2VyCRbkQKBySkSh6m8zMUa3sADAxGVWs3Z1aPcUkTJeK0ETG4Fc27tEmQBGUAXZjIsXOZqBvacuVNSC/fQ==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -5465,6 +5998,34 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iceberg-js": {
@@ -5765,6 +6326,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-string-blank": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
@@ -5816,6 +6384,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -5977,6 +6585,13 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -7253,6 +7868,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7401,6 +8023,19 @@
       "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7445,6 +8080,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/pbf": {
@@ -7781,6 +8433,44 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/probe-image-size": {
       "version": "7.2.3",
@@ -8302,6 +8992,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8366,6 +9063,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -8422,6 +9132,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signum": {
       "version": "1.0.0",
@@ -8483,6 +9200,13 @@
         "node": "*"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/static-browser-server": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/static-browser-server/-/static-browser-server-1.0.3.tgz",
@@ -8503,6 +9227,13 @@
       "dependencies": {
         "escodegen": "^2.1.0"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-parser": {
       "version": "0.3.1",
@@ -8603,6 +9334,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strongly-connected-components": {
       "version": "1.0.1",
@@ -8751,6 +9502,13 @@
         "svg-path-bounds": "^1.0.1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -8848,10 +9606,24 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -8899,11 +9671,61 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
     "node_modules/tinyqueue": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "license": "ISC"
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-float32": {
       "version": "1.1.0",
@@ -8944,6 +9766,32 @@
         "topo2geo": "bin/topo2geo",
         "topomerge": "bin/topomerge",
         "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/trim-lines": {
@@ -9328,6 +10176,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -9359,6 +10230,102 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vt-pbf": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
@@ -9376,6 +10343,19 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/weak-map": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
@@ -9389,6 +10369,67 @@
       "license": "MIT",
       "dependencies": {
         "get-canvas-context": "^1.0.1"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -9405,6 +10446,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -9452,6 +10510,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "test": "vitest run",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
@@ -43,6 +44,9 @@
     "postcss": "^8.5.12",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",
-    "vite": "^7.3.2"
+    "vite": "^7.3.2",
+    "vitest": "^3.0.5",
+    "@testing-library/react": "^16.2.0",
+    "jsdom": "^26.0.0"
   }
 }

--- a/frontend/src/components/ConnectorAccountLines.test.tsx
+++ b/frontend/src/components/ConnectorAccountLines.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ConnectorAccountLines } from './ConnectorAccountLines';
+
+describe('ConnectorAccountLines', () => {
+  it('renders distinct account subtitles and optional avatar (multi-account UI)', () => {
+    const { rerender } = render(
+      <ConnectorAccountLines
+        name="Gmail"
+        accountLabel="a@work.com"
+        accountIdentifier="a@work.com"
+        accountAvatarUrl={null}
+      />,
+    );
+    expect(screen.getByTestId('primary').textContent).toBe('Gmail');
+    expect(screen.getByTestId('sub').textContent).toBe('a@work.com');
+    expect(screen.queryByTestId('avatar')).toBeNull();
+
+    rerender(
+      <ConnectorAccountLines
+        name="Gmail"
+        accountLabel="b@home.com"
+        accountIdentifier="b@home.com"
+        accountAvatarUrl="https://example.com/a.png"
+      />,
+    );
+    expect(screen.getByTestId('sub').textContent).toBe('b@home.com');
+    expect(screen.getByTestId('avatar').getAttribute('src')).toBe('https://example.com/a.png');
+  });
+});

--- a/frontend/src/components/ConnectorAccountLines.tsx
+++ b/frontend/src/components/ConnectorAccountLines.tsx
@@ -1,0 +1,29 @@
+import type { JSX } from 'react';
+
+export interface ConnectorAccountLinesProps {
+  name: string;
+  accountLabel: string | null;
+  accountIdentifier: string | null;
+  accountAvatarUrl: string | null;
+}
+
+/** Primary + optional account subtitle (used by DataSources multi-account rows). */
+export function ConnectorAccountLines(props: ConnectorAccountLinesProps): JSX.Element {
+  const { name, accountLabel, accountIdentifier, accountAvatarUrl } = props;
+  const sub: string | null = accountLabel ?? accountIdentifier;
+  return (
+    <div>
+      <div className="flex items-center gap-2">
+        {accountAvatarUrl ? (
+          <img src={accountAvatarUrl} alt="" className="h-4 w-4 rounded-full" data-testid="avatar" />
+        ) : null}
+        <span data-testid="primary">{name}</span>
+      </div>
+      {sub ? (
+        <span data-testid="sub" className="text-xs text-surface-500">
+          {sub}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -377,7 +377,7 @@ export function DataSources(): JSX.Element {
     void checkInFlight();
     return () => { cancelled = true; };
   }, [organization?.id, rawIntegrations]);
-  const [disconnectingProviders, setDisconnectingProviders] = useState<Set<string>>(new Set());
+  const [disconnectingIntegrationIds, setDisconnectingIntegrationIds] = useState<Set<string>>(new Set());
   const [connectingProvider, setConnectingProvider] = useState<string | null>(null);
   const [slackMappings, setSlackMappings] = useState<SlackUserMapping[]>([]);
   const [slackMappingsLoading, setSlackMappingsLoading] = useState(false);
@@ -526,15 +526,17 @@ export function DataSources(): JSX.Element {
 
   // Disconnect confirmation modal state
   interface DisconnectModalState {
+    integrationId: string;
     provider: string;
+    accountSummary: string | null;
     step: 'confirm' | 'ask-delete';
   }
   const [disconnectModal, setDisconnectModal] = useState<DisconnectModalState | null>(null);
   const [syncError, setSyncError] = useState<string | null>(null);
   /** Which integration row id has the overflow menu open (null = closed). */
   const [rowMenuOpenForId, setRowMenuOpenForId] = useState<string | null>(null);
-  /** Provider slug for slide-out detail drawer (null = closed). */
-  const [detailProvider, setDetailProvider] = useState<string | null>(null);
+  /** Integration row id for slide-out detail drawer (null = closed). */
+  const [detailIntegrationId, setDetailIntegrationId] = useState<string | null>(null);
   /** Desktop header page overflow (Sync all, mobile-only helpers). */
   const [pageOverflowOpen, setPageOverflowOpen] = useState<boolean>(false);
   const [disconnectError, setDisconnectError] = useState<string | null>(null);
@@ -563,13 +565,13 @@ export function DataSources(): JSX.Element {
   }, [rowMenuOpenForId]);
 
   useEffect(() => {
-    if (detailProvider === null) return;
+    if (detailIntegrationId === null) return;
     const onKey = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') setDetailProvider(null);
+      if (e.key === 'Escape') setDetailIntegrationId(null);
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [detailProvider]);
+  }, [detailIntegrationId]);
 
   useEffect(() => {
     if (!pageOverflowOpen) return;
@@ -868,6 +870,10 @@ export function DataSources(): JSX.Element {
       };
     });
 
+  const githubPrimaryRowId: string | undefined = integrations.find(
+    (i) => i.provider === 'github' && i.currentUserConnected,
+  )?.id;
+
   // Also include available (not connected) integrations
   const connectedProviders = new Set(integrations.map((i) => i.provider));
   const connectorSlugs = connectorsFromApi.length > 0
@@ -892,6 +898,9 @@ export function DataSources(): JSX.Element {
       teamTotal: 0,
       syncStats: null,
       displayName: null,
+      accountIdentifier: null,
+      accountLabel: null,
+      accountAvatarUrl: null,
       shareSyncedData: defaults.shareSyncedData,
       shareQueryAccess: defaults.shareQueryAccess,
       shareWriteAccess: defaults.shareWriteAccess,
@@ -912,7 +921,7 @@ export function DataSources(): JSX.Element {
     if (!githubCard) return;
     githubCard.scrollIntoView({ behavior: 'smooth', block: 'center' });
     setGithubAutoScrollPending(false);
-  }, [allIntegrations.length, githubAutoScrollPending, githubReposExpanded]);
+  }, [allIntegrations.length, githubAutoScrollPending, githubReposExpanded, githubPrimaryRowId]);
 
   // Full list of all connectors for the add-connector modal (from API or fallback)
   const allConnectorsForModal: DisplayIntegration[] = connectorSlugs.map((provider: string): DisplayIntegration => {
@@ -933,6 +942,9 @@ export function DataSources(): JSX.Element {
       teamTotal: 0,
       syncStats: null,
       displayName: null,
+      accountIdentifier: null,
+      accountLabel: null,
+      accountAvatarUrl: null,
       shareSyncedData: defaults.shareSyncedData,
       shareQueryAccess: defaults.shareQueryAccess,
       shareWriteAccess: defaults.shareWriteAccess,
@@ -1137,22 +1149,36 @@ export function DataSources(): JSX.Element {
     }
   }, [connectBuiltinConnector, fetchIntegrations, ispotClientId, ispotClientSecret, ispotConnecting, organizationId, userId]);
 
-  const handleDisconnect = (provider: string): void => {
-    if (!organizationId || !userId || disconnectingProviders.has(provider)) return;
+  const handleDisconnect = (integration: DisplayIntegration): void => {
+    if (!organizationId || !userId || disconnectingIntegrationIds.has(integration.id)) return;
+    const accountSummary: string | null =
+      integration.accountLabel ?? integration.accountIdentifier ?? null;
     setSyncError(null);
     setDisconnectError(null);
-    setDisconnectModal({ provider, step: 'confirm' });
+    setDisconnectModal({
+      integrationId: integration.id,
+      provider: integration.provider,
+      accountSummary,
+      step: 'confirm',
+    });
   };
 
-  const executeDisconnect = async (provider: string, deleteData: boolean): Promise<void> => {
+  const executeDisconnect = async (
+    provider: string,
+    deleteData: boolean,
+    integrationRowId: string,
+  ): Promise<void> => {
     setDisconnectModal(null);
 
     // Set disconnecting state immediately for instant UI feedback
-    setDisconnectingProviders((prev) => new Set(prev).add(provider));
+    setDisconnectingIntegrationIds((prev) => new Set(prev).add(integrationRowId));
 
     const params = new URLSearchParams({ organization_id: organizationId, user_id: userId });
     if (deleteData) {
       params.set('delete_data', 'true');
+    }
+    if (integrationRowId && !integrationRowId.startsWith('pending-')) {
+      params.set('integration_id', integrationRowId);
     }
     const url = `${API_BASE}/auth/integrations/${provider}?${params.toString()}`;
 
@@ -1210,19 +1236,19 @@ export function DataSources(): JSX.Element {
       } catch (fetchError) {
         console.error('Failed to refresh integrations after disconnect:', fetchError);
       }
-      setDisconnectingProviders((prev) => {
-        if (!prev.has(provider)) return prev;
+      setDisconnectingIntegrationIds((prev) => {
+        if (!prev.has(integrationRowId)) return prev;
         const next = new Set(prev);
-        next.delete(provider);
+        next.delete(integrationRowId);
         return next;
       });
     } catch (error) {
       console.error('Failed to disconnect:', error);
       setDisconnectError(`Failed to disconnect: ${error instanceof Error ? error.message : 'Unknown error'}`);
       setTimeout(() => setDisconnectError(null), 6000);
-      setDisconnectingProviders((prev) => {
+      setDisconnectingIntegrationIds((prev) => {
         const next = new Set(prev);
-        next.delete(provider);
+        next.delete(integrationRowId);
         return next;
       });
     }
@@ -1624,16 +1650,16 @@ export function DataSources(): JSX.Element {
     ...fromTeamConnectorsSorted,
   ];
   const detailIntegration: DisplayIntegration | null =
-    detailProvider === null
+    detailIntegrationId === null
       ? null
-      : connectedIntegrationPool.find((i) => i.provider === detailProvider) ?? null;
+      : connectedIntegrationPool.find((i) => i.id === detailIntegrationId) ?? null;
 
   const detailTileState: TileState | null =
     detailIntegration === null
       ? null
-      : myConnectorsSorted.some((i) => i.provider === detailIntegration.provider)
+      : myConnectorsSorted.some((i) => i.id === detailIntegration.id)
         ? 'connected'
-        : orgConnectorsSorted.some((i) => i.provider === detailIntegration.provider)
+        : orgConnectorsSorted.some((i) => i.id === detailIntegration.id)
           ? 'org-connected'
           : 'team-only';
 
@@ -1862,7 +1888,9 @@ export function DataSources(): JSX.Element {
       getConnectorDisplay(integration.provider).hasSync !== false &&
       isFreshSyncStartedAt(integration.syncStats?.sync_started_at);
     const isSyncing = syncingProviders.has(integration.provider) || isSyncingFromServer;
-    const isDisconnecting = disconnectingProviders.has(integration.provider);
+    const isDisconnecting = disconnectingIntegrationIds.has(integration.id);
+    const accountSubtitle: string | null =
+      integration.accountLabel ?? integration.accountIdentifier ?? null;
     const syncPercent = isSyncing ? (syncProgressPercent[integration.provider] ?? 8) : 0;
 
     const hasSyncCapability: boolean = getConnectorDisplay(integration.provider).hasSync !== false;
@@ -1906,11 +1934,16 @@ export function DataSources(): JSX.Element {
     const canDisconnect: boolean =
       (state === 'connected' && integration.isOwner) || state === 'org-connected';
 
+    const showAddAnotherAccount: boolean =
+      ((state === 'connected' && integration.isOwner) || state === 'org-connected') &&
+      !integration.provider.startsWith('mcp_');
+
     const showRowMenu: boolean =
       (state === 'connected' && integration.isOwner) ||
       state === 'team-only' ||
       showResyncInMenu ||
-      canDisconnect;
+      canDisconnect ||
+      showAddAnotherAccount;
 
     const menuBtnClass =
       'inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-surface-600 text-surface-300 transition-colors hover:bg-surface-800 disabled:opacity-50';
@@ -1922,37 +1955,56 @@ export function DataSources(): JSX.Element {
           isDisconnecting ? 'pointer-events-none opacity-50 transition-opacity duration-200' : undefined
         }
         ref={(el) => {
-          connectorCardRefs.current[integration.provider] = el;
+          connectorCardRefs.current[integration.id] = el;
+          if (githubPrimaryRowId !== undefined && integration.id === githubPrimaryRowId) {
+            connectorCardRefs.current.github = el;
+          }
         }}
       >
         <div className="flex items-center gap-2 px-2 py-2 sm:gap-3">
           <button
             type="button"
             className="flex min-w-0 flex-1 items-center gap-2 rounded-md text-left outline-none ring-primary-500/40 hover:bg-surface-900/80 focus-visible:ring-2 sm:gap-3"
-            onClick={() => setDetailProvider(integration.provider)}
+            onClick={() => setDetailIntegrationId(integration.id)}
             title={integration.name}
           >
-            <span className="flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-md bg-surface-900">
-              {renderIconCompact(integration.icon)}
+            <span className="relative flex h-8 w-8 shrink-0 items-center justify-center overflow-visible rounded-md bg-surface-900">
+              {integration.accountAvatarUrl ? (
+                <img
+                  src={integration.accountAvatarUrl}
+                  alt=""
+                  className="absolute -right-0.5 -top-0.5 z-10 h-4 w-4 rounded-full border border-surface-900 object-cover"
+                />
+              ) : null}
+              <span className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-md bg-surface-900">
+                {renderIconCompact(integration.icon)}
+              </span>
             </span>
-            <span className="flex min-w-0 flex-1 items-center gap-2">
-              <span className="truncate text-sm text-surface-100">{integration.name}</span>
-              {integration.provider.startsWith('mcp_') && (
-                <span className="shrink-0 rounded bg-surface-700 px-1.5 py-0 text-[10px] font-medium uppercase tracking-wide text-surface-400">
-                  Custom
-                </span>
-              )}
-              {(state === 'org-connected' || state === 'team-only') && (
-                <span className="shrink-0 rounded bg-surface-800 px-1.5 py-0 text-[10px] font-medium text-surface-500">
-                  Team
-                </span>
-              )}
-              {renderSharedWithTeamPill(integration, state)}
-              {(state === 'connected' || state === 'org-connected') &&
-                integration.lastError &&
-                !isSyncing && (
-                  <span className="h-2 w-2 shrink-0 rounded-full bg-red-500" title={integration.lastError} />
+            <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <span className="flex min-w-0 flex-1 items-center gap-2">
+                <span className="truncate text-sm text-surface-100">{integration.name}</span>
+                {integration.provider.startsWith('mcp_') && (
+                  <span className="shrink-0 rounded bg-surface-700 px-1.5 py-0 text-[10px] font-medium uppercase tracking-wide text-surface-400">
+                    Custom
+                  </span>
                 )}
+                {(state === 'org-connected' || state === 'team-only') && (
+                  <span className="shrink-0 rounded bg-surface-800 px-1.5 py-0 text-[10px] font-medium text-surface-500">
+                    Team
+                  </span>
+                )}
+                {renderSharedWithTeamPill(integration, state)}
+                {(state === 'connected' || state === 'org-connected') &&
+                  integration.lastError &&
+                  !isSyncing && (
+                    <span className="h-2 w-2 shrink-0 rounded-full bg-red-500" title={integration.lastError} />
+                  )}
+              </span>
+              {accountSubtitle ? (
+                <span className="truncate text-xs text-surface-500" title={accountSubtitle}>
+                  {accountSubtitle}
+                </span>
+              ) : null}
             </span>
           </button>
 
@@ -2078,6 +2130,20 @@ export function DataSources(): JSX.Element {
                       </button>
                     </>
                   )}
+                  {showAddAnotherAccount && (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="w-full px-3 py-2 text-left text-sm text-surface-200 hover:bg-surface-800 disabled:opacity-50"
+                      disabled={isConnecting}
+                      onClick={() => {
+                        setRowMenuOpenForId(null);
+                        void handleConnect(integration.provider);
+                      }}
+                    >
+                      Add another account
+                    </button>
+                  )}
                   {canDisconnect && (
                     <button
                       type="button"
@@ -2086,7 +2152,7 @@ export function DataSources(): JSX.Element {
                       disabled={isDisconnecting}
                       onClick={() => {
                         setRowMenuOpenForId(null);
-                        void handleDisconnect(integration.provider);
+                        void handleDisconnect(integration);
                       }}
                     >
                       {isDisconnecting ? 'Disconnecting…' : 'Disconnect'}
@@ -2703,6 +2769,8 @@ export function DataSources(): JSX.Element {
           d.provider !== 'google_drive' &&
           hasSyncDrawer;
         const canDisconnectDrawer = (st === 'connected' && d.isOwner) || st === 'org-connected';
+        const showAddAnotherDrawer: boolean =
+          ((st === 'connected' && d.isOwner) || st === 'org-connected') && !d.provider.startsWith('mcp_');
 
         return (
           <>
@@ -2710,7 +2778,7 @@ export function DataSources(): JSX.Element {
               type="button"
               className="fixed inset-0 z-[44] bg-black/50"
               aria-label="Close details"
-              onClick={() => setDetailProvider(null)}
+              onClick={() => setDetailIntegrationId(null)}
             />
             <aside className="fixed inset-y-0 right-0 z-[45] flex w-full max-w-full flex-col border-l border-surface-800 bg-surface-950 shadow-2xl sm:max-w-md">
               <div className="flex items-start justify-between gap-3 border-b border-surface-800 px-4 py-4">
@@ -2728,12 +2796,20 @@ export function DataSources(): JSX.Element {
                   </div>
                   <div className="min-w-0">
                     <h2 className="text-lg font-semibold text-surface-100">{d.name}</h2>
+                    {(d.accountLabel ?? d.accountIdentifier) ? (
+                      <p
+                        className="mt-0.5 truncate text-xs text-surface-500"
+                        title={d.accountLabel ?? d.accountIdentifier ?? ''}
+                      >
+                        {d.accountLabel ?? d.accountIdentifier}
+                      </p>
+                    ) : null}
                     <p className="mt-1 text-sm text-surface-400">{d.description}</p>
                   </div>
                 </div>
                 <button
                   type="button"
-                  onClick={() => setDetailProvider(null)}
+                  onClick={() => setDetailIntegrationId(null)}
                   className="rounded-lg p-2 text-surface-400 hover:bg-surface-800 hover:text-surface-200"
                   aria-label="Close"
                 >
@@ -2875,6 +2951,15 @@ export function DataSources(): JSX.Element {
                     Configure sharing
                   </button>
                 )}
+                {showAddAnotherDrawer && (
+                  <button
+                    type="button"
+                    onClick={() => void handleConnect(d.provider)}
+                    className="rounded-lg border border-primary-500/30 px-3 py-2 text-xs font-medium text-primary-400 hover:bg-primary-500/10"
+                  >
+                    Add another account
+                  </button>
+                )}
                 {hasSyncDrawer && (st === 'connected' || st === 'org-connected') && (
                   <button
                     type="button"
@@ -2925,7 +3010,7 @@ export function DataSources(): JSX.Element {
                 {canDisconnectDrawer && (
                   <button
                     type="button"
-                    onClick={() => void handleDisconnect(d.provider)}
+                    onClick={() => void handleDisconnect(d)}
                     className="rounded-lg px-3 py-2 text-xs font-medium text-red-400 hover:bg-red-500/10"
                   >
                     Disconnect
@@ -2961,7 +3046,10 @@ export function DataSources(): JSX.Element {
             <div className="p-6">
               {disconnectModal.step === 'confirm' ? (
                 <>
-                  <h2 className="text-lg font-semibold text-surface-100 mb-2">Disconnect {disconnectModal.provider}?</h2>
+                  <h2 className="text-lg font-semibold text-surface-100 mb-2">
+                    Disconnect {getConnectorDisplay(disconnectModal.provider).name}
+                    {disconnectModal.accountSummary ? ` (${disconnectModal.accountSummary})` : ''}?
+                  </h2>
                   <p className="text-sm text-surface-400 mb-6">
                     This will remove the connection. You can reconnect later.
                   </p>
@@ -2988,13 +3076,13 @@ export function DataSources(): JSX.Element {
                   </p>
                   <div className="flex justify-end gap-3">
                     <button
-                      onClick={() => void executeDisconnect(disconnectModal.provider, false)}
+                      onClick={() => void executeDisconnect(disconnectModal.provider, false, disconnectModal.integrationId)}
                       className="px-4 py-2 text-sm font-medium text-surface-300 hover:text-surface-100 transition-colors"
                     >
                       Keep Data
                     </button>
                     <button
-                      onClick={() => void executeDisconnect(disconnectModal.provider, true)}
+                      onClick={() => void executeDisconnect(disconnectModal.provider, true, disconnectModal.integrationId)}
                       className="px-4 py-2 text-sm font-medium bg-red-600 hover:bg-red-500 text-white rounded-lg transition-colors"
                     >
                       Delete Data

--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -319,6 +319,12 @@ export function DataSources(): JSX.Element {
   }, [user?.id, fetchUserOrganizations]);
 
   const [syncingProviders, setSyncingProviders] = useState<Set<string>>(new Set());
+  /**
+   * Multi-account: track the integration row ids currently syncing. When a
+   * `sync_progress` WS event carries `integration_id`, only that one row spins.
+   * Falls back to provider-level state when the event predates this field.
+   */
+  const [syncingIntegrationIds, setSyncingIntegrationIds] = useState<Set<string>>(new Set());
   const [syncStartedAt, setSyncStartedAt] = useState<Record<string, number>>({});
   const [syncProgress, setSyncProgress] = useState<Record<string, number>>({});
   const [syncProgressPercent, setSyncProgressPercent] = useState<Record<string, number>>({});
@@ -624,6 +630,37 @@ export function DataSources(): JSX.Element {
     setSyncProgressPercent((prev) => ({ ...prev, [provider]: Math.max(prev[provider] ?? 0, 8) }));
   }, []);
 
+  const markIntegrationSyncing = useCallback(
+    (integrationId: string, provider?: string): void => {
+      setSyncingIntegrationIds((prev) => {
+        if (prev.has(integrationId)) return prev;
+        const next = new Set(prev);
+        next.add(integrationId);
+        return next;
+      });
+      // Seed provider-keyed bookkeeping so the percent-bar ticker continues to
+      // advance even though the spinner itself is gated per row.
+      if (provider !== undefined && provider.length > 0) {
+        const now: number = Date.now();
+        setSyncStartedAt((prev) => ({ ...prev, [provider]: prev[provider] ?? now }));
+        setSyncProgressPercent((prev) => ({
+          ...prev,
+          [provider]: Math.max(prev[provider] ?? 0, 8),
+        }));
+      }
+    },
+    [],
+  );
+
+  const finishIntegrationSync = useCallback((integrationId: string): void => {
+    setSyncingIntegrationIds((prev) => {
+      if (!prev.has(integrationId)) return prev;
+      const next = new Set(prev);
+      next.delete(integrationId);
+      return next;
+    });
+  }, []);
+
   const finishProviderSync = useCallback((provider: string): void => {
     setSyncProgressPercent((prev) => ({ ...prev, [provider]: 100 }));
     setTimeout(() => {
@@ -687,10 +724,16 @@ export function DataSources(): JSX.Element {
         count?: number;
         status?: string;
         step?: string;
+        integration_id?: string;
       };
       if (data.type !== 'sync_progress' || data.provider === undefined) return;
 
-      const provider = data.provider;
+      const provider: string = data.provider;
+      const integrationId: string | null =
+        typeof data.integration_id === 'string' && data.integration_id.length > 0
+          ? data.integration_id
+          : null;
+
       if (typeof data.count === 'number' && Number.isFinite(data.count)) {
         setSyncProgress((prev) => ({
           ...prev,
@@ -705,17 +748,31 @@ export function DataSources(): JSX.Element {
       }
 
       if (data.status === 'syncing') {
-        markProviderSyncing(provider);
+        if (integrationId !== null) {
+          markIntegrationSyncing(integrationId, provider);
+        } else {
+          // Legacy event with no per-row id: keep provider-wide behavior.
+          markProviderSyncing(provider);
+        }
       }
 
       if (data.status === 'completed' || data.status === 'failed') {
         void fetchIntegrations();
-        finishProviderSync(provider);
+        if (integrationId !== null) {
+          setSyncingIntegrationIds((prev) => {
+            if (!prev.has(integrationId)) return prev;
+            const next = new Set(prev);
+            next.delete(integrationId);
+            return next;
+          });
+        } else {
+          finishProviderSync(provider);
+        }
       }
     } catch {
       // Ignore non-JSON messages or parsing errors
     }
-  }, [fetchIntegrations, finishProviderSync, markProviderSyncing]);
+  }, [fetchIntegrations, finishProviderSync, markIntegrationSyncing, markProviderSyncing]);
   
   // Connect to WebSocket for sync progress updates - authenticated via JWT token
   useWebSocket(
@@ -1328,8 +1385,16 @@ export function DataSources(): JSX.Element {
     });
   };
 
-  const handleSync = async (provider: string, sinceIso?: string): Promise<void> => {
-    if (syncingProviders.has(provider) || !organizationId) return;
+  const handleSync = async (
+    provider: string,
+    sinceIso?: string,
+    integrationRowId?: string,
+  ): Promise<void> => {
+    if (!organizationId) return;
+    // Per-row sync: gate on the integration row, not the whole provider, so a
+    // second account for the same provider can still be triggered manually.
+    if (integrationRowId !== undefined && syncingIntegrationIds.has(integrationRowId)) return;
+    if (integrationRowId === undefined && syncingProviders.has(provider)) return;
     if (provider === 'github' && githubRequiresRepoReview) {
       setGithubReposExpanded(true);
       setSyncError('Select and save GitHub repositories before syncing.');
@@ -1338,7 +1403,19 @@ export function DataSources(): JSX.Element {
     }
 
     setSyncError(null);
-    markProviderSyncing(provider);
+    if (integrationRowId !== undefined) {
+      markIntegrationSyncing(integrationRowId, provider);
+    } else {
+      markProviderSyncing(provider);
+    }
+
+    const finishOptimistic = (): void => {
+      if (integrationRowId !== undefined) {
+        finishIntegrationSync(integrationRowId);
+      } else {
+        finishProviderSync(provider);
+      }
+    };
 
     try {
       // Google Drive uses its own sync endpoint (user-scoped)
@@ -1348,16 +1425,19 @@ export function DataSources(): JSX.Element {
         if (error) throw new Error(error);
         // Drive sync runs in background — wait a bit then refresh integrations
         setTimeout(() => {
-          finishProviderSync(provider);
+          finishOptimistic();
           void fetchIntegrations();
         }, 15000);
         return;
       }
 
-      const syncUrl: string =
-        sinceIso !== undefined && sinceIso.length > 0
-          ? `${API_BASE}/sync/${organizationId}/${provider}?since=${encodeURIComponent(sinceIso)}`
-          : `${API_BASE}/sync/${organizationId}/${provider}`;
+      const syncParams: URLSearchParams = new URLSearchParams();
+      if (sinceIso !== undefined && sinceIso.length > 0) syncParams.set('since', sinceIso);
+      if (integrationRowId !== undefined) syncParams.set('integration_id', integrationRowId);
+      const querySuffix: string = syncParams.toString();
+      const syncUrl: string = querySuffix
+        ? `${API_BASE}/sync/${organizationId}/${provider}?${querySuffix}`
+        : `${API_BASE}/sync/${organizationId}/${provider}`;
 
       const authHeaders = await getAuthenticatedRequestHeaders();
       const response = await fetch(syncUrl, {
@@ -1377,7 +1457,7 @@ export function DataSources(): JSX.Element {
         const status = await statusRes.json();
 
         if (status.status === 'completed' || status.status === 'failed' || attempts >= maxAttempts) {
-          finishProviderSync(provider);
+          finishOptimistic();
 
           if (status.status === 'failed') {
             const providerName = getConnectorDisplay(provider).name;
@@ -1403,7 +1483,7 @@ export function DataSources(): JSX.Element {
       console.error('Sync error:', error);
       setSyncError(error instanceof Error ? error.message : `Failed to sync ${getConnectorDisplay(provider).name}`);
       setTimeout(() => setSyncError(null), 8000);
-      finishProviderSync(provider);
+      finishOptimistic();
     }
   };
 
@@ -1887,7 +1967,14 @@ export function DataSources(): JSX.Element {
       (state === 'connected' || state === 'org-connected') &&
       getConnectorDisplay(integration.provider).hasSync !== false &&
       isFreshSyncStartedAt(integration.syncStats?.sync_started_at);
-    const isSyncing = syncingProviders.has(integration.provider) || isSyncingFromServer;
+    // Prefer per-integration tracking so that connecting / syncing one account
+    // does not spin every row for the same provider (multi-account UX). The
+    // provider-wide marker is intentionally NOT OR'd in here: it would make
+    // every row for the provider show "Syncing…" even when only one account
+    // was triggered. Server-side ``sync_started_at`` already gives us the
+    // authoritative per-row state.
+    const isSyncingThisRow: boolean = syncingIntegrationIds.has(integration.id);
+    const isSyncing: boolean = isSyncingThisRow || isSyncingFromServer;
     const isDisconnecting = disconnectingIntegrationIds.has(integration.id);
     const accountSubtitle: string | null =
       integration.accountLabel ?? integration.accountIdentifier ?? null;
@@ -1914,7 +2001,7 @@ export function DataSources(): JSX.Element {
           text: isSyncing ? 'Syncing...' : 'Sync',
           className:
             'inline-flex h-7 shrink-0 items-center justify-center gap-1.5 rounded-lg border border-surface-600 bg-surface-800 px-3 text-xs font-medium text-surface-200 transition-colors hover:bg-surface-700 disabled:opacity-50',
-          action: () => void handleSync(integration.provider),
+          action: () => void handleSync(integration.provider, undefined, integration.id),
           disabled: isSyncing,
         };
       }
@@ -2087,7 +2174,7 @@ export function DataSources(): JSX.Element {
                         disabled={isSyncing}
                         onClick={() => {
                           setRowMenuOpenForId(null);
-                          void handleSync(integration.provider);
+                          void handleSync(integration.provider, undefined, integration.id);
                         }}
                       >
                         Sync now
@@ -2099,7 +2186,11 @@ export function DataSources(): JSX.Element {
                         disabled={isSyncing}
                         onClick={() => {
                           setRowMenuOpenForId(null);
-                          void handleSync(integration.provider, isoUtcSubtractMs(RESYNC_OFFSET_MS.hours24));
+                          void handleSync(
+                            integration.provider,
+                            isoUtcSubtractMs(RESYNC_OFFSET_MS.hours24),
+                            integration.id,
+                          );
                         }}
                       >
                         Resync · last 24 hours
@@ -2111,7 +2202,11 @@ export function DataSources(): JSX.Element {
                         disabled={isSyncing}
                         onClick={() => {
                           setRowMenuOpenForId(null);
-                          void handleSync(integration.provider, isoUtcSubtractMs(RESYNC_OFFSET_MS.days7));
+                          void handleSync(
+                            integration.provider,
+                            isoUtcSubtractMs(RESYNC_OFFSET_MS.days7),
+                            integration.id,
+                          );
                         }}
                       >
                         Resync · last 7 days
@@ -2123,7 +2218,11 @@ export function DataSources(): JSX.Element {
                         disabled={isSyncing}
                         onClick={() => {
                           setRowMenuOpenForId(null);
-                          void handleSync(integration.provider, isoUtcSubtractMs(RESYNC_OFFSET_MS.days30));
+                          void handleSync(
+                            integration.provider,
+                            isoUtcSubtractMs(RESYNC_OFFSET_MS.days30),
+                            integration.id,
+                          );
                         }}
                       >
                         Resync · last 30 days
@@ -2220,7 +2319,7 @@ export function DataSources(): JSX.Element {
 
   return (
     <div className="flex-1 overflow-y-auto overflow-x-hidden">
-      {/* Mobile — Browse connectors + overflow for Sync all */}
+      {/* Mobile — Add connector + overflow for Sync all */}
       <div className="sticky top-0 z-20 flex-shrink-0 border-b border-surface-800 bg-surface-950/95 px-4 py-2 backdrop-blur-sm md:hidden">
         <div className="flex items-center justify-end gap-2">
           <button
@@ -2231,7 +2330,7 @@ export function DataSources(): JSX.Element {
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
             </svg>
-            Browse connectors
+            Add connector
           </button>
           {canSyncAllConnectors && (
             <div className="relative shrink-0" data-page-overflow-root>
@@ -2285,9 +2384,12 @@ export function DataSources(): JSX.Element {
             <button
               type="button"
               onClick={openAddConnectorModal}
-              className="rounded-lg border border-surface-600 px-4 py-2 text-sm font-medium text-surface-100 transition-colors hover:bg-surface-800"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-surface-600 px-4 py-2 text-sm font-medium text-surface-100 transition-colors hover:bg-surface-800"
             >
-              Browse connectors
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
+              </svg>
+              Add connector
             </button>
             {canSyncAllConnectors && (
               <div className="relative" data-page-overflow-root>
@@ -2761,7 +2863,8 @@ export function DataSources(): JSX.Element {
           (st === 'connected' || st === 'org-connected') &&
           getConnectorDisplay(d.provider).hasSync !== false &&
           isFreshSyncStartedAt(d.syncStats?.sync_started_at);
-        const isSyncingDrawer = syncingProviders.has(d.provider) || isSyncingDrawerFromServer;
+        const isSyncingDrawerThisRow: boolean = syncingIntegrationIds.has(d.id);
+        const isSyncingDrawer: boolean = isSyncingDrawerThisRow || isSyncingDrawerFromServer;
         const syncPercentDrawer = isSyncingDrawer ? (syncProgressPercent[d.provider] ?? 8) : 0;
         const hasSyncDrawer = getConnectorDisplay(d.provider).hasSync !== false;
         const showResyncDrawer =
@@ -2964,7 +3067,7 @@ export function DataSources(): JSX.Element {
                   <button
                     type="button"
                     disabled={isSyncingDrawer}
-                    onClick={() => void handleSync(d.provider)}
+                    onClick={() => void handleSync(d.provider, undefined, d.id)}
                     className="rounded-lg border border-surface-600 bg-surface-800 px-3 py-2 text-xs font-medium text-surface-100 hover:bg-surface-700 disabled:opacity-50"
                   >
                     {isSyncingDrawer ? 'Syncing…' : 'Sync now'}
@@ -2975,7 +3078,7 @@ export function DataSources(): JSX.Element {
                     <button
                       type="button"
                       disabled={isSyncingDrawer}
-                      onClick={() => void handleSync(d.provider, isoUtcSubtractMs(RESYNC_OFFSET_MS.hours24))}
+                      onClick={() => void handleSync(d.provider, isoUtcSubtractMs(RESYNC_OFFSET_MS.hours24), d.id)}
                       className="rounded-lg border border-surface-600 px-3 py-2 text-xs font-medium text-surface-200 hover:bg-surface-800 disabled:opacity-50"
                     >
                       Resync 24h
@@ -2983,7 +3086,7 @@ export function DataSources(): JSX.Element {
                     <button
                       type="button"
                       disabled={isSyncingDrawer}
-                      onClick={() => void handleSync(d.provider, isoUtcSubtractMs(RESYNC_OFFSET_MS.days7))}
+                      onClick={() => void handleSync(d.provider, isoUtcSubtractMs(RESYNC_OFFSET_MS.days7), d.id)}
                       className="rounded-lg border border-surface-600 px-3 py-2 text-xs font-medium text-surface-200 hover:bg-surface-800 disabled:opacity-50"
                     >
                       Resync 7d
@@ -2991,7 +3094,7 @@ export function DataSources(): JSX.Element {
                     <button
                       type="button"
                       disabled={isSyncingDrawer}
-                      onClick={() => void handleSync(d.provider, isoUtcSubtractMs(RESYNC_OFFSET_MS.days30))}
+                      onClick={() => void handleSync(d.provider, isoUtcSubtractMs(RESYNC_OFFSET_MS.days30), d.id)}
                       className="rounded-lg border border-surface-600 px-3 py-2 text-xs font-medium text-surface-200 hover:bg-surface-800 disabled:opacity-50"
                     >
                       Resync 30d

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -1436,6 +1436,9 @@ export const useChatStore = create<ChatState>()(
           team_total: number;
           sync_stats: SyncStats | null;
           display_name: string | null;
+          account_identifier: string | null;
+          account_label: string | null;
+          account_avatar_url: string | null;
         }
 
         const data = (await response.json()) as {
@@ -1465,6 +1468,9 @@ export const useChatStore = create<ChatState>()(
           teamTotal: i.team_total,
           syncStats: i.sync_stats,
           displayName: i.display_name ?? null,
+          accountIdentifier: i.account_identifier ?? null,
+          accountLabel: i.account_label ?? null,
+          accountAvatarUrl: i.account_avatar_url ?? null,
         }));
 
         set({ integrations, integrationsLoading: false });

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -104,6 +104,10 @@ export interface Integration {
   teamTotal: number;
   syncStats: SyncStats | null;
   displayName: string | null;
+  /** Provider account identity (email, portal id, Slack team id, …) */
+  accountIdentifier: string | null;
+  accountLabel: string | null;
+  accountAvatarUrl: string | null;
 }
 
 // =============================================================================

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,6 +7,11 @@ export default defineConfig({
   plugins: [react()],
   envDir: path.resolve(__dirname, '..'), // Read .env from project root
   appType: 'spa', // Enable SPA fallback for client-side routing
+  test: {
+    environment: 'jsdom',
+    include: ['src/**/*.test.{ts,tsx}'],
+    passWithNoTests: true,
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
Enables **multiple connected accounts per user per connector** (e.g. work + personal Gmail, multiple HubSpot portals) without overwriting Nango bindings.

## Database
- Migration **143**: `account_identifier`, `account_label`; partial unique indexes (one legacy NULL row per org/connector/user; one row per non-null account id).
- **Upgrade** is backward compatible for existing single-row integrations (`account_identifier` NULL until backfill). **Downgrade** is unsafe if multiple rows already exist.

## Backend
- **Confirm / legacy Nango callback**: upsert by account metadata; opportunistic backfill of legacy NULL row.
- **List integrations**: one response row per owned integration with `account_* ` fields; disconnect accepts `integration_id`.
- **Sync**: `integration_id` passed through Celery and global hourly dispatch; **GET …/status** aggregates all rows for the provider.
- **Agents**: `_query_on_connector` fans out when multiple active rows and no `account` filter; optional `account` on Gmail/Microsoft send and Slack `post_message`.
- **Connectors**: `fetch_account_metadata` hook + registry skips for helper modules.

## Frontend
- **DataSources**: one row per `integration_id`, account subtitle + avatar, disconnect by row, **Add another account** in row menu and drawer.
- **chatStore / types**: map API account fields.
- **Vitest**: `ConnectorAccountLines` + `npm run test`.

## Tests run
- `npm run build` (frontend)
- `python -m pytest -q tests/test_integration_multi_account.py tests/test_gmail_connector_query.py` (6 passed)

## Note
This branch is based on `feature/gmail-live-search` and therefore **also includes** the Gmail live QUERY commit ahead of `main`. If you want multi-account **only** against `main`, rebase this branch onto `main` and drop or split that commit before merge.

Made with [Cursor](https://cursor.com)