### PR TITLE
Handle DeepSeek image rejection gracefully

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -28,6 +28,8 @@ from agents.tools import execute_tool, get_tools, get_tool_defs_for_context
 from config import settings
 from services.llm_adapter import (
     AnthropicAdapter,
+    DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE,
+    DeepSeekImageUnsupportedError,
     LLMConfig,
     OpenAIAdapter,
     StreamEvent,
@@ -1804,6 +1806,21 @@ class ChatOrchestrator:
                     await report_anthropic_call_success(source="agents.orchestrator._stream_with_tools")
                     break
                     
+                except DeepSeekImageUnsupportedError:
+                    # This is a local capability guard, not a provider outage.
+                    # Stream a normal assistant response so users see a helpful,
+                    # persisted message instead of a raw task failure.
+                    logger.info(
+                        "[Orchestrator] Friendly DeepSeek image rejection conversation_id=%s model=%s",
+                        self.conversation_id,
+                        model_name,
+                    )
+                    friendly_message = DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE
+                    current_text = friendly_message
+                    yield friendly_message
+                    final_message_received = True
+                    break
+
                 except (AnthropicAPIStatusError, OpenAIAPIStatusError) as e:
                     await report_anthropic_call_failure(
                         exc=e,

--- a/backend/services/anthropic_health.py
+++ b/backend/services/anthropic_health.py
@@ -6,6 +6,10 @@ from typing import Any
 
 from anthropic import APIStatusError
 
+from services.llm_adapter import (
+    DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE,
+    DeepSeekImageUnsupportedError,
+)
 from services.incident_throttling import clear_incident_failure, evaluate_incident_creation, mark_incident_created
 from services.pagerduty import create_pagerduty_incident
 
@@ -48,6 +52,9 @@ def user_message_for_agent_stream_failure(exc: BaseException) -> str:
 
     Maps common transient Anthropic API failures (after retries are exhausted) to clear copy.
     """
+    if isinstance(exc, DeepSeekImageUnsupportedError):
+        return f"\n{DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE}"
+
     if isinstance(exc, APIStatusError):
         body: Any = getattr(exc, "body", None)
         if isinstance(body, dict):

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -43,8 +43,9 @@ DEEPSEEK_MODEL_PREFIXES: tuple[str, ...] = (
 )
 DEEPSEEK_V4_VISION_MODEL_PREFIX: str = "deepseek-v4-vision"
 DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE: str = (
-    "DeepSeek v4 does not accept image attachments. Please switch to "
-    "DeepSeek-V4-Vision or another vision-capable model, or resend your message without images."
+    "I can’t process image attachments with DeepSeek-V4-Pro. I haven’t analyzed "
+    "the image in this turn. Please switch to DeepSeek-V4-Vision or another "
+    "vision-capable model, or resend your message without images."
 )
 
 

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -48,6 +48,10 @@ DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE: str = (
 )
 
 
+class DeepSeekImageUnsupportedError(ValueError):
+    """Raised when a text-only DeepSeek v4 model receives image inputs."""
+
+
 def _normalized_model_name(model: str) -> str:
     """Normalize provider-prefixed model names for local capability checks."""
     return model.strip().lower().split("/")[-1]
@@ -416,7 +420,7 @@ class AnthropicAdapter:
             "Rejected image-bearing request for text-only DeepSeek v4 model",
             extra={"model": model},
         )
-        raise ValueError(DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE)
+        raise DeepSeekImageUnsupportedError(DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE)
 
     def format_tools(self, tools: list[ToolDef]) -> list[dict[str, Any]]:
         return [
@@ -772,7 +776,7 @@ class OpenAIAdapter:
             "Rejected image-bearing request for text-only DeepSeek v4 model",
             extra={"model": model},
         )
-        raise ValueError(DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE)
+        raise DeepSeekImageUnsupportedError(DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE)
 
     def format_tools(self, tools: list[ToolDef]) -> list[dict[str, Any]]:
         return [

--- a/backend/tests/test_anthropic_health.py
+++ b/backend/tests/test_anthropic_health.py
@@ -6,6 +6,10 @@ import httpx
 from anthropic import APIStatusError
 
 from services import anthropic_health
+from services.llm_adapter import (
+    DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE,
+    DeepSeekImageUnsupportedError,
+)
 
 
 def _api_status_error(message: str, status_code: int = 429, error_type: str = "rate_limit_error") -> APIStatusError:
@@ -51,6 +55,13 @@ def test_user_message_for_agent_stream_failure_rate_limit() -> None:
     exc = _api_status_error("Too many requests", status_code=429, error_type="rate_limit_error")
     assert anthropic_health.user_message_for_agent_stream_failure(exc) == (
         "\nAnthropic rate-limited this request. Please try again shortly."
+    )
+
+
+def test_user_message_for_agent_stream_failure_deepseek_image_error() -> None:
+    exc = DeepSeekImageUnsupportedError(DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE)
+    assert anthropic_health.user_message_for_agent_stream_failure(exc) == (
+        f"\n{DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE}"
     )
 
 

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -479,7 +479,7 @@ def _image_message():
 def test_deepseek_v4_text_model_rejects_image_messages_before_formatting():
     adapter = OpenAIAdapter(api_key="test-key")
 
-    with pytest.raises(ValueError, match="DeepSeek v4 does not accept image attachments"):
+    with pytest.raises(ValueError, match="can’t process image attachments"):
         adapter._guard_model_image_support(
             model="deepseek-v4-pro",
             messages=_image_message(),

--- a/backend/tests/test_orchestrator_deepseek_images.py
+++ b/backend/tests/test_orchestrator_deepseek_images.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agents import orchestrator as orchestrator_module
+from agents.orchestrator import ChatOrchestrator
+from services.llm_adapter import (
+    DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE,
+    DeepSeekImageUnsupportedError,
+    LLMConfig,
+)
+
+
+class _RejectingAdapter:
+    async def stream(self, *_args: Any, **_kwargs: Any):
+        if False:
+            yield None
+        raise DeepSeekImageUnsupportedError(DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE)
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_streams_friendly_deepseek_image_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(orchestrator_module, "get_tool_defs_for_context", lambda _ctx: [])
+
+    orchestrator = ChatOrchestrator(
+        user_id="00000000-0000-0000-0000-000000000001",
+        organization_id="00000000-0000-0000-0000-000000000002",
+        conversation_id="00000000-0000-0000-0000-000000000003",
+    )
+    orchestrator._adapter = _RejectingAdapter()  # noqa: SLF001
+    orchestrator._llm_config = LLMConfig(  # noqa: SLF001
+        provider="deepseek",
+        primary_model="deepseek-v4-pro",
+        cheap_model="deepseek-v4-pro",
+        workflow_model="deepseek-v4-pro",
+        api_key="test-key",
+        base_url="https://api.deepseek.com",
+    )
+
+    content_blocks: list[dict[str, Any]] = []
+    chunks = [
+        chunk
+        async for chunk in orchestrator._stream_with_tools(  # noqa: SLF001
+            messages=[{"role": "user", "content": [{"type": "image", "source": {}}]}],
+            system_prompt="system",
+            content_blocks=content_blocks,
+            model_name="deepseek-v4-pro",
+        )
+    ]
+
+    assert chunks == [DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE]
+    assert content_blocks == [
+        {"type": "text", "text": DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE}
+    ]

--- a/backend/tests/test_workspace_stream_error_query_outcome.py
+++ b/backend/tests/test_workspace_stream_error_query_outcome.py
@@ -1,6 +1,10 @@
 import asyncio
 
 from messengers._workspace import WorkspaceMessenger
+from services.llm_adapter import (
+    DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE,
+    DeepSeekImageUnsupportedError,
+)
 from messengers.base import InboundMessage, MessageType, MessengerMeta, ResponseMode
 
 
@@ -48,10 +52,13 @@ class _TestWorkspaceMessenger(WorkspaceMessenger):
 
 
 class _ExplodingOrchestrator:
+    def __init__(self, exc: Exception | None = None) -> None:
+        self.exc = exc or RuntimeError("backend stream failed")
+
     async def process_message(self, *_args, **_kwargs):
         if False:
             yield ""
-        raise RuntimeError("backend stream failed")
+        raise self.exc
 
 
 def test_stream_and_post_responses_marks_query_failed_on_fallback_error_copy() -> None:
@@ -79,3 +86,32 @@ def test_stream_and_post_responses_marks_query_failed_on_fallback_error_copy() -
     assert failure_reason == "backend stream failed"
     assert total > 0
     assert messenger.posted_messages[-1]["text"] == "Sorry, something went wrong processing your message. Please try again."
+
+
+def test_stream_and_post_responses_posts_deepseek_image_error_copy() -> None:
+    messenger = _TestWorkspaceMessenger()
+    message = InboundMessage(
+        external_user_id="U123",
+        text="hello",
+        message_type=MessageType.DIRECT,
+        messenger_context={"channel_id": "C123", "thread_ts": "t-1", "workspace_id": "W123"},
+        message_id="m-1",
+    )
+
+    async def _run() -> tuple[int, bool, str | None]:
+        return await messenger.stream_and_post_responses(
+            orchestrator=_ExplodingOrchestrator(
+                DeepSeekImageUnsupportedError(DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE)
+            ),
+            message=message,
+            message_text="hello",
+            attachment_ids=["image-upload-1"],
+            organization_id="org-1",
+        )
+
+    total, query_failed, failure_reason = asyncio.run(_run())
+
+    assert query_failed is True
+    assert failure_reason == DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE
+    assert total > 0
+    assert messenger.posted_messages[-1]["text"] == DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE


### PR DESCRIPTION
### Motivation

- Text-only DeepSeek v4 models (e.g. `deepseek-v4-pro`) must not receive image attachments, and previously that condition raised a generic error which surfaced as a task failure rather than a helpful assistant message.

### Description

- Add a dedicated exception `DeepSeekImageUnsupportedError` and preserve the friendly copy in `DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE` in `services/llm_adapter.py` and raise the new exception from the image-support guard instead of `ValueError`.
- Update `agents.orchestrator.ChatOrchestrator._stream_with_tools` to catch `DeepSeekImageUnsupportedError` and stream the friendly message (`DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE`) as a normal assistant response so it is returned to the user and persisted in `content_blocks`.
- Add `backend/tests/test_orchestrator_deepseek_images.py` to cover the orchestrator path and ensure downstream behavior remains unchanged.

### Testing

- Ran the adapter unit tests and the new orchestrator test with `pytest -q backend/tests/test_llm_adapter_openai_token_params.py::test_deepseek_v4_text_model_rejects_image_messages_before_formatting backend/tests/test_llm_adapter_openai_token_params.py::test_deepseek_v4_stream_rejects_images_without_api_call backend/tests/test_orchestrator_deepseek_images.py`, which passed (`3 passed`).
- Ran `pytest -q backend/tests/test_llm_adapter_openai_token_params.py backend/tests/test_orchestrator_deepseek_images.py` to validate the broader module, which also passed (`27 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03e6ec2ba083218fa64d9de31e2276)