### PR TITLE
Fix JSONB serialization for tool results

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -15,7 +15,8 @@ import json
 import logging
 import re
 from dataclasses import replace
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+from decimal import Decimal
 from typing import Any, AsyncGenerator, Sequence
 from uuid import UUID, uuid4
 
@@ -279,6 +280,8 @@ async def update_tool_result(
                 logger.warning(f"[update_tool_result] No message found for conversation {conversation_id}")
                 return False
             
+            result = ChatOrchestrator._json_safe(result)
+
             # Find and update the tool_use block
             # IMPORTANT: Deep-copy blocks to avoid in-place mutation of the original
             # dicts. SQLAlchemy JSONB columns compare old vs new by value; if we mutate
@@ -307,7 +310,7 @@ async def update_tool_result(
                 return False
             
             # Save updated blocks — new list with new dicts ensures SQLAlchemy detects the change
-            message.content_blocks = new_blocks
+            message.content_blocks = ChatOrchestrator._json_safe(new_blocks)
             await session.commit()
             
             logger.info(f"[update_tool_result] SUCCESS: Updated tool {tool_id[:8]} with status={status}")
@@ -2272,7 +2275,7 @@ class ChatOrchestrator:
                         user_id=user_uuid,
                         organization_id=org_uuid,
                         role="assistant",
-                        content_blocks=blocks,
+                        content_blocks=self._json_safe(blocks),
                     )
                 )
                 await session.commit()
@@ -2534,6 +2537,7 @@ class ChatOrchestrator:
         if attachment_meta:
             blocks.extend(attachment_meta)
         blocks.append({"type": "text", "text": user_msg})
+        blocks = self._json_safe(blocks)
 
         message_id: UUID = pre_generated_message_id if pre_generated_message_id is not None else uuid4()
         async with get_session(organization_id=self.organization_id, user_id=self.user_id) as session:
@@ -2590,19 +2594,43 @@ class ChatOrchestrator:
                 )
 
     @staticmethod
-    def _strip_null_bytes(obj: Any) -> Any:
-        """Recursively strip null bytes from strings in a JSON-serialisable structure.
+    def _json_safe(obj: Any) -> Any:
+        """Recursively coerce arbitrary tool payloads into JSONB-safe values.
 
-        PostgreSQL JSONB columns cannot store \\x00; Exa and other web-search
-        providers occasionally return content containing them, which causes
-        asyncpg.UntranslatableCharacterError and silently breaks message saves.
+        Tool outputs can include database-native values such as ``Decimal`` or
+        ``UUID`` objects. asyncpg serializes JSONB parameters with ``json.dumps``,
+        which raises ``TypeError`` for those objects and prevents assistant
+        messages from being saved. This helper keeps the existing null-byte
+        protection while normalizing common non-JSON primitives before every
+        chat message JSONB write.
         """
         if isinstance(obj, str):
             return obj.replace("\x00", "")
+        if isinstance(obj, Decimal):
+            if obj.is_finite():
+                integral = obj.to_integral_value()
+                if obj == integral:
+                    return int(integral)
+                return float(obj)
+            return str(obj)
+        if isinstance(obj, datetime):
+            if obj.tzinfo is not None:
+                return obj.isoformat()
+            return f"{obj.isoformat()}Z"
+        if isinstance(obj, date):
+            return obj.isoformat()
+        if isinstance(obj, UUID):
+            return str(obj)
+        if isinstance(obj, bytes):
+            return obj.decode("utf-8", errors="replace").replace("\x00", "")
         if isinstance(obj, list):
-            return [ChatOrchestrator._strip_null_bytes(item) for item in obj]
+            return [ChatOrchestrator._json_safe(item) for item in obj]
+        if isinstance(obj, tuple):
+            return [ChatOrchestrator._json_safe(item) for item in obj]
+        if isinstance(obj, set):
+            return [ChatOrchestrator._json_safe(item) for item in sorted(obj, key=str)]
         if isinstance(obj, dict):
-            return {k: ChatOrchestrator._strip_null_bytes(v) for k, v in obj.items()}
+            return {str(k): ChatOrchestrator._json_safe(v) for k, v in obj.items()}
         return obj
 
     async def _run_post_completion(self) -> None:
@@ -2622,7 +2650,7 @@ class ChatOrchestrator:
 
     async def _save_assistant_message(self, assistant_blocks: list[dict[str, Any]]) -> None:
         """Save or update assistant message in database."""
-        assistant_blocks = self._strip_null_bytes(assistant_blocks)
+        assistant_blocks = self._json_safe(assistant_blocks)
 
         conv_uuid: UUID | None = UUID(self.conversation_id) if self.conversation_id else None
         user_uuid: UUID | None = UUID(self.user_id) if self.user_id else None

--- a/backend/tests/test_tool_progress_dedup.py
+++ b/backend/tests/test_tool_progress_dedup.py
@@ -141,3 +141,81 @@ def test_update_tool_result_allows_status_change_with_same_result(monkeypatch) -
             "status": "complete",
         }
     ]
+
+
+def test_json_safe_coerces_decimal_uuid_dates_and_null_bytes() -> None:
+    import json
+    from datetime import date, datetime, timezone
+    from decimal import Decimal
+
+    value_id = uuid4()
+    payload = {
+        "amount": Decimal("123.45"),
+        "whole": Decimal("42.00"),
+        "id": value_id,
+        "created_at": datetime(2026, 5, 13, 12, 30, tzinfo=timezone.utc),
+        "day": date(2026, 5, 13),
+        "bad_text": "hello\x00world",
+    }
+
+    safe = orchestrator.ChatOrchestrator._json_safe(payload)
+
+    json.dumps(safe)
+    assert safe["amount"] == 123.45
+    assert safe["whole"] == 42
+    assert safe["id"] == str(value_id)
+    assert safe["created_at"] == "2026-05-13T12:30:00+00:00"
+    assert safe["day"] == "2026-05-13"
+    assert safe["bad_text"] == "helloworld"
+
+
+def test_update_tool_result_sanitizes_decimal_result_before_save_and_publish(monkeypatch) -> None:
+    from decimal import Decimal
+
+    conversation_id = str(uuid4())
+    tool_id = "tool-decimal"
+    organization_id = str(uuid4())
+    message = SimpleNamespace(
+        content_blocks=[
+            {
+                "type": "tool_use",
+                "id": tool_id,
+                "name": "query_on_connector",
+                "status": "running",
+                "result": None,
+            }
+        ]
+    )
+    fake_session = _FakeSession(message)
+    broadcasts: list[dict[str, object]] = []
+
+    async def _fake_publish_tool_progress(**kwargs: object) -> bool:
+        broadcasts.append(kwargs)
+        return True
+
+    monkeypatch.setattr(
+        orchestrator,
+        "get_session",
+        lambda **_kwargs: _FakeSessionContext(fake_session),
+    )
+    monkeypatch.setattr(
+        tool_progress_pubsub,
+        "publish_tool_progress",
+        _fake_publish_tool_progress,
+    )
+
+    updated = asyncio.run(
+        orchestrator.update_tool_result(
+            conversation_id=conversation_id,
+            tool_id=tool_id,
+            result={"rows": [{"amount": Decimal("10.50"), "count": Decimal("3")}]},
+            status="complete",
+            organization_id=organization_id,
+        )
+    )
+
+    expected_result = {"rows": [{"amount": 10.5, "count": 3}]}
+    assert updated is True
+    assert fake_session.commit_calls == 1
+    assert message.content_blocks[0]["result"] == expected_result
+    assert broadcasts[0]["result"] == expected_result


### PR DESCRIPTION
### Motivation
- Tool results and assistant/user content occasionally included Python-native types (e.g. `Decimal`, `UUID`, `datetime`, `bytes`) and NUL bytes that caused `json.dumps` / asyncpg JSONB writes to fail with `TypeError` or `UntranslatableCharacterError` when persisting `chat_messages.content_blocks` or publishing tool progress. 
- The change centralizes serialization safety to avoid intermittent failures when saving or updating messages and to make tool-result publishing stable.

### Description
- Added a recursive helper `ChatOrchestrator._json_safe(obj: Any)` that normalizes `Decimal`, `UUID`, `date`/`datetime`, `bytes`, `set`/`tuple`, `dict` keys, and strips NUL bytes while leaving other JSON-serializable values unchanged. 
- Coerced tool `result` payloads with `ChatOrchestrator._json_safe` before updating `chat_messages.content_blocks` in `update_tool_result`. 
- Applied `self._json_safe(...)` to assistant early INSERTs, user message `content_blocks`, and final assistant saves so all chat persistence paths write JSON-safe values. 
- Added regression tests in `backend/tests/test_tool_progress_dedup.py` covering the `_json_safe` behavior and ensuring `Decimal`-containing tool results are sanitized for both DB save and publish paths. 

### Testing
- Ran `pytest backend/tests/test_tool_progress_dedup.py -q` and all tests passed (4 passed). 
- Performed Python compilation checks with `python -m compileall -q backend/agents/orchestrator.py backend/tests/test_tool_progress_dedup.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a049164d7c08321aa8f853cc973202b)