### PR TITLE
Decode escaped Unicode in app titles

### DIFF
--- a/backend/api/routes/apps.py
+++ b/backend/api/routes/apps.py
@@ -37,10 +37,16 @@ from services.app_query_runner import (
 )
 from services.org_admin import user_is_org_admin
 from services.workflow_pause import get_workflow_execution_pause_until
+from utils.text_encoding import decode_escaped_unicode_text
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _display_app_title(title: str | None) -> str | None:
+    return decode_escaped_unicode_text(title)
+
 
 # ---------------------------------------------------------------------------
 # Pydantic models
@@ -442,7 +448,7 @@ async def list_apps(
             items.append(
                 AppListItem(
                     id=str(a.id),
-                    title=a.title,
+                    title=_display_app_title(a.title),
                     description=a.description,
                     created_at=f"{a.created_at.isoformat()}Z" if a.created_at else None,
                     creator_name=creator.name if creator else None,
@@ -566,7 +572,7 @@ async def get_home_app(
         return {
             "app": {
                 "id": str(app.id),
-                "title": app.title,
+                "title": _display_app_title(app.title),
                 "description": app.description,
                 "frontendCode": app.frontend_code,
                 "frontendCodeCompiled": app.frontend_code_compiled,
@@ -643,7 +649,7 @@ async def list_widgets(
         widgets = [
             {
                 "id": str(a.id),
-                "title": a.title,
+                "title": _display_app_title(a.title),
                 "widget_config": _strip_screenshot(a.widget_config),
             }
             for a in apps
@@ -824,7 +830,7 @@ async def get_app(
 
         return {
             "id": str(app.id),
-            "title": app.title,
+            "title": _display_app_title(app.title),
             "description": app.description,
             "frontend_code": app.frontend_code,
             "frontend_code_compiled": app.frontend_code_compiled,
@@ -921,7 +927,7 @@ async def get_app_embed_data(
 
         return {
             "id": str(app.id),
-            "title": app.title,
+            "title": _display_app_title(app.title),
             "frontend_code": app.frontend_code,
             "frontend_code_compiled": app.frontend_code_compiled,
         }

--- a/backend/api/routes/public.py
+++ b/backend/api/routes/public.py
@@ -24,6 +24,7 @@ from models.database import get_admin_session, get_session
 from models.user import User
 from services.app_query_runner import AppQueryResponse as QueryResponse, run_named_app_query
 from services.public_previews import build_preview_html, decode_data_url_image, render_card_png
+from utils.text_encoding import decode_escaped_unicode_text
 
 router = APIRouter()
 share_router = APIRouter()
@@ -99,7 +100,7 @@ async def get_public_app(app_id: str) -> dict[str, Any]:
 
     return {
         "id": str(app.id),
-        "title": app.title,
+        "title": decode_escaped_unicode_text(app.title),
         "description": app.description,
         "frontend_code": app.frontend_code,
         "frontend_code_compiled": app.frontend_code_compiled,
@@ -251,7 +252,7 @@ def _public_preview_description(
     if conversation and conversation.title:
         return f"{conversation.title} — {owner_label}"
     if app and app.title:
-        return f"{app.title} — {owner_label}"
+        return f"{decode_escaped_unicode_text(app.title)} — {owner_label}"
     if artifact:
         return f"Document — {owner_label}"
     return f"Application — {owner_label}"
@@ -260,7 +261,7 @@ def _public_preview_description(
 def _public_preview_title(*, app: App | None = None, artifact: Artifact | None = None) -> str:
     """Build a specific page title so social previews never look generic."""
     if app and app.title:
-        return f"{app.title} · Basebase"
+        return f"{decode_escaped_unicode_text(app.title)} · Basebase"
     if artifact and artifact.title:
         return f"{artifact.title} · Basebase"
     if app:
@@ -391,7 +392,7 @@ async def get_public_app_share_snapshot(app_id: str) -> Response:
     logger.info("[public_preview] app screenshot missing; serving generated card app_id=%s", app_id)
     image_bytes = render_card_png(
         heading="Basebase App",
-        title=app.title or "Untitled App",
+        title=decode_escaped_unicode_text(app.title) or "Untitled App",
         description=app.description or "Interactive app shared from Basebase.",
         footer=f"App ID: {app_id}",
     )

--- a/backend/connectors/apps.py
+++ b/backend/connectors/apps.py
@@ -39,6 +39,7 @@ from services.workflow_pause import get_workflow_execution_pause_until
 from services.public_preview_warmup import warm_public_preview_cache
 from services.slack_identity import get_alternate_slack_user_ids_for_identity
 from services.sql_safety import prepare_safe_sql_query
+from utils.text_encoding import decode_escaped_unicode_text
 
 logger = logging.getLogger(__name__)
 
@@ -437,7 +438,7 @@ class AppsConnector(BaseConnector):
             # Materialize all needed fields while the instance is still bound
             # to the active SQLAlchemy session. This avoids DetachedInstanceError
             # when attribute refresh is attempted after context exit.
-            title: str = app.title
+            title: str = decode_escaped_unicode_text(app.title) or app.title
             description: str | None = app.description
             queries: dict[str, Any] = dict(app.queries or {})
             frontend_code: str = app.frontend_code
@@ -545,7 +546,10 @@ class AppsConnector(BaseConnector):
 
     async def _create(self, data: dict[str, Any]) -> dict[str, Any]:
         """Create a new app."""
-        title: str = str(data.get("title", "Untitled App"))
+        title: str = (
+            decode_escaped_unicode_text(str(data.get("title", "Untitled App")))
+            or "Untitled App"
+        )
         description: str = str(data.get("description", ""))
         queries: dict[str, Any] = data.get("queries", {})
         frontend_code: str = str(data.get("frontend_code", ""))
@@ -831,7 +835,7 @@ class AppsConnector(BaseConnector):
                 app.frontend_code_compiled = transpile_result[0] if transpile_result else None
 
             if new_title is not None:
-                app.title = str(new_title)
+                app.title = decode_escaped_unicode_text(str(new_title)) or str(new_title)
 
             if new_description is not None:
                 app.description = str(new_description)

--- a/backend/tests/test_app_title_unicode_decoding.py
+++ b/backend/tests/test_app_title_unicode_decoding.py
@@ -1,0 +1,80 @@
+import asyncio
+from contextlib import asynccontextmanager
+
+from connectors.apps import AppsConnector
+from utils.text_encoding import decode_escaped_unicode_text
+
+
+class _FakeExecuteResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _CreateSession:
+    def __init__(self):
+        self.added = []
+        self.committed = False
+
+    async def execute(self, query, _params=None):
+        if "organizations.handle" in str(query):
+            return _FakeExecuteResult(None)
+        raise AssertionError(f"Unexpected query: {query}")
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.committed = True
+
+
+def test_decode_escaped_unicode_text_decodes_surrogate_pair_escape():
+    assert decode_escaped_unicode_text(r"Chat \uD83D\uDCAC") == "Chat 💬"
+
+
+def test_decode_escaped_unicode_text_decodes_bmp_escape_without_touching_plain_emoji():
+    assert decode_escaped_unicode_text(r"Caf\u00E9 💬") == "Café 💬"
+
+
+def test_apps_connector_create_normalizes_escaped_unicode_title(monkeypatch):
+    fake_session = _CreateSession()
+
+    @asynccontextmanager
+    async def _fake_get_session(*_args, **_kwargs):
+        yield fake_session
+
+    async def _fake_warm(*_args, **_kwargs):
+        return None
+
+    async def _fake_test_execute_queries(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr("connectors.apps.get_session", _fake_get_session)
+    monkeypatch.setattr("connectors.apps.warm_public_preview_cache", _fake_warm)
+    monkeypatch.setattr("utils.transpile_jsx.transpile_jsx", lambda _code: (None,))
+    monkeypatch.setattr(
+        "connectors.apps.AppsConnector._test_execute_queries",
+        _fake_test_execute_queries,
+    )
+
+    connector = AppsConnector(
+        organization_id="00000000-0000-0000-0000-000000000001",
+        user_id="00000000-0000-0000-0000-000000000002",
+    )
+
+    result = asyncio.run(
+        connector._create(
+            {
+                "title": r"Chat \uD83D\uDCAC",
+                "queries": {"q": {"sql": "SELECT 1 AS n", "params": {}}},
+                "frontend_code": "export default function App(){ return <div/>; }",
+            }
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["app"]["title"] == "Chat 💬"
+    assert fake_session.added[0].title == "Chat 💬"
+    assert fake_session.committed is True

--- a/backend/utils/text_encoding.py
+++ b/backend/utils/text_encoding.py
@@ -1,0 +1,50 @@
+"""Utilities for normalizing text received from LLM/tool JSON payloads."""
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+_UNICODE_ESCAPE_RE = re.compile(r"(?:\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})+")
+
+
+def _combine_surrogate_code_units(value: str) -> str:
+    """Combine UTF-16 surrogate code units in a Python string when possible."""
+    if not any(0xD800 <= ord(ch) <= 0xDFFF for ch in value):
+        return value
+    try:
+        return value.encode("utf-16", "surrogatepass").decode("utf-16")
+    except UnicodeDecodeError:
+        logger.debug("Unable to combine surrogate code units in text value", exc_info=True)
+        return value
+
+
+def decode_escaped_unicode_text(value: str | None) -> str | None:
+    """Decode literal JSON-style Unicode escapes in user-visible text.
+
+    LLM/tool calls can occasionally double-escape titles, storing text such as
+    ``"Chat \\uD83D\\uDCAC"`` instead of ``"Chat 💬"``. This helper decodes only
+    JSON Unicode escape sequences and also combines valid UTF-16 surrogate pairs
+    that Python may retain after JSON parsing.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        value = str(value)
+
+    def _replace(match: re.Match[str]) -> str:
+        raw = match.group(0)
+        chars: list[str] = []
+        index = 0
+        while index < len(raw):
+            escape_type = raw[index + 1]
+            width = 8 if escape_type == "U" else 4
+            start = index + 2
+            end = start + width
+            chars.append(chr(int(raw[start:end], 16)))
+            index = end
+        return _combine_surrogate_code_units("".join(chars))
+
+    decoded = _UNICODE_ESCAPE_RE.sub(_replace, value)
+    return _combine_surrogate_code_units(decoded)


### PR DESCRIPTION
### Motivation
- App titles were sometimes stored or returned with literal JSON-style Unicode escapes (e.g. `\uD83D\uDCAC`) which appear as raw text instead of emoji for users.
- Ensure user-visible app titles (API responses, public previews, connector flows) show decoded/normalized text without altering unrelated fields.

### Description
- Add a shared utility `backend/utils/text_encoding.py` exposing `decode_escaped_unicode_text` which decodes JSON `\u`/`\U` escapes and combines UTF-16 surrogate pairs. 
- Normalize titles on app create/update/read boundaries in the connector by applying `decode_escaped_unicode_text` in `backend/connectors/apps.py`. 
- Decode titles in authenticated API responses by adding a `_display_app_title` wrapper and using it across `backend/api/routes/apps.py` (lists, home, widgets, detail, embed). 
- Decode titles for public pages and social preview generation in `backend/api/routes/public.py` and add tests in `backend/tests/test_app_title_unicode_decoding.py` verifying decoding and connector create behavior.

### Testing
- Ran `cd backend && pytest -q tests/test_app_title_unicode_decoding.py` which returned `3 passed`.
- Ran `cd backend && pytest -q tests/test_app_title_unicode_decoding.py tests/test_apps_connector_owner_resolution.py tests/test_public_previews.py` which returned `32 passed` (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a049b102f208321bf50dc905dce9e04)