### PR TITLE
Warn on MiniMax image attachments

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1806,16 +1806,16 @@ class ChatOrchestrator:
                     await report_anthropic_call_success(source="agents.orchestrator._stream_with_tools")
                     break
                     
-                except DeepSeekImageUnsupportedError:
+                except DeepSeekImageUnsupportedError as exc:
                     # This is a local capability guard, not a provider outage.
                     # Stream a normal assistant response so users see a helpful,
                     # persisted message instead of a raw task failure.
                     logger.info(
-                        "[Orchestrator] Friendly DeepSeek image rejection conversation_id=%s model=%s",
+                        "[Orchestrator] Friendly image rejection conversation_id=%s model=%s",
                         self.conversation_id,
                         model_name,
                     )
-                    friendly_message = DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE
+                    friendly_message = str(exc) or DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE
                     current_text = friendly_message
                     yield friendly_message
                     final_message_received = True

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -47,10 +47,15 @@ DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE: str = (
     "the image in this turn. Please switch to DeepSeek-V4-Vision or another "
     "vision-capable model, or resend your message without images."
 )
+MINIMAX_IMAGE_UNSUPPORTED_MESSAGE: str = (
+    "I can’t process image attachments with MiniMax. I haven’t analyzed "
+    "the image in this turn. Please switch to a vision-capable model, or "
+    "resend your message without images."
+)
 
 
 class DeepSeekImageUnsupportedError(ValueError):
-    """Raised when a text-only DeepSeek v4 model receives image inputs."""
+    """Raised when a text-only model receives image inputs."""
 
 
 def _normalized_model_name(model: str) -> str:
@@ -63,6 +68,11 @@ def is_deepseek_model(model: str) -> bool:
     return _normalized_model_name(model).startswith(DEEPSEEK_MODEL_PREFIXES)
 
 
+def is_minimax_model(model: str) -> bool:
+    """Return whether a model name targets MiniMax's Anthropic-compatible API."""
+    return _normalized_model_name(model).startswith("minimax")
+
+
 def is_deepseek_v4_vision_model(model: str) -> bool:
     """Return whether a DeepSeek v4 model explicitly supports image inputs."""
     return _normalized_model_name(model).startswith(DEEPSEEK_V4_VISION_MODEL_PREFIX)
@@ -72,6 +82,15 @@ def deepseek_v4_rejects_images(model: str) -> bool:
     """Return whether a DeepSeek v4 model is text-only for image inputs."""
     normalized_model: str = _normalized_model_name(model)
     return normalized_model.startswith("deepseek-v4") and not is_deepseek_v4_vision_model(model)
+
+
+def model_image_unsupported_message(model: str) -> str | None:
+    """Return a local image unsupported warning for known text-only models."""
+    if deepseek_v4_rejects_images(model):
+        return DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE
+    if is_minimax_model(model):
+        return MINIMAX_IMAGE_UNSUPPORTED_MESSAGE
+    return None
 
 
 def messages_contain_images(messages: list[dict[str, Any]]) -> bool:
@@ -313,6 +332,7 @@ class AnthropicAdapter:
         thinking: bool = False,
         max_tokens: int = 32768,
     ) -> AsyncIterator[StreamEvent]:
+        self._guard_model_image_support(model=model, messages=messages)
         api_messages: list[dict[str, Any]] = self.format_messages_for_api(messages)
         api_kwargs: dict[str, Any] = {
             "model": model,
@@ -394,6 +414,7 @@ class AnthropicAdapter:
         messages: list[dict[str, Any]],
         max_tokens: int = 1024,
     ) -> CompletedMessage:
+        self._guard_model_image_support(model=model, messages=messages)
         api_messages: list[dict[str, Any]] = self.format_messages_for_api(messages)
         response = await self._client.messages.create(
             model=model,
@@ -414,14 +435,15 @@ class AnthropicAdapter:
         self, *, model: str, messages: list[dict[str, Any]]
     ) -> None:
         """Fail locally before sending images to text-only model variants."""
-        if not deepseek_v4_rejects_images(model) or not messages_contain_images(messages):
+        unsupported_message = model_image_unsupported_message(model)
+        if unsupported_message is None or not messages_contain_images(messages):
             return
 
         logger.info(
-            "Rejected image-bearing request for text-only DeepSeek v4 model",
-            extra={"model": model},
+            "Rejected image-bearing request for text-only model",
+            extra={"model": model, "adapter": self.__class__.__name__},
         )
-        raise DeepSeekImageUnsupportedError(DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE)
+        raise DeepSeekImageUnsupportedError(unsupported_message)
 
     def format_tools(self, tools: list[ToolDef]) -> list[dict[str, Any]]:
         return [
@@ -770,14 +792,15 @@ class OpenAIAdapter:
         self, *, model: str, messages: list[dict[str, Any]]
     ) -> None:
         """Fail locally before sending images to text-only model variants."""
-        if not deepseek_v4_rejects_images(model) or not messages_contain_images(messages):
+        unsupported_message = model_image_unsupported_message(model)
+        if unsupported_message is None or not messages_contain_images(messages):
             return
 
         logger.info(
-            "Rejected image-bearing request for text-only DeepSeek v4 model",
-            extra={"model": model},
+            "Rejected image-bearing request for text-only model",
+            extra={"model": model, "adapter": self.__class__.__name__},
         )
-        raise DeepSeekImageUnsupportedError(DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE)
+        raise DeepSeekImageUnsupportedError(unsupported_message)
 
     def format_tools(self, tools: list[ToolDef]) -> list[dict[str, Any]]:
         return [

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -5,7 +5,14 @@ import httpx
 import pytest
 from openai import APIStatusError
 
-from services.llm_adapter import LLMConfig, OpenAIAdapter, PROVIDER_BASE_URLS, get_adapter
+from services.llm_adapter import (
+    LLMConfig,
+    MINIMAX_IMAGE_UNSUPPORTED_MESSAGE,
+    AnthropicAdapter,
+    OpenAIAdapter,
+    PROVIDER_BASE_URLS,
+    get_adapter,
+)
 
 
 class _EmptyAsyncIterator:
@@ -499,6 +506,37 @@ def test_deepseek_v4_vision_model_allows_image_messages():
         "type": "image_url",
         "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
     }
+
+
+def test_minimax_model_rejects_image_messages_before_formatting():
+    adapter = AnthropicAdapter(api_key="test-key", supports_document_blocks=False)
+
+    with pytest.raises(ValueError, match="MiniMax"):
+        adapter._guard_model_image_support(
+            model="MiniMax-M2.7",
+            messages=_image_message(),
+        )
+
+
+def test_minimax_provider_prefix_rejects_image_messages_before_formatting():
+    adapter = AnthropicAdapter(api_key="test-key", supports_document_blocks=False)
+
+    with pytest.raises(ValueError) as exc_info:
+        adapter._guard_model_image_support(
+            model="minimax/MiniMax-M2.7-highspeed",
+            messages=_image_message(),
+        )
+
+    assert str(exc_info.value) == MINIMAX_IMAGE_UNSUPPORTED_MESSAGE
+
+
+def test_anthropic_model_allows_image_messages():
+    adapter = AnthropicAdapter(api_key="test-key")
+
+    adapter._guard_model_image_support(
+        model="claude-opus-4-6",
+        messages=_image_message(),
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_orchestrator_text_only_image_warnings.py
+++ b/backend/tests/test_orchestrator_text_only_image_warnings.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agents import orchestrator as orchestrator_module
+from agents.orchestrator import ChatOrchestrator
+from services.llm_adapter import (
+    DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE,
+    MINIMAX_IMAGE_UNSUPPORTED_MESSAGE,
+    DeepSeekImageUnsupportedError,
+    LLMConfig,
+)
+
+
+class _RejectingAdapter:
+    def __init__(self, message: str) -> None:
+        self._message = message
+
+    async def stream(self, *_args: Any, **_kwargs: Any):
+        if False:
+            yield None
+        raise DeepSeekImageUnsupportedError(self._message)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "model", "message"),
+    [
+        ("deepseek", "deepseek-v4-pro", DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE),
+        ("minimax", "MiniMax-M2.7", MINIMAX_IMAGE_UNSUPPORTED_MESSAGE),
+    ],
+)
+async def test_orchestrator_streams_friendly_text_only_image_error(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+    model: str,
+    message: str,
+) -> None:
+    monkeypatch.setattr(orchestrator_module, "get_tool_defs_for_context", lambda _ctx: [])
+
+    orchestrator = ChatOrchestrator(
+        user_id="00000000-0000-0000-0000-000000000001",
+        organization_id="00000000-0000-0000-0000-000000000002",
+        conversation_id="00000000-0000-0000-0000-000000000003",
+    )
+    orchestrator._adapter = _RejectingAdapter(message)  # noqa: SLF001
+    orchestrator._llm_config = LLMConfig(  # noqa: SLF001
+        provider=provider,  # type: ignore[arg-type]
+        primary_model=model,
+        cheap_model=model,
+        workflow_model=model,
+        api_key="test-key",
+        base_url="https://example.invalid",
+    )
+
+    content_blocks: list[dict[str, Any]] = []
+    chunks = [
+        chunk
+        async for chunk in orchestrator._stream_with_tools(  # noqa: SLF001
+            messages=[{"role": "user", "content": [{"type": "image", "source": {}}]}],
+            system_prompt="system",
+            content_blocks=content_blocks,
+            model_name=model,
+        )
+    ]
+
+    assert chunks == [message]
+    assert content_blocks == [{"type": "text", "text": message}]


### PR DESCRIPTION
### Motivation

- Text-only LLM variants (previously DeepSeek-only) should refuse image inputs locally for other providers that do not support vision, to give users a helpful rejection instead of sending invalid requests to providers.

### Description

- Add a MiniMax-specific unsupported-image message `MINIMAX_IMAGE_UNSUPPORTED_MESSAGE` and a `is_minimax_model` helper, and factor `model_image_unsupported_message` to choose provider-specific text in `services/llm_adapter.py`.
- Generalize the image-guard so both `AnthropicAdapter` and `OpenAIAdapter` call `_guard_model_image_support` before streaming and completion calls, and raise a `DeepSeekImageUnsupportedError` whose message now reflects the provider-specific warning.
- Update the orchestrator friendly-rejection path to stream the actual exception message (`str(exc)`) so the user-visible assistant message matches the provider-specific text.
- Add tests: new `backend/tests/test_orchestrator_text_only_image_warnings.py` and additional adapter tests in `backend/tests/test_llm_adapter_openai_token_params.py` covering MiniMax rejection, provider-prefixed MiniMax names, and Anthropic/DeepSeek behaviors.

### Testing

- Ran the targeted backend test suite: `cd backend && pytest -q tests/test_llm_adapter_openai_token_params.py tests/test_orchestrator_text_only_image_warnings.py tests/test_orchestrator_deepseek_images.py tests/test_anthropic_health.py` and all tests passed.
- New and updated tests exercise both streaming and non-streaming adapter guards and the orchestrator friendly-rejection path, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a19b2f5083218eecd29fdc612e6c)