### PR TITLE
Fix connector constructor integration filters

### DIFF
--- a/backend/connectors/apollo.py
+++ b/backend/connectors/apollo.py
@@ -59,10 +59,16 @@ class ApolloConnector(BaseConnector):
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         """Initialize Apollo connector."""
         super().__init__(
-            organization_id, user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
 
     async def _get_api_key(self) -> str:

--- a/backend/connectors/asana.py
+++ b/backend/connectors/asana.py
@@ -89,9 +89,15 @@ class AsanaConnector(BaseConnector):
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         super().__init__(
-            organization_id, user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
         self._workspace_gid: Optional[str] = None
 

--- a/backend/connectors/ispot_tv.py
+++ b/backend/connectors/ispot_tv.py
@@ -73,9 +73,15 @@ class ISpotTvConnector(BaseConnector):
         user_id: str | None = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         super().__init__(
-            organization_id, user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
         self._token_expires_at: datetime | None = None
 

--- a/backend/connectors/jira.py
+++ b/backend/connectors/jira.py
@@ -93,9 +93,15 @@ class JiraConnector(BaseConnector):
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         super().__init__(
-            organization_id, user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
         self._cloud_id: Optional[str] = None
         self._base_url: Optional[str] = None

--- a/backend/connectors/linear.py
+++ b/backend/connectors/linear.py
@@ -214,9 +214,15 @@ Use `write_on_connector(connector='linear', operation='...', data={...})` with `
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         super().__init__(
-            organization_id, user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
 
     # ── GraphQL helpers ──────────────────────────────────────────────────

--- a/backend/connectors/trello.py
+++ b/backend/connectors/trello.py
@@ -172,9 +172,15 @@ class TrelloConnector(BaseConnector):
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         super().__init__(
-            organization_id, user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
         self._member_me_id: Optional[str] = None
 

--- a/backend/tests/test_connector_constructor_filters.py
+++ b/backend/tests/test_connector_constructor_filters.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from connectors.apollo import ApolloConnector
+from connectors.asana import AsanaConnector
+from connectors.ispot_tv import ISpotTvConnector
+from connectors.jira import JiraConnector
+from connectors.linear import LinearConnector
+from connectors.trello import TrelloConnector
+
+
+@pytest.mark.parametrize(
+    "connector_cls",
+    [
+        ApolloConnector,
+        AsanaConnector,
+        ISpotTvConnector,
+        JiraConnector,
+        LinearConnector,
+        TrelloConnector,
+    ],
+)
+def test_connector_constructors_accept_integration_filters(connector_cls: type) -> None:
+    """Generic connector tools always pass multi-account filters into connector constructors."""
+    integration_id = "11111111-1111-1111-1111-111111111111"
+
+    connector = connector_cls(
+        organization_id="00000000-0000-0000-0000-000000000001",
+        user_id="00000000-0000-0000-0000-000000000002",
+        integration_id=integration_id,
+        account_identifier="linear-workspace",
+    )
+
+    assert connector._integration_id_filter == UUID(integration_id)
+    assert connector._account_identifier_filter == "linear-workspace"


### PR DESCRIPTION
### Motivation

- The generic connector tools pass `integration_id`/`account_identifier` filters into connector constructors for multi-account selection, which caused `LinearConnector.__init__()` to raise an unexpected keyword argument error.
- Align connector constructors with the `BaseConnector` contract so multi-account filtering and owner-scoped operations work reliably across tracker and query connectors.

### Description

- Added `integration_id: str | None = None` and `account_identifier: str | None = None` kwargs to connector constructors and forwarded them into `BaseConnector.__init__` for `Linear`, `Jira`, `Asana`, `Trello`, `iSpotTv`, and `Apollo` connectors (files under `backend/connectors/*.py`).
- Ensured the constructor call uses the explicit keyword forwarding: `integration_id=integration_id` and `account_identifier=account_identifier` so `_integration_id_filter` and `_account_identifier_filter` are populated consistently.
- Added a regression test `backend/tests/test_connector_constructor_filters.py` which instantiates the affected connectors with `integration_id`/`account_identifier` and asserts the filters are set on the connector instance.

### Testing

- Ran the new test with `pytest -q backend/tests/test_connector_constructor_filters.py`, which passed.
- Ran targeted connector and tools tests with `pytest -q backend/tests/test_linear_connector_assignment.py backend/tests/test_linear_issue_attachments.py backend/tests/test_tools_write_to_system_of_record.py`, and they all passed.
- Performed a quick `git diff --check` style verification to ensure no whitespace/format issues were introduced and none were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a64336848321b8058ff0c50ab7a8)