### PR TITLE
Allow intentionally empty LLM responses in system prompt

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -357,6 +357,8 @@ Do NOT narrate internal lookups like `get_connector_docs` or `list_connected_con
 
 Also please keep your responses concise and to the point (1-2 sentences), UNLESS the user is specifically asking your for detailed information.
 
+If the user's text does not require a response or action, you may do nothing and send an intentionally empty response.
+
 ## Planning for Complex Tasks
 
 For multi-step requests (e.g. "enrich these contacts and update their deals", "build me a report comparing X and Y"), call the `think` tool first to plan your approach before executing. In your plan, identify:

--- a/backend/tests/test_orchestrator_system_prompt.py
+++ b/backend/tests/test_orchestrator_system_prompt.py
@@ -1,0 +1,5 @@
+from agents.orchestrator import SYSTEM_PROMPT_MAIN
+
+
+def test_system_prompt_allows_intentionally_empty_response() -> None:
+    assert "may do nothing and send an intentionally empty response" in SYSTEM_PROMPT_MAIN


### PR DESCRIPTION
### Motivation
- Provide a concise system-prompt option so the LLM may choose to do nothing and send an intentionally empty response when the user's text does not require a reply or action.

### Description
- Add a single-line instruction to `SYSTEM_PROMPT_MAIN` in `backend/agents/orchestrator.py` and add `backend/tests/test_orchestrator_system_prompt.py` which asserts the new guidance is present.

### Testing
- Ran `pytest tests/test_orchestrator_system_prompt.py` in `backend/` and the new test passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a2d8489883219176193823340cd7)