### PR TITLE
Accept integration scope in connector constructors

### DIFF
--- a/backend/connectors/apollo.py
+++ b/backend/connectors/apollo.py
@@ -59,10 +59,16 @@ class ApolloConnector(BaseConnector):
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         """Initialize Apollo connector."""
         super().__init__(
-            organization_id, user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
 
     async def _get_api_key(self) -> str:

--- a/backend/connectors/asana.py
+++ b/backend/connectors/asana.py
@@ -89,9 +89,15 @@ class AsanaConnector(BaseConnector):
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         super().__init__(
-            organization_id, user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
         self._workspace_gid: Optional[str] = None
 

--- a/backend/connectors/ispot_tv.py
+++ b/backend/connectors/ispot_tv.py
@@ -73,9 +73,15 @@ class ISpotTvConnector(BaseConnector):
         user_id: str | None = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         super().__init__(
-            organization_id, user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
         self._token_expires_at: datetime | None = None
 

--- a/backend/connectors/jira.py
+++ b/backend/connectors/jira.py
@@ -93,9 +93,15 @@ class JiraConnector(BaseConnector):
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         super().__init__(
-            organization_id, user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
         self._cloud_id: Optional[str] = None
         self._base_url: Optional[str] = None

--- a/backend/connectors/linear.py
+++ b/backend/connectors/linear.py
@@ -214,9 +214,15 @@ Use `write_on_connector(connector='linear', operation='...', data={...})` with `
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         super().__init__(
-            organization_id, user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
 
     # ── GraphQL helpers ──────────────────────────────────────────────────

--- a/backend/connectors/trello.py
+++ b/backend/connectors/trello.py
@@ -172,9 +172,15 @@ class TrelloConnector(BaseConnector):
         user_id: Optional[str] = None,
         *,
         sync_since_override: datetime | None = None,
+        integration_id: str | None = None,
+        account_identifier: str | None = None,
     ) -> None:
         super().__init__(
-            organization_id, user_id, sync_since_override=sync_since_override
+            organization_id,
+            user_id,
+            sync_since_override=sync_since_override,
+            integration_id=integration_id,
+            account_identifier=account_identifier,
         )
         self._member_me_id: Optional[str] = None
 

--- a/backend/tests/test_connector_constructor_scope.py
+++ b/backend/tests/test_connector_constructor_scope.py
@@ -1,0 +1,37 @@
+"""Connector constructor compatibility tests."""
+from __future__ import annotations
+
+from uuid import UUID
+
+from connectors.base import BaseConnector
+from connectors.registry import discover_connectors
+
+
+_ORG_ID = "00000000-0000-0000-0000-000000000001"
+_USER_ID = "00000000-0000-0000-0000-000000000002"
+_INTEGRATION_ID = "00000000-0000-0000-0000-000000000003"
+_ACCOUNT_IDENTIFIER = "acct_constructor_scope"
+
+
+def test_discovered_connectors_accept_integration_scope_kwargs() -> None:
+    """All registry connectors must tolerate integration scoping kwargs.
+
+    Dynamic connector callers pass these kwargs uniformly.  Connectors that do
+    not need them should still forward them to BaseConnector so scoped DB
+    lookups continue to work when the connector later calls shared helpers.
+    """
+    registry = discover_connectors()
+
+    assert registry, "expected at least one discovered connector"
+
+    for slug, connector_cls in registry.items():
+        connector = connector_cls(
+            _ORG_ID,
+            user_id=_USER_ID,
+            integration_id=_INTEGRATION_ID,
+            account_identifier=_ACCOUNT_IDENTIFIER,
+        )
+
+        assert isinstance(connector, BaseConnector), slug
+        assert connector._integration_id_filter == UUID(_INTEGRATION_ID), slug
+        assert connector._account_identifier_filter == _ACCOUNT_IDENTIFIER, slug


### PR DESCRIPTION
### Motivation

- Dynamic callers sometimes need to scope connector instances to a particular Integration row; several connector constructors did not accept the scoping kwargs and therefore could not preserve that filter state. 
- Make connector instantiation uniform so callers can pass `integration_id` and `account_identifier` without connector-specific changes and so `BaseConnector` can perform scoped DB lookups.

### Description

- Updated connector constructors to accept `integration_id` and `account_identifier` and forward them to `BaseConnector` for: `apollo`, `asana`, `ispot_tv`, `jira`, `linear`, and `trello` (files under `backend/connectors/`).
- Ensured the forwarded args set the `BaseConnector` filters (`_integration_id_filter`, `_account_identifier_filter`) so later lookup helpers behave correctly.
- Added `backend/tests/test_connector_constructor_scope.py` which instantiates every discovered connector via `discover_connectors()` with `integration_id` and `account_identifier` and asserts the BaseConnector filters are set.

### Testing

- Ran `pytest -q backend/tests/test_connector_constructor_scope.py` and it passed.
- Ran `pytest -q backend/tests/test_connector_constructor_scope.py backend/tests/test_list_connectors.py` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a7d6fff48321829e8d9c683a2712)