### PR TITLE
Teach Slack agent SAY_NOTHING sentinel

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -357,7 +357,7 @@ Do NOT narrate internal lookups like `get_connector_docs` or `list_connected_con
 
 Also please keep your responses concise and to the point (1-2 sentences), UNLESS the user is specifically asking your for detailed information.
 
-If the user's text does not require a response or action, you may do nothing and send an intentionally empty response.
+If the user's text does not require a response or action, you may do nothing and send an intentionally empty response. For inbound Slack messages specifically, output exactly `SAY_NOTHING` (with no other text) when no response is needed; Slack delivery will suppress that token instead of posting it.
 
 ## Planning for Complex Tasks
 

--- a/backend/messengers/_workspace.py
+++ b/backend/messengers/_workspace.py
@@ -906,6 +906,16 @@ class WorkspaceMessenger(BaseMessenger):
                 text_to_send = current_text[:break_idx].strip()
                 current_text = current_text[break_idx:]
 
+            if text_to_send == "SAY_NOTHING":
+                logger.info(
+                    "[%s] Suppressing SAY_NOTHING sentinel response channel=%s thread_id=%s reason=%s",
+                    self.meta.slug,
+                    channel_id,
+                    thread_id,
+                    reason,
+                )
+                return
+
             if not text_to_send:
                 return
 

--- a/backend/tests/test_orchestrator_system_prompt.py
+++ b/backend/tests/test_orchestrator_system_prompt.py
@@ -3,3 +3,8 @@ from agents.orchestrator import SYSTEM_PROMPT_MAIN
 
 def test_system_prompt_allows_intentionally_empty_response() -> None:
     assert "may do nothing and send an intentionally empty response" in SYSTEM_PROMPT_MAIN
+
+
+def test_system_prompt_documents_slack_say_nothing_sentinel() -> None:
+    assert "output exactly `SAY_NOTHING`" in SYSTEM_PROMPT_MAIN
+    assert "Slack delivery will suppress that token" in SYSTEM_PROMPT_MAIN

--- a/backend/tests/test_workspace_stream_error_query_outcome.py
+++ b/backend/tests/test_workspace_stream_error_query_outcome.py
@@ -115,3 +115,35 @@ def test_stream_and_post_responses_posts_deepseek_image_error_copy() -> None:
     assert failure_reason == DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE
     assert total > 0
     assert messenger.posted_messages[-1]["text"] == DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE
+
+
+class _SayNothingOrchestrator:
+    async def process_message(self, *_args, **_kwargs):
+        yield "SAY_NOTHING"
+
+
+def test_stream_and_post_responses_suppresses_say_nothing_sentinel() -> None:
+    messenger = _TestWorkspaceMessenger()
+    message = InboundMessage(
+        external_user_id="U123",
+        text="thanks",
+        message_type=MessageType.DIRECT,
+        messenger_context={"channel_id": "C123", "thread_ts": "t-1", "workspace_id": "W123"},
+        message_id="m-1",
+    )
+
+    async def _run() -> tuple[int, bool, str | None]:
+        return await messenger.stream_and_post_responses(
+            orchestrator=_SayNothingOrchestrator(),
+            message=message,
+            message_text="thanks",
+            attachment_ids=None,
+            organization_id="org-1",
+        )
+
+    total, query_failed, failure_reason = asyncio.run(_run())
+
+    assert total == 0
+    assert query_failed is False
+    assert failure_reason is None
+    assert messenger.posted_messages == []


### PR DESCRIPTION
### Motivation

- Make it explicit in the agent system prompt that inbound Slack messages may emit a sentinel when no reply is needed so the model can intentionally choose silence.
- Ensure the streaming messenger layer does not post that sentinel back to Slack (suppress it server-side) to avoid annoying or confusing empty messages.
- Add tests to document the prompt guidance and to validate that the sentinel is suppressed in streaming delivery.

### Description

- Updated the orchestrator system prompt in `backend/agents/orchestrator.py` to document that for inbound Slack messages the agent may output exactly `SAY_NOTHING` when no response is required.  
- Added suppression logic in the workspace messenger in `backend/messengers/_workspace.py` so that when a streamed flush yields the exact text `SAY_NOTHING` it is logged and not posted to Slack.  
- Added unit tests: `backend/tests/test_orchestrator_system_prompt.py` now checks the new prompt text and `backend/tests/test_workspace_stream_error_query_outcome.py` includes a test ensuring a `SAY_NOTHING` yield results in no outbound posted messages.

### Testing

- Ran the targeted tests with `PYTHONPATH=backend pytest -q backend/tests/test_orchestrator_system_prompt.py backend/tests/test_workspace_stream_error_query_outcome.py`.  
- Results: all tests passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b1ee5e848321ac09178cd3667b73)