### PR TITLE
fix(mcp): accept wrapper-param aliases in call_tool action

### DIFF
--- a/backend/connectors/mcp.py
+++ b/backend/connectors/mcp.py
@@ -37,6 +37,17 @@ MCP_PROTOCOL_VERSION: str = "2025-03-26"
 MCP_CLIENT_INFO: dict[str, str] = {"name": "basebase", "version": "1.0.0"}
 DEFAULT_TIMEOUT: float = 60.0
 
+# Common aliases the LLM may use when calling the `call_tool` action.
+# The canonical names are the first entry of each tuple.
+_TOOL_NAME_ALIASES: tuple[str, ...] = ("tool", "tool_name", "name")
+_ARGUMENTS_ALIASES: tuple[str, ...] = (
+    "arguments",
+    "args",
+    "tool_args",
+    "parameters",
+    "input",
+)
+
 
 # ---------------------------------------------------------------------------
 # Generic MCP client (Streamable HTTP transport, JSON-RPC 2.0)
@@ -221,12 +232,19 @@ class McpConnector(BaseConnector):
         actions=[
             ConnectorAction(
                 name="call_tool",
-                description="Call a tool on the connected MCP server",
+                description=(
+                    "Call a tool on the connected MCP server. "
+                    "Pass params={'tool': '<tool_name>', 'arguments': {…}} where "
+                    "<tool_name> is one of the MCP tools discovered via list_tools, "
+                    "and 'arguments' is an object matching that tool's inputSchema "
+                    "(use {} if the tool takes no arguments). "
+                    "Example: params={'tool': 'search_docs', 'arguments': {'query': 'hello'}}."
+                ),
                 parameters=[
                     {"name": "tool", "type": "string", "required": True,
-                     "description": "Name of the MCP tool to call"},
+                     "description": "Name of the MCP tool to call (from list_tools)"},
                     {"name": "arguments", "type": "object", "required": False,
-                     "description": "Arguments to pass to the tool"},
+                     "description": "Object matching the tool's inputSchema. Pass {} if the tool takes no arguments. Do NOT inline the inner tool's fields at the top level of params."},
                 ],
             ),
         ],
@@ -249,9 +267,17 @@ class McpConnector(BaseConnector):
         ],
         usage_guide=(
             "This connector lets you interact with a remote MCP server.\n\n"
-            "1. Use query_on_connector(connector='<SLUG>', query='list_tools') to see available tools.\n"
+            "1. Use query_on_connector(connector='<SLUG>', query='list_tools') to "
+            "see available tools and their inputSchemas.\n"
             "2. Use run_on_connector(connector='<SLUG>', action='call_tool', "
             "params={'tool': '<tool_name>', 'arguments': {…}}) to invoke a tool.\n\n"
+            "IMPORTANT: there are two parameter layers — do not conflate them.\n"
+            "  - OUTER (the wrapper): params must be exactly {'tool': ..., 'arguments': ...}.\n"
+            "  - INNER (passed to the MCP tool): the 'arguments' object must match the\n"
+            "    tool's own inputSchema (e.g. {'type': 'X (Twitter) Trending', 'limit': 15}).\n"
+            "Do NOT inline the inner tool's fields (like 'type', 'limit') at the top level of params.\n"
+            "Do NOT use 'tool_name' / 'tool_args' / 'args' — the canonical wrapper keys are\n"
+            "'tool' and 'arguments' (other variants are accepted for robustness but discouraged).\n\n"
             "Replace <SLUG> with the actual connector slug (e.g. mcp_deepwiki).\n"
             "The available tools depend on which MCP server the user has connected."
         ),
@@ -317,16 +343,65 @@ class McpConnector(BaseConnector):
     # ACTION capability
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _resolve_tool_and_arguments(
+        params: dict[str, Any],
+    ) -> tuple[str | None, dict[str, Any], list[str]]:
+        """Pull the tool name + arguments out of ``params``, accepting common aliases.
+
+        Returns ``(tool_name, arguments, alias_warnings)``. ``tool_name`` is None
+        when no canonical or alias key holds a non-empty string. ``alias_warnings``
+        is a list of human-readable notes about non-canonical keys the caller used.
+        """
+        tool_name: str | None = None
+        tool_alias_used: str | None = None
+        for key in _TOOL_NAME_ALIASES:
+            candidate: Any = params.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                tool_name = candidate.strip()
+                tool_alias_used = key
+                break
+
+        arguments: dict[str, Any] = {}
+        arg_alias_used: str | None = None
+        for key in _ARGUMENTS_ALIASES:
+            candidate = params.get(key)
+            if isinstance(candidate, dict):
+                arguments = candidate
+                arg_alias_used = key
+                break
+
+        warnings: list[str] = []
+        if tool_alias_used and tool_alias_used != _TOOL_NAME_ALIASES[0]:
+            warnings.append(
+                f"Used non-canonical key '{tool_alias_used}' for the tool name; "
+                f"prefer '{_TOOL_NAME_ALIASES[0]}'."
+            )
+        if arg_alias_used and arg_alias_used != _ARGUMENTS_ALIASES[0]:
+            warnings.append(
+                f"Used non-canonical key '{arg_alias_used}' for the tool arguments; "
+                f"prefer '{_ARGUMENTS_ALIASES[0]}'."
+            )
+        return tool_name, arguments, warnings
+
     async def execute_action(self, action: str, params: dict[str, Any]) -> dict[str, Any]:
         """Call a tool on the MCP server."""
         if action != "call_tool":
             raise ValueError(f"Unknown action: {action}. Use 'call_tool'.")
 
-        tool_name: str | None = params.get("tool")
+        tool_name, arguments, alias_warnings = self._resolve_tool_and_arguments(params)
         if not tool_name:
-            return {"error": "Missing required parameter 'tool' (name of the MCP tool to call)"}
+            return {
+                "error": (
+                    "Missing required parameter 'tool' (the name of the MCP tool to call). "
+                    "Call run_on_connector with params={'tool': '<tool_name>', 'arguments': {…}}. "
+                    "Use query_on_connector(query='list_tools') first to see the available tool names."
+                ),
+                "received_keys": sorted(params.keys()),
+            }
 
-        arguments: dict[str, Any] = params.get("arguments") or {}
+        for note in alias_warnings:
+            logger.warning("[McpConnector] %s", note)
 
         endpoint_url, auth_header, _cached_tools = await self._get_mcp_config()
         client: GenericMcpClient = self._make_client(endpoint_url, auth_header)
@@ -340,7 +415,13 @@ class McpConnector(BaseConnector):
             return {"error": f"HTTP error calling MCP tool '{tool_name}': {exc.response.status_code}"}
 
         text_output: str = _extract_text_from_content(result)
-        return {"tool": tool_name, "output": text_output}
+        response: dict[str, Any] = {"tool": tool_name, "output": text_output}
+        if alias_warnings:
+            response["warning"] = (
+                "Non-canonical parameter keys were used and remapped. "
+                + " ".join(alias_warnings)
+            )
+        return response
 
     # ------------------------------------------------------------------
     # Stubs for abstract methods (MCP connector does not sync CRM data)

--- a/backend/tests/test_mcp_connector_actions.py
+++ b/backend/tests/test_mcp_connector_actions.py
@@ -1,0 +1,193 @@
+"""Tests for McpConnector.execute_action wrapper-param handling.
+
+The MCP connector exposes a single ``call_tool`` action whose ``params`` dict
+wraps the MCP tool name + arguments. The LLM frequently guesses at the wrapper
+key names (``tool_name`` / ``tool_args`` / ``args``), so the connector accepts
+common aliases and surfaces a clear error when the tool name is missing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from connectors.mcp import GenericMcpClient, McpConnector
+
+
+def _connector() -> McpConnector:
+    return McpConnector(
+        "00000000-0000-0000-0000-000000000001",
+        user_id="00000000-0000-0000-0000-000000000002",
+    )
+
+
+def _patch_mcp_io(
+    monkeypatch: pytest.MonkeyPatch,
+    recorded: list[tuple[str, dict[str, Any]]],
+    *,
+    result: Any = None,
+) -> None:
+    """Stub out config loading, client construction, and the actual RPC calls."""
+
+    async def fake_get_mcp_config(
+        self: McpConnector,
+    ) -> tuple[str, str | None, list[dict[str, Any]]]:
+        return ("https://mcp.example.com/mcp", None, [])
+
+    async def fake_initialize(self: GenericMcpClient) -> dict[str, Any]:
+        return {}
+
+    async def fake_call_tool(
+        self: GenericMcpClient,
+        tool_name: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> Any:
+        recorded.append((tool_name, arguments or {}))
+        return result if result is not None else {
+            "content": [{"type": "text", "text": "ok"}]
+        }
+
+    monkeypatch.setattr(McpConnector, "_get_mcp_config", fake_get_mcp_config)
+    monkeypatch.setattr(GenericMcpClient, "initialize", fake_initialize)
+    monkeypatch.setattr(GenericMcpClient, "call_tool", fake_call_tool)
+
+
+@pytest.mark.asyncio
+async def test_execute_action_unknown_raises() -> None:
+    c: McpConnector = _connector()
+    with pytest.raises(ValueError, match="Unknown action"):
+        await c.execute_action("not_a_real_action", {})
+
+
+@pytest.mark.asyncio
+async def test_execute_action_canonical_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The canonical {'tool', 'arguments'} shape works without warnings."""
+    recorded: list[tuple[str, dict[str, Any]]] = []
+    _patch_mcp_io(monkeypatch, recorded)
+
+    c: McpConnector = _connector()
+    out: dict[str, Any] = await c.execute_action(
+        "call_tool",
+        {"tool": "search_docs", "arguments": {"query": "hello"}},
+    )
+
+    assert recorded == [("search_docs", {"query": "hello"})]
+    assert out["tool"] == "search_docs"
+    assert out["output"] == "ok"
+    assert "warning" not in out
+
+
+@pytest.mark.asyncio
+async def test_execute_action_accepts_tool_name_and_tool_args_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LLM-guessed 'tool_name' + 'tool_args' should be normalised and forwarded."""
+    recorded: list[tuple[str, dict[str, Any]]] = []
+    _patch_mcp_io(monkeypatch, recorded)
+
+    c: McpConnector = _connector()
+    out: dict[str, Any] = await c.execute_action(
+        "call_tool",
+        {
+            "tool_name": "get_top_trends",
+            "tool_args": {"type": "X (Twitter) Trending", "limit": 15},
+        },
+    )
+
+    assert recorded == [
+        ("get_top_trends", {"type": "X (Twitter) Trending", "limit": 15})
+    ]
+    assert out["tool"] == "get_top_trends"
+    warning: str = out["warning"]
+    assert "tool_name" in warning
+    assert "tool_args" in warning
+
+
+@pytest.mark.asyncio
+async def test_execute_action_accepts_args_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """{'tool', 'args'} should forward the args dict through, not drop it.
+
+    This is the precise failure mode observed in the wild: when 'args' was
+    silently ignored, the remote MCP server returned a confusing
+    'missing required field' error because it received no arguments.
+    """
+    recorded: list[tuple[str, dict[str, Any]]] = []
+    _patch_mcp_io(monkeypatch, recorded)
+
+    c: McpConnector = _connector()
+    out: dict[str, Any] = await c.execute_action(
+        "call_tool",
+        {"tool": "get_top_trends", "args": {"type": "X (Twitter) Trending"}},
+    )
+
+    assert recorded == [("get_top_trends", {"type": "X (Twitter) Trending"})]
+    assert "warning" in out
+
+
+@pytest.mark.asyncio
+async def test_execute_action_prefers_canonical_when_both_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both canonical and alias keys are present, prefer the canonical key."""
+    recorded: list[tuple[str, dict[str, Any]]] = []
+    _patch_mcp_io(monkeypatch, recorded)
+
+    c: McpConnector = _connector()
+    out: dict[str, Any] = await c.execute_action(
+        "call_tool",
+        {
+            "tool": "real_tool",
+            "tool_name": "wrong_tool",
+            "arguments": {"a": 1},
+            "args": {"a": 999},
+        },
+    )
+
+    assert recorded == [("real_tool", {"a": 1})]
+    assert "warning" not in out
+
+
+@pytest.mark.asyncio
+async def test_execute_action_missing_tool_returns_helpful_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing tool name returns an error that points the LLM at the right shape."""
+    recorded: list[tuple[str, dict[str, Any]]] = []
+    _patch_mcp_io(monkeypatch, recorded)
+
+    c: McpConnector = _connector()
+    out: dict[str, Any] = await c.execute_action(
+        "call_tool",
+        {"arguments": {"query": "hello"}},
+    )
+
+    assert recorded == []
+    error_text: str = out["error"]
+    assert "tool" in error_text
+    assert "'tool'" in error_text
+    assert "arguments" in error_text
+    assert out["received_keys"] == ["arguments"]
+
+
+@pytest.mark.asyncio
+async def test_execute_action_empty_arguments_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool with no arguments still resolves to an empty dict."""
+    recorded: list[tuple[str, dict[str, Any]]] = []
+    _patch_mcp_io(monkeypatch, recorded)
+
+    c: McpConnector = _connector()
+    out: dict[str, Any] = await c.execute_action(
+        "call_tool",
+        {"tool": "ping"},
+    )
+
+    assert recorded == [("ping", {})]
+    assert out["tool"] == "ping"
+    assert out["output"] == "ok"


### PR DESCRIPTION
## Summary

When the agent calls a tool on a connected MCP server (e.g. `mcp_trendsmcp`), it invokes the wrapper `run_on_connector(connector=…, action='call_tool', params={'tool': …, 'arguments': …})`. In practice the LLM confused that **outer wrapper** with the **inner MCP tool's own `inputSchema`** and kept guessing variants — first `{tool_name, tool_args}` (rejected), then `{tool, args}` (silently dropped → remote MCP server returned a confusing "missing required field" error), and finally `{tool, arguments}` (success). Two wasted round-trips and ~6 wasted credits before each successful MCP call.

This PR makes the wrapper robust and self-documenting:

- `McpConnector.execute_action` now accepts `tool_name`/`name` as aliases for `tool`, and `args`/`tool_args`/`parameters`/`input` as aliases for `arguments`. When a non-canonical key is used, the response includes a `warning` field and a server log line so we still nudge callers (and us) toward the canonical shape.
- The `call_tool` action description, `usage_guide`, and the missing-`tool` error message now explicitly call out the **outer vs inner parameter layer** distinction and include a concrete example, so the LLM gets it right on the first try.
- The missing-`tool` error payload now echoes back `received_keys` so the LLM can self-correct.
- New tests in `backend/tests/test_mcp_connector_actions.py` (7 cases) lock in: canonical shape, `tool_name`+`tool_args` aliasing, the precise `{tool, args}` failure mode from the wild, alias precedence under the canonical, the helpful missing-tool error, and empty-arguments default.

## Test plan

- [x] `pytest -q tests` (831 passed)
- [x] `pytest -q tests/test_mcp_connector_actions.py` (7 new tests pass)
- [x] `npm run build` (frontend builds cleanly)
- [ ] Manually replay the trendsMCP flow in the local app to confirm a single successful call from the agent


Made with [Cursor](https://cursor.com)