### PR TITLE
Fix MiniMax adaptive thinking requests

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -313,12 +313,14 @@ class AnthropicAdapter:
         api_key: str,
         base_url: str | None = None,
         supports_document_blocks: bool = True,
+        supports_adaptive_thinking: bool = True,
     ) -> None:
         kwargs: dict[str, Any] = {"api_key": api_key}
         if base_url is not None:
             kwargs["base_url"] = base_url
         self._client: AsyncAnthropic = AsyncAnthropic(**kwargs)
         self._supports_document_blocks: bool = supports_document_blocks
+        self._supports_adaptive_thinking: bool = supports_adaptive_thinking
 
     # -- streaming ----------------------------------------------------------
 
@@ -342,8 +344,7 @@ class AnthropicAdapter:
         }
         if tools:
             api_kwargs["tools"] = self.format_tools(tools)
-        if thinking:
-            api_kwargs["thinking"] = {"type": "adaptive"}
+        api_kwargs.update(self._build_thinking_kwargs(model=model, thinking=thinking))
 
         self._current_block_type = "text"
         async with self._client.messages.stream(**api_kwargs) as stream:
@@ -430,6 +431,19 @@ class AnthropicAdapter:
         )
 
     # -- formatting helpers -------------------------------------------------
+
+    def _build_thinking_kwargs(self, *, model: str, thinking: bool) -> dict[str, Any]:
+        """Return Anthropic-compatible thinking controls supported by this adapter."""
+        if not thinking:
+            return {}
+        if self._supports_adaptive_thinking:
+            return {"thinking": {"type": "adaptive"}}
+
+        logger.info(
+            "Skipping adaptive thinking for Anthropic-compatible provider without support",
+            extra={"model": model, "adapter": self.__class__.__name__},
+        )
+        return {}
 
     def _guard_model_image_support(
         self, *, model: str, messages: list[dict[str, Any]]
@@ -1007,6 +1021,7 @@ def get_adapter(config: LLMConfig) -> AnthropicAdapter | OpenAIAdapter:
             api_key=config.api_key,
             base_url=base_url,
             supports_document_blocks=supports_docs,
+            supports_adaptive_thinking=provider == "anthropic",
         )
 
     if provider in ("openai", "gemini", "qwen", "deepseek"):

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -47,6 +47,39 @@ def _openai_api_status_error(message: str, status_code: int = 404) -> APIStatusE
     )
 
 
+def test_anthropic_thinking_kwargs_use_adaptive_when_supported():
+    adapter = AnthropicAdapter(api_key="test-key")
+
+    assert adapter._build_thinking_kwargs(model="claude-opus-4-6", thinking=True) == {
+        "thinking": {"type": "adaptive"}
+    }
+
+
+def test_minimax_thinking_kwargs_are_omitted_when_unsupported():
+    adapter = AnthropicAdapter(
+        api_key="test-key",
+        supports_document_blocks=False,
+        supports_adaptive_thinking=False,
+    )
+
+    assert adapter._build_thinking_kwargs(model="MiniMax-M2.7", thinking=True) == {}
+
+
+def test_minimax_factory_disables_adaptive_thinking():
+    adapter = get_adapter(
+        LLMConfig(
+            provider="minimax",
+            primary_model="MiniMax-M2.7",
+            cheap_model="MiniMax-M2.7-highspeed",
+            workflow_model="MiniMax-M2.7-highspeed",
+            api_key="test-key",
+        )
+    )
+
+    assert isinstance(adapter, AnthropicAdapter)
+    assert adapter._build_thinking_kwargs(model="MiniMax-M2.7", thinking=True) == {}
+
+
 def test_openai_gpt5_uses_max_completion_tokens():
     adapter = OpenAIAdapter(api_key="test-key")
 
@@ -528,7 +561,6 @@ def test_minimax_provider_prefix_rejects_image_messages_before_formatting():
         )
 
     assert str(exc_info.value) == MINIMAX_IMAGE_UNSUPPORTED_MESSAGE
-
 
 def test_anthropic_model_allows_image_messages():
     adapter = AnthropicAdapter(api_key="test-key")


### PR DESCRIPTION
### Motivation
- MiniMax (Anthropic-compatible) requests were always sent with `thinking: {"type": "adaptive"}`, which some MiniMax models reject and produced 400 errors.
- The change makes thinking controls provider-aware so only providers that support adaptive thinking receive that parameter.

### Description
- Added a `supports_adaptive_thinking` flag to `AnthropicAdapter` and stored it on the adapter instance as `_supports_adaptive_thinking`.
- Replaced the unconditional `api_kwargs["thinking"] = {"type": "adaptive"}` with a provider-aware helper `._build_thinking_kwargs(...)` and applied it via `api_kwargs.update(...)` in the Anthropic stream path.
- Updated `get_adapter` to set `supports_adaptive_thinking=provider == "anthropic"` so `minimax` adapters created by the factory omit adaptive thinking.
- Added unit tests `test_anthropic_thinking_kwargs_use_adaptive_when_supported`, `test_minimax_thinking_kwargs_are_omitted_when_unsupported`, and `test_minimax_factory_disables_adaptive_thinking` to cover expected behavior.

### Testing
- Ran `pytest backend/tests/test_llm_adapter_openai_token_params.py -q`, and the test suite passed (`32 passed`).
- Ran `git diff --check` to verify there are no whitespace/issues; it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05251fa09c8321b805efb342b25598)