### PR TITLE
Gate Anthropic adaptive thinking to supported models (avoid Haiku)

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -52,6 +52,12 @@ MINIMAX_IMAGE_UNSUPPORTED_MESSAGE: str = (
     "the image in this turn. Please switch to a vision-capable model, or "
     "resend your message without images."
 )
+ANTHROPIC_ADAPTIVE_THINKING_MODEL_PREFIXES: tuple[str, ...] = (
+    "claude-mythos-preview",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+)
 
 
 class DeepSeekImageUnsupportedError(ValueError):
@@ -71,6 +77,13 @@ def is_deepseek_model(model: str) -> bool:
 def is_minimax_model(model: str) -> bool:
     """Return whether a model name targets MiniMax's Anthropic-compatible API."""
     return _normalized_model_name(model).startswith("minimax")
+
+
+def supports_anthropic_adaptive_thinking(model: str) -> bool:
+    """Return whether an Anthropic-family model accepts adaptive thinking."""
+    return _normalized_model_name(model).startswith(
+        ANTHROPIC_ADAPTIVE_THINKING_MODEL_PREFIXES
+    )
 
 
 def is_deepseek_v4_vision_model(model: str) -> bool:
@@ -342,8 +355,7 @@ class AnthropicAdapter:
         }
         if tools:
             api_kwargs["tools"] = self.format_tools(tools)
-        if thinking:
-            api_kwargs["thinking"] = {"type": "adaptive"}
+        api_kwargs.update(self._build_thinking_kwargs(model=model, thinking=thinking))
 
         self._current_block_type = "text"
         async with self._client.messages.stream(**api_kwargs) as stream:
@@ -360,6 +372,23 @@ class AnthropicAdapter:
                 )
 
     _current_block_type: str = "text"
+
+    def _build_thinking_kwargs(self, *, model: str, thinking: bool) -> dict[str, Any]:
+        """Return Anthropic Messages API thinking options supported by the model."""
+        if not thinking:
+            return {}
+        if supports_anthropic_adaptive_thinking(model):
+            logger.debug(
+                "Anthropic adaptive thinking controls selected",
+                extra={"model": model, "thinking_type": "adaptive"},
+            )
+            return {"thinking": {"type": "adaptive"}}
+
+        logger.info(
+            "Skipping Anthropic adaptive thinking for unsupported model",
+            extra={"model": model, "thinking_requested": thinking},
+        )
+        return {}
 
     def _translate_event(self, event: Any) -> list[StreamEvent]:
         """Translate a single Anthropic stream event into common StreamEvents."""

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -9,6 +9,7 @@ from services.llm_adapter import (
     LLMConfig,
     MINIMAX_IMAGE_UNSUPPORTED_MESSAGE,
     AnthropicAdapter,
+    supports_anthropic_adaptive_thinking,
     OpenAIAdapter,
     PROVIDER_BASE_URLS,
     get_adapter,
@@ -45,6 +46,37 @@ def _openai_api_status_error(message: str, status_code: int = 404) -> APIStatusE
         response=response,
         body={"error": {"type": "not_found_error", "message": message}},
     )
+
+
+def test_anthropic_adaptive_thinking_supported_models_send_adaptive():
+    adapter = AnthropicAdapter(api_key="test-key")
+
+    assert supports_anthropic_adaptive_thinking("claude-opus-4-6")
+    assert supports_anthropic_adaptive_thinking("claude-opus-4-6-20260401")
+    assert supports_anthropic_adaptive_thinking("claude-sonnet-4-6")
+    assert adapter._build_thinking_kwargs(
+        model="claude-opus-4-6",
+        thinking=True,
+    ) == {"thinking": {"type": "adaptive"}}
+
+
+def test_anthropic_adaptive_thinking_omitted_for_haiku():
+    adapter = AnthropicAdapter(api_key="test-key")
+
+    assert not supports_anthropic_adaptive_thinking("claude-haiku-4-5-20251001")
+    assert adapter._build_thinking_kwargs(
+        model="claude-haiku-4-5-20251001",
+        thinking=True,
+    ) == {}
+
+
+def test_anthropic_adaptive_thinking_omitted_when_not_requested():
+    adapter = AnthropicAdapter(api_key="test-key")
+
+    assert adapter._build_thinking_kwargs(
+        model="claude-opus-4-6",
+        thinking=False,
+    ) == {}
 
 
 def test_openai_gpt5_uses_max_completion_tokens():
@@ -528,7 +560,6 @@ def test_minimax_provider_prefix_rejects_image_messages_before_formatting():
         )
 
     assert str(exc_info.value) == MINIMAX_IMAGE_UNSUPPORTED_MESSAGE
-
 
 def test_anthropic_model_allows_image_messages():
     adapter = AnthropicAdapter(api_key="test-key")


### PR DESCRIPTION
### Motivation
- Prevent sending Anthropic "adaptive thinking" parameters to models that do not support them because that causes provider errors (e.g. the 400 "adaptive thinking is not supported on this model" observed with Haiku). 

### Description
- Add `ANTHROPIC_ADAPTIVE_THINKING_MODEL_PREFIXES` and `supports_anthropic_adaptive_thinking()` to detect Anthropic models that accept adaptive thinking. 
- Add `AnthropicAdapter._build_thinking_kwargs()` and change `AnthropicAdapter.stream()` to use it so adaptive thinking is only added when supported. 
- Log an informational message when adaptive thinking is requested but omitted for unsupported Anthropic models. 
- Add unit tests to `backend/tests/test_llm_adapter_openai_token_params.py` covering supported Anthropic models, omission for `claude-haiku-4-5-20251001`, and omission when `thinking=False`.

### Testing
- Ran `pytest -q backend/tests/test_llm_adapter_openai_token_params.py -q` and the test suite for that file passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05277aa3448321a6c96d2ce2970c9f)