### PR TITLE
Handle warned images for text-only models

### DIFF
--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -206,7 +206,7 @@ def strip_image_blocks_for_text_only_model(
 
         if len(filtered_content) == len(content):
             stripped_messages.append(msg)
-        else:
+        elif filtered_content:
             stripped_messages.append({**msg, "content": filtered_content})
 
     if removed_count:

--- a/backend/services/llm_adapter.py
+++ b/backend/services/llm_adapter.py
@@ -106,19 +106,115 @@ def model_image_unsupported_message(model: str) -> str | None:
     return None
 
 
+def _is_image_block(block: Any) -> bool:
+    """Return whether a content block carries image bytes/URLs."""
+    if not isinstance(block, dict):
+        return False
+    block_type: str = str(block.get("type", "")).lower()
+    return block_type in {"image", "image_url"}
+
+
 def messages_contain_images(messages: list[dict[str, Any]]) -> bool:
     """Detect image content blocks before dispatching to a provider API."""
     for msg in messages:
         content: Any = msg.get("content")
         if not isinstance(content, list):
             continue
-        for block in content:
-            if not isinstance(block, dict):
-                continue
-            block_type: str = str(block.get("type", "")).lower()
-            if block_type in {"image", "image_url"}:
-                return True
+        if any(_is_image_block(block) for block in content):
+            return True
     return False
+
+
+def _content_text(content: Any) -> str:
+    """Extract user-visible text from common message content shapes."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
+            parts.append(str(block.get("text", "")))
+        elif block_type == "tool_result":
+            parts.append(str(block.get("content", "")))
+    return "\n".join(parts)
+
+
+def _is_text_only_image_warning(content: Any) -> bool:
+    """Detect assistant turns that already warned about text-only image support."""
+    text = _content_text(content).lower()
+    if not text:
+        return False
+    return (
+        "can’t process image attachments" in text
+        or "can't process image attachments" in text
+        or "haven’t analyzed the image" in text
+        or "haven't analyzed the image" in text
+    )
+
+
+def messages_contain_unwarned_images(messages: list[dict[str, Any]]) -> bool:
+    """Return whether images appear after the latest text-only image warning.
+
+    Images are intentionally preserved in stored conversation history. For
+    text-only models, a prior assistant warning marks the earlier image-bearing
+    user turn as acknowledged, so later model calls can silently omit those
+    image blocks instead of repeating the same refusal.
+    """
+    has_image_since_warning = False
+    for msg in messages:
+        role = msg.get("role")
+        content: Any = msg.get("content")
+        if isinstance(content, list) and any(
+            _is_image_block(block) for block in content
+        ):
+            has_image_since_warning = True
+            continue
+
+        if (
+            role == "assistant"
+            and has_image_since_warning
+            and _is_text_only_image_warning(content)
+        ):
+            has_image_since_warning = False
+
+    return has_image_since_warning
+
+
+def strip_image_blocks_for_text_only_model(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return a copy of messages with image blocks removed for text-only models."""
+    stripped_messages: list[dict[str, Any]] = []
+    removed_count = 0
+    for msg in messages:
+        content: Any = msg.get("content")
+        if not isinstance(content, list):
+            stripped_messages.append(msg)
+            continue
+
+        filtered_content: list[Any] = []
+        for block in content:
+            if _is_image_block(block):
+                removed_count += 1
+                continue
+            filtered_content.append(block)
+
+        if len(filtered_content) == len(content):
+            stripped_messages.append(msg)
+        else:
+            stripped_messages.append({**msg, "content": filtered_content})
+
+    if removed_count:
+        logger.info(
+            "Dropped image blocks before text-only model dispatch",
+            extra={"removed_image_blocks": removed_count},
+        )
+    return stripped_messages
 
 
 def _get_attr_or_item(value: Any, name: str, default: Any = None) -> Any:
@@ -345,8 +441,10 @@ class AnthropicAdapter:
         thinking: bool = False,
         max_tokens: int = 32768,
     ) -> AsyncIterator[StreamEvent]:
-        self._guard_model_image_support(model=model, messages=messages)
-        api_messages: list[dict[str, Any]] = self.format_messages_for_api(messages)
+        prepared_messages = self._prepare_messages_for_model(
+            model=model, messages=messages
+        )
+        api_messages: list[dict[str, Any]] = self.format_messages_for_api(prepared_messages)
         api_kwargs: dict[str, Any] = {
             "model": model,
             "max_tokens": max_tokens,
@@ -443,8 +541,10 @@ class AnthropicAdapter:
         messages: list[dict[str, Any]],
         max_tokens: int = 1024,
     ) -> CompletedMessage:
-        self._guard_model_image_support(model=model, messages=messages)
-        api_messages: list[dict[str, Any]] = self.format_messages_for_api(messages)
+        prepared_messages = self._prepare_messages_for_model(
+            model=model, messages=messages
+        )
+        api_messages: list[dict[str, Any]] = self.format_messages_for_api(prepared_messages)
         response = await self._client.messages.create(
             model=model,
             max_tokens=max_tokens,
@@ -463,9 +563,9 @@ class AnthropicAdapter:
     def _guard_model_image_support(
         self, *, model: str, messages: list[dict[str, Any]]
     ) -> None:
-        """Fail locally before sending images to text-only model variants."""
+        """Fail locally before sending new images to text-only model variants."""
         unsupported_message = model_image_unsupported_message(model)
-        if unsupported_message is None or not messages_contain_images(messages):
+        if unsupported_message is None or not messages_contain_unwarned_images(messages):
             return
 
         logger.info(
@@ -473,6 +573,15 @@ class AnthropicAdapter:
             extra={"model": model, "adapter": self.__class__.__name__},
         )
         raise DeepSeekImageUnsupportedError(unsupported_message)
+
+    def _prepare_messages_for_model(
+        self, *, model: str, messages: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Validate image support and strip already-warned images if needed."""
+        self._guard_model_image_support(model=model, messages=messages)
+        if model_image_unsupported_message(model) is None:
+            return messages
+        return strip_image_blocks_for_text_only_model(messages)
 
     def format_tools(self, tools: list[ToolDef]) -> list[dict[str, Any]]:
         return [
@@ -626,10 +735,12 @@ class OpenAIAdapter:
         thinking: bool = False,
         max_tokens: int = 32768,
     ) -> AsyncIterator[StreamEvent]:
-        self._guard_model_image_support(model=model, messages=messages)
+        prepared_messages = self._prepare_messages_for_model(
+            model=model, messages=messages
+        )
         api_messages: list[dict[str, Any]] = [
             {"role": "system", "content": system}
-        ] + self.format_messages_for_api(messages)
+        ] + self.format_messages_for_api(prepared_messages)
 
         api_kwargs: dict[str, Any] = {
             "messages": api_messages,
@@ -772,10 +883,12 @@ class OpenAIAdapter:
         messages: list[dict[str, Any]],
         max_tokens: int = 1024,
     ) -> CompletedMessage:
-        self._guard_model_image_support(model=model, messages=messages)
+        prepared_messages = self._prepare_messages_for_model(
+            model=model, messages=messages
+        )
         api_messages: list[dict[str, Any]] = [
             {"role": "system", "content": system}
-        ] + self.format_messages_for_api(messages)
+        ] + self.format_messages_for_api(prepared_messages)
 
         response: Any = None
         model_candidates: list[str] = [model, *self._openai_not_found_fallback_models(model)]
@@ -820,9 +933,9 @@ class OpenAIAdapter:
     def _guard_model_image_support(
         self, *, model: str, messages: list[dict[str, Any]]
     ) -> None:
-        """Fail locally before sending images to text-only model variants."""
+        """Fail locally before sending new images to text-only model variants."""
         unsupported_message = model_image_unsupported_message(model)
-        if unsupported_message is None or not messages_contain_images(messages):
+        if unsupported_message is None or not messages_contain_unwarned_images(messages):
             return
 
         logger.info(
@@ -830,6 +943,15 @@ class OpenAIAdapter:
             extra={"model": model, "adapter": self.__class__.__name__},
         )
         raise DeepSeekImageUnsupportedError(unsupported_message)
+
+    def _prepare_messages_for_model(
+        self, *, model: str, messages: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Validate image support and strip already-warned images if needed."""
+        self._guard_model_image_support(model=model, messages=messages)
+        if model_image_unsupported_message(model) is None:
+            return messages
+        return strip_image_blocks_for_text_only_model(messages)
 
     def format_tools(self, tools: list[ToolDef]) -> list[dict[str, Any]]:
         return [

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -529,6 +529,23 @@ def _warned_image_history():
     ]
 
 
+def _image_only_message():
+    return [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "media_type": "image/png",
+                        "data": "iVBORw0KGgo=",
+                    },
+                },
+            ],
+        }
+    ]
+
+
 def test_deepseek_v4_text_model_rejects_image_messages_before_formatting():
     adapter = OpenAIAdapter(api_key="test-key")
 
@@ -688,6 +705,28 @@ def test_deepseek_v4_text_model_rejects_new_image_after_prior_warning():
             model="deepseek-v4-pro",
             messages=messages,
         )
+
+
+def test_deepseek_v4_text_model_strips_already_warned_image_only_turn():
+    adapter = OpenAIAdapter(api_key="test-key")
+    messages = [
+        _image_only_message()[0],
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE}
+            ],
+        },
+        {"role": "user", "content": "Please continue without the image."},
+    ]
+
+    prepared = adapter._prepare_messages_for_model(
+        model="deepseek-v4-pro",
+        messages=messages,
+    )
+
+    assert prepared == messages[1:]
+    assert messages[0]["content"][0]["type"] == "image"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_llm_adapter_openai_token_params.py
+++ b/backend/tests/test_llm_adapter_openai_token_params.py
@@ -7,6 +7,7 @@ from openai import APIStatusError
 
 from services.llm_adapter import (
     LLMConfig,
+    DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE,
     MINIMAX_IMAGE_UNSUPPORTED_MESSAGE,
     AnthropicAdapter,
     supports_anthropic_adaptive_thinking,
@@ -515,6 +516,19 @@ def _image_message():
     ]
 
 
+def _warned_image_history():
+    return [
+        _image_message()[0],
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": DEEPSEEK_V4_IMAGE_UNSUPPORTED_MESSAGE}
+            ],
+        },
+        {"role": "user", "content": "Thanks, please continue without the image."},
+    ]
+
+
 def test_deepseek_v4_text_model_rejects_image_messages_before_formatting():
     adapter = OpenAIAdapter(api_key="test-key")
 
@@ -560,6 +574,34 @@ def test_minimax_provider_prefix_rejects_image_messages_before_formatting():
         )
 
     assert str(exc_info.value) == MINIMAX_IMAGE_UNSUPPORTED_MESSAGE
+
+
+def test_minimax_model_allows_already_warned_image_history():
+    adapter = AnthropicAdapter(api_key="test-key", supports_document_blocks=False)
+    messages = [
+        _image_message()[0],
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": MINIMAX_IMAGE_UNSUPPORTED_MESSAGE}
+            ],
+        },
+        {"role": "user", "content": "Please continue without the image."},
+    ]
+
+    adapter._guard_model_image_support(
+        model="MiniMax-M2.7",
+        messages=messages,
+    )
+
+    prepared = adapter._prepare_messages_for_model(
+        model="MiniMax-M2.7",
+        messages=messages,
+    )
+    assert prepared[0]["content"] == [
+        {"type": "text", "text": "What is in this image?"}
+    ]
+
 
 def test_anthropic_model_allows_image_messages():
     adapter = AnthropicAdapter(api_key="test-key")
@@ -616,3 +658,61 @@ async def test_deepseek_v4_vision_stream_sends_images_to_api():
         "type": "image_url",
         "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
     }
+
+
+def test_deepseek_v4_text_model_allows_already_warned_image_history():
+    adapter = OpenAIAdapter(api_key="test-key")
+    messages = _warned_image_history()
+
+    adapter._guard_model_image_support(
+        model="deepseek-v4-pro",
+        messages=messages,
+    )
+
+    prepared = adapter._prepare_messages_for_model(
+        model="deepseek-v4-pro",
+        messages=messages,
+    )
+    assert messages[0]["content"][1]["type"] == "image"
+    assert prepared[0]["content"] == [
+        {"type": "text", "text": "What is in this image?"}
+    ]
+
+
+def test_deepseek_v4_text_model_rejects_new_image_after_prior_warning():
+    adapter = OpenAIAdapter(api_key="test-key")
+    messages = _warned_image_history() + _image_message()
+
+    with pytest.raises(ValueError, match="DeepSeek-V4-Vision"):
+        adapter._guard_model_image_support(
+            model="deepseek-v4-pro",
+            messages=messages,
+        )
+
+
+@pytest.mark.asyncio
+async def test_deepseek_v4_stream_drops_already_warned_images_at_api_layer():
+    adapter = OpenAIAdapter(api_key="test-key")
+    create_mock = AsyncMock(return_value=_EmptyAsyncIterator())
+    adapter._client = SimpleNamespace(  # type: ignore[assignment]
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+    )
+    messages = _warned_image_history()
+
+    events = [
+        event
+        async for event in adapter.stream(
+            model="deepseek-v4-pro",
+            system="sys",
+            messages=messages,
+            max_tokens=42,
+        )
+    ]
+
+    assert events == []
+    assert create_mock.await_count == 1
+    sent_messages = create_mock.await_args.kwargs["messages"]
+    assert sent_messages[1]["content"] == [
+        {"type": "text", "text": "What is in this image?"}
+    ]
+    assert messages[0]["content"][1]["type"] == "image"


### PR DESCRIPTION
### Motivation
- Prevent repeated "I can’t process image attachments" replies by treating an assistant warning as acknowledgement of prior images and only rejecting new image submissions for text-only models. 
- Preserve original conversation content while removing previously-warned image blocks from the payload sent to text-only provider APIs so future model swaps can still access the images.

### Description
- Add helpers to detect image blocks and extract visible text, plus logic to detect whether an assistant previously warned about text-only image support (`_is_image_block`, `_content_text`, `_is_text_only_image_warning`, `messages_contain_unwarned_images`).
- Implement image-stripping for API dispatch with `strip_image_blocks_for_text_only_model` and a central `_prepare_messages_for_model` path that adapters call before formatting/sending provider requests. 
- Change Anthropic/MiniMax (`AnthropicAdapter`) and OpenAI/DeepSeek (`OpenAIAdapter`) streaming and completion flows to use the new preparation path and to only raise the friendly rejection for image blocks that are "unwarned". 
- Add tests covering warned-image history handling, rejection of newly added images after a prior warning, and verifying the API-layer drops already-warned images while keeping the stored context intact (`backend/tests/test_llm_adapter_openai_token_params.py`).

### Testing
- Ran the focused test suite: `pytest backend/tests/test_llm_adapter_openai_token_params.py backend/tests/test_orchestrator_text_only_image_warnings.py backend/tests/test_orchestrator_deepseek_images.py` and observed all tests pass. 
- Full run of the affected tests produced: `39 passed` (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a055d9fef5c8321b171229be2779613)