### PR TITLE
feat: token-cost-based credit system

### DIFF
--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -1705,6 +1705,7 @@ class ChatOrchestrator:
             is_thinking_block: bool = False
             final_message_received: bool = False
             context_retry_needed = False
+            llm_out_of_credits: bool = False
 
             # Keep provider-agnostic message history here; provider adapters are
             # responsible for final API translation.
@@ -1823,11 +1824,26 @@ class ChatOrchestrator:
                                 current_tool_input_json = ""
 
                         elif event.type == "usage":
+                            usage_input: int = int(event.input_tokens or 0)
+                            usage_output: int = int(event.output_tokens or 0)
                             yield _json_dumps({
                                 "type": "context_usage",
-                                "input_tokens": event.input_tokens,
-                                "output_tokens": event.output_tokens,
+                                "input_tokens": usage_input,
+                                "output_tokens": usage_output,
                             })
+                            if self.organization_id and (usage_input > 0 or usage_output > 0):
+                                from services.credits import deduct_for_llm
+
+                                charge_ok, used_grace = await deduct_for_llm(
+                                    self.organization_id,
+                                    model_name,
+                                    usage_input,
+                                    usage_output,
+                                    user_id=self.user_id,
+                                    conversation_id=self.conversation_id,
+                                )
+                                if not charge_ok or used_grace:
+                                    llm_out_of_credits = True
 
                     final_message_received = True
                     await report_anthropic_call_success(source="agents.orchestrator._stream_with_tools")
@@ -1930,6 +1946,22 @@ class ChatOrchestrator:
             # If we exhausted retries without success, raise the last error
             if not final_message_received and last_error is not None:
                 raise last_error
+
+            if llm_out_of_credits:
+                out_of_credits_message = (
+                    "You're out of credits. I paused here before finishing your last request. "
+                    "Please add a payment method in Basebase to continue."
+                )
+                logger.info(
+                    "[Orchestrator] Ending turn after LLM usage charge org_id=%s conversation_id=%s",
+                    self.organization_id,
+                    self.conversation_id,
+                )
+                if current_text.strip():
+                    content_blocks.append({"type": "text", "text": current_text})
+                content_blocks.append({"type": "text", "text": out_of_credits_message})
+                yield out_of_credits_message
+                break
             
             # If no tool calls, we're done
             if not tool_uses:

--- a/backend/agents/tools.py
+++ b/backend/agents/tools.py
@@ -292,15 +292,15 @@ async def execute_tool(
         return {"error": "No organization associated with user. Please complete onboarding."}
 
     conversation_id: str | None = (context or {}).get("conversation_id")
-    # Deduct credits before running the tool (fail fast if insufficient); import here to avoid circular import
-    from services.credits import credits_for_tool, deduct_with_grace
-    cost: int = credits_for_tool(tool_name, tool_input or {}, context)
+    from services.credits import credits_for_external_surcharge, deduct_with_grace
+
+    surcharge: int = credits_for_external_surcharge(tool_name, tool_input or {}, context)
     used_grace_credits: bool = False
-    if cost > 0:
+    if surcharge > 0:
         ok, used_grace_credits = await deduct_with_grace(
             organization_id,
-            cost,
-            "tool",
+            surcharge,
+            "tool_surcharge",
             reference_type="conversation",
             reference_id=conversation_id,
             user_id=user_id,
@@ -2320,6 +2320,10 @@ async def _openai_web_search_fallback(
     query: str,
     context_answer: str | None,
     provider_context: str | None = None,
+    *,
+    organization_id: str | None = None,
+    user_id: str | None = None,
+    conversation_id: str | None = None,
 ) -> dict[str, Any] | None:
     """Run an OpenAI synthesis pass for web-search results using known context."""
     if not settings.OPENAI_API_KEY:
@@ -2375,6 +2379,17 @@ async def _openai_web_search_fallback(
                     model,
                 )
                 continue
+            if organization_id and response.usage is not None:
+                from services.credits import deduct_for_llm
+
+                await deduct_for_llm(
+                    organization_id,
+                    model,
+                    int(response.usage.prompt_tokens or 0),
+                    int(response.usage.completion_tokens or 0),
+                    user_id=user_id,
+                    conversation_id=conversation_id,
+                )
             return {
                 "answer": content,
                 "provider": "openai",

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -20,7 +20,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
 from api.websockets import websocket_endpoint
-from api.routes import action_ledger, admin_dashboard, apps, artifacts, auth, billing, change_sessions, chat, connectors, daily_digests, data, deals, drive, memories, notifications, public, search, slack_events, slack_user_mappings, support, sync, teams_events, tool_settings, topic_graph, twilio_events, whatsapp_events, waitlist, workstreams, workflows
+from api.routes import action_ledger, admin_dashboard, admin_models, apps, artifacts, auth, billing, change_sessions, chat, connectors, daily_digests, data, deals, drive, memories, notifications, public, search, slack_events, slack_user_mappings, support, sync, teams_events, tool_settings, topic_graph, twilio_events, whatsapp_events, waitlist, workstreams, workflows
 from models.database import close_db, get_pool_status
 from services.task_manager import task_manager
 from config import log_missing_env_vars, settings
@@ -183,6 +183,7 @@ app.include_router(whatsapp_events.router, prefix="/api/whatsapp", tags=["whatsa
 app.include_router(teams_events.router, prefix="/api/teams", tags=["teams"])
 app.include_router(action_ledger.router, prefix="/api", tags=["action-ledger"])
 app.include_router(admin_dashboard.router, prefix="/api/admin-dashboard", tags=["admin-dashboard"])
+app.include_router(admin_models.router, prefix="/api/admin/models", tags=["admin-models"])
 app.include_router(topic_graph.router, prefix="/api/admin-topic-graph", tags=["admin-topic-graph"])
 # Keep share router after /api routers so generic org-slug routes (e.g. /{org_slug}/artifacts/{id})
 # do not shadow concrete API endpoints like /api/artifacts/{id}.

--- a/backend/api/routes/admin_models.py
+++ b/backend/api/routes/admin_models.py
@@ -1,0 +1,114 @@
+"""
+Admin CRUD for the models registry (pricing and capabilities).
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+
+from api.auth_middleware import AuthContext, require_global_admin
+from models.database import get_admin_session
+from models.llm_model import LlmModel
+from services.llm_pricing import invalidate_model_price_cache
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+class ModelResponse(BaseModel):
+    id: str
+    model_name: str
+    provider: str
+    input_cost_per_m: float
+    output_cost_per_m: float
+    is_enabled: bool
+    supports_images: bool
+    supports_tools: bool
+    max_context_tokens: Optional[int] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ModelUpdateRequest(BaseModel):
+    provider: Optional[str] = None
+    input_cost_per_m: Optional[float] = Field(None, ge=0)
+    output_cost_per_m: Optional[float] = Field(None, ge=0)
+    is_enabled: Optional[bool] = None
+    supports_images: Optional[bool] = None
+    supports_tools: Optional[bool] = None
+    max_context_tokens: Optional[int] = Field(None, ge=1)
+
+
+def _to_response(row: LlmModel) -> ModelResponse:
+    return ModelResponse(
+        id=str(row.id),
+        model_name=row.model_name,
+        provider=row.provider,
+        input_cost_per_m=float(row.input_cost_per_m),
+        output_cost_per_m=float(row.output_cost_per_m),
+        is_enabled=row.is_enabled,
+        supports_images=row.supports_images,
+        supports_tools=row.supports_tools,
+        max_context_tokens=row.max_context_tokens,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+@router.get("", response_model=list[ModelResponse])
+async def list_models(
+    auth: AuthContext = Depends(require_global_admin),
+) -> list[ModelResponse]:
+    """List all models in the registry."""
+    _ = auth
+    async with get_admin_session() as session:
+        result = await session.execute(
+            select(LlmModel).order_by(LlmModel.provider, LlmModel.model_name)
+        )
+        rows: list[LlmModel] = list(result.scalars().all())
+    return [_to_response(row) for row in rows]
+
+
+@router.put("/{model_name}", response_model=ModelResponse)
+async def update_model(
+    model_name: str,
+    body: ModelUpdateRequest,
+    auth: AuthContext = Depends(require_global_admin),
+) -> ModelResponse:
+    """Update pricing or capability flags for a model."""
+    _ = auth
+    async with get_admin_session() as session:
+        result = await session.execute(
+            select(LlmModel).where(LlmModel.model_name == model_name)
+        )
+        row: LlmModel | None = result.scalar_one_or_none()
+        if row is None:
+            raise HTTPException(status_code=404, detail="Model not found")
+
+        if body.provider is not None:
+            row.provider = body.provider.strip()
+        if body.input_cost_per_m is not None:
+            row.input_cost_per_m = Decimal(str(body.input_cost_per_m))
+        if body.output_cost_per_m is not None:
+            row.output_cost_per_m = Decimal(str(body.output_cost_per_m))
+        if body.is_enabled is not None:
+            row.is_enabled = body.is_enabled
+        if body.supports_images is not None:
+            row.supports_images = body.supports_images
+        if body.supports_tools is not None:
+            row.supports_tools = body.supports_tools
+        if body.max_context_tokens is not None:
+            row.max_context_tokens = body.max_context_tokens
+        row.updated_at = datetime.now(timezone.utc)
+        await session.commit()
+        await session.refresh(row)
+
+    invalidate_model_price_cache()
+    logger.info("[AdminModels] updated model=%s", model_name)
+    return _to_response(row)

--- a/backend/api/routes/billing.py
+++ b/backend/api/routes/billing.py
@@ -1012,6 +1012,64 @@ def _tier_from_subscription(sub: Any) -> Optional[str]:
     return None
 
 
+class UsageByDayItem(BaseModel):
+    date: str
+    input_tokens: int
+    output_tokens: int
+    credits_charged: int
+    call_count: int
+
+
+class UsageByDayResponse(BaseModel):
+    days: list[UsageByDayItem]
+
+
+@router.get("/usage-by-day", response_model=UsageByDayResponse)
+async def get_usage_by_day(
+    auth: AuthContext = Depends(require_organization),
+    days: int = 30,
+) -> UsageByDayResponse:
+    """Daily LLM token usage and credit spend for the current organization."""
+    org_id = auth.organization_id
+    if not org_id:
+        raise HTTPException(status_code=403, detail="Organization required")
+
+    lookback_days: int = max(1, min(int(days), 90))
+    cutoff = datetime.now(timezone.utc) - timedelta(days=lookback_days)
+
+    async with get_admin_session() as session:
+        from sqlalchemy import cast, Date, func
+        from models.llm_usage import LlmUsage
+
+        result = await session.execute(
+            select(
+                cast(LlmUsage.created_at, Date).label("usage_date"),
+                func.coalesce(func.sum(LlmUsage.input_tokens), 0).label("input_tokens"),
+                func.coalesce(func.sum(LlmUsage.output_tokens), 0).label("output_tokens"),
+                func.coalesce(func.sum(LlmUsage.credits_charged), 0).label("credits_charged"),
+                func.count(LlmUsage.id).label("call_count"),
+            )
+            .where(LlmUsage.organization_id == org_id)
+            .where(LlmUsage.created_at >= cutoff)
+            .group_by(cast(LlmUsage.created_at, Date))
+            .order_by(cast(LlmUsage.created_at, Date).asc())
+        )
+        rows = result.all()
+
+    return UsageByDayResponse(
+        days=[
+            UsageByDayItem(
+                date=str(row.usage_date),
+                input_tokens=int(row.input_tokens or 0),
+                output_tokens=int(row.output_tokens or 0),
+                credits_charged=int(row.credits_charged or 0),
+                call_count=int(row.call_count or 0),
+            )
+            for row in rows
+        ]
+    )
+
+
 async def _handle_subscription_deleted(sub: Any) -> None:
     """Mark org subscription as canceled."""
     org_id = sub.metadata.get("organization_id")

--- a/backend/connectors/web_search.py
+++ b/backend/connectors/web_search.py
@@ -223,6 +223,15 @@ class WebSearchConnector(BaseConnector):
                 )
                 content: str = (response.choices[0].message.content or "").strip()
                 if content:
+                    if self.organization_id and response.usage is not None:
+                        from services.credits import deduct_for_llm
+
+                        await deduct_for_llm(
+                            self.organization_id,
+                            model,
+                            int(response.usage.prompt_tokens or 0),
+                            int(response.usage.completion_tokens or 0),
+                        )
                     return {"answer": content, "provider": "openai", "model": model}
             except Exception as exc:
                 logger.warning("[WebSearch] OpenAI fallback model %s failed: %s", model, exc)

--- a/backend/db/migrations/versions/144_add_models_and_llm_usage.py
+++ b/backend/db/migrations/versions/144_add_models_and_llm_usage.py
@@ -18,19 +18,20 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 # (model_name, provider, input_$/M, output_$/M, is_enabled, supports_images, supports_tools, max_context)
+# Pricing sourced May 2026; DeepSeek uses discounted launch pricing.
 _SEED_MODELS: tuple[tuple[str, str, str, str, bool, bool, bool, int | None], ...] = (
-    ("claude-opus-4-6", "anthropic", "15.000000", "75.000000", True, True, True, 200000),
+    ("claude-opus-4-6", "anthropic", "5.000000", "25.000000", True, True, True, 1000000),
     ("claude-haiku-4-5-20251001", "anthropic", "1.000000", "5.000000", True, True, True, 200000),
-    ("MiniMax-M2.7", "minimax", "0.300000", "1.200000", True, False, True, 200000),
-    ("MiniMax-M2.7-highspeed", "minimax", "0.300000", "1.200000", True, False, True, 200000),
-    ("gpt-5.5", "openai", "2.500000", "10.000000", True, True, True, 128000),
-    ("gpt-5.5-mini", "openai", "0.400000", "1.600000", True, True, True, 128000),
-    ("gpt-5", "openai", "2.500000", "10.000000", True, True, True, 128000),
+    ("MiniMax-M2.7", "minimax", "0.300000", "1.200000", True, False, True, 205000),
+    ("MiniMax-M2.7-highspeed", "minimax", "0.600000", "2.400000", True, False, True, 205000),
+    ("gpt-5.5", "openai", "5.000000", "30.000000", True, True, True, 128000),
+    ("gpt-5.5-mini", "openai", "0.750000", "4.500000", True, True, True, 400000),
+    ("gpt-5", "openai", "1.250000", "10.000000", True, True, True, 128000),
     ("gemini-2.5-pro", "gemini", "1.250000", "10.000000", True, True, True, 1000000),
     ("gemini-2.5-flash", "gemini", "0.300000", "2.500000", True, True, True, 1000000),
-    ("qwen3.6-plus", "qwen", "0.800000", "3.200000", True, False, True, 128000),
-    ("qwen3-30b-a3b-instruct-2507", "qwen", "0.200000", "0.800000", True, False, True, 128000),
-    ("deepseek-v4-pro", "deepseek", "0.550000", "2.190000", True, False, True, 128000),
+    ("qwen3.6-plus", "qwen", "0.280000", "1.650000", True, False, True, 1000000),
+    ("qwen3-30b-a3b-instruct-2507", "qwen", "0.080000", "0.280000", True, False, True, 131000),
+    ("deepseek-v4-pro", "deepseek", "0.440000", "0.870000", True, False, True, 1000000),
 )
 
 _ORG_MATCH_SQL: str = """

--- a/backend/db/migrations/versions/144_add_models_and_llm_usage.py
+++ b/backend/db/migrations/versions/144_add_models_and_llm_usage.py
@@ -1,0 +1,168 @@
+"""Add models registry and llm_usage tables for token-based credits.
+
+Revision ID: 144_add_models_llm_usage
+Revises: 143_int_acct_id
+Create Date: 2026-05-18
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "144_add_models_llm_usage"
+down_revision: Union[str, None] = "143_int_acct_id"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# (model_name, provider, input_$/M, output_$/M, is_enabled, supports_images, supports_tools, max_context)
+_SEED_MODELS: tuple[tuple[str, str, str, str, bool, bool, bool, int | None], ...] = (
+    ("claude-opus-4-6", "anthropic", "15.000000", "75.000000", True, True, True, 200000),
+    ("claude-haiku-4-5-20251001", "anthropic", "1.000000", "5.000000", True, True, True, 200000),
+    ("MiniMax-M2.7", "minimax", "0.300000", "1.200000", True, False, True, 200000),
+    ("MiniMax-M2.7-highspeed", "minimax", "0.300000", "1.200000", True, False, True, 200000),
+    ("gpt-5.5", "openai", "2.500000", "10.000000", True, True, True, 128000),
+    ("gpt-5.5-mini", "openai", "0.400000", "1.600000", True, True, True, 128000),
+    ("gpt-5", "openai", "2.500000", "10.000000", True, True, True, 128000),
+    ("gemini-2.5-pro", "gemini", "1.250000", "10.000000", True, True, True, 1000000),
+    ("gemini-2.5-flash", "gemini", "0.300000", "2.500000", True, True, True, 1000000),
+    ("qwen3.6-plus", "qwen", "0.800000", "3.200000", True, False, True, 128000),
+    ("qwen3-30b-a3b-instruct-2507", "qwen", "0.200000", "0.800000", True, False, True, 128000),
+    ("deepseek-v4-pro", "deepseek", "0.550000", "2.190000", True, False, True, 128000),
+)
+
+_ORG_MATCH_SQL: str = """
+    organization_id::text = COALESCE(
+        NULLIF(current_setting('app.current_org_id', true), ''),
+        '00000000-0000-0000-0000-000000000000'
+    )
+"""
+
+
+def upgrade() -> None:
+    op.create_table(
+        "models",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("model_name", sa.String(128), nullable=False),
+        sa.Column("provider", sa.String(32), nullable=False),
+        sa.Column("input_cost_per_m", sa.Numeric(12, 6), nullable=False),
+        sa.Column("output_cost_per_m", sa.Numeric(12, 6), nullable=False),
+        sa.Column("is_enabled", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("supports_images", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("supports_tools", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("max_context_tokens", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_models_model_name", "models", ["model_name"], unique=True)
+
+    op.create_table(
+        "llm_usage",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "organization_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL", onupdate="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
+            "conversation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("conversations.id", ondelete="SET NULL", onupdate="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("model_name", sa.String(128), nullable=False),
+        sa.Column("input_tokens", sa.Integer(), nullable=False),
+        sa.Column("output_tokens", sa.Integer(), nullable=False),
+        sa.Column("credits_charged", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index("ix_llm_usage_organization_id", "llm_usage", ["organization_id"])
+    op.create_index(
+        "ix_llm_usage_org_created_at",
+        "llm_usage",
+        ["organization_id", "created_at"],
+    )
+
+    models_table = sa.table(
+        "models",
+        sa.column("model_name", sa.String),
+        sa.column("provider", sa.String),
+        sa.column("input_cost_per_m", sa.Numeric),
+        sa.column("output_cost_per_m", sa.Numeric),
+        sa.column("is_enabled", sa.Boolean),
+        sa.column("supports_images", sa.Boolean),
+        sa.column("supports_tools", sa.Boolean),
+        sa.column("max_context_tokens", sa.Integer),
+    )
+    op.bulk_insert(
+        models_table,
+        [
+            {
+                "model_name": name,
+                "provider": provider,
+                "input_cost_per_m": inp,
+                "output_cost_per_m": out,
+                "is_enabled": enabled,
+                "supports_images": images,
+                "supports_tools": tools,
+                "max_context_tokens": ctx,
+            }
+            for name, provider, inp, out, enabled, images, tools, ctx in _SEED_MODELS
+        ],
+    )
+
+    op.execute("ALTER TABLE llm_usage ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE llm_usage FORCE ROW LEVEL SECURITY")
+    op.execute("DROP POLICY IF EXISTS org_isolation ON llm_usage")
+    op.execute(
+        f"""
+        CREATE POLICY org_isolation ON llm_usage
+        FOR ALL
+        USING (
+            {_ORG_MATCH_SQL.strip()}
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS org_isolation ON llm_usage")
+    op.drop_index("ix_llm_usage_org_created_at", table_name="llm_usage")
+    op.drop_index("ix_llm_usage_organization_id", table_name="llm_usage")
+    op.drop_table("llm_usage")
+    op.drop_index("ix_models_model_name", table_name="models")
+    op.drop_table("models")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -27,6 +27,8 @@ from models.memory import Memory
 from models.org_member import OrgMember
 from models.goal import Goal
 from models.credit_transaction import CreditTransaction
+from models.llm_model import LlmModel
+from models.llm_usage import LlmUsage
 from models.tracker_team import TrackerTeam
 from models.tracker_project import TrackerProject
 from models.tracker_issue import TrackerIssue
@@ -70,6 +72,8 @@ __all__ = [
     "OrgMember",
     "Goal",
     "CreditTransaction",
+    "LlmModel",
+    "LlmUsage",
     "TrackerTeam",
     "TrackerProject",
     "TrackerIssue",

--- a/backend/models/llm_model.py
+++ b/backend/models/llm_model.py
@@ -1,0 +1,46 @@
+"""
+LLM model registry: pricing, capabilities, and product visibility.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import Boolean, DateTime, Integer, Numeric, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.database import Base
+
+
+class LlmModel(Base):
+    """Per-model configuration (pricing, capabilities, UI visibility)."""
+
+    __tablename__ = "models"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    model_name: Mapped[str] = mapped_column(String(128), nullable=False, unique=True)
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    input_cost_per_m: Mapped[Decimal] = mapped_column(
+        Numeric(12, 6), nullable=False
+    )
+    output_cost_per_m: Mapped[Decimal] = mapped_column(
+        Numeric(12, 6), nullable=False
+    )
+    is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    supports_images: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    supports_tools: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    max_context_tokens: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/backend/models/llm_usage.py
+++ b/backend/models/llm_usage.py
@@ -1,0 +1,57 @@
+"""
+Per-call LLM token usage for billing and trend reporting.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from models.database import Base
+
+if TYPE_CHECKING:
+    from models.organization import Organization
+    from models.user import User
+
+
+class LlmUsage(Base):
+    """Granular LLM token usage row for an organization."""
+
+    __tablename__ = "llm_usage"
+    __table_args__ = (
+        {"extend_existing": True},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL", onupdate="CASCADE"),
+        nullable=True,
+    )
+    conversation_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("conversations.id", ondelete="SET NULL", onupdate="CASCADE"),
+        nullable=True,
+    )
+    model_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    input_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
+    output_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
+    credits_charged: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    organization: Mapped["Organization"] = relationship("Organization")
+    user: Mapped[Optional["User"]] = relationship("User")

--- a/backend/services/conversation_summary.py
+++ b/backend/services/conversation_summary.py
@@ -237,6 +237,15 @@ async def generate_conversation_summary(
             await report_anthropic_call_success(
                 source="services.conversation_summary.generate_conversation_summary"
             )
+            from services.credits import deduct_for_llm
+
+            await deduct_for_llm(
+                organization_id,
+                llm_config.cheap_model,
+                getattr(completed, "input_tokens", 0),
+                getattr(completed, "output_tokens", 0),
+                conversation_id=conversation_id,
+            )
         except Exception as exc:
             await report_anthropic_call_failure(
                 exc=exc,
@@ -345,6 +354,15 @@ async def generate_conversation_title(
             )
             await report_anthropic_call_success(
                 source="services.conversation_summary.generate_conversation_title"
+            )
+            from services.credits import deduct_for_llm
+
+            await deduct_for_llm(
+                organization_id,
+                llm_config.cheap_model,
+                getattr(completed, "input_tokens", 0),
+                getattr(completed, "output_tokens", 0),
+                conversation_id=conversation_id,
             )
         except Exception as exc:
             await report_anthropic_call_failure(

--- a/backend/services/credits.py
+++ b/backend/services/credits.py
@@ -2,7 +2,8 @@
 Credit balance and metering for subscription tiers.
 
 - get_balance / check_sufficient / deduct for usage tracking
-- credits_for_tool maps tool names and context to credit cost
+- deduct_for_llm charges token-based LLM usage (via services.llm_pricing)
+- credits_for_external_surcharge covers non-LLM third-party API costs on tools
 """
 from __future__ import annotations
 
@@ -284,34 +285,64 @@ async def deduct_with_grace(
         return ok, used_grace
 
 
-def credits_for_tool(
+async def deduct_for_llm(
+    organization_id: str,
+    model_name: str,
+    input_tokens: int,
+    output_tokens: int,
+    *,
+    user_id: str | None = None,
+    conversation_id: str | None = None,
+) -> tuple[bool, bool]:
+    """Charge token-based LLM usage. Returns (ok, used_grace).
+
+    Fails gracefully (returns (True, False)) for invalid org IDs or zero usage.
+    """
+    if not organization_id:
+        return True, False
+    try:
+        UUID(organization_id)
+    except (ValueError, TypeError):
+        logger.warning("[Credits] deduct_for_llm: invalid org_id %r, skipping", organization_id)
+        return True, False
+
+    safe_input: int = max(0, int(input_tokens or 0))
+    safe_output: int = max(0, int(output_tokens or 0))
+    if safe_input == 0 and safe_output == 0:
+        return True, False
+
+    from services.llm_pricing import charge_llm_usage
+
+    ok, used_grace, _credits = await charge_llm_usage(
+        organization_id=organization_id,
+        model_name=model_name,
+        input_tokens=safe_input,
+        output_tokens=safe_output,
+        user_id=user_id,
+        conversation_id=conversation_id,
+        reason="llm",
+    )
+    return ok, used_grace
+
+
+def credits_for_external_surcharge(
     tool_name: str,
     tool_input: dict[str, Any],
     context: dict[str, Any] | None,
 ) -> int:
     """
-    Map tool execution to credit cost (pricing doc: simple 1, cross-source 2-3,
-    write-back 2, artifact 5-10, bulk ~1 per record, etc.).
+    Fixed surcharge for tools that incur third-party API cost beyond LLM tokens.
+
+    LLM token usage is charged separately via deduct_for_llm.
     """
-    # Simple read-only / list
-    if tool_name in ("run_sql_query", "list_connected_connectors"):
-        return 1
-    # Connector write-back
+    _ = context
     if tool_name == "write_on_connector":
         connector: str = (tool_input or {}).get("connector", "")
         if connector in ("artifacts", "apps"):
             return 5
         return 2
-    # Connector queries often cross sources
-    if tool_name == "query_on_connector":
-        return 2
-    # Run on connector (enrichment, etc.)
     if tool_name == "run_on_connector":
         return 3
-    # Workflow run
-    if tool_name == "run_workflow":
-        return 3
-    # Bulk: ~1 per item, cap at 50 for a single foreach
     if tool_name == "foreach":
         total = (
             (tool_input or {}).get("total_items")
@@ -321,11 +352,4 @@ def credits_for_tool(
         if isinstance(total, (int, float)):
             return min(max(1, int(total)), 50)
         return 5
-    # Sync, keep_notes, manage_memory
-    if tool_name in ("trigger_sync", "keep_notes", "manage_memory"):
-        return 1
-    # run_sql_write
-    if tool_name == "run_sql_write":
-        return 2
-    # Default for unknown tools
-    return 1
+    return 0

--- a/backend/services/daily_digest.py
+++ b/backend/services/daily_digest.py
@@ -446,6 +446,15 @@ async def _call_llm_for_summary(raw: dict[str, Any], organization_id: UUID | str
             max_tokens=2048,
         )
         await report_anthropic_call_success(source="daily_digest")
+        from services.credits import deduct_for_llm
+
+        await deduct_for_llm(
+            organization_id,
+            llm_config.cheap_model,
+            getattr(completed, "input_tokens", 0),
+            getattr(completed, "output_tokens", 0),
+            user_id=user_id,
+        )
     except Exception as exc:
         await report_anthropic_call_failure(exc=exc, source="daily_digest")
         logger.exception("daily_digest LLM failed: %s", exc)
@@ -619,6 +628,14 @@ async def generate_team_summary(
                 max_tokens=512,
             )
             await report_anthropic_call_success(source="daily_team_summary")
+            from services.credits import deduct_for_llm
+
+            await deduct_for_llm(
+                organization_id,
+                llm_config.cheap_model,
+                getattr(completed, "input_tokens", 0),
+                getattr(completed, "output_tokens", 0),
+            )
             text_parts: list[str] = []
             for block in completed.content_blocks:
                 if block.text:

--- a/backend/services/llm_pricing.py
+++ b/backend/services/llm_pricing.py
@@ -22,8 +22,8 @@ logger = logging.getLogger(__name__)
 
 CREDITS_PER_DOLLAR: Final[int] = 1000
 MIN_CREDITS_PER_CALL: Final[int] = 1
-DEFAULT_INPUT_COST_PER_M: Final[Decimal] = Decimal("2.500000")
-DEFAULT_OUTPUT_COST_PER_M: Final[Decimal] = Decimal("10.000000")
+DEFAULT_INPUT_COST_PER_M: Final[Decimal] = Decimal("5.000000")
+DEFAULT_OUTPUT_COST_PER_M: Final[Decimal] = Decimal("25.000000")
 _CACHE_TTL_SECONDS: Final[float] = 300.0
 
 _price_cache: dict[str, tuple[Decimal, Decimal]] = {}

--- a/backend/services/llm_pricing.py
+++ b/backend/services/llm_pricing.py
@@ -1,0 +1,191 @@
+"""
+LLM token pricing and usage metering.
+
+1 credit = $0.001 of estimated LLM spend (1000 credits per dollar).
+"""
+from __future__ import annotations
+
+import logging
+import time
+from decimal import Decimal, ROUND_CEILING
+from typing import Final
+from uuid import UUID
+
+from sqlalchemy import select
+
+from models.database import get_admin_session
+from models.llm_model import LlmModel
+from models.llm_usage import LlmUsage
+from services.credits import deduct_with_grace
+
+logger = logging.getLogger(__name__)
+
+CREDITS_PER_DOLLAR: Final[int] = 1000
+MIN_CREDITS_PER_CALL: Final[int] = 1
+DEFAULT_INPUT_COST_PER_M: Final[Decimal] = Decimal("2.500000")
+DEFAULT_OUTPUT_COST_PER_M: Final[Decimal] = Decimal("10.000000")
+_CACHE_TTL_SECONDS: Final[float] = 300.0
+
+_price_cache: dict[str, tuple[Decimal, Decimal]] = {}
+_cache_loaded_at: float = 0.0
+
+
+def _invalidate_price_cache() -> None:
+    global _cache_loaded_at
+    _price_cache.clear()
+    _cache_loaded_at = 0.0
+
+
+async def _load_price_cache() -> None:
+    global _cache_loaded_at
+    now: float = time.monotonic()
+    if _price_cache and (now - _cache_loaded_at) < _CACHE_TTL_SECONDS:
+        return
+    async with get_admin_session() as session:
+        result = await session.execute(
+            select(
+                LlmModel.model_name,
+                LlmModel.input_cost_per_m,
+                LlmModel.output_cost_per_m,
+            )
+        )
+        rows = result.all()
+    _price_cache.clear()
+    for model_name, input_cost, output_cost in rows:
+        _price_cache[str(model_name)] = (Decimal(input_cost), Decimal(output_cost))
+    _cache_loaded_at = now
+
+
+async def get_model_price(model_name: str) -> tuple[Decimal, Decimal]:
+    """Return (input_cost_per_m, output_cost_per_m) in dollars."""
+    await _load_price_cache()
+    key: str = model_name.strip()
+    cached = _price_cache.get(key)
+    if cached is not None:
+        return cached
+    return DEFAULT_INPUT_COST_PER_M, DEFAULT_OUTPUT_COST_PER_M
+
+
+def compute_credit_cost(
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    input_cost_per_m: Decimal,
+    output_cost_per_m: Decimal,
+) -> int:
+    """Convert token counts and $/M rates to integer credits (min 1)."""
+    safe_input: int = max(0, int(input_tokens))
+    safe_output: int = max(0, int(output_tokens))
+    dollar_cost: Decimal = (
+        Decimal(safe_input) * input_cost_per_m + Decimal(safe_output) * output_cost_per_m
+    ) / Decimal(1_000_000)
+    credits_decimal: Decimal = dollar_cost * Decimal(CREDITS_PER_DOLLAR)
+    credits: int = int(credits_decimal.to_integral_value(rounding=ROUND_CEILING))
+    return max(MIN_CREDITS_PER_CALL, credits)
+
+
+async def compute_credit_cost_for_model(
+    model_name: str,
+    input_tokens: int,
+    output_tokens: int,
+) -> int:
+    """Look up model pricing and compute credits."""
+    input_rate, output_rate = await get_model_price(model_name)
+    return compute_credit_cost(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        input_cost_per_m=input_rate,
+        output_cost_per_m=output_rate,
+    )
+
+
+async def record_llm_usage(
+    *,
+    organization_id: str,
+    model_name: str,
+    input_tokens: int,
+    output_tokens: int,
+    credits_charged: int,
+    user_id: str | None = None,
+    conversation_id: str | None = None,
+) -> None:
+    """Persist granular usage for reporting."""
+    async with get_admin_session() as session:
+        session.add(
+            LlmUsage(
+                organization_id=UUID(organization_id),
+                user_id=UUID(user_id) if user_id else None,
+                conversation_id=UUID(conversation_id) if conversation_id else None,
+                model_name=model_name,
+                input_tokens=max(0, int(input_tokens)),
+                output_tokens=max(0, int(output_tokens)),
+                credits_charged=max(0, int(credits_charged)),
+            )
+        )
+        await session.commit()
+
+
+async def charge_llm_usage(
+    *,
+    organization_id: str,
+    model_name: str,
+    input_tokens: int,
+    output_tokens: int,
+    user_id: str | None = None,
+    conversation_id: str | None = None,
+    reason: str = "llm",
+) -> tuple[bool, bool, int]:
+    """
+    Compute cost, deduct credits, and record usage.
+
+    Returns (ok, used_grace, credits_charged).
+    """
+    if not organization_id:
+        return True, False, 0
+
+    credits: int = await compute_credit_cost_for_model(
+        model_name, input_tokens, output_tokens
+    )
+    if credits <= 0:
+        return True, False, 0
+
+    ok, used_grace = await deduct_with_grace(
+        organization_id,
+        credits,
+        reason[:64],
+        reference_type="conversation" if conversation_id else None,
+        reference_id=conversation_id,
+        user_id=user_id,
+    )
+    if ok:
+        await record_llm_usage(
+            organization_id=organization_id,
+            model_name=model_name,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            credits_charged=credits,
+            user_id=user_id,
+            conversation_id=conversation_id,
+        )
+        logger.info(
+            "[LLMPricing] charged org=%s model=%s in=%d out=%d credits=%d grace=%s",
+            organization_id,
+            model_name,
+            input_tokens,
+            output_tokens,
+            credits,
+            used_grace,
+        )
+    else:
+        logger.info(
+            "[LLMPricing] charge failed org=%s model=%s credits=%d",
+            organization_id,
+            model_name,
+            credits,
+        )
+    return ok, used_grace, credits
+
+
+def invalidate_model_price_cache() -> None:
+    """Call after admin updates to models table."""
+    _invalidate_price_cache()

--- a/backend/services/widget_inference.py
+++ b/backend/services/widget_inference.py
@@ -109,10 +109,19 @@ async def generate_widget_config(
         await report_anthropic_call_success(source="services.widget_inference.generate_widget_config")
     except Exception as exc:
         await report_anthropic_call_failure(
+            exc=exc,
             source="services.widget_inference.generate_widget_config",
-            error=exc,
         )
         raise
+
+    from services.credits import deduct_for_llm
+
+    await deduct_for_llm(
+        organization_id,
+        llm_config.cheap_model,
+        getattr(completed, "input_tokens", 0),
+        getattr(completed, "output_tokens", 0),
+    )
 
     raw_text = (completed.content_blocks[0].text or "").strip() if completed.content_blocks else ""
     # Strip markdown fences if present

--- a/backend/services/workstream_clustering.py
+++ b/backend/services/workstream_clustering.py
@@ -122,6 +122,14 @@ async def _generate_cluster_labels(
                 messages=[{"role": "user", "content": prompt}],
                 max_tokens=150,
             )
+            from services.credits import deduct_for_llm
+
+            await deduct_for_llm(
+                organization_id,
+                llm_config.cheap_model,
+                getattr(completed, "input_tokens", 0),
+                getattr(completed, "output_tokens", 0),
+            )
             raw: str = ""
             for block in completed.content_blocks:
                 if block.text:

--- a/backend/tests/test_llm_pricing.py
+++ b/backend/tests/test_llm_pricing.py
@@ -1,0 +1,36 @@
+from decimal import Decimal
+
+from services.llm_pricing import compute_credit_cost
+
+
+def test_compute_credit_cost_minimum_one() -> None:
+    credits = compute_credit_cost(
+        input_tokens=0,
+        output_tokens=0,
+        input_cost_per_m=Decimal("15"),
+        output_cost_per_m=Decimal("75"),
+    )
+    assert credits == 1
+
+
+def test_compute_credit_cost_scales_with_tokens() -> None:
+    # 1M input tokens at $2.5/M => $2.5 => 2500 credits
+    credits = compute_credit_cost(
+        input_tokens=1_000_000,
+        output_tokens=0,
+        input_cost_per_m=Decimal("2.5"),
+        output_cost_per_m=Decimal("10"),
+    )
+    assert credits == 2500
+
+
+def test_compute_credit_cost_mixed_io() -> None:
+    # 1000 in @ $15/M + 500 out @ $75/M
+    credits = compute_credit_cost(
+        input_tokens=1000,
+        output_tokens=500,
+        input_cost_per_m=Decimal("15"),
+        output_cost_per_m=Decimal("75"),
+    )
+    # $0.015 + $0.0375 = $0.0525 => 53 credits (ceil)
+    assert credits == 53

--- a/backend/tests/test_token_credit_tracking.py
+++ b/backend/tests/test_token_credit_tracking.py
@@ -1,0 +1,242 @@
+"""
+Tests for token-cost credit tracking:
+- charge_llm_usage records to llm_usage and deducts credits
+- deduct_for_llm handles edge cases (invalid org, zero tokens)
+- usage-by-day endpoint returns aggregated data
+- admin models CRUD endpoint
+"""
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from services import credits
+from services.llm_pricing import (
+    compute_credit_cost,
+    compute_credit_cost_for_model,
+    charge_llm_usage,
+    invalidate_model_price_cache,
+    _price_cache,
+)
+
+
+# ─── Unit: compute_credit_cost ─────────────────────────────────────────────────
+
+
+def test_compute_credit_cost_opus_typical_turn() -> None:
+    # Typical Opus 4.6 turn: 5000 in @ $5/M, 1000 out @ $25/M
+    result = compute_credit_cost(
+        input_tokens=5000,
+        output_tokens=1000,
+        input_cost_per_m=Decimal("5"),
+        output_cost_per_m=Decimal("25"),
+    )
+    # ($5*5000 + $25*1000) / 1M = ($25000 + $25000) / 1M = $0.05 => 50 credits
+    assert result == 50
+
+
+def test_compute_credit_cost_haiku_cheap_call() -> None:
+    # Haiku: 2000 in @ $1/M, 500 out @ $5/M
+    result = compute_credit_cost(
+        input_tokens=2000,
+        output_tokens=500,
+        input_cost_per_m=Decimal("1"),
+        output_cost_per_m=Decimal("5"),
+    )
+    # ($1*2000 + $5*500) / 1M = ($2000 + $2500) / 1M = $0.0045 => 5 credits (ceil)
+    assert result == 5
+
+
+def test_compute_credit_cost_rounds_up() -> None:
+    # Tiny call: 1 input token at $5/M => $0.000005 => 0.005 credits => ceil to 1
+    result = compute_credit_cost(
+        input_tokens=1,
+        output_tokens=0,
+        input_cost_per_m=Decimal("5"),
+        output_cost_per_m=Decimal("25"),
+    )
+    assert result == 1
+
+
+def test_compute_credit_cost_large_output() -> None:
+    # GPT-5.5: 1000 in @ $5/M, 4000 out @ $30/M
+    result = compute_credit_cost(
+        input_tokens=1000,
+        output_tokens=4000,
+        input_cost_per_m=Decimal("5"),
+        output_cost_per_m=Decimal("30"),
+    )
+    # ($5*1000 + $30*4000) / 1M = ($5000 + $120000) / 1M = $0.125 => 125 credits
+    assert result == 125
+
+
+# ─── Unit: deduct_for_llm edge cases ──────────────────────────────────────────
+
+
+def test_deduct_for_llm_skips_invalid_org_id() -> None:
+    result = asyncio.run(credits.deduct_for_llm(
+        "not-a-uuid",
+        "claude-opus-4-6",
+        5000,
+        1000,
+    ))
+    assert result == (True, False)
+
+
+def test_deduct_for_llm_skips_empty_org_id() -> None:
+    result = asyncio.run(credits.deduct_for_llm(
+        "",
+        "claude-opus-4-6",
+        5000,
+        1000,
+    ))
+    assert result == (True, False)
+
+
+def test_deduct_for_llm_skips_zero_tokens() -> None:
+    result = asyncio.run(credits.deduct_for_llm(
+        "00000000-0000-0000-0000-000000000001",
+        "claude-opus-4-6",
+        0,
+        0,
+    ))
+    assert result == (True, False)
+
+
+# ─── Integration: charge_llm_usage calls deduct + record ─────────────────────
+
+
+def test_charge_llm_usage_deducts_and_records(monkeypatch) -> None:
+    """charge_llm_usage should compute cost, deduct, and record usage."""
+    deduct_mock = AsyncMock(return_value=(True, False))
+    record_mock = AsyncMock()
+
+    monkeypatch.setattr("services.llm_pricing.deduct_with_grace", deduct_mock)
+    monkeypatch.setattr("services.llm_pricing.record_llm_usage", record_mock)
+
+    # Pre-populate price cache to avoid DB hit
+    invalidate_model_price_cache()
+    _price_cache["claude-opus-4-6"] = (Decimal("5"), Decimal("25"))
+
+    ok, used_grace, credits_charged = asyncio.run(charge_llm_usage(
+        organization_id="00000000-0000-0000-0000-000000000001",
+        model_name="claude-opus-4-6",
+        input_tokens=5000,
+        output_tokens=1000,
+        user_id="00000000-0000-0000-0000-000000000002",
+        conversation_id="00000000-0000-0000-0000-000000000003",
+        reason="llm",
+    ))
+
+    assert ok is True
+    assert used_grace is False
+    assert credits_charged == 50
+
+    # deduct_with_grace called with correct amount
+    deduct_mock.assert_called_once()
+    call_args = deduct_mock.call_args
+    assert call_args[0][0] == "00000000-0000-0000-0000-000000000001"
+    assert call_args[0][1] == 50  # credits
+    assert call_args[0][2] == "llm"
+
+    # record_llm_usage called with all fields
+    record_mock.assert_called_once()
+    record_kwargs = record_mock.call_args[1]
+    assert record_kwargs["organization_id"] == "00000000-0000-0000-0000-000000000001"
+    assert record_kwargs["model_name"] == "claude-opus-4-6"
+    assert record_kwargs["input_tokens"] == 5000
+    assert record_kwargs["output_tokens"] == 1000
+    assert record_kwargs["credits_charged"] == 50
+
+    # Cleanup
+    invalidate_model_price_cache()
+
+
+def test_charge_llm_usage_reports_failure_on_insufficient_balance(monkeypatch) -> None:
+    """When deduct fails, charge_llm_usage should not record usage."""
+    deduct_mock = AsyncMock(return_value=(False, False))
+    record_mock = AsyncMock()
+
+    monkeypatch.setattr("services.llm_pricing.deduct_with_grace", deduct_mock)
+    monkeypatch.setattr("services.llm_pricing.record_llm_usage", record_mock)
+
+    invalidate_model_price_cache()
+    _price_cache["claude-opus-4-6"] = (Decimal("5"), Decimal("25"))
+
+    ok, used_grace, credits_charged = asyncio.run(charge_llm_usage(
+        organization_id="00000000-0000-0000-0000-000000000001",
+        model_name="claude-opus-4-6",
+        input_tokens=5000,
+        output_tokens=1000,
+        reason="llm",
+    ))
+
+    assert ok is False
+    assert used_grace is False
+    assert credits_charged == 50
+    record_mock.assert_not_called()
+
+    invalidate_model_price_cache()
+
+
+def test_compute_credit_cost_for_model_uses_cache(monkeypatch) -> None:
+    """compute_credit_cost_for_model should use cached pricing."""
+    invalidate_model_price_cache()
+    _price_cache["deepseek-v4-pro"] = (Decimal("0.44"), Decimal("0.87"))
+
+    # Patch _load_price_cache to avoid DB access (cache is already warm)
+    monkeypatch.setattr("services.llm_pricing._CACHE_TTL_SECONDS", 99999)
+    import services.llm_pricing as lp
+    monkeypatch.setattr(lp, "_cache_loaded_at", 1e18)
+
+    result = asyncio.run(compute_credit_cost_for_model(
+        "deepseek-v4-pro",
+        input_tokens=100_000,
+        output_tokens=10_000,
+    ))
+    # ($0.44 * 100k + $0.87 * 10k) / 1M = ($44000 + $8700) / 1M = $0.0527 => 53 credits
+    assert result == 53
+
+    invalidate_model_price_cache()
+
+
+# ─── API: admin models endpoint ───────────────────────────────────────────────
+
+
+def test_admin_models_list_requires_auth() -> None:
+    """GET /api/admin/models without auth should return 401."""
+    from fastapi.testclient import TestClient
+    from api.main import app
+
+    client = TestClient(app)
+    response = client.get("/api/admin/models")
+    assert response.status_code in (401, 403)
+
+
+def test_admin_models_update_requires_auth() -> None:
+    """PUT /api/admin/models/:name without auth should return 401."""
+    from fastapi.testclient import TestClient
+    from api.main import app
+
+    client = TestClient(app)
+    response = client.put(
+        "/api/admin/models/claude-opus-4-6",
+        json={"input_cost_per_m": 10.0},
+    )
+    assert response.status_code in (401, 403)
+
+
+# ─── API: usage-by-day endpoint ───────────────────────────────────────────────
+
+
+def test_usage_by_day_requires_auth() -> None:
+    """GET /api/billing/usage-by-day without auth should return 401."""
+    from fastapi.testclient import TestClient
+    from api.main import app
+
+    client = TestClient(app)
+    response = client.get("/api/billing/usage-by-day")
+    assert response.status_code in (401, 403)

--- a/backend/tests/test_tools_credit_grace.py
+++ b/backend/tests/test_tools_credit_grace.py
@@ -16,8 +16,8 @@ def test_execute_tool_returns_credit_error_when_grace_exhausted(monkeypatch) -> 
 
     result = asyncio.run(
         tools.execute_tool(
-            tool_name="list_connected_connectors",
-            tool_input={},
+            tool_name="write_on_connector",
+            tool_input={"connector": "salesforce"},
             organization_id="00000000-0000-0000-0000-000000000001",
             user_id="00000000-0000-0000-0000-000000000002",
             context={},
@@ -35,22 +35,22 @@ def test_execute_tool_marks_turn_for_credit_closeout_when_grace_used(monkeypatch
     async def _fake_should_skip_approval(*args, **kwargs) -> bool:
         return True
 
-    async def _fake_list_connected_connectors(*_args: object):
-        return {"connectors": []}
+    async def _fake_write_on_connector(*_args: object, **_kwargs: object):
+        return {"status": "success"}
 
     monkeypatch.setattr(credits, "deduct_with_grace", _fake_deduct_with_grace)
     monkeypatch.setattr(tools, "_should_skip_approval", _fake_should_skip_approval)
-    monkeypatch.setattr(tools, "_list_connected_connectors", _fake_list_connected_connectors)
+    monkeypatch.setattr(tools, "_write_on_connector", _fake_write_on_connector)
 
     result = asyncio.run(
         tools.execute_tool(
-            tool_name="list_connected_connectors",
-            tool_input={},
+            tool_name="write_on_connector",
+            tool_input={"connector": "salesforce"},
             organization_id="00000000-0000-0000-0000-000000000001",
             user_id="00000000-0000-0000-0000-000000000002",
             context={},
         )
     )
 
-    assert result.get("connectors") == []
+    assert result.get("status") == "success"
     assert result.get("_out_of_credits_after_turn") is True

--- a/backend/workers/tasks/sync.py
+++ b/backend/workers/tasks/sync.py
@@ -1683,6 +1683,14 @@ async def _generate_meeting_summary(
             max_tokens=1024,
         )
         await report_anthropic_call_success(source="workers.tasks.sync._generate_meeting_summary")
+        from services.credits import deduct_for_llm
+
+        await deduct_for_llm(
+            organization_id,
+            llm_config.cheap_model,
+            getattr(completed, "input_tokens", 0),
+            getattr(completed, "output_tokens", 0),
+        )
     except Exception as exc:
         await report_anthropic_call_failure(
             exc=exc,

--- a/backend/workers/tasks/workflows.py
+++ b/backend/workers/tasks/workflows.py
@@ -2017,8 +2017,19 @@ async def _action_llm(
         )
         raise
 
+    if org_id:
+        from services.credits import deduct_for_llm
+
+        await deduct_for_llm(
+            org_id,
+            model,
+            getattr(completed, "input_tokens", 0),
+            getattr(completed, "output_tokens", 0),
+            user_id=str(context.get("user_id")) if context.get("user_id") else None,
+        )
+
     output: str = (completed.content_blocks[0].text or "") if completed.content_blocks else ""
-    
+
     return {
         "status": "completed",
         "action": "llm",

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -523,6 +523,26 @@ export function AdminPanel(): JSX.Element {
   const [cancellingJobId, setCancellingJobId] = useState<string | null>(null);
   const [killingAllJobs, setKillingAllJobs] = useState<boolean>(false);
 
+  // Models tab state
+  interface AdminModel {
+    id: string;
+    model_name: string;
+    provider: string;
+    input_cost_per_m: number;
+    output_cost_per_m: number;
+    is_enabled: boolean;
+    supports_images: boolean;
+    supports_tools: boolean;
+    max_context_tokens: number | null;
+    created_at: string;
+    updated_at: string;
+  }
+  const [adminModels, setAdminModels] = useState<AdminModel[]>([]);
+  const [modelsLoading, setModelsLoading] = useState<boolean>(true);
+  const [modelsError, setModelsError] = useState<string | null>(null);
+  const [editingModel, setEditingModel] = useState<AdminModel | null>(null);
+  const [savingModel, setSavingModel] = useState<boolean>(false);
+
   // Dashboard tab state
   const [creditUsage, setCreditUsage] = useState<CreditUsageResponse | null>(null);
   const [creditUsageLoading, setCreditUsageLoading] = useState<boolean>(true);
@@ -701,6 +721,39 @@ export function AdminPanel(): JSX.Element {
     }
   }, [user]);
 
+  const fetchModels = useCallback(async (): Promise<void> => {
+    setModelsLoading(true);
+    setModelsError(null);
+    try {
+      const { data, error: reqErr } = await apiRequest<AdminModel[]>('/admin/models');
+      if (reqErr || !data) { setModelsError(reqErr ?? 'Failed to fetch models'); return; }
+      setAdminModels(data);
+    } catch { setModelsError('Request failed'); }
+    finally { setModelsLoading(false); }
+  }, []);
+
+  const handleSaveModel = async (model: AdminModel): Promise<void> => {
+    setSavingModel(true);
+    try {
+      const { data, error: reqErr } = await apiRequest<AdminModel>(`/admin/models/${encodeURIComponent(model.model_name)}`, {
+        method: 'PUT',
+        body: JSON.stringify({
+          provider: model.provider,
+          input_cost_per_m: model.input_cost_per_m,
+          output_cost_per_m: model.output_cost_per_m,
+          is_enabled: model.is_enabled,
+          supports_images: model.supports_images,
+          supports_tools: model.supports_tools,
+          max_context_tokens: model.max_context_tokens,
+        }),
+      });
+      if (reqErr || !data) { alert(reqErr ?? 'Save failed'); return; }
+      setAdminModels((prev) => prev.map((m) => m.id === data.id ? data : m));
+      setEditingModel(null);
+    } catch { alert('Save failed'); }
+    finally { setSavingModel(false); }
+  };
+
   const fetchQueryOutcomeRate = useCallback(async (): Promise<void> => {
     if (!user) return;
 
@@ -737,10 +790,12 @@ export function AdminPanel(): JSX.Element {
       void fetchQueryOutcomeRate();
     } else if (activeTab === 'jobs') {
       void fetchRunningJobs();
+    } else if (activeTab === 'models') {
+      void fetchModels();
     } else if (activeTab === 'graph-magic') {
       // graph tab fetches on-demand in component
     }
-  }, [activeTab, fetchCreditUsage, fetchTopConversations, fetchWaitlist, fetchUsers, fetchOrganizations, fetchIntegrations, fetchQueryOutcomeRate, fetchRunningJobs]);
+  }, [activeTab, fetchCreditUsage, fetchTopConversations, fetchWaitlist, fetchUsers, fetchOrganizations, fetchIntegrations, fetchQueryOutcomeRate, fetchRunningJobs, fetchModels]);
 
   const handleCancelJob = async (job: AdminRunningJob): Promise<void> => {
     if (!user) return;
@@ -2602,6 +2657,140 @@ export function AdminPanel(): JSX.Element {
               <div className="text-sm text-surface-500 text-center">
                 Showing {filteredIntegrations.length} of {adminIntegrations.length} connectors
                 {sourceSearch && ` matching "${sourceSearch}"`}
+              </div>
+            )}
+          </div>
+        )}
+
+        {activeTab === 'models' && (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-surface-400">Manage LLM model pricing and capabilities.</p>
+              <button
+                onClick={() => void fetchModels()}
+                className="rounded-lg border border-surface-700 bg-surface-800 px-3 py-1.5 text-sm text-surface-200 hover:bg-surface-700"
+              >
+                Refresh
+              </button>
+            </div>
+
+            {modelsError && (
+              <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400">{modelsError}</div>
+            )}
+
+            {modelsLoading ? (
+              <p className="text-surface-400 text-sm">Loading models…</p>
+            ) : (
+              <div className="overflow-x-auto rounded-xl border border-surface-800">
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-b border-surface-800 bg-surface-900/50">
+                      <th className="px-4 py-3 text-left text-xs font-medium text-surface-400 uppercase">Model</th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-surface-400 uppercase">Provider</th>
+                      <th className="px-4 py-3 text-right text-xs font-medium text-surface-400 uppercase">Input $/M</th>
+                      <th className="px-4 py-3 text-right text-xs font-medium text-surface-400 uppercase">Output $/M</th>
+                      <th className="px-4 py-3 text-center text-xs font-medium text-surface-400 uppercase">Enabled</th>
+                      <th className="px-4 py-3 text-center text-xs font-medium text-surface-400 uppercase">Images</th>
+                      <th className="px-4 py-3 text-center text-xs font-medium text-surface-400 uppercase">Tools</th>
+                      <th className="px-4 py-3 text-right text-xs font-medium text-surface-400 uppercase">Context</th>
+                      <th className="px-4 py-3 text-center text-xs font-medium text-surface-400 uppercase">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-surface-800">
+                    {adminModels.map((model) => (
+                      <tr key={model.id} className="hover:bg-surface-800/40 transition-colors">
+                        <td className="px-4 py-3 text-sm font-mono text-surface-200">{model.model_name}</td>
+                        <td className="px-4 py-3 text-sm text-surface-300">{model.provider}</td>
+                        <td className="px-4 py-3 text-sm text-surface-300 text-right">${model.input_cost_per_m.toFixed(2)}</td>
+                        <td className="px-4 py-3 text-sm text-surface-300 text-right">${model.output_cost_per_m.toFixed(2)}</td>
+                        <td className="px-4 py-3 text-center">{model.is_enabled ? <span className="text-green-400">Yes</span> : <span className="text-surface-500">No</span>}</td>
+                        <td className="px-4 py-3 text-center">{model.supports_images ? <span className="text-green-400">Yes</span> : <span className="text-surface-500">No</span>}</td>
+                        <td className="px-4 py-3 text-center">{model.supports_tools ? <span className="text-green-400">Yes</span> : <span className="text-surface-500">No</span>}</td>
+                        <td className="px-4 py-3 text-sm text-surface-300 text-right">{model.max_context_tokens ? `${(model.max_context_tokens / 1000).toFixed(0)}k` : '—'}</td>
+                        <td className="px-4 py-3 text-center">
+                          <button
+                            onClick={() => setEditingModel({ ...model })}
+                            className="text-xs text-primary-400 hover:text-primary-300"
+                          >
+                            Edit
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {editingModel && (
+              <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setEditingModel(null)}>
+                <div className="bg-surface-900 border border-surface-700 rounded-xl p-6 w-full max-w-md space-y-4" onClick={(e) => e.stopPropagation()}>
+                  <h3 className="text-lg font-semibold text-surface-100">Edit {editingModel.model_name}</h3>
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-xs text-surface-400 mb-1">Provider</label>
+                      <input
+                        type="text"
+                        value={editingModel.provider}
+                        onChange={(e) => setEditingModel({ ...editingModel, provider: e.target.value })}
+                        className="input-field w-full"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-surface-400 mb-1">Max Context (tokens)</label>
+                      <input
+                        type="number"
+                        value={editingModel.max_context_tokens ?? ''}
+                        onChange={(e) => setEditingModel({ ...editingModel, max_context_tokens: e.target.value ? Number(e.target.value) : null })}
+                        className="input-field w-full"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-surface-400 mb-1">Input $/M tokens</label>
+                      <input
+                        type="number"
+                        step="0.01"
+                        value={editingModel.input_cost_per_m}
+                        onChange={(e) => setEditingModel({ ...editingModel, input_cost_per_m: Number(e.target.value) })}
+                        className="input-field w-full"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs text-surface-400 mb-1">Output $/M tokens</label>
+                      <input
+                        type="number"
+                        step="0.01"
+                        value={editingModel.output_cost_per_m}
+                        onChange={(e) => setEditingModel({ ...editingModel, output_cost_per_m: Number(e.target.value) })}
+                        className="input-field w-full"
+                      />
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-6">
+                    <label className="flex items-center gap-2 text-sm text-surface-300">
+                      <input type="checkbox" checked={editingModel.is_enabled} onChange={(e) => setEditingModel({ ...editingModel, is_enabled: e.target.checked })} className="rounded" />
+                      Enabled
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-surface-300">
+                      <input type="checkbox" checked={editingModel.supports_images} onChange={(e) => setEditingModel({ ...editingModel, supports_images: e.target.checked })} className="rounded" />
+                      Images
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-surface-300">
+                      <input type="checkbox" checked={editingModel.supports_tools} onChange={(e) => setEditingModel({ ...editingModel, supports_tools: e.target.checked })} className="rounded" />
+                      Tools
+                    </label>
+                  </div>
+                  <div className="flex justify-end gap-3 pt-2">
+                    <button onClick={() => setEditingModel(null)} className="px-4 py-2 text-sm text-surface-300 hover:text-surface-100">Cancel</button>
+                    <button
+                      onClick={() => void handleSaveModel(editingModel)}
+                      disabled={savingModel}
+                      className="px-4 py-2 text-sm font-medium text-white bg-primary-500 hover:bg-primary-600 rounded-lg disabled:opacity-50"
+                    >
+                      {savingModel ? 'Saving…' : 'Save'}
+                    </button>
+                  </div>
+                </div>
               </div>
             )}
           </div>

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -66,6 +66,7 @@ const ADMIN_TAB_TO_PATH: Record<AdminPanelTab, string> = {
   organizations: '/admin/teams',
   connectors: '/admin/connectors',
   jobs: '/admin/jobs',
+  models: '/admin/models',
   'graph-magic': '/admin/graph-magic',
 };
 

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -79,6 +79,18 @@ interface CreditDetails {
   starting_balance: number;
 }
 
+interface UsageByDayItem {
+  date: string;
+  input_tokens: number;
+  output_tokens: number;
+  credits_charged: number;
+  call_count: number;
+}
+
+interface UsageByDayResponse {
+  days: UsageByDayItem[];
+}
+
 /** Total credits for a chat (team + former-user) for sorting. */
 function chatTotalCredits(conv: ConversationUsage): number {
   return conv.total_credits_used + (conv.unattributed_credits_used ?? 0);
@@ -194,6 +206,22 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
   const [showCreditDetails, setShowCreditDetails] = useState(false);
   const [creditDetails, setCreditDetails] = useState<CreditDetails | null>(null);
   const [creditDetailsLoading, setCreditDetailsLoading] = useState(false);
+  const [usageByDay, setUsageByDay] = useState<UsageByDayItem[]>([]);
+  const [usageByDayLoading, setUsageByDayLoading] = useState(false);
+
+  useEffect(() => {
+    if (activeTab !== 'billing') return;
+    let cancelled = false;
+    setUsageByDayLoading(true);
+    (async () => {
+      const { data } = await apiRequest<UsageByDayResponse>('/billing/usage-by-day?days=30');
+      if (!cancelled) {
+        setUsageByDay(data?.days ?? []);
+        setUsageByDayLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [activeTab, organization.id, billingRefresh]);
 
   useEffect(() => {
     if (!showCreditDetails) return;
@@ -1528,6 +1556,46 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                               return resetDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
                             })()}
                           </span>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div>
+                    <h3 className="text-sm font-medium text-surface-200 mb-3">LLM usage (last 30 days)</h3>
+                    <div className="card p-4">
+                      {usageByDayLoading ? (
+                        <p className="text-sm text-surface-400">Loading usage…</p>
+                      ) : usageByDay.length === 0 ? (
+                        <p className="text-sm text-surface-400">No LLM usage recorded yet.</p>
+                      ) : (
+                        <div className="space-y-2">
+                          {(() => {
+                            const maxCredits = Math.max(...usageByDay.map((d) => d.credits_charged), 1);
+                            return usageByDay.map((day) => (
+                              <div key={day.date} className="flex items-center gap-3 text-xs">
+                                <span className="w-20 shrink-0 text-surface-400">
+                                  {new Date(`${day.date}T12:00:00`).toLocaleDateString(undefined, {
+                                    month: 'short',
+                                    day: 'numeric',
+                                  })}
+                                </span>
+                                <div className="flex-1 h-5 bg-surface-700 rounded overflow-hidden">
+                                  <div
+                                    className="h-full bg-primary-500/80 rounded"
+                                    style={{ width: `${(day.credits_charged / maxCredits) * 100}%` }}
+                                    title={`${day.credits_charged} credits · ${day.input_tokens + day.output_tokens} tokens · ${day.call_count} calls`}
+                                  />
+                                </div>
+                                <span className="w-16 shrink-0 text-right text-surface-300">
+                                  {day.credits_charged}
+                                </span>
+                              </div>
+                            ));
+                          })()}
+                          <p className="text-xs text-surface-500 pt-2">
+                            Bar height = credits charged per day (1 credit ≈ $0.001 LLM spend).
+                          </p>
                         </div>
                       )}
                     </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -400,6 +400,15 @@ const GLOBAL_ADMIN_NAV_ITEMS: ReadonlyArray<{
     ),
   },
   {
+    id: 'models',
+    label: 'Models',
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+      </svg>
+    ),
+  },
+  {
     id: 'graph-magic',
     label: "Graph Magic",
     icon: (

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -395,4 +395,5 @@ export type AdminPanelTab =
   | "organizations"
   | "connectors"
   | "jobs"
+  | "models"
   | "graph-magic";


### PR DESCRIPTION
## Summary

- Replaces fixed per-tool credit pricing with token-cost-based credits (1 credit ≈ $0.001 of LLM spend)
- Adds `models` table as a general-purpose model registry (pricing, capabilities, visibility flags)
- Adds `llm_usage` table for granular per-call token tracking and daily trend reporting
- Charges credits **after** each LLM response using actual token counts from the provider
- Adds admin CRUD endpoint (`/api/admin/models`) and usage-by-day billing endpoint (`/api/billing/usage-by-day`)
- Frontend: daily LLM usage bar chart in the billing panel

## Test plan

- [ ] Run migration (`alembic upgrade head`) — verify `models` and `llm_usage` tables created with seed data
- [ ] Send a chat message → verify `llm_usage` row inserted with correct token counts and credits
- [ ] Confirm `credit_transactions` row matches computed cost (not old fixed-per-tool amounts)
- [ ] Hit credit limit → verify orchestrator ends turn with out-of-credits message
- [ ] `GET /api/billing/usage-by-day` returns daily aggregates
- [ ] `GET /api/admin/models` lists seeded models; `PUT` updates pricing and invalidates cache
- [ ] Frontend billing tab shows the usage chart
- [ ] `pytest -q tests/test_llm_pricing.py tests/test_tools_credit_grace.py tests/test_credits_access.py` passes


Made with [Cursor](https://cursor.com)