### PR TITLE
Add logging to topic graph generation and view endpoints

### DIFF
--- a/backend/api/routes/topic_graph.py
+++ b/backend/api/routes/topic_graph.py
@@ -53,9 +53,12 @@ async def get_graph_snapshot(
     auth: AuthContext = Depends(require_global_admin),
 ) -> dict[str, Any]:
     d = _parse_graph_date(graph_date)
+    logger.info("topic_graph.stage=view_graph_request org_id=%s graph_date=%s by=%s", organization_id, d.isoformat(), auth.user_id)
     snapshot = await get_topic_graph_snapshot(organization_id, d)
     if snapshot is None:
+        logger.warning("topic_graph.stage=view_graph_not_found org_id=%s graph_date=%s by=%s", organization_id, d.isoformat(), auth.user_id)
         raise HTTPException(status_code=404, detail="Graph snapshot not found")
+    logger.info("topic_graph.stage=view_graph_success org_id=%s graph_date=%s by=%s status=%s", organization_id, d.isoformat(), auth.user_id, snapshot.status)
     return {
         "organization_id": organization_id,
         "graph_date": d.isoformat(),
@@ -73,7 +76,9 @@ async def get_graph_node_evidence(
     auth: AuthContext = Depends(require_global_admin),
 ) -> dict[str, Any]:
     d = _parse_graph_date(graph_date)
+    logger.info("topic_graph.stage=view_evidence_request org_id=%s graph_date=%s node_id=%s by=%s", organization_id, d.isoformat(), node_id, auth.user_id)
     snippets = await get_node_evidence(organization_id, d, node_id)
+    logger.info("topic_graph.stage=view_evidence_success org_id=%s graph_date=%s node_id=%s by=%s snippet_count=%d", organization_id, d.isoformat(), node_id, auth.user_id, len(snippets))
     return {
         "organization_id": organization_id,
         "graph_date": d.isoformat(),

--- a/backend/services/topic_graph.py
+++ b/backend/services/topic_graph.py
@@ -258,6 +258,7 @@ async def generate_topic_graph_for_org_day(org_id: str, graph_date: date) -> dic
             sd = await fn(org_id, graph_date)
             docs.extend(sd)
             coverage["sources"][source_name] = {"docs": len(sd), "status": "ok"}
+            logger.info("topic_graph.stage=ingest_source_ok org_id=%s graph_date=%s source=%s docs=%d", org_id, graph_date.isoformat(), source_name, len(sd))
         except Exception as exc:
             logger.exception("topic_graph.stage=ingest_failed source=%s org_id=%s", source_name, org_id)
             warnings.append(f"{source_name}:{exc}")
@@ -267,6 +268,7 @@ async def generate_topic_graph_for_org_day(org_id: str, graph_date: date) -> dic
         slack_docs, slack_channels = await _collect_slack_docs(org_id, graph_date)
         docs.extend(slack_docs)
         coverage["sources"]["slack"] = {"docs": len(slack_docs), "status": "ok"}
+        logger.info("topic_graph.stage=ingest_source_ok org_id=%s graph_date=%s source=slack docs=%d channels=%d", org_id, graph_date.isoformat(), len(slack_docs), len(slack_channels))
     except Exception as exc:
         warnings.append(f"slack:{exc}")
         coverage["sources"]["slack"] = {"docs": 0, "status": "failed"}
@@ -274,12 +276,13 @@ async def generate_topic_graph_for_org_day(org_id: str, graph_date: date) -> dic
     try:
         crm_people, crm_companies = await _seed_crm_nodes(org_id)
         coverage["sources"]["crm"] = {"people": len(crm_people), "companies": len(crm_companies), "status": "ok"}
+        logger.info("topic_graph.stage=ingest_source_ok org_id=%s graph_date=%s source=crm people=%d companies=%d", org_id, graph_date.isoformat(), len(crm_people), len(crm_companies))
     except Exception as exc:
         warnings.append(f"crm:{exc}")
         crm_people, crm_companies = [], []
         coverage["sources"]["crm"] = {"people": 0, "companies": 0, "status": "failed"}
 
-    logger.info("topic_graph.stage=extract org_id=%s docs=%d", org_id, len(docs))
+    logger.info("topic_graph.stage=extract org_id=%s graph_date=%s docs=%d", org_id, graph_date.isoformat(), len(docs))
     node_to_docs: dict[str, set[str]] = defaultdict(set)
     node_newest: dict[str, datetime] = {}
     node_oldest: dict[str, datetime] = {}
@@ -411,6 +414,7 @@ async def generate_topic_graph_for_org_day(org_id: str, graph_date: date) -> dic
     edges = [{"source": a, "target": b, "weight": w} for (a, b), w in sorted(edge_weights.items())]
 
     coverage["partial"] = any(v.get("status") == "failed" for v in coverage["sources"].values())
+    logger.info("topic_graph.stage=build_summary org_id=%s graph_date=%s docs=%d merged_nodes=%d edges=%d partial=%s", org_id, graph_date.isoformat(), len(docs), len(merged_docs), len(edge_weights), coverage["partial"])
     if coverage["partial"]:
         coverage["warning_text"] = PARTIAL_WARNING
 

--- a/backend/tests/test_topic_graph_logging.py
+++ b/backend/tests/test_topic_graph_logging.py
@@ -1,0 +1,39 @@
+import logging
+from datetime import date
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from api.auth_middleware import AuthContext
+from api.routes import topic_graph as topic_graph_routes
+
+
+@pytest.mark.asyncio
+async def test_get_graph_snapshot_logs_view_success(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    async def _fake_get_snapshot(_org_id: str, _date: date):
+        return SimpleNamespace(status="completed", graph_payload={"nodes": []}, run_metadata={})
+
+    monkeypatch.setattr(topic_graph_routes, "get_topic_graph_snapshot", _fake_get_snapshot)
+    auth = AuthContext(user_id=uuid4(), organization_id=None, email="test@example.com", role="admin", is_global_admin=True)
+
+    caplog.set_level(logging.INFO, logger=topic_graph_routes.logger.name)
+    await topic_graph_routes.get_graph_snapshot("org-1", "2026-04-10", auth)
+
+    assert "topic_graph.stage=view_graph_request" in caplog.text
+    assert "topic_graph.stage=view_graph_success" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_get_graph_node_evidence_logs_success(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    async def _fake_get_evidence(_org_id: str, _date: date, _node_id: str):
+        return [{"snippet": "hello"}]
+
+    monkeypatch.setattr(topic_graph_routes, "get_node_evidence", _fake_get_evidence)
+    auth = AuthContext(user_id=uuid4(), organization_id=None, email="test@example.com", role="admin", is_global_admin=True)
+
+    caplog.set_level(logging.INFO, logger=topic_graph_routes.logger.name)
+    await topic_graph_routes.get_graph_node_evidence("org-1", "2026-04-10", "node-a", auth)
+
+    assert "topic_graph.stage=view_evidence_request" in caplog.text
+    assert "topic_graph.stage=view_evidence_success" in caplog.text


### PR DESCRIPTION
### Motivation
- Improve observability and make topic-graph generation and viewing easier to debug by emitting structured lifecycle logs for ingest, build, and view flows.

### Description
- Log request / not-found / success (with `status`) for snapshot views in `backend/api/routes/topic_graph.py` and add request / success (with `snippet_count`) for node-evidence endpoints.
- Add per-source ingestion success logs for activities, Slack, and CRM plus include `graph_date` in extract logs and emit a `build_summary` log with docs / merged_nodes / edges / partial status in `backend/services/topic_graph.py`.
- Add async route-level tests in `backend/tests/test_topic_graph_logging.py` that assert the new view/evidence log messages are emitted.

### Testing
- Ran `cd backend && pytest -q tests/test_topic_graph.py tests/test_topic_graph_logging.py` and all tests passed.
- Test run summary: `10 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bd9071da88321ab0400382ea6fd2a)