### PR TITLE
Add Fly.io deployment and GitHub Actions CI/CD

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,84 @@
+# Deploy Basebase to Fly.io after Conformance Tests pass on main.
+# Setup: add repository secret FLY_API_TOKEN (see FLY_DEPLOY.md).
+name: Deploy to Fly.io
+
+on:
+  workflow_run:
+    workflows: ["Conformance Tests"]
+    types: [completed]
+  workflow_dispatch:
+
+concurrency:
+  group: fly-deploy-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy production
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.event == 'push'
+      )
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
+
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+            frontend:
+              - 'frontend/**'
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy API
+        if: steps.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
+        working-directory: backend
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy --app basebase-api --ha=false
+
+      - name: Deploy Celery worker
+        if: steps.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
+        working-directory: backend
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy -c fly.worker.toml --app basebase-worker --ha=false
+
+      - name: Deploy Celery beat
+        if: steps.changes.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
+        working-directory: backend
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy -c fly.beat.toml --app basebase-beat --ha=false
+
+      - name: Deploy frontend
+        if: steps.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
+        working-directory: frontend
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          args=(
+            --app basebase-frontend
+            --ha=false
+            --build-arg "VITE_API_URL=https://api.basebase.com"
+            --build-arg "VITE_SUPABASE_URL=https://izcwxmpvafizqkcxioje.supabase.co"
+            --build-arg "VITE_SUPABASE_ANON_KEY=sb_publishable_cT376efSsrslvrZF8jgmoA_JLsatNyO"
+            --build-arg "VITE_STRIPE_PUBLISHABLE_KEY=pk_live_51SeKtdP5SO7X9dBUvZL79msr7pCl9mVGT67Psm9EGzPbeZfctym5qIUQwIxvFoCnp1VqefqMGtMv0voQq8Ypv26600tRnmNRiP"
+          )
+          if [ -n "${{ secrets.VITE_NANGO_PUBLIC_KEY }}" ]; then
+            args+=(--build-arg "VITE_NANGO_PUBLIC_KEY=${{ secrets.VITE_NANGO_PUBLIC_KEY }}")
+          fi
+          flyctl deploy "${args[@]}"

--- a/FLY_DEPLOY.md
+++ b/FLY_DEPLOY.md
@@ -1,0 +1,114 @@
+# Deploy Basebase to Fly.io
+
+Emergency / production deploy using Docker on [Fly.io](https://fly.io). Supabase stays external.
+
+## Prerequisites
+
+1. **Billing**: Fly trial accounts must add a card at [fly.io/dashboard](https://fly.io/dashboard) → Billing (deploy fails with 422 otherwise).
+2. **CLI**: `brew install flyctl && fly auth login`
+3. **Env**: Production values in repo root [`.env`](.env)
+
+## CI/CD (GitHub Actions)
+
+On every **push to `main`**, after [Conformance Tests](.github/workflows/conformance-tests.yml) pass, [.github/workflows/fly-deploy.yml](.github/workflows/fly-deploy.yml) deploys:
+
+| Change in | Deploys |
+|-----------|---------|
+| `backend/**` | API, Celery worker, Celery beat |
+| `frontend/**` | Frontend |
+
+**One-time setup** (repo admin):
+
+1. Create a Fly deploy token (deploys all apps in your org):
+
+   ```bash
+   fly auth token
+   ```
+
+   Copy the full token (starts with `FlyV1 `).
+
+2. GitHub → **Settings** → **Secrets and variables** → **Actions** → **New repository secret**:
+   - `FLY_API_TOKEN` = token from step 1
+   - Optional: `VITE_NANGO_PUBLIC_KEY` if you use Nango OAuth in the UI
+
+3. Merge the workflow to `main`. The next green conformance run on `main` triggers deploy.
+
+**Manual deploy from GitHub**: Actions → **Deploy to Fly.io** → **Run workflow**.
+
+`basebase-redis` is not in CI (image-only, rarely changes). Redeploy with `./scripts/fly-deploy.sh` or `fly deploy -c fly.redis.toml --app basebase-redis` if needed.
+
+## One-command deploy
+
+```bash
+./scripts/fly-deploy.sh
+```
+
+This creates/updates:
+
+| Fly app | Config | Role |
+|---------|--------|------|
+| `basebase-redis` | [backend/fly.redis.toml](backend/fly.redis.toml) | Internal Redis (`redis://basebase-redis.internal:6379`) |
+| `basebase-api` | [backend/fly.toml](backend/fly.toml) | FastAPI, health `GET /health` |
+| `basebase-worker` | [backend/fly.worker.toml](backend/fly.worker.toml) | Celery worker |
+| `basebase-beat` | [backend/fly.beat.toml](backend/fly.beat.toml) | Celery beat (`ENABLE_CELERY_BEAT=true`) |
+| `basebase-frontend` | [frontend/fly.toml](frontend/fly.toml) | Vite build + nginx |
+
+Production URLs:
+
+- API: `https://api.basebase.com`
+- App: `https://app.basebase.com`
+- Fly defaults (fallback): `https://basebase-api.fly.dev`, `https://basebase-frontend.fly.dev`
+
+## Manual steps (optional)
+
+```bash
+# Redis
+cd backend && fly deploy -c fly.redis.toml --app basebase-redis
+
+# API
+fly secrets import --app basebase-api < <(./scripts/fly-secrets-export.sh)
+cd backend && fly deploy --app basebase-api
+
+# Worker / beat
+cd backend && fly deploy -c fly.worker.toml --app basebase-worker
+cd backend && fly deploy -c fly.beat.toml --app basebase-beat
+
+# Frontend (build-time VITE_* args)
+cd frontend && fly deploy --app basebase-frontend \
+  --build-arg VITE_API_URL=https://basebase-api.fly.dev \
+  --build-arg VITE_SUPABASE_URL=... \
+  --build-arg VITE_SUPABASE_ANON_KEY=...
+```
+
+## Custom domains
+
+```bash
+fly certs create api.basebase.com --app basebase-api
+fly certs create app.basebase.com --app basebase-frontend
+```
+
+Update DNS per `fly certs show`, then set secrets:
+
+```bash
+fly secrets set BACKEND_PUBLIC_URL=https://api.basebase.com FRONTEND_URL=https://app.basebase.com --app basebase-api
+```
+
+Redeploy frontend with `VITE_API_URL=https://api.basebase.com`.
+
+## Upstash Redis (optional)
+
+To use managed Redis instead of `basebase-redis`:
+
+```bash
+fly redis create --name basebase-redis --region sjc --enable-eviction --no-replicas
+```
+
+Set `REDIS_URL` from `fly redis status` and skip the `basebase-redis` app deploy in the script.
+
+## Verify
+
+```bash
+curl -s https://basebase-api.fly.dev/health
+fly status --app basebase-api
+fly logs --app basebase-worker
+```

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim AS base
 
 WORKDIR /app
 
@@ -29,8 +29,15 @@ COPY . .
 # Set Python path
 ENV PYTHONPATH=/app
 
-# Expose port (Railway provides PORT env var)
+# Expose port (Railway / Fly provide PORT env var)
 EXPOSE 8000
 
-# Run the application - use shell to expand $PORT
+# Fly.io / multi-service builds (Railway uses final stage = api)
+FROM base AS worker
+CMD ["python", "-m", "celery", "-A", "workers.celery_app", "worker", "--loglevel=info"]
+
+FROM base AS beat
+CMD ["python", "-m", "celery", "-A", "workers.celery_app", "beat", "--loglevel=info"]
+
+FROM base AS api
 CMD ["/bin/sh", "-c", "uvicorn api.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/fly.beat.toml
+++ b/backend/fly.beat.toml
@@ -1,0 +1,16 @@
+# Celery beat — deploy: fly deploy -c fly.beat.toml --app basebase-beat
+app = "basebase-beat"
+primary_region = "sjc"
+
+[build]
+  dockerfile = "Dockerfile"
+  build-target = "beat"
+
+[env]
+  ENVIRONMENT = "production"
+  PYTHONPATH = "/app"
+  ENABLE_CELERY_BEAT = "true"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "1gb"

--- a/backend/fly.redis.toml
+++ b/backend/fly.redis.toml
@@ -1,0 +1,23 @@
+# Internal Redis (Celery broker) — deploy: fly deploy -c fly.redis.toml --app basebase-redis
+# Connect from other Fly apps: redis://basebase-redis.internal:6379
+app = "basebase-redis"
+primary_region = "sjc"
+
+[build]
+  image = "redis:7-alpine"
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 6379
+  processes = ["app"]
+
+  [[services.ports]]
+    port = 6379
+
+  [[services.tcp_checks]]
+    interval = "15s"
+    timeout = "2s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -1,0 +1,30 @@
+# Basebase API (FastAPI) — deploy: fly deploy --app basebase-api
+app = "basebase-api"
+primary_region = "sjc"
+
+[build]
+  dockerfile = "Dockerfile"
+  build-target = "api"
+
+[env]
+  ENVIRONMENT = "production"
+  PORT = "8000"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [[http_service.checks]]
+    grace_period = "60s"
+    interval = "15s"
+    method = "GET"
+    path = "/health"
+    timeout = "10s"
+
+[[vm]]
+  size = "shared-cpu-2x"
+  memory = "2gb"

--- a/backend/fly.worker.toml
+++ b/backend/fly.worker.toml
@@ -1,0 +1,15 @@
+# Celery worker — deploy: fly deploy -c fly.worker.toml --app basebase-worker
+app = "basebase-worker"
+primary_region = "sjc"
+
+[build]
+  dockerfile = "Dockerfile"
+  build-target = "worker"
+
+[env]
+  ENVIRONMENT = "production"
+  PYTHONPATH = "/app"
+
+[[vm]]
+  size = "shared-cpu-2x"
+  memory = "2gb"

--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -1,0 +1,33 @@
+# Basebase frontend (Vite + nginx) — deploy: fly deploy --app basebase-frontend
+app = "basebase-frontend"
+primary_region = "sjc"
+
+[build]
+  dockerfile = "Dockerfile.prod"
+
+  [build.args]
+    VITE_API_URL = "https://api.basebase.com"
+    VITE_SUPABASE_URL = "https://izcwxmpvafizqkcxioje.supabase.co"
+    VITE_SUPABASE_ANON_KEY = "sb_publishable_cT376efSsrslvrZF8jgmoA_JLsatNyO"
+    VITE_STRIPE_PUBLISHABLE_KEY = "pk_live_51SeKtdP5SO7X9dBUvZL79msr7pCl9mVGT67Psm9EGzPbeZfctym5qIUQwIxvFoCnp1VqefqMGtMv0voQq8Ypv26600tRnmNRiP"
+    # Set at deploy time if you use Nango OAuth in the UI (see scripts/fly-deploy.sh)
+    VITE_NANGO_PUBLIC_KEY = ""
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [[http_service.checks]]
+    grace_period = "30s"
+    interval = "15s"
+    method = "GET"
+    path = "/"
+    timeout = "10s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/scripts/fly-deploy.sh
+++ b/scripts/fly-deploy.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Deploy Basebase to Fly.io (API, worker, beat, frontend + Upstash Redis).
+# Prerequisites: flyctl installed, `fly auth login`, project root `.env` with production values.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if ! command -v fly >/dev/null 2>&1; then
+  echo "Install flyctl: brew install flyctl"
+  exit 1
+fi
+
+if ! fly auth whoami >/dev/null 2>&1; then
+  echo "Run: fly auth login"
+  exit 1
+fi
+
+if ! fly deploy --help >/dev/null 2>&1; then
+  echo "flyctl is required"
+  exit 1
+fi
+
+echo "Note: Fly trial accounts need a card on file before deploy."
+echo "      https://fly.io/dashboard/teg-grenager/billing"
+echo ""
+
+if [[ ! -f .env ]]; then
+  echo "Missing .env at repo root"
+  exit 1
+fi
+
+# Load .env safely (handles values with spaces/special chars)
+load_env() {
+  "$ROOT/venv/bin/python" - <<'PY'
+import shlex
+from pathlib import Path
+from dotenv import dotenv_values
+
+for key, value in dotenv_values(Path(".env")).items():
+    if value is None or value == "":
+        continue
+    print(f"export {key}={shlex.quote(str(value))}")
+PY
+}
+# shellcheck disable=SC1090
+eval "$(load_env)"
+
+REGION="${FLY_REGION:-sjc}"
+
+fly_apps_ensure() {
+  local app="$1"
+  if ! fly apps list 2>/dev/null | awk '{print $1}' | grep -qx "$app"; then
+    fly apps create "$app" --org personal 2>/dev/null || fly apps create "$app"
+  fi
+}
+
+# Internal Redis on Fly private network (avoids interactive Upstash CLI prompts)
+FLY_REDIS_URL="redis://basebase-redis.internal:6379"
+echo "==> Redis app (basebase-redis)"
+fly_apps_ensure basebase-redis
+(cd backend && fly deploy -c fly.redis.toml --app basebase-redis --ha=false)
+
+if [[ "${REDIS_URL:-}" == *localhost* ]] || [[ -z "${REDIS_URL:-}" ]]; then
+  export REDIS_URL="$FLY_REDIS_URL"
+  echo "Using REDIS_URL=$REDIS_URL"
+fi
+
+# Production URLs on Fly (*.fly.dev until custom certs are added)
+export ENVIRONMENT=production
+export BACKEND_PUBLIC_URL="https://basebase-api.fly.dev"
+export FRONTEND_URL="https://basebase-frontend.fly.dev"
+export VITE_API_URL="https://basebase-api.fly.dev"
+
+if [[ -z "${NANGO_PUBLIC_KEY:-}" ]] && [[ -n "${VITE_NANGO_PUBLIC_KEY:-}" ]]; then
+  export NANGO_PUBLIC_KEY="$VITE_NANGO_PUBLIC_KEY"
+fi
+
+fly_apps_ensure basebase-api
+fly_apps_ensure basebase-worker
+fly_apps_ensure basebase-beat
+fly_apps_ensure basebase-frontend
+
+# Backend secrets (API + worker need full bundle; beat needs Redis + shared flags)
+backend_secret_keys=(
+  DATABASE_URL MIGRATION_DATABASE_URL REDIS_URL
+  ANTHROPIC_API_KEY OPENAI_API_KEY GEMINI_API_KEY MINIMAX_API_KEY DEEPSEEK_API_KEY
+  DEFAULT_PRIMARY_MODEL DEFAULT_CHEAP_MODEL ALL_MODEL_STRINGS
+  NANGO_SECRET_KEY NANGO_PUBLIC_KEY
+  SECRET_KEY ENVIRONMENT FRONTEND_URL BACKEND_PUBLIC_URL
+  SUPABASE_URL SUPABASE_ANON_KEY SUPABASE_JWT_SECRET
+  SLACK_CLIENT_ID SLACK_CLIENT_SECRET SLACK_BOT_TOKEN SLACK_SIGNING_SECRET SUPPORT_SLACK_WEBHOOK_URL
+  MICROSOFT_APP_ID MICROSOFT_APP_PASSWORD MICROSOFT_TENANT_ID
+  TWILIO_ACCOUNT_SID TWILIO_AUTH_TOKEN TWILIO_PHONE_NUMBER TWILIO_VERIFY_SERVICE_SID
+  TWILIO_WEBHOOK_URL WHATSAPP_WEBHOOK_URL
+  GMAIL_CLIENT_ID GMAIL_CLIENT_SECRET SCRAPINGBEE_API_KEY
+  PERPLEXITY_API_KEY EXA_API_KEY AIRTOP_API_KEY AIRTOP_KEY
+  GOOGLE_ADS_DEVELOPER_TOKEN HUBSPOT_API_KEY HUBSPOT_PERSONAL_ACCESS_KEY
+  GOOGLE_SHEETS_DOCS_SLIDES_API_KEY AIRTABLE_API_KEY TRELLO_API_KEY
+  E2B_API_KEY PINECONE_API_KEY RESEND_API_KEY EMAIL_FROM
+  STRIPE_SECRET_KEY STRIPE_WEBHOOK_SECRET STRIPE_PUBLISHABLE_KEY
+)
+
+set_backend_secrets() {
+  local app="$1"
+  local args=()
+  for key in "${backend_secret_keys[@]}"; do
+  local val="${!key:-}"
+    if [[ -n "$val" ]]; then
+      args+=("$key=$val")
+    fi
+  done
+  if [[ ${#args[@]} -gt 0 ]]; then
+    echo "==> fly secrets set (${#args[@]} vars) on $app"
+    fly secrets set "${args[@]}" --app "$app"
+  fi
+}
+
+set_backend_secrets basebase-api
+set_backend_secrets basebase-worker
+fly secrets set REDIS_URL="$REDIS_URL" ENABLE_CELERY_BEAT=true ENVIRONMENT=production --app basebase-beat
+
+echo "==> Deploy API"
+(cd backend && fly deploy --app basebase-api --ha=false)
+
+echo "==> Deploy worker"
+(cd backend && fly deploy -c fly.worker.toml --app basebase-worker --ha=false)
+
+echo "==> Deploy beat"
+(cd backend && fly deploy -c fly.beat.toml --app basebase-beat --ha=false)
+
+echo "==> Deploy frontend"
+FRONTEND_BUILD_ARGS=(
+  --build-arg "VITE_API_URL=$VITE_API_URL"
+  --build-arg "VITE_SUPABASE_URL=${VITE_SUPABASE_URL}"
+  --build-arg "VITE_SUPABASE_ANON_KEY=${VITE_SUPABASE_ANON_KEY}"
+  --build-arg "VITE_STRIPE_PUBLISHABLE_KEY=${VITE_STRIPE_PUBLISHABLE_KEY:-}"
+)
+if [[ -n "${VITE_NANGO_PUBLIC_KEY:-${NANGO_PUBLIC_KEY:-}}" ]]; then
+  FRONTEND_BUILD_ARGS+=(--build-arg "VITE_NANGO_PUBLIC_KEY=${VITE_NANGO_PUBLIC_KEY:-$NANGO_PUBLIC_KEY}")
+fi
+(cd frontend && fly deploy --app basebase-frontend --ha=false "${FRONTEND_BUILD_ARGS[@]}")
+
+echo ""
+echo "Done. Smoke test:"
+echo "  curl -s https://basebase-api.fly.dev/health"
+echo "  open https://basebase-frontend.fly.dev"
+echo ""
+echo "After DNS: fly certs create api.basebase.com --app basebase-api"
+echo "           fly certs create app.basebase.com --app basebase-frontend"


### PR DESCRIPTION
## Summary
- Adds Fly.io configs for API, Celery worker, Celery beat, frontend, and internal Redis
- Multi-stage `backend/Dockerfile` targets (`api`, `worker`, `beat`) for separate Fly apps
- GitHub Actions workflow deploys to Fly after **Conformance Tests** pass on `main`
- Path-aware deploys: `backend/**` → API + worker + beat; `frontend/**` → frontend
- Manual deploy script and docs in `FLY_DEPLOY.md`

## Setup (already done)
- `FLY_API_TOKEN` repository secret added in GitHub

## After merge
1. Push to `main` (or run **Actions → Deploy to Fly.io → Run workflow**)
2. Verify https://api.basebase.com/health and https://app.basebase.com

## Test plan
- [ ] Merge PR
- [ ] Confirm Conformance Tests pass on `main`
- [ ] Confirm **Deploy to Fly.io** workflow runs and succeeds
- [ ] Smoke test API health and app load

Made with [Cursor](https://cursor.com)