### PR TITLE
fix: Fly deploy concurrency race

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: fly-deploy-production
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   deploy:
@@ -20,8 +20,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.head_branch == 'main' &&
-        github.event.workflow_run.event == 'push'
+        github.event.workflow_run.head_branch == 'main'
       )
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Disable cancel-in-progress so a started production deploy is not aborted by a later workflow_run
- Deploy only when conformance succeeds on `main` (drops redundant `event == push` check)

## Test plan
- [ ] Merge and run **Actions → Deploy to Fly.io → Run workflow**

Made with [Cursor](https://cursor.com)