### PR TITLE
Add missing `pointIndexBy` prop to Cosmograph in GraphMagic

### DIFF
--- a/frontend/src/components/GraphMagic.tsx
+++ b/frontend/src/components/GraphMagic.tsx
@@ -485,6 +485,7 @@ export function GraphMagic(): JSX.Element {
           <Cosmograph
             key={`graph-${orgId}-${selectedDate}-${repulsionLevel}-${sizeMode}`}
             points={cosmographPoints}
+            pointIndexBy="id"
             pointIdBy="id"
             pointLabelBy="label"
             pointColorBy="color"


### PR DESCRIPTION
### Motivation
- The `Cosmograph` component requires a `pointIndexBy` mapping and the missing prop caused the runtime error `Missing required properties: "pointIndexBy"` when loading graph points.

### Description
- Add `pointIndexBy="id"` to the `Cosmograph` invocation in `frontend/src/components/GraphMagic.tsx` so index mapping aligns with the existing `pointIdBy="id"` and `points` data.

### Testing
- Ran `cd frontend && npm run -s build` and the frontend build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfe84ccfc8321b43599c0222a95b6)