### PR TITLE
Fix connector visibility for team-connected providers

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -4438,9 +4438,11 @@ async def list_integrations(
             integrations_for_provider = integrations_by_provider.get(provider, [])
 
             team_connections: list[TeamConnection] = []
+            team_visible_integrations: list[Integration] = []
             for integration in integrations_for_provider:
                 if integration.user_id and integration.user_id in team_members:
                     user_obj = team_members[integration.user_id]
+                    team_visible_integrations.append(integration)
                     team_connections.append(TeamConnection(
                         user_id=str(integration.user_id),
                         user_name=user_obj.name or user_obj.email,
@@ -4499,11 +4501,11 @@ async def list_integrations(
                     ))
             else:
                 representative_integration: Integration | None = None
-                if integrations_for_provider:
+                if team_visible_integrations:
                     # When only teammates have connected a provider, expose it as
                     # connected for discovery ("from team" / org-shared sections).
                     representative_integration = sorted(
-                        integrations_for_provider,
+                        team_visible_integrations,
                         key=lambda row: (
                             not row.is_active,
                             row.account_identifier or "",
@@ -4512,7 +4514,11 @@ async def list_integrations(
                     )[0]
 
                 response_integrations.append(IntegrationResponse(
-                    id=f"pending-{provider}",
+                    id=(
+                        str(representative_integration.id)
+                        if representative_integration and representative_integration.is_active
+                        else f"pending-{provider}"
+                    ),
                     provider=provider,
                     is_active=(representative_integration.is_active if representative_integration else False),
                     last_sync_at=(

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -4508,6 +4508,11 @@ async def list_integrations(
                         team_visible_integrations,
                         key=lambda row: (
                             not row.is_active,
+                            not (
+                                row.share_synced_data
+                                or row.share_query_access
+                                or row.share_write_access
+                            ),
                             row.account_identifier or "",
                             str(row.id),
                         ),

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -4560,7 +4560,15 @@ async def list_integrations(
                     team_connections=team_connections,
                     team_total=team_total,
                     sync_stats=(representative_integration.sync_stats if representative_integration else None),
-                    display_name=None,
+                    display_name=(
+                        representative_integration.extra_data.get("display_name")
+                        if (
+                            representative_integration
+                            and provider.startswith("mcp_")
+                            and isinstance(representative_integration.extra_data, dict)
+                        )
+                        else None
+                    ),
                     account_identifier=(
                         representative_integration.account_identifier
                         if representative_integration

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -4504,7 +4504,11 @@ async def list_integrations(
                     # connected for discovery ("from team" / org-shared sections).
                     representative_integration = sorted(
                         integrations_for_provider,
-                        key=lambda row: (row.account_identifier or "", str(row.id)),
+                        key=lambda row: (
+                            not row.is_active,
+                            row.account_identifier or "",
+                            str(row.id),
+                        ),
                     )[0]
 
                 response_integrations.append(IntegrationResponse(

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -4498,29 +4498,74 @@ async def list_integrations(
                         account_avatar_url=avatar_url,
                     ))
             else:
+                representative_integration: Integration | None = None
+                if integrations_for_provider:
+                    # When only teammates have connected a provider, expose it as
+                    # connected for discovery ("from team" / org-shared sections).
+                    representative_integration = sorted(
+                        integrations_for_provider,
+                        key=lambda row: (row.account_identifier or "", str(row.id)),
+                    )[0]
+
                 response_integrations.append(IntegrationResponse(
                     id=f"pending-{provider}",
                     provider=provider,
-                    is_active=False,
-                    last_sync_at=None,
-                    last_error=None,
-                    connected_at=None,
+                    is_active=(representative_integration.is_active if representative_integration else False),
+                    last_sync_at=(
+                        f"{representative_integration.last_sync_at.isoformat()}Z"
+                        if representative_integration and representative_integration.last_sync_at
+                        else None
+                    ),
+                    last_error=(representative_integration.last_error if representative_integration else None),
+                    connected_at=(
+                        f"{representative_integration.created_at.isoformat()}Z"
+                        if representative_integration and representative_integration.created_at
+                        else None
+                    ),
                     scope=scope_by_provider.get(provider, ConnectorScope.USER.value),
                     user_id=None,
                     connected_by=None,
-                    share_synced_data=False,
-                    share_query_access=False,
-                    share_write_access=False,
-                    pending_sharing_config=False,
+                    share_synced_data=(
+                        representative_integration.share_synced_data
+                        if representative_integration
+                        else False
+                    ),
+                    share_query_access=(
+                        representative_integration.share_query_access
+                        if representative_integration
+                        else False
+                    ),
+                    share_write_access=(
+                        representative_integration.share_write_access
+                        if representative_integration
+                        else False
+                    ),
+                    pending_sharing_config=(
+                        representative_integration.pending_sharing_config
+                        if representative_integration
+                        else False
+                    ),
                     is_owner=False,
                     current_user_connected=False,
                     team_connections=team_connections,
                     team_total=team_total,
-                    sync_stats=None,
+                    sync_stats=(representative_integration.sync_stats if representative_integration else None),
                     display_name=None,
-                    account_identifier=None,
-                    account_label=None,
-                    account_avatar_url=None,
+                    account_identifier=(
+                        representative_integration.account_identifier
+                        if representative_integration
+                        else None
+                    ),
+                    account_label=(
+                        representative_integration.account_label
+                        if representative_integration
+                        else None
+                    ),
+                    account_avatar_url=(
+                        read_account_avatar_url(representative_integration.extra_data)
+                        if representative_integration
+                        else None
+                    ),
                 ))
 
         return IntegrationsListResponse(integrations=response_integrations)

--- a/backend/tests/test_list_integrations_visibility.py
+++ b/backend/tests/test_list_integrations_visibility.py
@@ -162,3 +162,50 @@ def test_list_integrations_team_rep_ignores_non_team_rows(monkeypatch):
     gmail_row = [row for row in result.integrations if row.provider == "gmail"][0]
     assert gmail_row.id == str(teammate_integration.id)
     assert gmail_row.account_identifier == "teammate@gmail.com"
+
+
+def test_list_integrations_team_rep_preserves_mcp_display_name(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    current_user_id = UUID("22222222-2222-2222-2222-222222222222")
+    teammate_id = UUID("33333333-3333-3333-3333-333333333333")
+
+    teammate_integration = SimpleNamespace(
+        id=UUID("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+        connector="mcp_salesforce",
+        organization_id=org_id,
+        user_id=teammate_id,
+        is_active=True,
+        last_sync_at=None,
+        last_error=None,
+        created_at=None,
+        share_synced_data=True,
+        share_query_access=True,
+        share_write_access=False,
+        pending_sharing_config=False,
+        sync_stats={"activities": 7},
+        account_identifier="salesforce-teammate",
+        account_label="Salesforce MCP",
+        extra_data={"display_name": "Salesforce MCP"},
+    )
+    teammate_user = SimpleNamespace(id=teammate_id, name="Teammate", email="teammate@example.com")
+
+    fake_session = _FakeSession([teammate_integration], [teammate_user])
+    monkeypatch.setattr(auth, "get_session", lambda **kwargs: _FakeSessionContext(fake_session))
+    monkeypatch.setattr(auth, "_get_scope_by_provider", lambda: {"mcp_salesforce": "user"})
+    monkeypatch.setattr(auth, "PROVIDER_SHARING_DEFAULTS", {"mcp_salesforce": {}})
+
+    result = asyncio.run(
+        auth.list_integrations(
+            auth=auth.AuthContext(
+                user_id=current_user_id,
+                organization_id=org_id,
+                email="requester@example.com",
+                role="member",
+                is_global_admin=False,
+            ),
+        )
+    )
+
+    row = [r for r in result.integrations if r.provider == "mcp_salesforce"][0]
+    assert row.current_user_connected is False
+    assert row.display_name == "Salesforce MCP"

--- a/backend/tests/test_list_integrations_visibility.py
+++ b/backend/tests/test_list_integrations_visibility.py
@@ -209,3 +209,71 @@ def test_list_integrations_team_rep_preserves_mcp_display_name(monkeypatch):
     row = [r for r in result.integrations if r.provider == "mcp_salesforce"][0]
     assert row.current_user_connected is False
     assert row.display_name == "Salesforce MCP"
+
+
+def test_list_integrations_team_rep_prioritizes_shared_active_rows(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    current_user_id = UUID("22222222-2222-2222-2222-222222222222")
+    teammate_a_id = UUID("33333333-3333-3333-3333-333333333333")
+    teammate_b_id = UUID("44444444-4444-4444-4444-444444444444")
+
+    active_not_shared = SimpleNamespace(
+        id=UUID("dddddddd-dddd-dddd-dddd-dddddddddddd"),
+        connector="gmail",
+        organization_id=org_id,
+        user_id=teammate_a_id,
+        is_active=True,
+        last_sync_at=None,
+        last_error=None,
+        created_at=None,
+        share_synced_data=False,
+        share_query_access=False,
+        share_write_access=False,
+        pending_sharing_config=False,
+        sync_stats={"activities": 1},
+        account_identifier="alpha@example.com",
+        account_label="Alpha",
+        extra_data={},
+    )
+    active_shared = SimpleNamespace(
+        id=UUID("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"),
+        connector="gmail",
+        organization_id=org_id,
+        user_id=teammate_b_id,
+        is_active=True,
+        last_sync_at=None,
+        last_error=None,
+        created_at=None,
+        share_synced_data=True,
+        share_query_access=False,
+        share_write_access=False,
+        pending_sharing_config=False,
+        sync_stats={"activities": 2},
+        account_identifier="zeta@example.com",
+        account_label="Zeta",
+        extra_data={},
+    )
+
+    teammate_a = SimpleNamespace(id=teammate_a_id, name="Alpha", email="alpha@example.com")
+    teammate_b = SimpleNamespace(id=teammate_b_id, name="Zeta", email="zeta@example.com")
+
+    fake_session = _FakeSession([active_not_shared, active_shared], [teammate_a, teammate_b])
+    monkeypatch.setattr(auth, "get_session", lambda **kwargs: _FakeSessionContext(fake_session))
+    monkeypatch.setattr(auth, "_get_scope_by_provider", lambda: {"gmail": "user"})
+    monkeypatch.setattr(auth, "PROVIDER_SHARING_DEFAULTS", {"gmail": {}})
+
+    result = asyncio.run(
+        auth.list_integrations(
+            auth=auth.AuthContext(
+                user_id=current_user_id,
+                organization_id=org_id,
+                email="requester@example.com",
+                role="member",
+                is_global_admin=False,
+            ),
+        )
+    )
+
+    gmail_row = [row for row in result.integrations if row.provider == "gmail"][0]
+    assert gmail_row.id == str(active_shared.id)
+    assert gmail_row.share_synced_data is True

--- a/backend/tests/test_list_integrations_visibility.py
+++ b/backend/tests/test_list_integrations_visibility.py
@@ -1,0 +1,96 @@
+import asyncio
+from types import SimpleNamespace
+from uuid import UUID
+
+from api.routes import auth
+
+
+class _ScalarResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeSession:
+    def __init__(self, integrations, team_members):
+        self._integrations = integrations
+        self._team_members = team_members
+        self._execute_calls = 0
+
+    async def execute(self, _query):
+        self._execute_calls += 1
+        if self._execute_calls == 1:
+            return _ScalarResult(self._integrations)
+        if self._execute_calls == 2:
+            return _ScalarResult(self._team_members)
+        raise AssertionError("Unexpected execute call")
+
+
+class _FakeSessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_list_integrations_includes_team_connected_provider_as_connected(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    current_user_id = UUID("22222222-2222-2222-2222-222222222222")
+    teammate_id = UUID("33333333-3333-3333-3333-333333333333")
+
+    teammate_integration = SimpleNamespace(
+        id=UUID("44444444-4444-4444-4444-444444444444"),
+        connector="gmail",
+        organization_id=org_id,
+        user_id=teammate_id,
+        is_active=True,
+        last_sync_at=None,
+        last_error=None,
+        created_at=None,
+        share_synced_data=True,
+        share_query_access=True,
+        share_write_access=False,
+        pending_sharing_config=False,
+        sync_stats={"activities": 12},
+        account_identifier="teammate@gmail.com",
+        account_label="Teammate Gmail",
+        extra_data={"account_avatar_url": "https://example.com/avatar.png"},
+    )
+
+    teammate_user = SimpleNamespace(id=teammate_id, name="Teammate", email="teammate@example.com")
+
+    fake_session = _FakeSession([teammate_integration], [teammate_user])
+    monkeypatch.setattr(auth, "get_session", lambda **kwargs: _FakeSessionContext(fake_session))
+    monkeypatch.setattr(auth, "_get_scope_by_provider", lambda: {"gmail": "user"})
+    monkeypatch.setattr(auth, "PROVIDER_SHARING_DEFAULTS", {"gmail": {}})
+
+    result = asyncio.run(
+        auth.list_integrations(
+            auth=auth.AuthContext(
+                user_id=current_user_id,
+                organization_id=org_id,
+                email="requester@example.com",
+                role="member",
+                is_global_admin=False,
+            ),
+        )
+    )
+
+    gmail_rows = [row for row in result.integrations if row.provider == "gmail"]
+    assert len(gmail_rows) == 1
+    gmail_row = gmail_rows[0]
+
+    assert gmail_row.current_user_connected is False
+    assert gmail_row.is_active is True
+    assert gmail_row.team_connections
+    assert gmail_row.team_connections[0].user_name == "Teammate"
+    assert gmail_row.account_identifier == "teammate@gmail.com"

--- a/backend/tests/test_list_integrations_visibility.py
+++ b/backend/tests/test_list_integrations_visibility.py
@@ -94,3 +94,71 @@ def test_list_integrations_includes_team_connected_provider_as_connected(monkeyp
     assert gmail_row.team_connections
     assert gmail_row.team_connections[0].user_name == "Teammate"
     assert gmail_row.account_identifier == "teammate@gmail.com"
+    assert gmail_row.id == str(teammate_integration.id)
+
+
+def test_list_integrations_team_rep_ignores_non_team_rows(monkeypatch):
+    org_id = UUID("11111111-1111-1111-1111-111111111111")
+    current_user_id = UUID("22222222-2222-2222-2222-222222222222")
+    teammate_id = UUID("33333333-3333-3333-3333-333333333333")
+    former_member_id = UUID("99999999-9999-9999-9999-999999999999")
+
+    non_team_integration = SimpleNamespace(
+        id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        connector="gmail",
+        organization_id=org_id,
+        user_id=former_member_id,
+        is_active=True,
+        last_sync_at=None,
+        last_error=None,
+        created_at=None,
+        share_synced_data=True,
+        share_query_access=True,
+        share_write_access=True,
+        pending_sharing_config=False,
+        sync_stats={"activities": 99},
+        account_identifier="former@example.com",
+        account_label="Former Member Gmail",
+        extra_data={"account_avatar_url": "https://example.com/former.png"},
+    )
+    teammate_integration = SimpleNamespace(
+        id=UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+        connector="gmail",
+        organization_id=org_id,
+        user_id=teammate_id,
+        is_active=True,
+        last_sync_at=None,
+        last_error=None,
+        created_at=None,
+        share_synced_data=True,
+        share_query_access=True,
+        share_write_access=False,
+        pending_sharing_config=False,
+        sync_stats={"activities": 12},
+        account_identifier="teammate@gmail.com",
+        account_label="Teammate Gmail",
+        extra_data={"account_avatar_url": "https://example.com/avatar.png"},
+    )
+
+    teammate_user = SimpleNamespace(id=teammate_id, name="Teammate", email="teammate@example.com")
+
+    fake_session = _FakeSession([non_team_integration, teammate_integration], [teammate_user])
+    monkeypatch.setattr(auth, "get_session", lambda **kwargs: _FakeSessionContext(fake_session))
+    monkeypatch.setattr(auth, "_get_scope_by_provider", lambda: {"gmail": "user"})
+    monkeypatch.setattr(auth, "PROVIDER_SHARING_DEFAULTS", {"gmail": {}})
+
+    result = asyncio.run(
+        auth.list_integrations(
+            auth=auth.AuthContext(
+                user_id=current_user_id,
+                organization_id=org_id,
+                email="requester@example.com",
+                role="member",
+                is_global_admin=False,
+            ),
+        )
+    )
+
+    gmail_row = [row for row in result.integrations if row.provider == "gmail"][0]
+    assert gmail_row.id == str(teammate_integration.id)
+    assert gmail_row.account_identifier == "teammate@gmail.com"


### PR DESCRIPTION
### Motivation
- Team-scoped connectors that are connected only by teammates were returned as inactive placeholders by `GET /integrations`, which prevented them from appearing in the UI’s “team/shared” grouping even though they should be visible to the current user.

### Description
- Update `backend/api/routes/auth.py` so when the current user has no integration for a provider but teammates do, the endpoint selects a representative integration and emits its metadata (e.g. `is_active`, sync timestamps, share flags, `sync_stats`, account fields and avatar) while keeping `current_user_connected=false` and preserving `team_connections` for correct UI grouping.
- Use `read_account_avatar_url` for representative avatar extraction and sort integrations to deterministically pick a representative account.
- Add regression test `backend/tests/test_list_integrations_visibility.py` to assert teammate-only connected providers are returned as connected/visible with team metadata.

### Testing
- Added and ran `pytest -q backend/tests/test_list_integrations_visibility.py`. 
- Result: `1 passed` (test verifies representative integration appears with `current_user_connected` false and includes `team_connections` and account identifier).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d35eefd6c8321a5cad6147ee988ba)