### PR TITLE
Normalize REDIS_URL for query outcome metrics

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -5,6 +5,7 @@ import logging
 import os
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -256,6 +257,26 @@ def get_redis_connection_kwargs(
     if decode_responses:
         kwargs["decode_responses"] = True
     return kwargs
+
+
+def get_normalized_redis_url(redis_url: str | None = None) -> str:
+    """Return REDIS_URL with a valid scheme for redis-py URL parsing."""
+    raw_url = (redis_url or settings.REDIS_URL or "").strip()
+    if not raw_url:
+        return "redis://localhost:6379"
+
+    parsed_url = urlparse(raw_url)
+    if parsed_url.scheme in {"redis", "rediss", "unix"}:
+        return raw_url
+
+    normalized_url = f"redis://{raw_url.lstrip('/')}"
+    logger = logging.getLogger(__name__)
+    logger.warning(
+        "REDIS_URL missing scheme; normalizing value to redis:// URL. original=%s normalized=%s",
+        raw_url,
+        normalized_url,
+    )
+    return normalized_url
 
 
 EXPECTED_ENV_VARS: tuple[str, ...] = (

--- a/backend/services/query_outcome_metrics.py
+++ b/backend/services/query_outcome_metrics.py
@@ -7,7 +7,7 @@ from collections import Counter
 
 import redis.asyncio as aioredis
 
-from config import get_redis_connection_kwargs, settings
+from config import get_normalized_redis_url, get_redis_connection_kwargs
 from services.incident_throttling import clear_incident_failure, evaluate_incident_creation, mark_incident_created
 from services.pagerduty import create_pagerduty_incident
 
@@ -46,7 +46,7 @@ async def get_query_outcome_window_stats() -> dict[str, object]:
     timestamp = int(time.time())
     window_start = timestamp - _WINDOW_SECONDS
     redis_client = aioredis.from_url(
-        settings.REDIS_URL,
+        get_normalized_redis_url(),
         **get_redis_connection_kwargs(),
     )
 
@@ -120,7 +120,7 @@ async def record_query_outcome(
     normalized_conversation_id = (conversation_id or "unknown").strip() or "unknown"
 
     redis_client = aioredis.from_url(
-        settings.REDIS_URL,
+        get_normalized_redis_url(),
         **get_redis_connection_kwargs(),
     )
 

--- a/backend/tests/test_config_redis_url.py
+++ b/backend/tests/test_config_redis_url.py
@@ -1,0 +1,9 @@
+from config import get_normalized_redis_url
+
+
+def test_get_normalized_redis_url_keeps_supported_scheme() -> None:
+    assert get_normalized_redis_url("rediss://example.com:6379/0") == "rediss://example.com:6379/0"
+
+
+def test_get_normalized_redis_url_adds_scheme_for_host_port() -> None:
+    assert get_normalized_redis_url("example.com:6379") == "redis://example.com:6379"


### PR DESCRIPTION
### Motivation
- Query outcome recording was failing when `REDIS_URL` was provided without a scheme, causing redis-py to raise a scheme parse error and breaking metrics logging.
- Normalize host:port or other scheme-less values to a valid Redis URL so metrics recording is robust across deployments.

### Description
- Added `get_normalized_redis_url` in `backend/config.py` which uses `urlparse` and returns a valid Redis URL, prefixes `redis://` for scheme-less values, and logs a warning with the original and normalized values.
- Updated `backend/services/query_outcome_metrics.py` to use `get_normalized_redis_url()` when creating Redis clients in both `get_query_outcome_window_stats` and `record_query_outcome`.
- The normalization function returns a sensible default `redis://localhost:6379` when no URL is configured.
- Added unit tests in `backend/tests/test_config_redis_url.py` to verify preserving supported schemes and adding `redis://` for host:port inputs.

### Testing
- Ran `pytest -q backend/tests/test_config_redis_url.py backend/tests/test_query_outcome_metrics.py` and all tests passed.
- Test run result: `12 passed` which includes the new normalization tests and existing query outcome metrics tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d36c2740c8321bed8e1850503ce58)