### PR TITLE
Bucketize Slack MPDM channels as direct

### DIFF
--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -294,7 +294,7 @@ def _derive_bucket(
     if source == _WEB_PLATFORM_SLUG:
         return ("direct", "direct")
     if source == "slack" and normalized_channel_id:
-        if normalized_channel_id.startswith("D"):
+        if normalized_channel_id.startswith("D") or normalized_channel_id.startswith("MPDM"):
             return ("direct", "direct")
         return ("channel", f"channel:{normalized_channel_id}")
     return ("uncategorized", "uncategorized")

--- a/backend/tests/test_chat_bucket_derivation.py
+++ b/backend/tests/test_chat_bucket_derivation.py
@@ -29,6 +29,14 @@ def test_derive_bucket_returns_direct_for_slack_dm_channel() -> None:
     )
 
 
+
+
+def test_derive_bucket_returns_direct_for_slack_mpdm_channel() -> None:
+    assert chat._derive_bucket(source="slack", scope="shared", normalized_channel_id="MPDM123") == (
+        "direct",
+        "direct",
+    )
+
 def test_derive_bucket_returns_uncategorized_for_other_sources() -> None:
     assert chat._derive_bucket(source="teams", scope="shared", normalized_channel_id=None) == (
         "uncategorized",


### PR DESCRIPTION
### Motivation
- Ensure Slack multi-party direct-message channels (IDs starting with `MPDM`) are categorized as direct conversations so they appear in the direct bucket instead of channel buckets.

### Description
- Update `_derive_bucket` in `backend/api/routes/chat.py` to treat `normalized_channel_id` values starting with `MPDM` as `("direct", "direct")` and add `test_derive_bucket_returns_direct_for_slack_mpdm_channel` to `backend/tests/test_chat_bucket_derivation.py` to cover the behavior.

### Testing
- Ran `pytest -q backend/tests/test_chat_bucket_derivation.py` and the suite passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d3800f6fc8321b93d90d6bfc4df3c)