### PR TITLE
Adjust morning greeting to start at 6am

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -4859,7 +4859,7 @@ function greetingFirstName(user: { name: string | null; email: string } | null |
 function buildChatGreeting(user: { name: string | null; email: string } | null | undefined): string {
   const first: string = greetingFirstName(user);
   const hour: number = new Date().getHours();
-  if (hour < 12) return `Good morning, ${first}`;
+  if (hour >= 6 && hour < 12) return `Good morning, ${first}`;
   if (hour < 18) return `Good afternoon, ${first}`;
   return `Back at it, ${first}`;
 }


### PR DESCRIPTION
### Motivation
- The chat landing greeting currently treats midnight–5:59am as "morning", which is unexpected, so the morning bucket should begin at 6:00 AM.

### Description
- Update `buildChatGreeting` in `frontend/src/components/Chat.tsx` to return `Good morning` only when `hour >= 6 && hour < 12`, leaving the afternoon and fallback greetings unchanged.

### Testing
- Ran frontend lint for the changed file: `cd frontend && npm run -s lint -- src/components/Chat.tsx`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d3868fb7c8321969f15b247cea938)