### PR TITLE
Remove inactive model-label chevron in chat composer

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2601,9 +2601,6 @@ export function Chat({
                 title={activeModelName ?? undefined}
               >
                 {activeModelLabel}
-                <svg className="w-3 h-3 opacity-60 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                </svg>
               </span>
             ) : null;
 
@@ -3112,9 +3109,6 @@ export function Chat({
                 title={activeModelName ?? undefined}
               >
                 {activeModelLabel}
-                <svg className="w-3 h-3 opacity-60 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                </svg>
               </span>
             ) : null;
 


### PR DESCRIPTION
### Motivation
- The chat composer showed a down-arrow chevron beside the agent/model label that was non-interactive and could imply an expandable control, so remove it to avoid misleading users.

### Description
- Deleted the inactive down-arrow SVG next to the model/agent label in both composer render branches in `frontend/src/components/Chat.tsx`, leaving only the model text.
- This is a visual cleanup only and does not change runtime behavior or API interactions.

### Testing
- Ran the frontend linter successfully with `npm --prefix frontend run lint`.
- Attempted to run a typecheck but no `typecheck` script exists in `frontend/package.json`, so no automated typecheck was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d38a4e960832193f38fbc76b59404)