### PR TITLE
Redesign sidebar nav, add Artifacts hub, streamline page layouts

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -354,36 +354,6 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
     setShowReleaseBanner(false);
   }, []);
 
-  // Sidebar resize drag
-  const sidebarWidth = useAppStore((state) => state.sidebarWidth);
-  const setSidebarWidth = useAppStore((state) => state.setSidebarWidth);
-  const isDraggingRef = useRef(false);
-  const startXRef = useRef(0);
-  const startWidthRef = useRef(0);
-
-  const handleDividerMouseDown = useCallback((e: React.MouseEvent): void => {
-    e.preventDefault();
-    isDraggingRef.current = true;
-    startXRef.current = e.clientX;
-    startWidthRef.current = sidebarWidth;
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
-
-    const onMouseMove = (ev: MouseEvent): void => {
-      if (!isDraggingRef.current) return;
-      const newWidth = Math.min(400, Math.max(200, startWidthRef.current + ev.clientX - startXRef.current));
-      setSidebarWidth(newWidth);
-    };
-    const onMouseUp = (): void => {
-      isDraggingRef.current = false;
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-    };
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
-  }, [sidebarWidth, setSidebarWidth]);
   
   // Close mobile sidebar when view changes
   useEffect(() => {
@@ -1835,7 +1805,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
   };
 
   return (
-    <div className="h-full flex flex-col bg-surface-900 overflow-hidden">
+    <div className="h-full flex flex-col bg-surface-950 overflow-hidden">
       {/* Masquerade Banner */}
       {masquerade && (
         <div className="bg-amber-500/20 dark:bg-amber-500/20 px-4 py-2 flex items-center justify-between flex-shrink-0">
@@ -1900,13 +1870,14 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
         />
       )}
 
-      {/* Sidebar - hidden on mobile, shown as overlay when open */}
+      {/* Sidebar - floating card on desktop, drawer on mobile */}
       <div className={`
         ${isMobile 
           ? `fixed inset-y-0 left-0 z-50 transform transition-transform duration-300 ease-in-out ${mobileSidebarOpen ? 'translate-x-0' : '-translate-x-full'}`
-          : ''
+          : 'p-2 flex-shrink-0'
         }
       `}>
+        <div className={isMobile ? '' : 'h-full rounded-xl bg-surface-900 shadow-[0_1px_3px_rgba(0,0,0,0.04),0_4px_16px_rgba(0,0,0,0.06)] overflow-hidden'}>
         <Sidebar
           collapsed={isMobile ? false : sidebarCollapsed}
           onToggleCollapse={() => isMobile ? setMobileSidebarOpen(false) : setSidebarCollapsed(!sidebarCollapsed)}
@@ -1925,19 +1896,11 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
           isMobile={isMobile}
           onCloseMobile={() => setMobileSidebarOpen(false)}
         />
+        </div>
       </div>
 
-      {/* Resize divider (desktop only, expanded sidebar only) */}
-      {!isMobile && !sidebarCollapsed && (
-        <div
-          onMouseDown={handleDividerMouseDown}
-          onDoubleClick={() => setSidebarWidth(256)}
-          className="w-1 cursor-col-resize hover:bg-primary-500/40 active:bg-primary-500/60 transition-colors flex-shrink-0"
-        />
-      )}
-
       {/* Main Content */}
-      <main className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden">
+      <main className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden bg-surface-950">
         {orgAccessError ? (
           <div className="flex-1 flex flex-col items-center justify-center p-6 text-center">
             <div className="max-w-md rounded-lg bg-surface-900/80 p-6 shadow-2xl ring-1 ring-white/10">

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -354,7 +354,37 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
     setShowReleaseBanner(false);
   }, []);
 
-  
+  // Sidebar resize drag
+  const sidebarWidth = useAppStore((state) => state.sidebarWidth);
+  const setSidebarWidth = useAppStore((state) => state.setSidebarWidth);
+  const isDraggingRef = useRef(false);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+
+  const handleDividerMouseDown = (e: React.MouseEvent): void => {
+    e.preventDefault();
+    isDraggingRef.current = true;
+    startXRef.current = e.clientX;
+    startWidthRef.current = sidebarWidth;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const onMouseMove = (ev: MouseEvent): void => {
+      if (!isDraggingRef.current) return;
+      const newWidth: number = Math.min(400, Math.max(200, startWidthRef.current + ev.clientX - startXRef.current));
+      setSidebarWidth(newWidth);
+    };
+    const onMouseUp = (): void => {
+      isDraggingRef.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  };
+
   // Close mobile sidebar when view changes
   useEffect(() => {
     if (isMobile) {
@@ -1871,12 +1901,15 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       )}
 
       {/* Sidebar - floating card on desktop, drawer on mobile */}
-      <div className={`
-        ${isMobile 
-          ? `fixed inset-y-0 left-0 z-50 transform transition-transform duration-300 ease-in-out ${mobileSidebarOpen ? 'translate-x-0' : '-translate-x-full'}`
-          : 'p-2 flex-shrink-0'
-        }
-      `}>
+      <div
+        className={`
+          ${isMobile 
+            ? `fixed inset-y-0 left-0 z-50 transform transition-transform duration-300 ease-in-out ${mobileSidebarOpen ? 'translate-x-0' : '-translate-x-full'}`
+            : 'p-2 flex-shrink-0'
+          }
+        `}
+        style={!isMobile && !sidebarCollapsed ? { width: `${sidebarWidth + 16}px` } : undefined}
+      >
         <div className={isMobile ? '' : 'h-full rounded-xl bg-surface-900 shadow-[0_1px_3px_rgba(0,0,0,0.04),0_4px_16px_rgba(0,0,0,0.06)] overflow-hidden'}>
         <Sidebar
           collapsed={isMobile ? false : sidebarCollapsed}
@@ -1898,6 +1931,15 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
         />
         </div>
       </div>
+
+      {/* Resize handle (desktop only, expanded sidebar) */}
+      {!isMobile && !sidebarCollapsed && (
+        <div
+          onMouseDown={handleDividerMouseDown}
+          onDoubleClick={() => setSidebarWidth(288)}
+          className="w-1.5 cursor-col-resize hover:bg-surface-700/40 active:bg-surface-700/60 transition-colors flex-shrink-0 rounded-full my-4"
+        />
+      )}
 
       {/* Main Content */}
       <main className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden bg-surface-950">

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -683,12 +683,13 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
   // Panels
   const [showOrgPanel, setShowOrgPanel] = useState(false);
   const [showProfilePanel, setShowProfilePanel] = useState(false);
-  const [orgPanelTab, setOrgPanelTab] = useState<'team' | 'billing' | 'settings'>('team');
-  const orgSettingsInitialTab: 'team' | 'billing' | 'settings' = (() => {
+  const [orgPanelTab, setOrgPanelTab] = useState<'team' | 'billing' | 'settings' | 'connectors'>('team');
+  const orgSettingsInitialTab: 'team' | 'billing' | 'settings' | 'connectors' = (() => {
     if (typeof window === 'undefined') return 'settings';
     const tab = new URLSearchParams(window.location.search).get('tab')?.toLowerCase();
     if (tab === 'team' || tab === 'members') return 'team';
     if (tab === 'billing') return 'billing';
+    if (tab === 'connectors') return 'connectors';
     return 'settings';
   })();
 

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -31,6 +31,7 @@ import { Memories } from './Memories';
 import { AdminPanel } from './AdminPanel';
 import { PendingChangesPage } from './PendingChangesPage';
 import { ActivityLog } from './ActivityLog';
+import { DataPage } from './DataPage';
 import { OrganizationPanel } from './OrganizationPanel';
 
 // Lazy-load app components (heavy due to Sandpack/Plotly deps)
@@ -518,6 +519,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
         chats: "chats",
         connectors: "data-sources",
         data: "data",
+        "data-hub": "data-hub",
         workflows: "workflows",
         memory: "memory",
         apps: "apps",
@@ -568,6 +570,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
       "/chats": "chats",
       "/connectors": "data-sources",
       "/data": "data",
+      "/data-hub": "data-hub",
       "/workflows": "workflows",
       "/memory": "memory",
       "/apps": "apps",
@@ -659,6 +662,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
           chats: "/chats",
           "data-sources": "/connectors",
           data: "/data",
+          "data-hub": "/data-hub",
           workflows: "/workflows",
           memory: "/memory",
           apps: "/apps",
@@ -1743,7 +1747,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
     const handleNavigate = (event: Event): void => {
       const customEvent = event as CustomEvent<string>;
       if (customEvent.detail) {
-        setCurrentView(customEvent.detail as 'home' | 'chat' | 'data-sources' | 'data' | 'workflows' | 'memory' | 'admin');
+        setCurrentView(customEvent.detail as 'home' | 'chat' | 'data-sources' | 'data' | 'data-hub' | 'workflows' | 'memory' | 'admin');
       }
     };
     window.addEventListener('navigate', handleNavigate);
@@ -1911,7 +1915,7 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
         `}
         style={!isMobile && !sidebarCollapsed ? { width: `${sidebarWidth + 16}px` } : undefined}
       >
-        <div className={isMobile ? '' : 'h-full rounded-xl bg-surface-900 shadow-[0_1px_3px_rgba(0,0,0,0.04),0_4px_16px_rgba(0,0,0,0.06)] overflow-hidden'}>
+        <div className={isMobile ? 'h-full bg-surface-950 w-[85vw] max-w-xs overflow-hidden' : 'h-full rounded-xl bg-surface-900 shadow-[0_1px_3px_rgba(0,0,0,0.04),0_4px_16px_rgba(0,0,0,0.06)] overflow-hidden'}>
         <Sidebar
           collapsed={isMobile ? false : sidebarCollapsed}
           onToggleCollapse={() => isMobile ? setMobileSidebarOpen(false) : setSidebarCollapsed(!sidebarCollapsed)}
@@ -2018,6 +2022,9 @@ export function AppLayout({ onLogout, onCreateNewOrg }: AppLayoutProps): JSX.Ele
         )}
         {currentView === 'data' && (
           <Data />
+        )}
+        {currentView === 'data-hub' && (
+          <DataPage />
         )}
         {currentView === 'workflows' && (
           <Workflows />

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -34,12 +34,14 @@ import {
   useChatStore,
   useConversationState,
   useActiveTasksByConversation,
+  useConnectedIntegrations,
   useIsOrgAdmin,
   useOrganization,
   useUser,
   type AppBlock,
   type ChatMessage,
   type ConversationSummaryText,
+  type Integration,
   type ThinkingBlock as ThinkingBlockType,
   type ToolCallData,
   type ToolUseBlock,
@@ -4879,50 +4881,46 @@ function ChatLandingGreeting({
   );
 }
 
-const QUICK_ACTION_ITEMS: readonly { label: string; icon: JSX.Element; prompt: string }[] = [
-  {
-    label: 'Write',
-    prompt: 'Help me write something',
-    icon: <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" /></svg>,
-  },
-  {
-    label: 'Research',
-    prompt: 'Help me research a topic',
-    icon: <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>,
-  },
-  {
-    label: 'Analyze',
-    prompt: 'Analyze my data',
-    icon: <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" /></svg>,
-  },
-  {
-    label: 'Summarize',
-    prompt: 'Summarize something for me',
-    icon: <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 6h16M4 12h16m-7 6h7" /></svg>,
-  },
-  {
-    label: 'Explore',
-    prompt: 'What can you help me with?',
-    icon: <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" /></svg>,
-  },
-];
+function buildSuggestions(connected: Integration[]): string[] {
+  const providers = new Set(connected.map((i) => i.provider));
+  const suggestions: string[] = [];
+
+  if (providers.has('hubspot') || providers.has('salesforce'))
+    suggestions.push('Find all the inactive deals', 'Show me my pipeline by stage');
+  if (providers.has('gmail') || providers.has('microsoft_mail'))
+    suggestions.push('Summarize my unread emails from today');
+  if (providers.has('google_calendar') || providers.has('microsoft_calendar') || providers.has('zoom'))
+    suggestions.push('What meetings do I have this week?');
+  if (providers.has('github') || providers.has('linear') || providers.has('jira') || providers.has('asana'))
+    suggestions.push('Show me open issues assigned to me');
+  if (providers.has('slack'))
+    suggestions.push('What are the latest messages in my Slack channels?');
+
+  if (suggestions.length < 3)
+    return ['What can you help me with?', 'What connectors can I connect?', 'Show me what you can do'];
+
+  return suggestions.slice(0, 5);
+}
 
 function ChatQuickActions({
   onSuggestionClick,
 }: {
   onSuggestionClick: (text: string) => void;
 }): JSX.Element {
+  const connected: Integration[] = useConnectedIntegrations();
+  const suggestions: string[] = buildSuggestions(connected).slice(0, 5);
+
   return (
     <div className="flex flex-wrap gap-2 justify-center w-full max-w-2xl flex-shrink-0 px-1">
-      {QUICK_ACTION_ITEMS.map((item) => (
+      {suggestions.map((text) => (
         <button
-          key={item.label}
+          key={text}
           type="button"
-          onClick={() => onSuggestionClick(item.prompt)}
-          className="chat-quick-action"
+          onClick={() => onSuggestionClick(text)}
+          className="chat-quick-action max-w-[260px] truncate"
+          title={text}
         >
-          {item.icon}
-          {item.label}
+          {text}
         </button>
       ))}
     </div>

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -2601,6 +2601,9 @@ export function Chat({
                 title={activeModelName ?? undefined}
               >
                 {activeModelLabel}
+                <svg className="w-3 h-3 opacity-60 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
               </span>
             ) : null;
 
@@ -3109,6 +3112,9 @@ export function Chat({
                 title={activeModelName ?? undefined}
               >
                 {activeModelLabel}
+                <svg className="w-3 h-3 opacity-60 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
               </span>
             ) : null;
 

--- a/frontend/src/components/ChatsList.tsx
+++ b/frontend/src/components/ChatsList.tsx
@@ -8,8 +8,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ChatSummary } from '../store/types';
 import { useActiveTasksByConversation, useAppStore, useChatStore } from '../store';
 import { listConversations, type ConversationSummary } from '../api/client';
-import { Avatar } from './Avatar';
-import { GallerySearchInput } from './shared/GallerySearchInput';
+
+
 
 interface ChatsListProps {
   chats: ChatSummary[];
@@ -259,46 +259,23 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
   return (
     <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
       {/* Header */}
-      <div className="flex-shrink-0 px-6 pt-6 pb-0">
-        <div className="flex items-center justify-between mb-4 gap-4">
-          <div>
-            <h1 className="text-xl font-bold text-surface-100">All Chats</h1>
-            <p className="text-sm text-surface-400 mt-1">
-              Browse and search conversations in your organization
-            </p>
+      <div className="flex-shrink-0 px-6 pt-4 pb-0">
+        <div className="space-y-2 mb-3">
+          <div className="relative">
+            <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-surface-500 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => handleSearchValueChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleSearchSubmit();
+                if (e.key === 'Escape') handleSearchClear();
+              }}
+              placeholder="Search conversations…"
+              className="w-full pl-9 pr-3 py-2 text-sm bg-surface-900 border border-surface-700 rounded-lg text-surface-100 placeholder-surface-500 focus:outline-none focus:ring-1 focus:ring-surface-500 focus:border-surface-500"
+            />
           </div>
-          <div className="flex items-center gap-3 flex-shrink-0">
-            {initialLoaded ? (
-              <span className="text-sm text-surface-500">
-                <span className="sm:hidden">{mergedChats.length}{hasMore ? '+' : ''}</span>
-                <span className="hidden sm:inline">
-                  {mergedChats.length} conversation{mergedChats.length !== 1 ? 's' : ''}
-                  {hasMore ? '+' : ''}
-                </span>
-              </span>
-            ) : null}
-            <button type="button" onClick={onNewChat} className="btn-primary flex items-center gap-2">
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-              </svg>
-              New Chat
-            </button>
-          </div>
-        </div>
-
-        {/* Filters + Search */}
-        <div className="flex items-center gap-3 mb-4">
-          <GallerySearchInput
-            value={searchQuery}
-            onChange={handleSearchValueChange}
-            placeholder="Search conversations… (press Enter)"
-            aria-label="Search conversations"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') handleSearchSubmit();
-              if (e.key === 'Escape') handleSearchClear();
-            }}
-          />
-          <div className="flex items-center gap-1 rounded-lg border border-surface-700 p-0.5 flex-shrink-0 bg-surface-900">
+          <div className="flex items-center gap-1 rounded-lg border border-surface-700 p-0.5 bg-surface-900 w-fit">
             {(['all', 'shared', 'private', 'mine'] as const).map((f) => (
               <button
                 key={f}
@@ -321,17 +298,12 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
       <div ref={scrollContainerRef} className="flex-1 overflow-y-auto min-h-0">
         <div className="px-6 pb-6 pt-4">
           {(!initialLoaded || (isLoadingMore && allChats.length === 0)) ? (
-            <div className="space-y-3">
-              {Array.from({ length: 8 }, (_, i) => (
-                <div key={i} className="p-4 rounded-xl bg-surface-900 border border-surface-800 animate-pulse">
-                  <div className="flex items-start gap-4">
-                    <div className="w-5 h-5 rounded bg-surface-800 flex-shrink-0" />
-                    <div className="flex-1 space-y-2">
-                      <div className="h-4 rounded bg-surface-800 w-2/3" />
-                      <div className="h-3 rounded bg-surface-800 w-1/2" />
-                    </div>
-                    <div className="h-3 rounded bg-surface-800 w-16" />
-                  </div>
+            <div className="space-y-0.5">
+              {Array.from({ length: 12 }, (_, i) => (
+                <div key={i} className="px-2 py-1.5 rounded-lg animate-pulse flex items-center gap-2">
+                  <div className="w-3.5 h-3.5 rounded bg-surface-800 flex-shrink-0" />
+                  <div className="flex-1 h-4 rounded bg-surface-800" />
+                  <div className="h-3 rounded bg-surface-800 w-14 flex-shrink-0" />
                 </div>
               ))}
             </div>
@@ -361,7 +333,7 @@ export function ChatsList({ chats: sidebarChats, onSelectChat, onNewChat }: Chat
               )}
             </div>
           ) : (
-            <div className="space-y-2">
+            <div className="space-y-0.5">
               {groupedChats.pinned.length > 0 && <Section title="Pinned" />}
               {groupedChats.pinned.map((chat) => (
                 <ChatRow key={`pinned-${chat.id}`} chat={chat} searchTerm={committedSearch} hasActiveTask={chat.id in activeTasksByConversation} isPinned onSelect={onSelectChat} onTogglePin={togglePinChat} />
@@ -427,97 +399,35 @@ function ChatRow({
   return (
     <button
       onClick={() => onSelect(chat.id, isSearching ? searchTerm : undefined, isSearching ? chat.matchCount : undefined)}
-      className="relative w-full text-left p-4 rounded-xl bg-surface-900 hover:bg-surface-800 border border-surface-800 hover:border-surface-700 transition-colors group"
+      className="relative w-full text-left px-2 py-1.5 rounded-lg hover:bg-surface-800/60 transition-colors group flex items-center gap-2 min-w-0"
     >
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex-1 min-w-0 grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1">
-          <div className="flex-shrink-0 mt-0.5">
-            {chat.scope === 'private' ? (
-              <svg className="w-5 h-5 text-surface-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-              </svg>
-            ) : (
-              <svg className="w-5 h-5 text-surface-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-              </svg>
-            )}
-          </div>
-          <div className="flex items-start gap-2 min-w-0">
-            <div className="flex items-center gap-2 min-w-0 flex-1">
-              <h3 className="font-medium text-surface-100 truncate group-hover:text-white transition-colors">
-                {isSearching ? <HighlightText text={chat.title} term={searchTerm} /> : chat.title}
-              </h3>
-              {chat.type === 'workflow' && (
-                <span className="flex-shrink-0 px-1.5 py-0.5 rounded text-xs bg-amber-500/20 text-amber-400">Workflow</span>
-              )}
-              {hasActiveTask && (
-                <span className="flex-shrink-0 flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-primary-500/20 text-primary-400 text-xs">
-                  <svg className="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                  </svg>
-                  Active
-                </span>
-              )}
-              {isSearching && (chat.matchCount ?? 0) > 0 && (
-                <span className="flex-shrink-0 px-1.5 py-0.5 rounded text-[10px] font-bold bg-amber-300 text-black">
-                  {chat.matchCount} {chat.matchCount === 1 ? 'match' : 'matches'}
-                </span>
-              )}
-            </div>
-            <div className={`flex-shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wide ${
-              chat.scope === 'shared'
-                ? 'bg-primary-500/20 text-primary-400'
-                : 'bg-surface-700 text-surface-400'
-            }`}>
-              <span>{chat.scope}</span>
-              <span className="normal-case tracking-normal text-xs text-surface-300 whitespace-nowrap">
-                {formatDate(chat.lastMessageAt)}
-              </span>
-            </div>
-          </div>
-          <div className="flex min-h-[1.25rem] items-center">
-            {chat.participants && chat.participants.length > 0 && (
-              <div className="flex -space-x-1.5">
-                {chat.participants.slice(0, 3).map((p, idx) => (
-                  <Avatar key={p.id} user={p} size="xs" bordered style={{ zIndex: 3 - idx }} />
-                ))}
-                {chat.participants.length > 3 && (
-                  <div className="w-5 h-5 rounded-full border border-surface-700 dark:border-surface-600 bg-surface-700 flex items-center justify-center text-[10px] font-medium text-surface-300">
-                    +{chat.participants.length - 3}
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-          <div className="flex items-center gap-2 min-w-0">
-            <p className="text-sm text-surface-400 truncate">
-              {isSearching && chat.matchSnippet ? (
-                <HighlightText text={chat.matchSnippet} term={searchTerm} />
-              ) : isSearching ? (
-                <HighlightText text={chat.previewText} term={searchTerm} />
-              ) : (
-                chat.previewText
-              )}
-            </p>
-            <div className="ml-auto flex items-center gap-1.5 flex-shrink-0">
-              <button
-                onClick={(e) => { e.stopPropagation(); onTogglePin(chat.id); }}
-                className={`p-1 rounded ${
-                  isPinned
-                    ? 'opacity-100 text-primary-400'
-                    : 'opacity-100 md:opacity-0 text-surface-500'
-                } md:group-hover:opacity-100 hover:bg-surface-700 hover:text-surface-200 transition-all`}
-                title={isPinned ? 'Unpin conversation' : 'Pin conversation'}
-              >
-                <svg className={`w-4 h-4 ${isPinned ? 'text-primary-400' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 21l-5-3-5 3V5a2 2 0 012-2h6a2 2 0 012 2v16z" />
-                </svg>
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
+      <span className="flex-shrink-0 text-surface-500 w-4">
+        {chat.scope === 'private' ? (
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" /></svg>
+        ) : (
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>
+        )}
+      </span>
+      <span className="flex-1 min-w-0 truncate text-sm text-surface-200 group-hover:text-surface-100">
+        {isSearching ? <HighlightText text={chat.title} term={searchTerm} /> : chat.title}
+      </span>
+      {hasActiveTask && (
+        <svg className="w-3 h-3 text-primary-400 flex-shrink-0 animate-spin" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+        </svg>
+      )}
+      {isSearching && (chat.matchCount ?? 0) > 0 && (
+        <span className="flex-shrink-0 px-1 py-0.5 rounded text-[10px] font-bold bg-amber-300 text-black">{chat.matchCount}</span>
+      )}
+      <span className="flex-shrink-0 text-[11px] text-surface-500 whitespace-nowrap">{formatDate(chat.lastMessageAt)}</span>
+      <button
+        onClick={(e) => { e.stopPropagation(); onTogglePin(chat.id); }}
+        className={`flex-shrink-0 p-0.5 rounded ${isPinned ? 'opacity-100 text-primary-400' : 'opacity-0 text-surface-500'} group-hover:opacity-100 hover:text-surface-200 transition-all`}
+        title={isPinned ? 'Unpin' : 'Pin'}
+      >
+        <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 21l-5-3-5 3V5a2 2 0 012-2h6a2 2 0 012 2v16z" /></svg>
+      </button>
     </button>
   );
 }

--- a/frontend/src/components/Data.tsx
+++ b/frontend/src/components/Data.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { apiRequest } from '../lib/api';
 import { useAppStore } from '../store';
 
@@ -37,7 +37,7 @@ interface DataSummaryResponse {
 type SortOrder = 'asc' | 'desc';
 
 export function Data(): JSX.Element {
-  const { organization, setCurrentView, startNewChat, setPendingChatInput, setPendingChatAutoSend } = useAppStore();
+  const { organization } = useAppStore();
   const [tables, setTables] = useState<TableSummary[]>([]);
   const [selectedTargets, setSelectedTargets] = useState<string[]>(['contacts']);
   const [dataByTarget, setDataByTarget] = useState<Record<string, DataResponse>>({});
@@ -185,52 +185,21 @@ export function Data(): JSX.Element {
     return groups;
   }, [selectedTargets, tables, dataByTarget]);
 
-  const buildChatPrompt = useCallback((): string => {
-    const targetSnippets = groupedResults
-      .map(({ table, data }) => {
-        if (!data || data.rows.length === 0) return null;
-        const label = table?.display_name ?? data.table;
-        const previewRows = data.rows.slice(0, 5).map((row) => {
-          const rowSummary = data.columns.slice(0, 6).map((column) => `${column}: ${formatCellValue(row.data[column])}`).join(', ');
-          return `- ${rowSummary}`;
-        }).join('\n');
-        return `${label} (showing ${Math.min(data.rows.length, 5)} of ${data.total}):\n${previewRows}`;
-      })
-      .filter(Boolean)
-      .join('\n\n');
-
-    return `Summarise this data:\n\n${targetSnippets || 'No records were returned for the selected targets.'}`;
-  }, [groupedResults]);
-
-  const handleStartChat = (): void => {
-    const prompt = buildChatPrompt();
-    setPendingChatInput(prompt);
-    setPendingChatAutoSend(false);
-    startNewChat();
-    setCurrentView('chat');
-  };
-
   return (
     <div className="flex-1 overflow-hidden flex flex-col">
-      <header className="sticky top-0 bg-surface-950 border-b border-surface-800 px-4 md:px-8 py-4 md:py-6">
-        <h1 className="text-xl md:text-2xl font-bold text-surface-50">Search Data</h1>
-        <p className="text-surface-400 mt-1 text-sm md:text-base">Browse and compare synced data from your connectors</p>
-      </header>
-
-      <div className="flex-1 overflow-hidden flex flex-col px-4 md:px-8 py-4 md:py-6">
-        <div className="flex flex-wrap gap-2 mb-4">
+      <div className="flex-1 overflow-hidden flex flex-col px-4 md:px-8 pt-4 pb-4 md:pb-6">
+        <div className="flex gap-1.5 mb-3 overflow-x-auto scrollbar-none flex-shrink-0">
           {tables.map((table) => {
             const isSelected = selectedTargets.includes(table.name);
             return (
               <button
                 key={table.name}
                 onClick={() => toggleTarget(table.name)}
-                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isSelected ? 'bg-primary-500 text-white' : 'bg-surface-800 text-surface-300 hover:bg-surface-700'
+                className={`px-2.5 py-1 rounded-full text-xs font-medium whitespace-nowrap transition-colors ${
+                  isSelected ? 'bg-primary-500 text-white' : 'bg-surface-800 text-surface-400 hover:bg-surface-700 hover:text-surface-200'
                 }`}
               >
-                {table.display_name}
-                <span className="ml-2 px-2 py-0.5 rounded-full text-xs bg-surface-900/50">{table.count.toLocaleString()}</span>
+                {table.display_name} <span className="opacity-60">{table.count.toLocaleString()}</span>
               </button>
             );
           })}
@@ -270,14 +239,6 @@ export function Data(): JSX.Element {
             placeholder={`Type to filter ${selectedTargets.join(', ')}...`}
             className="flex-1 min-w-[200px] px-4 py-2 bg-surface-800 border border-surface-700 rounded-lg text-surface-100 placeholder-surface-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
           />
-
-          <button
-            type="button"
-            onClick={handleStartChat}
-            className="px-4 py-2 bg-primary-600 hover:bg-primary-500 text-white rounded-lg transition-colors"
-          >
-            Start Chat
-          </button>
 
           {(search || sourceSystemFilter || typeFilter) && (
             <button

--- a/frontend/src/components/DataPage.tsx
+++ b/frontend/src/components/DataPage.tsx
@@ -1,0 +1,66 @@
+/**
+ * DataPage: tabbed hub for Documents, Apps, Workflows, and Search Data.
+ * Consolidates multiple views into a single sidebar entry point.
+ */
+
+import { useState, Suspense, lazy } from 'react';
+import { Data } from './Data';
+import { Workflows } from './Workflows';
+
+const AppsGallery = lazy(() => import('./apps/AppsGallery').then((m) => ({ default: m.AppsGallery })));
+const DocumentsGallery = lazy(() => import('./documents/DocumentsGallery').then((m) => ({ default: m.DocumentsGallery })));
+
+type DataTab = 'documents' | 'apps' | 'workflows' | 'search';
+
+const LOADING_SPINNER: JSX.Element = (
+  <div className="flex items-center justify-center h-64">
+    <div className="animate-spin w-8 h-8 border-2 border-surface-500 border-t-primary-500 rounded-full" />
+  </div>
+);
+
+export function DataPage(): JSX.Element {
+  const [activeTab, setActiveTab] = useState<DataTab>('apps');
+
+  const tabs: readonly { id: DataTab; label: string }[] = [
+    { id: 'apps', label: 'Apps' },
+    { id: 'workflows', label: 'Workflows' },
+    { id: 'documents', label: 'Documents' },
+    { id: 'search', label: 'Synced Data' },
+  ];
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex border-b border-surface-800 px-6 sm:px-8 overflow-x-auto scrollbar-none flex-shrink-0">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setActiveTab(tab.id)}
+            className={`px-4 py-3 text-sm font-medium transition-colors whitespace-nowrap ${
+              activeTab === tab.id
+                ? 'text-primary-400 border-b-2 border-primary-500'
+                : 'text-surface-400 hover:text-surface-200'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {activeTab === 'documents' && (
+          <Suspense fallback={LOADING_SPINNER}>
+            <DocumentsGallery />
+          </Suspense>
+        )}
+        {activeTab === 'apps' && (
+          <Suspense fallback={LOADING_SPINNER}>
+            <AppsGallery />
+          </Suspense>
+        )}
+        {activeTab === 'workflows' && <Workflows />}
+        {activeTab === 'search' && <Data />}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -20,6 +20,7 @@ import type { TeamMember, IdentityMapping } from '../hooks';
 import { apiRequest } from '../lib/api';
 import { formatModelNameForUi } from '../lib/modelDisplay';
 import { Avatar } from './Avatar';
+import { DataSources } from './DataSources';
 import { SubscriptionSetup } from './SubscriptionSetup';
 
 interface BillingStatus {
@@ -131,7 +132,7 @@ function canonicalCreditId(id: string): string {
 interface OrganizationPanelProps {
   organization: OrganizationInfo;
   currentUser: UserProfile;
-  initialTab?: 'team' | 'billing' | 'settings';
+  initialTab?: 'team' | 'billing' | 'settings' | 'connectors';
   onClose: () => void;
   mode?: 'panel' | 'page';
 }
@@ -171,7 +172,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
   const fetchUserOrganizations = useAppStore((state) => state.fetchUserOrganizations);
   const switchActiveOrganization = useAppStore((state) => state.switchActiveOrganization);
   const setCurrentView = useAppStore((state) => state.setCurrentView);
-  const [activeTab, setActiveTab] = useState<'team' | 'billing' | 'settings'>(initialTab);
+  const [activeTab, setActiveTab] = useState<'team' | 'billing' | 'settings' | 'connectors'>(initialTab);
 
   useEffect(() => {
     setActiveTab(initialTab);
@@ -960,7 +961,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
 
         {/* Tabs */}
         <div className={`flex border-b border-surface-800 overflow-x-auto ${isPageMode ? 'px-6 sm:px-8' : ''}`}>
-          {(isPageMode ? (['settings', 'team', 'billing'] as const) : (['team', 'billing', 'settings'] as const)).map((tab) => (
+          {(isPageMode ? (['settings', 'connectors', 'team', 'billing'] as const) : (['team', 'billing', 'settings', 'connectors'] as const)).map((tab) => (
             <button
               key={tab}
               onClick={() => setActiveTab(tab)}
@@ -970,7 +971,7 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                   : 'text-surface-400 hover:text-surface-200'
               }`}
             >
-              {tab === 'team' ? 'Members' : tab.charAt(0).toUpperCase() + tab.slice(1)}
+              {tab === 'team' ? 'Members' : tab === 'connectors' ? 'Connectors' : tab.charAt(0).toUpperCase() + tab.slice(1)}
             </button>
           ))}
         </div>
@@ -1788,6 +1789,10 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                 </button>
               </div>
             </div>
+          )}
+
+          {activeTab === 'connectors' && (
+            <DataSources />
           )}
         </div>
       </div>

--- a/frontend/src/components/OrganizationPanel.tsx
+++ b/frontend/src/components/OrganizationPanel.tsx
@@ -928,26 +928,26 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
         ? 'flex-1 flex flex-col overflow-hidden'
         : 'fixed right-0 top-0 bottom-0 w-full max-w-lg bg-surface-900 border-l border-surface-800 z-50 flex flex-col shadow-2xl'
       }>
-        {/* Header */}
-        <header className={`flex items-center justify-between border-b border-surface-800 ${isPageMode ? 'px-6 sm:px-8 py-5' : 'px-4 sm:px-6 py-4'}`}>
-          <div className="flex items-center gap-3">
-            {logoUrl ? (
-              <img
-                src={logoUrl}
-                alt={organization.name}
-                className="w-10 h-10 rounded-lg object-cover"
-              />
-            ) : (
-              <div className="w-10 h-10 rounded-lg bg-surface-700 flex items-center justify-center text-surface-300 font-bold text-lg">
-                {organization.name.charAt(0).toUpperCase()}
+        {/* Header — only show org name in modal mode; page mode shows tabs directly */}
+        {!isPageMode && (
+          <header className="flex items-center justify-between border-b border-surface-800 px-4 sm:px-6 py-4">
+            <div className="flex items-center gap-3">
+              {logoUrl ? (
+                <img
+                  src={logoUrl}
+                  alt={organization.name}
+                  className="w-10 h-10 rounded-lg object-cover"
+                />
+              ) : (
+                <div className="w-10 h-10 rounded-lg bg-surface-700 flex items-center justify-center text-surface-300 font-bold text-lg">
+                  {organization.name.charAt(0).toUpperCase()}
+                </div>
+              )}
+              <div>
+                <h2 className="font-semibold text-surface-100">{organization.name}</h2>
+                <p className="text-xs text-surface-400">Team settings</p>
               </div>
-            )}
-            <div>
-              <h2 className={`font-semibold text-surface-100 ${isPageMode ? 'text-lg' : ''}`}>{organization.name}</h2>
-              <p className="text-xs text-surface-400">Team settings</p>
             </div>
-          </div>
-          {!isPageMode && (
             <button
               onClick={onClose}
               className="p-2 text-surface-400 hover:text-surface-200 hover:bg-surface-800 rounded-lg transition-colors"
@@ -956,11 +956,11 @@ export function OrganizationPanel({ organization, currentUser, initialTab = 'tea
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
               </svg>
             </button>
-          )}
-        </header>
+          </header>
+        )}
 
         {/* Tabs */}
-        <div className={`flex border-b border-surface-800 overflow-x-auto ${isPageMode ? 'px-6 sm:px-8' : ''}`}>
+        <div className={`flex border-b border-surface-800 overflow-x-auto scrollbar-none ${isPageMode ? 'px-6 sm:px-8' : ''}`}>
           {(isPageMode ? (['settings', 'connectors', 'team', 'billing'] as const) : (['team', 'billing', 'settings', 'connectors'] as const)).map((tab) => (
             <button
               key={tab}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -11,7 +11,7 @@
 
 import { useMemo, useState, useRef, useEffect, useCallback } from 'react';
 import type { View, ChatSummary, OrganizationInfo } from './AppLayout';
-import { useAppStore, useAuthStore, useChatStore, useIsGlobalAdmin, useIsOrgAdmin, useActiveTasksByConversation, type UserOrganization, type AdminPanelTab } from '../store';
+import { useAppStore, useAuthStore, useChatStore, useIsGlobalAdmin, useActiveTasksByConversation, type UserOrganization, type AdminPanelTab } from '../store';
 import { apiRequest } from '../lib/api';
 import { Avatar } from './Avatar';
 import { ScopeLockIcon } from './ScopeVisibilityIcons';
@@ -441,7 +441,7 @@ export function Sidebar({
   const isGlobalAdmin = useIsGlobalAdmin();
   const activeTasksByConversation = useActiveTasksByConversation();
   const storedWidth = useAppStore((state) => state.sidebarWidth);
-  const widthPx = collapsed ? 64 : storedWidth;
+  const widthPx: number | undefined = isMobile ? undefined : (collapsed ? 64 : storedWidth);
 
   const [panelMode, setPanelMode] = useState<'chats' | 'org'>('chats');
   const togglePanel = useCallback((): void => {
@@ -463,7 +463,7 @@ export function Sidebar({
 
   return (
     <aside
-      style={{ width: widthPx }}
+      style={widthPx != null ? { width: widthPx } : undefined}
       className="h-full flex flex-col transition-all duration-200 ease-in-out flex-shrink-0 overflow-hidden"
     >
       {/* Header: Organization identity */}
@@ -516,26 +516,18 @@ export function Sidebar({
               }`}
               aria-hidden={panelMode !== 'chats'}
             >
-            <div className={`px-3 pt-0.5 pb-0.5 flex-shrink-0 ${collapsed ? 'flex flex-col items-center' : ''}`}>
-              <button
-                type="button"
-                onClick={onNewChat}
-                className={`w-full flex items-center gap-2 px-2 py-1 rounded-lg text-[13px] text-surface-200 hover:text-surface-100 hover:bg-surface-800 transition-colors outline-none focus:outline-none ${collapsed ? 'justify-center' : ''}`}
-              >
-                <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                </svg>
-                {!collapsed && <span>New chat</span>}
-              </button>
-            </div>
+            <HubNav
+              collapsed={collapsed}
+              currentView={currentView}
+              onViewChange={onViewChange}
+              onNewChat={onNewChat}
+            />
 
             <ChatAccordion
               collapsed={collapsed}
-              currentView={currentView}
               orderedChats={orderedChats}
               currentChatId={currentChatId}
               activeTasksByConversation={activeTasksByConversation}
-              onViewChange={onViewChange}
               onSelectChat={(id) => {
                 onSelectChat(id);
                 if (isMobile) onCloseMobile?.();
@@ -615,27 +607,31 @@ interface ChannelMemoryResponse {
   content: string;
 }
 
-function normalizeChannelIdForMemory(source: string | null | undefined, channelKey: string, normalizedChannelId?: string | null): string {
-  const raw = (normalizedChannelId ?? '').trim() || channelKey.replace(/^channel:/, '').trim();
-  if ((source ?? '').toLowerCase() === 'slack') {
-    return raw.split(':', 1)[0] ?? raw;
-  }
-  return raw;
-}
-
-/** Hub navigation: always-visible icon+label links above the chat list. */
+/** Always-visible hub nav: New Chat, Search, Artifacts, Settings. */
 function HubNav({
   collapsed,
   currentView,
   onViewChange,
+  onNewChat,
 }: {
   collapsed: boolean;
   currentView: View;
   onViewChange: (view: View) => void;
+  onNewChat: () => void;
 }): JSX.Element {
   const DATA_HUB_VIEWS: readonly View[] = ['data', 'documents', 'apps', 'workflows', 'activity-log'];
 
-  const items: readonly { label: string; view: View; icon: JSX.Element }[] = [
+  const items: readonly { label: string; view: View | null; icon: JSX.Element; onClick?: () => void }[] = [
+    {
+      label: 'New chat',
+      view: null,
+      onClick: onNewChat,
+      icon: (
+        <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        </svg>
+      ),
+    },
     {
       label: 'Search',
       view: 'chats',
@@ -646,17 +642,8 @@ function HubNav({
       ),
     },
     {
-      label: 'Connectors',
-      view: 'data-sources',
-      icon: (
-        <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-        </svg>
-      ),
-    },
-    {
-      label: 'Data',
-      view: 'data',
+      label: 'Artifacts',
+      view: 'data-hub',
       icon: (
         <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
@@ -676,17 +663,19 @@ function HubNav({
   ];
 
   return (
-    <div className={`${collapsed ? 'px-1' : 'px-3'} pt-0 pb-0.5 space-y-px flex-shrink-0`}>
+    <div className={`${collapsed ? 'px-1' : 'px-3'} pt-0.5 pb-1 space-y-px flex-shrink-0`}>
       {items.map((item) => {
-        const isActive: boolean = currentView === item.view
-          || (item.view === 'data' && DATA_HUB_VIEWS.includes(currentView));
+        const isActive: boolean = item.view != null && (
+          currentView === item.view
+          || (item.view === 'data-hub' && DATA_HUB_VIEWS.includes(currentView))
+        );
 
         return (
           <button
             key={item.label}
             type="button"
             title={collapsed ? item.label : undefined}
-            onClick={() => onViewChange(item.view)}
+            onClick={item.onClick ?? (() => item.view && onViewChange(item.view))}
             className={`w-full flex items-center gap-2 ${collapsed ? 'justify-center' : ''} px-2 py-1 rounded-lg text-[13px] transition-colors outline-none focus:outline-none ${
               isActive
                 ? 'bg-surface-800 text-surface-100'
@@ -705,24 +694,19 @@ function HubNav({
 /** Recent chats: shared + private in one list (recency), pinned first; lock marks private. Row actions live in the chat ⋮ menu. */
 function ChatAccordion({
   collapsed,
-  currentView,
   orderedChats,
   currentChatId,
   activeTasksByConversation,
-  onViewChange,
   onSelectChat,
 }: {
   collapsed: boolean;
-  currentView: View;
   orderedChats: ChatSummary[];
   currentChatId: string | null;
   activeTasksByConversation: Record<string, string>;
-  onViewChange: (view: View) => void;
   onSelectChat: (id: string) => void;
 }): JSX.Element | null {
-  const isOrgAdmin: boolean = useIsOrgAdmin();
   const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>({ hub: true });
+  const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>({});
   const [channelPersonalityTarget, setChannelPersonalityTarget] = useState<{
     key: string;
     label: string;
@@ -745,7 +729,7 @@ function ChatAccordion({
       if (!raw) return;
       const parsed: unknown = JSON.parse(raw);
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        const normalized: Record<string, boolean> = { hub: true };
+        const normalized: Record<string, boolean> = {};
         for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
           if (typeof value === 'boolean') normalized[key] = value;
         }
@@ -947,40 +931,6 @@ function ChatAccordion({
   return (
     <div className="flex-1 flex flex-col min-h-0 px-3 pt-1 pb-px">
       <div className="flex-1 overflow-y-auto scrollbar-thin space-y-0 min-h-0">
-        <div className="mb-1">
-          <SidebarSectionHeader
-            title="Hub"
-            collapsed={isSectionCollapsed('hub')}
-            onToggle={() => toggleSection('hub')}
-          />
-          {!isSectionCollapsed('hub') && (
-            <div className="space-y-0.5 mb-1">
-              {[
-                { label: 'Home', view: 'home' as View },
-                { label: 'Connectors', view: 'data-sources' as View },
-                { label: 'Search Data', view: 'data' as View },
-                { label: 'Workflows', view: 'workflows' as View },
-                { label: 'Apps', view: 'apps' as View },
-                { label: 'Documents', view: 'documents' as View },
-                ...(isOrgAdmin ? [{ label: 'Activity', view: 'activity-log' as View }] : []),
-                { label: 'Settings', view: 'org-settings' as View },
-              ].map((item) => (
-                <button
-                  key={item.label}
-                  type="button"
-                  onClick={() => onViewChange(item.view)}
-                  className={`w-full text-left px-2 py-1.5 rounded-md text-sm transition-colors ${
-                    currentView === item.view
-                      ? 'bg-surface-800 text-surface-100'
-                      : 'text-surface-300 hover:text-surface-100 hover:bg-surface-800/70'
-                  }`}
-                >
-                  {item.label}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
         {groupedSidebarChats.flattenCount > 0 ? (
           <>
             {groupedSidebarChats.pinned.length > 0 && (

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -516,11 +516,11 @@ export function Sidebar({
               }`}
               aria-hidden={panelMode !== 'chats'}
             >
-            <div className={`px-3 pt-0.5 pb-1 flex-shrink-0 ${collapsed ? 'flex flex-col items-center' : ''}`}>
+            <div className={`px-3 pt-0.5 pb-0.5 flex-shrink-0 ${collapsed ? 'flex flex-col items-center' : ''}`}>
               <button
                 type="button"
                 onClick={onNewChat}
-                className={`flex items-center gap-1.5 px-1.5 py-1 rounded-md text-[13px] text-surface-300 hover:text-surface-100 hover:bg-surface-800/50 transition-colors ${collapsed ? 'justify-center' : ''}`}
+                className={`flex items-center gap-1.5 px-1.5 py-0.5 rounded-md text-[13px] text-surface-300 hover:text-surface-100 hover:bg-surface-800/50 transition-colors ${collapsed ? 'justify-center' : ''}`}
               >
                 <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
@@ -685,7 +685,7 @@ function HubNav({
   ];
 
   return (
-    <div className={`${collapsed ? 'px-1' : 'px-3'} pt-0.5 pb-1 space-y-px flex-shrink-0`}>
+    <div className={`${collapsed ? 'px-1' : 'px-3'} pt-0 pb-0.5 space-y-px flex-shrink-0`}>
       {items.map((item) => {
         const isActive: boolean = currentView === item.view
           || (item.view === 'data' && DATA_HUB_VIEWS.includes(currentView));
@@ -696,7 +696,7 @@ function HubNav({
             type="button"
             title={collapsed ? item.label : undefined}
             onClick={() => onViewChange(item.view)}
-            className={`w-full flex items-center ${collapsed ? 'justify-center' : ''} px-2 py-1.5 rounded-lg text-[13px] transition-colors outline-none focus:outline-none ${
+            className={`w-full flex items-center ${collapsed ? 'justify-center' : ''} px-2 py-1 rounded-lg text-[13px] transition-colors outline-none focus:outline-none ${
               isActive
                 ? 'bg-surface-800 text-surface-100'
                 : 'text-surface-200 hover:text-surface-100 hover:bg-surface-800'
@@ -880,7 +880,7 @@ function ChatAccordion({
     return (
       <div
         key={itemKey}
-        className={`group/chat relative w-full text-left px-2 py-[5px] rounded-md transition-colors cursor-pointer leading-tight min-h-[28px] flex items-center ${
+        className={`group/chat relative w-full text-left px-2 py-[3px] rounded-md transition-colors cursor-pointer leading-tight min-h-[24px] flex items-center ${
           isActive
             ? 'bg-surface-800/60 text-surface-100 font-medium'
             : 'text-surface-200 hover:text-surface-100 hover:bg-surface-800/40'
@@ -1076,7 +1076,7 @@ function SidebarSectionHeader({
   onOptionsClick?: () => void;
 }): JSX.Element {
   return (
-    <div className="group/section flex items-center gap-1 px-1 pt-1 pb-0.5 min-h-[22px]">
+    <div className="group/section flex items-center gap-1 px-1 pt-1.5 pb-0 min-h-[20px]">
       <button
         type="button"
         onClick={onToggle}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -520,7 +520,7 @@ export function Sidebar({
               <button
                 type="button"
                 onClick={onNewChat}
-                className={`flex items-center gap-1.5 px-1.5 py-0.5 rounded-md text-[13px] text-surface-300 hover:text-surface-100 hover:bg-surface-800/50 transition-colors ${collapsed ? 'justify-center' : ''}`}
+                className={`w-full flex items-center gap-2 px-2 py-1 rounded-lg text-[13px] text-surface-200 hover:text-surface-100 hover:bg-surface-800 transition-colors outline-none focus:outline-none ${collapsed ? 'justify-center' : ''}`}
               >
                 <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -101,18 +101,16 @@ function OrgSwitcherSection({
         onClick={onTogglePanel}
         aria-expanded={panelOpen}
         aria-label={panelOpen ? 'Hide workspace menu' : 'Show workspace menu'}
-        className="w-full flex items-center gap-3 px-4 pt-3 pb-1 hover:bg-surface-800/50 transition-colors"
+        className="w-full flex items-center gap-2.5 px-3.5 pt-3 pb-2 hover:bg-surface-800/40 rounded-lg mx-auto transition-colors"
       >
         {isAdminConsole ? (
           <>
-            <div className="w-9 h-9 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0 self-start mt-0.5 text-amber-400">
-              <GlobalAdminShieldIcon className="w-6 h-6" />
+            <div className="w-7 h-7 rounded-md bg-surface-800 flex items-center justify-center flex-shrink-0 text-amber-400">
+              <GlobalAdminShieldIcon className="w-4 h-4" />
             </div>
-            <div className="flex-1 min-w-0 text-left">
-              <div className="text-lg font-semibold text-surface-100 truncate leading-tight">
-                Global Admin
-              </div>
-            </div>
+            <span className="flex-1 min-w-0 text-left text-sm font-semibold text-surface-100 truncate">
+              Global Admin
+            </span>
           </>
         ) : (
           <>
@@ -120,22 +118,20 @@ function OrgSwitcherSection({
               <img
                 src={organization.logoUrl}
                 alt={organization.name}
-                className="w-9 h-9 rounded-lg object-cover flex-shrink-0 self-start mt-0.5"
+                className="w-7 h-7 rounded-md object-cover flex-shrink-0"
               />
             ) : (
-              <div className="w-9 h-9 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0 self-start mt-0.5">
-                <img src={LOGO_PATH} alt={APP_NAME} className="w-6 h-6" />
+              <div className="w-7 h-7 rounded-md bg-surface-800 flex items-center justify-center flex-shrink-0">
+                <img src={LOGO_PATH} alt={APP_NAME} className="w-4 h-4" />
               </div>
             )}
-            <div className="flex-1 min-w-0 text-left">
-              <div className="text-lg font-semibold text-surface-100 truncate leading-tight">
-                {organization.name}
-              </div>
-            </div>
+            <span className="flex-1 min-w-0 text-left text-sm font-semibold text-surface-100 truncate">
+              {organization.name}
+            </span>
           </>
         )}
         <svg
-          className={`w-4 h-4 text-surface-400 flex-shrink-0 transition-transform duration-200 ${panelOpen ? 'rotate-180' : ''}`}
+          className={`w-3.5 h-3.5 text-surface-400 flex-shrink-0 transition-transform duration-200 ${panelOpen ? 'rotate-180' : ''}`}
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -468,7 +464,7 @@ export function Sidebar({
   return (
     <aside
       style={{ width: widthPx }}
-      className="h-full bg-surface-950 flex flex-col transition-all duration-200 ease-in-out flex-shrink-0 overflow-hidden"
+      className="h-full flex flex-col transition-all duration-200 ease-in-out flex-shrink-0 overflow-hidden"
     >
       {/* Header: Organization identity */}
       <div className="relative min-w-0 overflow-hidden flex-shrink-0">
@@ -520,27 +516,16 @@ export function Sidebar({
               }`}
               aria-hidden={panelMode !== 'chats'}
             >
-            <div className={`px-3 py-2 flex-shrink-0 flex items-center gap-1.5 ${collapsed ? 'flex-col' : ''}`}>
+            <div className={`px-3 pt-0.5 pb-1 flex-shrink-0 ${collapsed ? 'flex flex-col items-center' : ''}`}>
               <button
                 type="button"
                 onClick={onNewChat}
-                className={`flex-1 flex items-center gap-2 px-3 py-[5px] rounded-lg bg-primary-600 hover:bg-primary-700 text-white font-medium text-sm transition-colors ${collapsed ? 'w-full justify-center' : ''}`}
+                className={`flex items-center gap-1.5 px-1.5 py-1 rounded-md text-[13px] text-surface-300 hover:text-surface-100 hover:bg-surface-800/50 transition-colors ${collapsed ? 'justify-center' : ''}`}
               >
-                <svg className="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
                 </svg>
-                {!collapsed && <span>New Chat</span>}
-              </button>
-              <button
-                type="button"
-                onClick={() => onViewChange('chats')}
-                title="Search all chats"
-                aria-label="Search all chats"
-                className={`flex items-center justify-center rounded-lg text-surface-400 hover:text-surface-100 hover:bg-surface-800/60 transition-colors ${collapsed ? 'w-full py-[5px]' : 'h-8 w-8'}`}
-              >
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                </svg>
+                {!collapsed && <span>New chat</span>}
               </button>
             </div>
 
@@ -584,20 +569,25 @@ export function Sidebar({
       </div>
 
       {/* Bottom Section */}
-      <div className="mt-auto bg-surface-900/40">
+      <div className="mt-auto px-3 py-2">
         {user && (
           <button
+            type="button"
             onClick={onOpenProfilePanel}
-            className={`w-full flex items-center gap-3 px-4 py-3 hover:bg-surface-800/60 transition-colors ${collapsed ? 'justify-center' : ''}`}
+            className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-surface-800/40 transition-colors ${collapsed ? 'justify-center' : ''}`}
           >
-            <Avatar user={user} size="md" />
+            <Avatar user={user} size="xs" />
             {!collapsed && (
-              <div className="flex-1 min-w-0 text-left">
-                <div className="text-sm font-medium text-surface-200 truncate">
-                  {user.name ?? 'User'}
-                </div>
-                <div className="text-xs text-surface-500 truncate">{user.email}</div>
-              </div>
+              <>
+                <span className="text-[13px] text-surface-200 truncate text-left">
+                  {user.name ?? user.email?.split('@')[0] ?? 'User'}
+                </span>
+                <span className="flex-1" />
+                <svg className="w-3.5 h-3.5 text-surface-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
+              </>
             )}
           </button>
         )}
@@ -631,6 +621,84 @@ function normalizeChannelIdForMemory(source: string | null | undefined, channelK
     return raw.split(':', 1)[0] ?? raw;
   }
   return raw;
+}
+
+/** Hub navigation: always-visible icon+label links above the chat list. */
+function HubNav({
+  collapsed,
+  currentView,
+  onViewChange,
+}: {
+  collapsed: boolean;
+  currentView: View;
+  onViewChange: (view: View) => void;
+}): JSX.Element {
+  const DATA_HUB_VIEWS: readonly View[] = ['data', 'documents', 'apps', 'workflows', 'activity-log'];
+
+  const items: readonly { label: string; view: View; icon: JSX.Element }[] = [
+    {
+      label: 'Home',
+      view: 'home',
+      icon: (
+        <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+        </svg>
+      ),
+    },
+    {
+      label: 'Connectors',
+      view: 'data-sources',
+      icon: (
+        <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+        </svg>
+      ),
+    },
+    {
+      label: 'Data',
+      view: 'data',
+      icon: (
+        <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4" />
+        </svg>
+      ),
+    },
+    {
+      label: 'Settings',
+      view: 'org-settings',
+      icon: (
+        <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        </svg>
+      ),
+    },
+  ];
+
+  return (
+    <div className={`${collapsed ? 'px-1' : 'px-3'} pt-0.5 pb-1 space-y-px flex-shrink-0`}>
+      {items.map((item) => {
+        const isActive: boolean = currentView === item.view
+          || (item.view === 'data' && DATA_HUB_VIEWS.includes(currentView));
+
+        return (
+          <button
+            key={item.label}
+            type="button"
+            title={collapsed ? item.label : undefined}
+            onClick={() => onViewChange(item.view)}
+            className={`w-full flex items-center ${collapsed ? 'justify-center' : ''} px-2 py-1.5 rounded-lg text-[13px] transition-colors outline-none focus:outline-none ${
+              isActive
+                ? 'bg-surface-800 text-surface-100'
+                : 'text-surface-200 hover:text-surface-100 hover:bg-surface-800'
+            }`}
+          >
+            {collapsed ? item.icon : <span>{item.label}</span>}
+          </button>
+        );
+      })}
+    </div>
+  );
 }
 
 /** Recent chats: shared + private in one list (recency), pinned first; lock marks private. Row actions live in the chat ⋮ menu. */
@@ -803,10 +871,10 @@ function ChatAccordion({
     return (
       <div
         key={itemKey}
-        className={`group/chat relative w-full text-left px-2 py-1.5 rounded-md transition-colors cursor-pointer leading-tight min-h-[32px] flex items-center ${
+        className={`group/chat relative w-full text-left px-2 py-[5px] rounded-md transition-colors cursor-pointer leading-tight min-h-[28px] flex items-center ${
           isActive
-            ? 'bg-surface-800 text-surface-100'
-            : 'text-surface-300 hover:text-surface-100 hover:bg-surface-800/70'
+            ? 'bg-surface-800/60 text-surface-100 font-medium'
+            : 'text-surface-200 hover:text-surface-100 hover:bg-surface-800/40'
         }`}
         onClick={() => onSelectChat(chat.id)}
         onMouseEnter={() => {
@@ -828,7 +896,7 @@ function ChatAccordion({
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
             </svg>
           )}
-          <div className="truncate text-[15px] flex-1 leading-tight">
+          <div className="truncate text-[13px] flex-1 leading-tight">
             {chat.title}
           </div>
           {isUnread && (
@@ -844,10 +912,8 @@ function ChatAccordion({
               <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
             </svg>
           )}
-          {/* Hover metadata: in flow so it pushes the title to truncate.
-              Row min-height keeps avatar height from shifting the row. */}
-          <div className="hidden group-hover/chat:flex items-center gap-1.5 leading-none flex-shrink-0">
-            <span className="text-xs text-surface-500">
+          <div className="hidden group-hover/chat:flex items-center gap-1.5 leading-none flex-shrink-0 absolute right-2 top-1/2 -translate-y-1/2 bg-surface-800/90 rounded px-1 py-0.5">
+            <span className="text-[11px] text-surface-500">
               {formatRelativeTime(chat.lastMessageAt)}
             </span>
             {hasParticipants && (
@@ -923,52 +989,50 @@ function ChatAccordion({
                   collapsed={isSectionCollapsed('pinned')}
                   onToggle={() => toggleSection('pinned')}
                 />
-                {!isSectionCollapsed('pinned') && groupedSidebarChats.pinned.map((chat) => renderChatItem(chat, `pinned-${chat.id}`))}
+                {!isSectionCollapsed('pinned') &&
+                  groupedSidebarChats.pinned.map((chat) => renderChatItem(chat, `pinned-${chat.id}`))}
               </>
             )}
+
             {groupedSidebarChats.direct.length > 0 && (
               <>
                 <SidebarSectionHeader
-                  title="Direct"
+                  title="Recents"
                   collapsed={isSectionCollapsed('direct')}
                   onToggle={() => toggleSection('direct')}
                 />
-                {!isSectionCollapsed('direct') && groupedSidebarChats.direct.map((chat) => renderChatItem(chat, `direct-${chat.id}`, { suppressLockIcon: true }))}
+                {!isSectionCollapsed('direct') &&
+                  groupedSidebarChats.direct.map((chat) => renderChatItem(chat, `direct-${chat.id}`, { suppressLockIcon: false }))}
               </>
             )}
-            {groupedSidebarChats.channels.map((channel) => (
-              <div key={channel.key}>
+
+            {groupedSidebarChats.channels.map((section) => (
+              <div key={section.key}>
                 <SidebarSectionHeader
-                  title={channel.label}
-                  collapsed={isSectionCollapsed(`channel:${channel.key}`)}
-                  onToggle={() => toggleSection(`channel:${channel.key}`)}
-                  onOptionsClick={() => {
-                    const normalizedChannelId = normalizeChannelIdForMemory(
-                      channel.source,
-                      channel.key,
-                      channel.normalizedChannelId,
-                    );
-                    setChannelPersonalityTarget({
-                      key: channel.key,
-                      label: channel.label,
-                      source: channel.source,
-                      normalizedChannelId,
-                    });
-                  }}
+                  title={section.label}
+                  collapsed={isSectionCollapsed(section.key)}
+                  onToggle={() => toggleSection(section.key)}
+                  onOptionsClick={() => setChannelPersonalityTarget({
+                    key: section.key,
+                    label: section.label,
+                    source: section.source,
+                    normalizedChannelId: section.normalizedChannelId ?? section.key,
+                  })}
                 />
-                {!isSectionCollapsed(`channel:${channel.key}`) &&
-                  channel.chats.map((chat) => renderChatItem(chat, `channel-${channel.key}-${chat.id}`))}
+                {!isSectionCollapsed(section.key) &&
+                  section.chats.map((chat) => renderChatItem(chat, `chan-${section.key}-${chat.id}`))}
               </div>
             ))}
+
             {groupedSidebarChats.uncategorized.length > 0 && (
               <>
                 <SidebarSectionHeader
-                  title="Uncategorized"
+                  title="Other"
                   collapsed={isSectionCollapsed('uncategorized')}
                   onToggle={() => toggleSection('uncategorized')}
                 />
                 {!isSectionCollapsed('uncategorized') &&
-                  groupedSidebarChats.uncategorized.map((chat) => renderChatItem(chat, `uncategorized-${chat.id}`))}
+                  groupedSidebarChats.uncategorized.map((chat) => renderChatItem(chat, `uncat-${chat.id}`))}
               </>
             )}
           </>
@@ -1003,7 +1067,7 @@ function SidebarSectionHeader({
   onOptionsClick?: () => void;
 }): JSX.Element {
   return (
-    <div className="group/section flex items-center gap-1 px-1 pt-1.5 pb-0.5 min-h-[26px]">
+    <div className="group/section flex items-center gap-1 px-1 pt-1 pb-0.5 min-h-[22px]">
       <button
         type="button"
         onClick={onToggle}
@@ -1011,7 +1075,7 @@ function SidebarSectionHeader({
         aria-expanded={!collapsed}
         aria-label={`${collapsed ? 'Expand' : 'Collapse'} ${title}`}
       >
-        <h3 className="truncate text-[10px] uppercase tracking-wider text-primary-500/85 font-semibold">
+        <h3 className="truncate text-[11px] text-surface-500 font-normal">
           {title}
         </h3>
       </button>
@@ -1032,7 +1096,7 @@ function SidebarSectionHeader({
       <button
         type="button"
         onClick={onToggle}
-        className="shrink-0 p-0.5 rounded text-primary-500/60 hover:text-primary-500 hover:bg-surface-800/60 transition-colors"
+        className="shrink-0 p-0.5 rounded text-surface-500 hover:text-surface-300 hover:bg-surface-800/60 transition-colors"
         aria-label={collapsed ? `Expand ${title}` : `Collapse ${title}`}
         aria-expanded={!collapsed}
       >

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -696,13 +696,14 @@ function HubNav({
             type="button"
             title={collapsed ? item.label : undefined}
             onClick={() => onViewChange(item.view)}
-            className={`w-full flex items-center ${collapsed ? 'justify-center' : ''} px-2 py-1 rounded-lg text-[13px] transition-colors outline-none focus:outline-none ${
+            className={`w-full flex items-center gap-2 ${collapsed ? 'justify-center' : ''} px-2 py-1 rounded-lg text-[13px] transition-colors outline-none focus:outline-none ${
               isActive
                 ? 'bg-surface-800 text-surface-100'
                 : 'text-surface-200 hover:text-surface-100 hover:bg-surface-800'
             }`}
           >
-            {collapsed ? item.icon : <span>{item.label}</span>}
+            {item.icon}
+            {!collapsed && <span>{item.label}</span>}
           </button>
         );
       })}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -646,6 +646,15 @@ function HubNav({
       ),
     },
     {
+      label: 'Search',
+      view: 'chats',
+      icon: (
+        <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+      ),
+    },
+    {
       label: 'Connectors',
       view: 'data-sources',
       icon: (

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -637,15 +637,6 @@ function HubNav({
 
   const items: readonly { label: string; view: View; icon: JSX.Element }[] = [
     {
-      label: 'Home',
-      view: 'home',
-      icon: (
-        <svg className="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-        </svg>
-      ),
-    },
-    {
       label: 'Search',
       view: 'chats',
       icon: (

--- a/frontend/src/components/Workflows.tsx
+++ b/frontend/src/components/Workflows.tsx
@@ -1431,31 +1431,18 @@ export function Workflows(): JSX.Element {
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* Header */}
-      <div className="flex-shrink-0 px-6 pt-6 pb-0">
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h1 className="text-xl font-bold text-surface-100">Workflows</h1>
-            <p className="text-sm text-surface-400 mt-1">
-              Automated tasks that run on schedule or manually
-            </p>
-          </div>
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={openCreateModal}
-              className="px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-lg text-sm font-medium transition-colors flex items-center gap-2"
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-              </svg>
-              <span className="sm:hidden">Create</span>
-              <span className="hidden sm:inline">Create Workflow</span>
-            </button>
-          </div>
-        </div>
-
-        {/* Search + view toggle */}
+      <div className="flex-shrink-0 px-6 pt-4 pb-0">
         <div className="flex items-center gap-3 mb-4">
+          <button
+            type="button"
+            onClick={openCreateModal}
+            className="px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white rounded-lg text-sm font-medium transition-colors flex items-center gap-2 shrink-0"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            <span className="hidden sm:inline">Create</span>
+          </button>
           <GallerySearchInput
             value={searchInput}
             onChange={setSearchInput}

--- a/frontend/src/components/apps/AppsGallery.tsx
+++ b/frontend/src/components/apps/AppsGallery.tsx
@@ -347,19 +347,7 @@ export function AppsGallery(): JSX.Element {
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
-      <div className="flex-shrink-0 px-6 pt-6 pb-0">
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h1 className="text-xl font-bold text-surface-100">Apps</h1>
-            <p className="text-sm text-surface-400 mt-1">
-              Interactive dashboards and data views created by Basebase
-            </p>
-          </div>
-          <span className="hidden sm:inline text-sm text-surface-500">
-            {apps.length} app{apps.length !== 1 ? "s" : ""}
-          </span>
-        </div>
-
+      <div className="flex-shrink-0 px-6 pt-4 pb-0">
         <div className="flex items-center gap-3 mb-4">
           <GallerySearchInput
             value={searchInput}

--- a/frontend/src/components/documents/DocumentsGallery.tsx
+++ b/frontend/src/components/documents/DocumentsGallery.tsx
@@ -191,20 +191,7 @@ export function DocumentsGallery(): JSX.Element {
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* Header */}
-      <div className="flex-shrink-0 px-6 pt-6 pb-0">
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h1 className="text-xl font-bold text-surface-100">Documents</h1>
-            <p className="text-sm text-surface-400 mt-1">
-              Reports, charts, and files created for you by Basebase
-            </p>
-          </div>
-          <span className="hidden sm:inline text-sm text-surface-500">
-            {artifacts.length} document{artifacts.length !== 1 ? "s" : ""}
-          </span>
-        </div>
-
-        {/* Search + view toggle */}
+      <div className="flex-shrink-0 px-6 pt-4 pb-0">
         <div className="flex items-center gap-3 mb-4">
           <GallerySearchInput
             value={searchInput}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,17 +6,17 @@
  *   rule (#d9d2c2) → hairlines (surface-700). Darker steps are derived for text.
  */
 :root {
-  --surface-50: #151617;
-  --surface-100: #333538;
-  --surface-200: #4b4e52;
-  --surface-300: #64686d;
-  --surface-400: #7e8288;
-  --surface-500: #989ca2;
-  --surface-600: #b4b8bd;
-  --surface-700: #e2e4e7;
-  --surface-800: #f0f1f3;
+  --surface-50: #171513;
+  --surface-100: #3c3832;
+  --surface-200: #554e47;
+  --surface-300: #6e665d;
+  --surface-400: #887e71;
+  --surface-500: #a39687;
+  --surface-600: #bfb4a5;
+  --surface-700: #e5e2db;
+  --surface-800: #f2efe9;
   --surface-900: #ffffff;
-  --surface-950: #f9fafb;
+  --surface-950: #faf9f7;
   color-scheme: light;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,17 +6,17 @@
  *   rule (#d9d2c2) → hairlines (surface-700). Darker steps are derived for text.
  */
 :root {
-  --surface-50: #171513;
-  --surface-100: #3c3832;
-  --surface-200: #554e47;
-  --surface-300: #6e665d;
-  --surface-400: #887e71;
-  --surface-500: #a39687;
-  --surface-600: #bfb4a5;
-  --surface-700: #e5e2db;
-  --surface-800: #f2efe9;
+  --surface-50: #151617;
+  --surface-100: #333538;
+  --surface-200: #4b4e52;
+  --surface-300: #64686d;
+  --surface-400: #7e8288;
+  --surface-500: #989ca2;
+  --surface-600: #b4b8bd;
+  --surface-700: #e2e4e7;
+  --surface-800: #f0f1f3;
   --surface-900: #ffffff;
-  --surface-950: #faf9f7;
+  --surface-950: #f9fafb;
   color-scheme: light;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -109,7 +109,7 @@
 
   /* Claude-style chat greeting (serif, spacious) */
   .chat-greeting {
-    @apply font-serif text-3xl md:text-4xl text-surface-100 tracking-tight;
+    @apply font-sans text-3xl md:text-4xl text-surface-100 tracking-tight font-light;
   }
 
   /* Centered composer shell for new-chat empty state */

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -376,6 +376,7 @@ export type View =
   | "chats"
   | "data-sources"
   | "data"
+  | "data-hub"
   | "workflows"
   | "memory"
   | "apps"


### PR DESCRIPTION
## Summary
- Restructures sidebar with HubNav containing New Chat, Search, Artifacts, and Settings items
- Adds tabbed Artifacts/DataPage hub (Apps, Workflows, Documents, Synced Data) accessible from sidebar
- Converts ChatsList from card tiles to compact row layout with full-width search input
- Removes redundant titles/descriptions from gallery pages (Apps, Workflows, Documents, Synced Data, Chats)
- Cleans up Settings page: removes redundant org header in page mode, hides tab scrollbar

## Test plan
- [ ] Verify sidebar renders correctly on desktop and mobile (hamburger menu)
- [ ] Click each sidebar item (New Chat, Search, Artifacts, Settings) and confirm navigation
- [ ] Verify Artifacts page tabs switch between Apps, Workflows, Documents, Synced Data
- [ ] Verify ChatsList search input works and scope filters (All/Shared/Private/Mine) function
- [ ] Check Settings page tabs render without horizontal scrollbar
- [ ] Test mobile layout for all pages


Made with [Cursor](https://cursor.com)