### PR TITLE
Preserve Slack bot and file-only messages for channel context

### DIFF
--- a/backend/connectors/slack.py
+++ b/backend/connectors/slack.py
@@ -1072,15 +1072,16 @@ Returns normalized messages for one channel since a cutoff (does not write to th
         channel_name: str,
     ) -> Optional[Activity]:
         """Transform Slack message to our Activity model."""
-        # Skip bot messages and system messages
-        if slack_msg.get("subtype") in ["bot_message", "channel_join", "channel_leave"]:
+        # Skip Slack join/leave system messages, but keep bot messages so
+        # workflow/bot outputs are available in channel history context.
+        if slack_msg.get("subtype") in ["channel_join", "channel_leave"]:
             return None
 
         msg_ts = slack_msg.get("ts", "")
         text = slack_msg.get("text", "")
 
-        # Skip empty messages
-        if not text.strip():
+        # Skip messages with no text and no file attachments.
+        if not text.strip() and not slack_msg.get("files"):
             return None
 
         # Parse timestamp

--- a/backend/tests/test_slack_sync_activities.py
+++ b/backend/tests/test_slack_sync_activities.py
@@ -93,3 +93,47 @@ def test_sync_activities_returns_joined_count(monkeypatch) -> None:
 
     count = asyncio.run(connector.sync_activities())
     assert count == 3
+
+
+def test_normalize_message_includes_bot_messages_for_history_context() -> None:
+    connector = _make_connector()
+
+    activity = connector._normalize_message(
+        {
+            "subtype": "bot_message",
+            "bot_id": "B123",
+            "ts": "1710711600.200",
+            "text": "Workflow update: completed action",
+            "thread_ts": "1710711600.100",
+            "files": [],
+            "attachments": [],
+        },
+        channel_id="C123",
+        channel_name="sales",
+    )
+
+    assert activity is not None
+    assert activity.description == "Workflow update: completed action"
+    assert activity.custom_fields["sender_type"] == "bot"
+    assert activity.custom_fields["channel_id"] == "C123"
+
+
+def test_normalize_message_keeps_file_only_message() -> None:
+    connector = _make_connector()
+
+    activity = connector._normalize_message(
+        {
+            "subtype": "bot_message",
+            "bot_id": "B123",
+            "ts": "1710711600.300",
+            "text": "",
+            "thread_ts": "",
+            "files": [{"id": "F123", "name": "report.pdf"}],
+            "attachments": [],
+        },
+        channel_id="C123",
+        channel_name="sales",
+    )
+
+    assert activity is not None
+    assert activity.custom_fields["has_files"] is True


### PR DESCRIPTION
### Motivation
- Workflow outputs posted to Slack are often delivered as `bot_message` events and were previously dropped during normalization, causing recent channel context to miss workflow messages. 
- Messages that contain only files (no text) were also being discarded, which removes attachment updates from LLM-visible context.

### Description
- Updated `SlackConnector._normalize_message` in `backend/connectors/slack.py` to only skip Slack system `channel_join`/`channel_leave` events and retain `bot_message` events so workflow/bot outputs are normalized into `Activity` rows. 
- Changed empty-message filtering to keep messages that have file attachments by checking `files` before skipping. 
- Added regression tests in `backend/tests/test_slack_sync_activities.py` to assert that `bot_message` events are normalized and that file-only messages are preserved with `has_files=True`.

### Testing
- Ran `pytest -q backend/tests/test_slack_sync_activities.py`, which completed successfully with `4 passed` tests. 
- The new tests validate bot-message inclusion and file-only message handling and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e0fbeffac8321b8d60ccea1ab92c7)