### PR TITLE
Fix mobile connector flag wrapping

### DIFF
--- a/frontend/src/components/DataSources.tsx
+++ b/frontend/src/components/DataSources.tsx
@@ -2170,8 +2170,8 @@ export function DataSources(): JSX.Element {
               </span>
             </span>
             <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-              <span className="flex min-w-0 flex-1 items-center gap-2">
-                <span className="truncate text-sm text-surface-100">{integration.name}</span>
+              <span className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5 sm:flex-nowrap sm:gap-2">
+                <span className="min-w-0 basis-full truncate text-sm text-surface-100 sm:basis-auto">{integration.name}</span>
                 {integration.provider.startsWith('mcp_') && (
                   <span className="shrink-0 rounded bg-surface-700 px-1.5 py-0 text-[10px] font-medium uppercase tracking-wide text-surface-400">
                     Custom


### PR DESCRIPTION
### Motivation
- Prevent connector flag/badge pills from overlapping action controls on narrow screens by letting the connector name and badges wrap into two rows when needed.

### Description
- Adjusted the layout in `frontend/src/components/DataSources.tsx` to allow the title+badge group to `flex-wrap` on small screens, set the connector name to `basis-full` on mobile and `sm:basis-auto`, and keep `sm:flex-nowrap` for desktop so larger viewports preserve the single-line appearance.

### Testing
- Ran lint on the modified file with `cd frontend && npx eslint src/components/DataSources.tsx`, which completed successfully (only a non-blocking npm env warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148d3e35308321aa93dfc3f8a7012a)