### PR TITLE
Admin dashboard: add per-user data exfiltration metrics and UI

### DIFF
--- a/backend/api/routes/admin_dashboard.py
+++ b/backend/api/routes/admin_dashboard.py
@@ -13,7 +13,7 @@ from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import cast, Date, desc, func, select
+from sqlalchemy import cast, Date, desc, func, select, text
 
 from api.auth_middleware import (
     AuthContext,
@@ -24,6 +24,7 @@ from models.conversation import Conversation
 from models.credit_transaction import CreditTransaction
 from models.organization import Organization
 from models.user import User
+from models.app import App
 from models.database import get_admin_session
 from services.query_outcome_metrics import get_query_outcome_window_stats
 
@@ -208,3 +209,103 @@ async def get_top_conversations(
         })
 
     return {"organizations": organizations}
+
+
+@router.get("/data-exfiltration")
+async def get_data_exfiltration(
+    auth: AuthContext = Depends(require_global_admin),
+) -> dict[str, Any]:
+    """Return per-user data-exfiltration counters over the trailing 30 days."""
+    window_start: datetime = datetime.now(timezone.utc) - timedelta(days=30)
+    logger.info("[admin_dashboard] Computing data exfiltration metrics window_start=%s", window_start.isoformat())
+
+    async with get_admin_session() as session:
+        tool_rows = (
+            await session.execute(
+                text(
+                    """
+                    WITH tool_uses AS (
+                      SELECT
+                        cm.user_id,
+                        block->>'name' AS tool_name,
+                        COALESCE(block->'input'->>'connector', '') AS connector_name,
+                        COALESCE(block->'input'->>'query', '') AS sql_query
+                      FROM chat_messages cm
+                      CROSS JOIN LATERAL jsonb_array_elements(COALESCE(cm.content_blocks, '[]'::jsonb)) AS block
+                      WHERE cm.user_id IS NOT NULL
+                        AND cm.created_at >= :window_start
+                        AND block->>'type' = 'tool_use'
+                    )
+                    SELECT
+                      user_id,
+                      COUNT(*) FILTER (WHERE tool_name IN ('query_on_connector', 'write_on_connector', 'run_on_connector') AND connector_name = 'code_sandbox') AS code_unix_data_out_count,
+                      COUNT(*) FILTER (WHERE tool_name IN ('query_on_connector', 'write_on_connector', 'run_on_connector') AND connector_name LIKE 'mcp_%') AS custom_mcp_data_out_count,
+                      COUNT(*) FILTER (WHERE tool_name = 'run_sql_query' AND sql_query ~* '^\\s*select\\b') AS select_query_count
+                    FROM tool_uses
+                    GROUP BY user_id
+                    """
+                ),
+                {"window_start": window_start},
+            )
+        ).all()
+
+        app_rows = (
+            await session.execute(
+                select(App.user_id, func.count(App.id).label("owned_app_count"))
+                .where(App.created_at >= window_start)
+                .group_by(App.user_id)
+            )
+        ).all()
+
+        user_ids: set[UUID] = set()
+        for row in tool_rows:
+            user_ids.add(row.user_id)
+        for row in app_rows:
+            user_ids.add(row.user_id)
+
+        name_map: dict[str, str] = {}
+        if user_ids:
+            user_rows = (await session.execute(select(User.id, User.name).where(User.id.in_(list(user_ids))))).all()
+            name_map = {str(u.id): u.name for u in user_rows if u.name}
+
+    by_user: dict[str, dict[str, Any]] = {}
+    for row in tool_rows:
+        uid = str(row.user_id)
+        by_user[uid] = {
+            "user_id": uid,
+            "user_name": name_map.get(uid),
+            "code_unix_data_out_count": int(row.code_unix_data_out_count or 0),
+            "custom_mcp_data_out_count": int(row.custom_mcp_data_out_count or 0),
+            "select_query_count": int(row.select_query_count or 0),
+            "owned_app_count": 0,
+        }
+    for row in app_rows:
+        uid = str(row.user_id)
+        if uid not in by_user:
+            by_user[uid] = {
+                "user_id": uid,
+                "user_name": name_map.get(uid),
+                "code_unix_data_out_count": 0,
+                "custom_mcp_data_out_count": 0,
+                "select_query_count": 0,
+                "owned_app_count": 0,
+            }
+        by_user[uid]["owned_app_count"] = int(row.owned_app_count or 0)
+
+    users: list[dict[str, Any]] = sorted(
+        by_user.values(),
+        key=lambda r: (
+            r["code_unix_data_out_count"]
+            + r["custom_mcp_data_out_count"]
+            + r["select_query_count"]
+            + r["owned_app_count"]
+        ),
+        reverse=True,
+    )
+    logger.info("[admin_dashboard] Computed data exfiltration rows=%d", len(users))
+    return {
+        "window": "rolling_30_days",
+        "window_start": window_start.isoformat().replace("+00:00", "Z"),
+        "owned_app_count_is_proxy": True,
+        "users": users,
+    }

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -62,6 +62,22 @@ interface QueryOutcomeRateResponse {
   }>;
 }
 
+interface DataExfiltrationUserRow {
+  user_id: string;
+  user_name: string | null;
+  code_unix_data_out_count: number;
+  custom_mcp_data_out_count: number;
+  select_query_count: number;
+  owned_app_count: number;
+}
+
+interface DataExfiltrationResponse {
+  window: string;
+  window_start: string;
+  owned_app_count_is_proxy?: boolean;
+  users: DataExfiltrationUserRow[];
+}
+
 function formatRelativeTime(iso: string): string {
   const diffMs: number = Date.now() - new Date(iso).getTime();
   const mins: number = Math.floor(diffMs / 60_000);
@@ -552,6 +568,9 @@ export function AdminPanel(): JSX.Element {
   const [topConversationsError, setTopConversationsError] = useState<string | null>(null);
   const [PlotComponent, setPlotComponent] = useState<typeof import('react-plotly.js').default | null>(null);
   const [chartLoadError, setChartLoadError] = useState<boolean>(false);
+  const [dataExfiltration, setDataExfiltration] = useState<DataExfiltrationResponse | null>(null);
+  const [dataExfiltrationLoading, setDataExfiltrationLoading] = useState<boolean>(true);
+  const [dataExfiltrationError, setDataExfiltrationError] = useState<string | null>(null);
 
   useEffect(() => {
     import('react-plotly.js')
@@ -579,6 +598,17 @@ export function AdminPanel(): JSX.Element {
       setTopConversations(data);
     } catch { setTopConversationsError('Request failed'); }
     finally { setTopConversationsLoading(false); }
+  }, []);
+
+  const fetchDataExfiltration = useCallback(async (): Promise<void> => {
+    setDataExfiltrationLoading(true);
+    setDataExfiltrationError(null);
+    try {
+      const { data, error: reqErr } = await apiRequest<DataExfiltrationResponse>('/admin-dashboard/data-exfiltration');
+      if (reqErr || !data) { setDataExfiltrationError(reqErr ?? 'Failed to fetch'); return; }
+      setDataExfiltration(data);
+    } catch { setDataExfiltrationError('Request failed'); }
+    finally { setDataExfiltrationLoading(false); }
   }, []);
 
   const fetchWaitlist = useCallback(async (): Promise<void> => {
@@ -779,6 +809,7 @@ export function AdminPanel(): JSX.Element {
     if (activeTab === 'dashboard') {
       void fetchCreditUsage();
       void fetchTopConversations();
+      void fetchDataExfiltration();
     } else if (activeTab === 'waitlist') {
       void fetchWaitlist();
     } else if (activeTab === 'users') {
@@ -795,7 +826,7 @@ export function AdminPanel(): JSX.Element {
     } else if (activeTab === 'graph-magic') {
       // graph tab fetches on-demand in component
     }
-  }, [activeTab, fetchCreditUsage, fetchTopConversations, fetchWaitlist, fetchUsers, fetchOrganizations, fetchIntegrations, fetchQueryOutcomeRate, fetchRunningJobs, fetchModels]);
+  }, [activeTab, fetchCreditUsage, fetchTopConversations, fetchDataExfiltration, fetchWaitlist, fetchUsers, fetchOrganizations, fetchIntegrations, fetchQueryOutcomeRate, fetchRunningJobs, fetchModels]);
 
   const handleCancelJob = async (job: AdminRunningJob): Promise<void> => {
     if (!user) return;
@@ -1321,7 +1352,7 @@ export function AdminPanel(): JSX.Element {
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-lg font-semibold text-surface-100">Credit Usage — Past 7 Days</h2>
                 <button
-                  onClick={() => { void fetchCreditUsage(); void fetchTopConversations(); }}
+                  onClick={() => { void fetchCreditUsage(); void fetchTopConversations(); void fetchDataExfiltration(); }}
                   className="px-3 py-1.5 rounded-lg border border-surface-700 text-xs font-medium text-surface-300 hover:bg-surface-800 transition-colors"
                 >
                   Refresh
@@ -1342,6 +1373,41 @@ export function AdminPanel(): JSX.Element {
               )}
               {!creditUsageLoading && !creditUsageError && creditUsage && creditUsage.series.length === 0 && (
                 <div className="text-center py-16 text-surface-400">No credit usage in the past 7 days.</div>
+              )}
+            </section>
+
+            <section>
+              <h2 className="text-lg font-semibold text-surface-100 mb-4">Per-User Data Exfiltration — Rolling Month</h2>
+              {dataExfiltrationLoading && <div className="text-center py-12 text-surface-400">Loading exfiltration metrics...</div>}
+              {dataExfiltrationError && <div className="text-center py-12 text-red-400">{dataExfiltrationError}</div>}
+              {!dataExfiltrationLoading && !dataExfiltrationError && dataExfiltration && dataExfiltration.users.length === 0 && (
+                <div className="text-center py-12 text-surface-400">No exfiltration activity in this window.</div>
+              )}
+              {!dataExfiltrationLoading && !dataExfiltrationError && dataExfiltration && dataExfiltration.users.length > 0 && (
+                <div className="overflow-x-auto rounded-xl border border-surface-800 bg-surface-900">
+                  <table className="w-full">
+                    <thead>
+                      <tr className="border-b border-surface-800 text-left">
+                        <th className="px-4 py-3 text-sm font-medium text-surface-400">User</th>
+                        <th className="px-4 py-3 text-sm font-medium text-surface-400">Code/Unix Out</th>
+                        <th className="px-4 py-3 text-sm font-medium text-surface-400">Custom MCP Out</th>
+                        <th className="px-4 py-3 text-sm font-medium text-surface-400">SELECT Queries</th>
+                        <th className="px-4 py-3 text-sm font-medium text-surface-400">Owned Apps (Proxy)</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-surface-800">
+                      {dataExfiltration.users.map((row) => (
+                        <tr key={row.user_id} className="hover:bg-surface-800/50">
+                          <td className="px-4 py-3 text-sm text-surface-200">{row.user_name || row.user_id}</td>
+                          <td className="px-4 py-3 text-sm text-surface-300">{row.code_unix_data_out_count.toLocaleString()}</td>
+                          <td className="px-4 py-3 text-sm text-surface-300">{row.custom_mcp_data_out_count.toLocaleString()}</td>
+                          <td className="px-4 py-3 text-sm text-surface-300">{row.select_query_count.toLocaleString()}</td>
+                          <td className="px-4 py-3 text-sm text-surface-300">{row.owned_app_count.toLocaleString()}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
               )}
             </section>
 


### PR DESCRIPTION
### Motivation
- Provide admins with visibility into potential data exfiltration by correlating recent tool uses, SQL SELECT queries, and newly created apps over a rolling 30-day window.

### Description
- Added a new backend admin route `GET /admin-dashboard/data-exfiltration` that computes per-user counts from `chat_messages.content_blocks` JSONB (tool uses) and counts of owned `App` records using a 30-day rolling window and returns aggregated rows with user name lookup.
- Implemented the DB logic via a raw SQL `WITH` query (uses `sqlalchemy.text`) to extract `tool_name`, connector info, and SQL query text, and combined that with an `App` count query before assembling the response payload.
- Extended the frontend `AdminPanel` with TypeScript types for the response, a `fetchDataExfiltration` function and state, added the call when the dashboard tab is active, wired the Refresh button to reload exfiltration metrics, and rendered a responsive table of per-user metrics.
- Minor imports and dependency array updates: imported `App` and `text` on the backend and added `fetchDataExfiltration` to the `useEffect` dependency list on the frontend.

### Testing
- Ran backend automated tests via `pytest` which completed successfully against the modified admin routes.
- Built and type-checked the frontend with `yarn build` (TypeScript compilation) which succeeded and the new UI compiled without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148cfff97c8321ab6cc39476805387)