### PR TITLE
Add count-only egress telemetry, migration, API and admin UI for per-user egress (30d)

### DIFF
--- a/backend/api/routes/admin_dashboard.py
+++ b/backend/api/routes/admin_dashboard.py
@@ -24,6 +24,7 @@ from models.conversation import Conversation
 from models.credit_transaction import CreditTransaction
 from models.organization import Organization
 from models.user import User
+from models.egress_event import EgressEvent
 from models.database import get_admin_session
 from services.query_outcome_metrics import get_query_outcome_window_stats
 
@@ -208,3 +209,49 @@ async def get_top_conversations(
         })
 
     return {"organizations": organizations}
+
+
+@router.get("/egress-by-user")
+async def get_egress_by_user_30d(
+    auth: AuthContext = Depends(require_global_admin),
+) -> dict[str, Any]:
+    """Return per-user outbound bytes over a rolling 30-day window."""
+    now_utc = datetime.now(timezone.utc)
+    window_start = now_utc - timedelta(days=30)
+
+    async with get_admin_session() as session:
+        rows = (
+            await session.execute(
+                select(
+                    EgressEvent.user_id,
+                    User.email.label("user_email"),
+                    User.name.label("user_name"),
+                    func.sum(EgressEvent.bytes_out).label("bytes_out_total"),
+                    func.count(EgressEvent.id).label("event_count"),
+                    func.max(EgressEvent.created_at).label("last_event_at"),
+                )
+                .join(User, User.id == EgressEvent.user_id, isouter=True)
+                .where(EgressEvent.created_at >= window_start)
+                .group_by(EgressEvent.user_id, User.email, User.name)
+                .order_by(desc("bytes_out_total"))
+                .limit(500)
+            )
+        ).all()
+
+    users: list[dict[str, Any]] = []
+    for row in rows:
+        users.append({
+            "user_id": str(row.user_id) if row.user_id else None,
+            "user_email": row.user_email,
+            "user_name": row.user_name,
+            "bytes_out_total": int(row.bytes_out_total or 0),
+            "event_count": int(row.event_count or 0),
+            "last_event_at": row.last_event_at.isoformat() + "Z" if row.last_event_at else None,
+        })
+
+    return {
+        "window_days": 30,
+        "window_start": window_start.isoformat(),
+        "window_end": now_utc.isoformat(),
+        "users": users,
+    }

--- a/backend/db/migrations/versions/135_egress_events.py
+++ b/backend/db/migrations/versions/135_egress_events.py
@@ -1,0 +1,50 @@
+"""135_egress_events
+
+Revision ID: 135_egress_events
+Revises: 134_topic_graph
+Create Date: 2026-05-26
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "135_egress_events"
+down_revision = "134_topic_graph"
+branch_labels = None
+depends_on = None
+
+assert len(revision) <= 32
+assert not isinstance(down_revision, str) or len(down_revision) <= 32
+
+
+def upgrade() -> None:
+    op.create_table(
+        "egress_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("conversation_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("workflow_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("connector", sa.String(length=50), nullable=False),
+        sa.Column("operation", sa.String(length=100), nullable=False),
+        sa.Column("destination", sa.String(length=255), nullable=True),
+        sa.Column("bytes_out", sa.Integer(), nullable=False),
+        sa.Column("scan_mode", sa.String(length=32), nullable=False, server_default="count_only"),
+        sa.Column("metadata_json", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"]),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["conversation_id"], ["conversations.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["workflow_id"], ["workflows.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_egress_events_org_created", "egress_events", ["organization_id", "created_at"], unique=False)
+    op.create_index("ix_egress_events_connector_created", "egress_events", ["connector", "created_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_egress_events_connector_created", table_name="egress_events")
+    op.drop_index("ix_egress_events_org_created", table_name="egress_events")
+    op.drop_table("egress_events")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -36,6 +36,7 @@ from models.workstream_snapshot import WorkstreamSnapshot
 from models.notification import Notification
 from models.action_ledger import ActionLedgerEntry
 from models.topic_graph_snapshot import TopicGraphSnapshot
+from models.egress_event import EgressEvent
 
 __all__ = [
     "Base",
@@ -80,4 +81,5 @@ __all__ = [
     "Notification",
     "ActionLedgerEntry",
     "TopicGraphSnapshot",
+    "EgressEvent",
 ]

--- a/backend/models/egress_event.py
+++ b/backend/models/egress_event.py
@@ -1,0 +1,39 @@
+"""Egress event model for count-only outbound telemetry."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.database import Base
+
+
+class EgressEvent(Base):
+    """Append-only outbound telemetry row for future egress scanning policies."""
+
+    __tablename__ = "egress_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False)
+    user_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    conversation_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("conversations.id", ondelete="SET NULL"), nullable=True
+    )
+    workflow_id: Mapped[Optional[uuid.UUID]] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("workflows.id", ondelete="SET NULL"), nullable=True
+    )
+
+    connector: Mapped[str] = mapped_column(String(50), nullable=False)
+    operation: Mapped[str] = mapped_column(String(100), nullable=False)
+    destination: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    bytes_out: Mapped[int] = mapped_column(Integer, nullable=False)
+    scan_mode: Mapped[str] = mapped_column(String(32), nullable=False, default="count_only")
+    metadata_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default="now()")

--- a/backend/services/action_ledger.py
+++ b/backend/services/action_ledger.py
@@ -13,6 +13,7 @@ from typing import Any, Optional
 
 from models.action_ledger import ActionLedgerEntry
 from models.database import get_session
+from services.egress_scanner import record_count_only_egress_event
 
 logger = logging.getLogger(__name__)
 GOOGLE_DRIVE_LOG_MAX_CHARS = 200
@@ -108,6 +109,17 @@ async def record_intent(
         async with get_session(organization_id) as session:
             session.add(entry)
             await session.commit()
+
+        await record_count_only_egress_event(
+            organization_id=organization_id,
+            user_id=user_id,
+            context=ctx,
+            connector=connector,
+            operation=operation,
+            payload=sanitized_data,
+            destination=None,
+            metadata={"dispatch_type": dispatch_type, "source": "action_ledger"},
+        )
 
         return change_id
     except Exception:

--- a/backend/services/egress_scanner.py
+++ b/backend/services/egress_scanner.py
@@ -1,0 +1,72 @@
+"""Count-only outbound telemetry helper used by connectors and auditing services."""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any
+
+from models.database import get_session
+from models.egress_event import EgressEvent
+
+logger = logging.getLogger(__name__)
+
+
+def estimate_bytes_out(payload: dict[str, Any]) -> int:
+    """Best-effort UTF-8 byte estimate for outbound payload logging."""
+    try:
+        return len(json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+    except Exception:
+        logger.warning("[EgressScanner] Failed to JSON-encode payload; falling back to string length", exc_info=True)
+        return len(str(payload).encode("utf-8"))
+
+
+async def record_count_only_egress_event(
+    *,
+    organization_id: str,
+    user_id: str | None,
+    context: dict[str, Any] | None,
+    connector: str,
+    operation: str,
+    payload: dict[str, Any],
+    destination: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Record a count-only egress event in a short insert-only transaction."""
+    bytes_out = estimate_bytes_out(payload)
+    ctx = context or {}
+    conversation_id = ctx.get("conversation_id")
+    workflow_id = ctx.get("workflow_id")
+
+    logger.info(
+        "[EgressScanner] Recording count-only event org=%s connector=%s operation=%s bytes_out=%d destination=%s",
+        organization_id,
+        connector,
+        operation,
+        bytes_out,
+        destination,
+    )
+
+    try:
+        entry = EgressEvent(
+            organization_id=uuid.UUID(organization_id),
+            user_id=uuid.UUID(user_id) if user_id else None,
+            conversation_id=uuid.UUID(conversation_id) if conversation_id else None,
+            workflow_id=uuid.UUID(workflow_id) if workflow_id else None,
+            connector=connector,
+            operation=operation,
+            destination=destination,
+            bytes_out=bytes_out,
+            scan_mode="count_only",
+            metadata_json=json.dumps(metadata, ensure_ascii=False) if metadata else None,
+        )
+        async with get_session(organization_id) as session:
+            session.add(entry)
+            await session.commit()
+    except Exception:
+        logger.warning(
+            "[EgressScanner] Failed to record count-only egress event for %s.%s",
+            connector,
+            operation,
+            exc_info=True,
+        )

--- a/backend/tests/test_egress_scanner.py
+++ b/backend/tests/test_egress_scanner.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+
+from services import egress_scanner
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.added: list[object] = []
+        self.committed: bool = False
+
+    def add(self, obj: object) -> None:
+        self.added.append(obj)
+
+    async def commit(self) -> None:
+        self.committed = True
+
+
+class _FakeSessionCtx:
+    def __init__(self, session: _FakeSession) -> None:
+        self.session = session
+
+    async def __aenter__(self) -> _FakeSession:
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+def test_estimate_bytes_out_counts_utf8_payload() -> None:
+    payload = {"message": "héllo", "count": 3}
+    byte_count = egress_scanner.estimate_bytes_out(payload)
+    assert byte_count > len("héllo")
+    assert isinstance(byte_count, int)
+
+
+def test_record_count_only_egress_event_writes_append_only_row(monkeypatch) -> None:
+    fake_session = _FakeSession()
+
+    def _fake_get_session(_org_id: str) -> _FakeSessionCtx:
+        return _FakeSessionCtx(fake_session)
+
+    monkeypatch.setattr(egress_scanner, "get_session", _fake_get_session)
+
+    asyncio.run(
+        egress_scanner.record_count_only_egress_event(
+            organization_id="11111111-1111-1111-1111-111111111111",
+            user_id="22222222-2222-2222-2222-222222222222",
+            context={"conversation_id": "33333333-3333-3333-3333-333333333333"},
+            connector="code_sandbox",
+            operation="execute_command",
+            payload={"command": "echo hello"},
+            destination="sandbox",
+            metadata={"dispatch_type": "action"},
+        )
+    )
+
+    assert fake_session.committed is True
+    assert len(fake_session.added) == 1
+    row = fake_session.added[0]
+    assert row.connector == "code_sandbox"
+    assert row.operation == "execute_command"
+    assert row.bytes_out > 0
+    assert row.scan_mode == "count_only"

--- a/frontend/src/components/AdminPanel.tsx
+++ b/frontend/src/components/AdminPanel.tsx
@@ -45,6 +45,23 @@ interface TopOrgConversations {
   conversations: TopConversation[];
 }
 
+
+interface UserEgressRow {
+  user_id: string | null;
+  user_email: string | null;
+  user_name: string | null;
+  bytes_out_total: number;
+  event_count: number;
+  last_event_at: string | null;
+}
+
+interface UserEgressResponse {
+  window_days: number;
+  window_start: string;
+  window_end: string;
+  users: UserEgressRow[];
+}
+
 interface TopConversationsResponse {
   organizations: TopOrgConversations[];
 }
@@ -552,6 +569,10 @@ export function AdminPanel(): JSX.Element {
   const [topConversationsError, setTopConversationsError] = useState<string | null>(null);
   const [PlotComponent, setPlotComponent] = useState<typeof import('react-plotly.js').default | null>(null);
   const [chartLoadError, setChartLoadError] = useState<boolean>(false);
+  const [userEgress, setUserEgress] = useState<UserEgressResponse | null>(null);
+  const [userEgressLoading, setUserEgressLoading] = useState<boolean>(true);
+  const [userEgressError, setUserEgressError] = useState<string | null>(null);
+
 
   useEffect(() => {
     import('react-plotly.js')
@@ -775,6 +796,26 @@ export function AdminPanel(): JSX.Element {
     }
   }, [user]);
 
+
+  const fetchUserEgress = useCallback(async (): Promise<void> => {
+    if (!user) return;
+    setUserEgressLoading(true);
+    setUserEgressError(null);
+    try {
+      const { data, error: reqErr } = await apiRequest<UserEgressResponse>('/admin-dashboard/egress-by-user');
+      if (reqErr || !data) {
+        setUserEgressError(reqErr ?? 'Failed to fetch per-user egress');
+        setUserEgress(null);
+        return;
+      }
+      setUserEgress(data);
+    } catch {
+      setUserEgressError('Failed to fetch per-user egress');
+      setUserEgress(null);
+    } finally {
+      setUserEgressLoading(false);
+    }
+  }, [user]);
   useEffect(() => {
     if (activeTab === 'dashboard') {
       void fetchCreditUsage();
@@ -792,10 +833,12 @@ export function AdminPanel(): JSX.Element {
       void fetchRunningJobs();
     } else if (activeTab === 'models') {
       void fetchModels();
+    } else if (activeTab === 'egress') {
+      void fetchUserEgress();
     } else if (activeTab === 'graph-magic') {
       // graph tab fetches on-demand in component
     }
-  }, [activeTab, fetchCreditUsage, fetchTopConversations, fetchWaitlist, fetchUsers, fetchOrganizations, fetchIntegrations, fetchQueryOutcomeRate, fetchRunningJobs, fetchModels]);
+  }, [activeTab, fetchCreditUsage, fetchTopConversations, fetchWaitlist, fetchUsers, fetchOrganizations, fetchIntegrations, fetchQueryOutcomeRate, fetchRunningJobs, fetchModels, fetchUserEgress]);
 
   const handleCancelJob = async (job: AdminRunningJob): Promise<void> => {
     if (!user) return;
@@ -2657,6 +2700,53 @@ export function AdminPanel(): JSX.Element {
               <div className="text-sm text-surface-500 text-center">
                 Showing {filteredIntegrations.length} of {adminIntegrations.length} connectors
                 {sourceSearch && ` matching "${sourceSearch}"`}
+              </div>
+            )}
+          </div>
+        )}
+
+
+        {activeTab === 'egress' && (
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-surface-100">Per-User Egress — Rolling 30 Days</h2>
+              <button
+                onClick={() => { void fetchUserEgress(); }}
+                className="px-3 py-1.5 rounded-lg border border-surface-700 text-xs font-medium text-surface-300 hover:bg-surface-800 transition-colors"
+              >
+                Refresh
+              </button>
+            </div>
+            {userEgressLoading && <div className="text-center py-10 text-surface-400">Loading egress data...</div>}
+            {userEgressError && <div className="text-center py-10 text-red-400">{userEgressError}</div>}
+            {!userEgressLoading && !userEgressError && userEgress && userEgress.users.length === 0 && (
+              <div className="text-center py-10 text-surface-400">No egress events in the past 30 days.</div>
+            )}
+            {!userEgressLoading && !userEgressError && userEgress && userEgress.users.length > 0 && (
+              <div className="overflow-x-auto rounded-xl border border-surface-800">
+                <table className="min-w-full divide-y divide-surface-800">
+                  <thead className="bg-surface-900">
+                    <tr>
+                      <th className="px-4 py-3 text-left text-xs text-surface-400">User</th>
+                      <th className="px-4 py-3 text-right text-xs text-surface-400">Bytes Out (30d)</th>
+                      <th className="px-4 py-3 text-right text-xs text-surface-400">Events</th>
+                      <th className="px-4 py-3 text-right text-xs text-surface-400">Last Event</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-surface-800 bg-surface-950">
+                    {userEgress.users.map((row) => (
+                      <tr key={`${row.user_id ?? 'unknown'}-${row.user_email ?? 'none'}`}>
+                        <td className="px-4 py-3 text-sm text-surface-200">
+                          <div className="font-medium">{row.user_name || 'Unknown user'}</div>
+                          <div className="text-xs text-surface-500">{row.user_email || row.user_id || 'N/A'}</div>
+                        </td>
+                        <td className="px-4 py-3 text-sm text-surface-200 text-right">{row.bytes_out_total.toLocaleString()}</td>
+                        <td className="px-4 py-3 text-sm text-surface-300 text-right">{row.event_count.toLocaleString()}</td>
+                        <td className="px-4 py-3 text-sm text-surface-300 text-right">{row.last_event_at ? formatRelativeTime(row.last_event_at) : '—'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               </div>
             )}
           </div>

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -56,6 +56,7 @@ function adminTabFromPathSegment(segment: string): AdminPanelTab {
   if (s === 'teams') return 'organizations';
   if (s === 'sources' || s === 'connectors') return 'connectors';
   if (s === 'jobs') return 'jobs';
+  if (s === 'egress') return 'egress';
   if (s === 'graph-magic') return 'graph-magic';
   return 'dashboard';
 }
@@ -68,6 +69,7 @@ const ADMIN_TAB_TO_PATH: Record<AdminPanelTab, string> = {
   connectors: '/admin/connectors',
   jobs: '/admin/jobs',
   models: '/admin/models',
+  egress: '/admin/egress',
   'graph-magic': '/admin/graph-magic',
 };
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -405,6 +405,15 @@ const GLOBAL_ADMIN_NAV_ITEMS: ReadonlyArray<{
     ),
   },
   {
+    id: 'egress',
+    label: 'Egress (30d)',
+    icon: (
+      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden>
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7h18M3 12h12m-12 5h18" />
+      </svg>
+    ),
+  },
+  {
     id: 'graph-magic',
     label: "Graph Magic",
     icon: (

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -397,4 +397,5 @@ export type AdminPanelTab =
   | "connectors"
   | "jobs"
   | "models"
+  | "egress"
   | "graph-magic";


### PR DESCRIPTION
### Motivation
- Capture lightweight, count-only outbound telemetry for connector operations to audit and measure bytes leaving the system without storing payloads. 
- Surface per-user outbound bandwidth over a rolling 30-day window in the global admin dashboard for visibility and investigation.

### Description
- Add a new `EgressEvent` model (`backend/models/egress_event.py`) and export it from `models.__init__` and create an Alembic migration `135_egress_events.py` to create the `egress_events` table and indexes. 
- Implement an `egress_scanner` service (`backend/services/egress_scanner.py`) providing `estimate_bytes_out` and `record_count_only_egress_event` to estimate UTF-8 payload size and append a count-only row. 
- Call `record_count_only_egress_event` from the action ledger in `services/action_ledger.py` when recording intent so connector operations are logged for accounting. 
- Add an admin API endpoint `GET /api/admin-dashboard/egress-by-user` in `backend/api/routes/admin_dashboard.py` that returns per-user aggregated `bytes_out`, `event_count`, and `last_event_at` over the last 30 days. 
- Add frontend support: new `Egress` admin tab and sidebar item, types in `store/types.ts`, UI components and fetch logic in `frontend/src/components/AdminPanel.tsx` and route mapping in `frontend/src/components/AppLayout.tsx` to display per-user rows and totals. 
- Add unit tests `backend/tests/test_egress_scanner.py` that validate UTF-8 byte estimation and that `record_count_only_egress_event` inserts an append-only row via a mocked session.

### Testing
- Ran the new unit tests in `backend/tests/test_egress_scanner.py` which exercise `estimate_bytes_out` and `record_count_only_egress_event`, and they passed. 
- No other automated test failures were observed in the touched backend units during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14975f5d8c8321980946001591799c)