### PR TITLE
Bootstrap JWT auth for /auth/users/sync to allow first-time Supabase users

### DIFF
--- a/backend/api/auth_middleware.py
+++ b/backend/api/auth_middleware.py
@@ -94,6 +94,25 @@ def _cache_set_org_membership(user_id: UUID, org_id: UUID, is_member: bool) -> N
 
 
 @dataclass
+class VerifiedTokenContext:
+    """Verified JWT claims that do not require a local users row.
+
+    Used by bootstrap endpoints such as /auth/users/sync, where a brand-new
+    Supabase user may have a valid JWT before our application has created the
+    corresponding users row.
+    """
+
+    user_id: UUID
+    email: str
+    payload: dict
+
+    @property
+    def user_id_str(self) -> str:
+        """String representation of the JWT subject."""
+        return str(self.user_id)
+
+
+@dataclass
 class AuthContext:
     """
     Verified authentication context.
@@ -537,6 +556,43 @@ async def _resolve_default_org_for_masquerade_user(user: User) -> Optional[UUID]
             .limit(1)
         )
         return first_org_row.scalar_one_or_none()
+
+
+async def get_verified_token_auth(
+    authorization: Optional[str] = Header(None, alias="Authorization"),
+) -> VerifiedTokenContext:
+    """Verify the bearer JWT and return claims without requiring a DB user.
+
+    Most protected routes should use get_current_auth so the JWT subject is
+    tied to an application user and organization membership. This dependency is
+    intentionally narrower for auth bootstrap endpoints that must create the
+    application user row after Supabase has already issued the first JWT.
+    """
+    token = _extract_token(authorization)
+    payload = await _verify_jwt(token)
+
+    sub = payload.get("sub")
+    if not sub:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token: missing subject",
+        )
+    try:
+        user_uuid = UUID(sub)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token: malformed subject",
+        )
+
+    email = (payload.get("email") or "").strip()
+    if not email:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token: missing email",
+        )
+
+    return VerifiedTokenContext(user_id=user_uuid, email=email, payload=payload)
 
 
 async def get_current_auth(

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -27,7 +27,13 @@ import uuid as uuid_stdlib
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
 
-from api.auth_middleware import AuthContext, get_current_auth, require_global_admin
+from api.auth_middleware import (
+    AuthContext,
+    VerifiedTokenContext,
+    get_current_auth,
+    get_verified_token_auth,
+    require_global_admin,
+)
 from pydantic import BaseModel, Field
 from sqlalchemy import and_, bindparam, func, or_, select, text
 from sqlalchemy.exc import IntegrityError
@@ -816,12 +822,14 @@ class SyncUserResponse(BaseModel):
 @router.post("/users/sync", response_model=SyncUserResponse)
 async def sync_user(
     request: SyncUserRequest,
-    auth: AuthContext = Depends(get_current_auth),
+    auth: VerifiedTokenContext = Depends(get_verified_token_auth),
 ) -> SyncUserResponse:
     """Sync a user from Supabase auth to our database.
     
     Called when a user authenticates via Supabase OAuth.
-    Creates the user in our database if they don't exist.
+    Creates the user in our database if they don't exist. This endpoint uses
+    JWT-only auth because first-time users have a valid Supabase JWT before
+    their local users row exists.
     """
     try:
         user_uuid = UUID(request.id)
@@ -835,16 +843,16 @@ async def sync_user(
     request_email: str = request.email.strip().lower()
     auth_email: str = (auth.email or "").strip().lower()
     if not auth_email or request_email != auth_email:
-        raise HTTPException(status_code=403, detail="Email does not match authenticated user")
+        raise HTTPException(
+            status_code=403, detail="Email does not match authenticated user"
+        )
 
-    # NOTE: Do NOT 403 on `auth.user_id != user_uuid` here. `request.id` is
-    # the Supabase auth `sub`, while `auth.user_id` is the DB primary key
-    # — and `_get_user_from_token` falls back to email-lookup when the DB
-    # has no user with that PK (the case for invited / waitlist users
-    # whose row was created with an auto-generated UUID before they
-    # signed in via OAuth). This very endpoint then migrates `users.id`
-    # to the Supabase `sub` further below; a 403 here would create a
-    # deadlock that prevents invited users from completing onboarding.
+    # NOTE: Do NOT 403 on `auth.user_id != user_uuid` here. Real requests
+    # should match because both values are the Supabase JWT subject, but
+    # preserving email-based validation keeps the invited/waitlist migration
+    # path safe if this function is reused with a DB-backed auth context.
+    # The endpoint will migrate any legacy users.id value to the Supabase
+    # `sub` further below.
     if auth.user_id != user_uuid:
         logger.info(
             "User ID mismatch on /users/sync — proceeding with migration: "
@@ -1083,6 +1091,11 @@ async def sync_user(
 
         # Create a new active user with no org. Organization assignment is now
         # invite/membership-driven and no longer inferred from email domain.
+        logger.info(
+            "Creating first-time app user from verified Supabase JWT: user_id=%s email=%s",
+            user_uuid,
+            request_email,
+        )
         new_user = User(
             id=user_uuid,
             email=request.email,
@@ -1145,8 +1158,15 @@ async def sync_user(
                     whatsapp_consent=existing.whatsapp_consent,
                     phone_number_verified=existing.phone_number_verified_at is not None,
                 )
-            raise HTTPException(status_code=500, detail="User creation conflict; please retry")
+            raise HTTPException(
+                status_code=500, detail="User creation conflict; please retry"
+            )
         await session.refresh(new_user)
+        logger.info(
+            "Created first-time app user from Supabase JWT: user_id=%s email=%s",
+            new_user.id,
+            new_user.email,
+        )
 
         return SyncUserResponse(
             id=str(new_user.id),

--- a/backend/tests/test_auth_middleware_jwks.py
+++ b/backend/tests/test_auth_middleware_jwks.py
@@ -105,3 +105,25 @@ async def test_get_jwks_suppresses_incident_when_throttled(monkeypatch: pytest.M
         await am._get_jwks()
 
     assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_get_verified_token_auth_does_not_require_database_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_verify_jwt(_token: str) -> dict:
+        return {
+            "sub": "66401176-354f-48ec-8115-d2922e44cf49",
+            "email": "new.user@example.com",
+        }
+
+    async def _fail_user_lookup(_payload: dict):
+        raise AssertionError("JWT-only bootstrap auth must not query users")
+
+    monkeypatch.setattr(am, "_verify_jwt", _fake_verify_jwt)
+    monkeypatch.setattr(am, "_get_user_from_token", _fail_user_lookup)
+
+    ctx = await am.get_verified_token_auth("Bearer fake-token")
+
+    assert ctx.user_id_str == "66401176-354f-48ec-8115-d2922e44cf49"
+    assert ctx.email == "new.user@example.com"

--- a/backend/tests/test_users_sync_id_migration.py
+++ b/backend/tests/test_users_sync_id_migration.py
@@ -156,8 +156,21 @@ def test_sync_user_rejects_invalid_user_id(
     with pytest.raises(HTTPException) as exc_info:
         asyncio.run(
             auth.sync_user(
-                request=auth.SyncUserRequest(id="not-a-uuid", email="jim@example.com"),
+                request=auth.SyncUserRequest(
+                    id="not-a-uuid", email="jim@example.com"
+                ),
                 auth=_auth_ctx(_DB_ID, "jim@example.com"),
             )
         )
     assert exc_info.value.status_code == 400
+
+
+def test_sync_user_route_uses_jwt_only_bootstrap_auth() -> None:
+    """Brand-new Supabase users must reach sync before a DB user row exists."""
+    route = next(
+        r for r in auth.router.routes if getattr(r, "path", None) == "/users/sync"
+    )
+    dependency_calls = {dep.call for dep in route.dependant.dependencies}
+
+    assert auth.get_verified_token_auth in dependency_calls
+    assert auth.get_current_auth not in dependency_calls


### PR DESCRIPTION
### Motivation
- First-time Supabase users can present a valid JWT before our app has created a local `users` row, causing `get_current_auth` to fail with "User not found" and breaking the NUX onboarding flow.  
- The change makes it possible for the `/auth/users/sync` bootstrap endpoint to validate the JWT without requiring a preexisting DB user so the endpoint can create or migrate the app user record during signup/onboarding.

### Description
- Add a JWT-only auth context `VerifiedTokenContext` and dependency `get_verified_token_auth` in `backend/api/auth_middleware.py` that verifies the bearer JWT and returns `sub`/`email` without doing a DB user lookup.  
- Switch the `/auth/users/sync` route in `backend/api/routes/auth.py` to depend on `get_verified_token_auth` instead of the DB-backed `get_current_auth`, preserving strict email validation before creating or migrating users.  
- Add informative logging around first-time user creation in `sync_user` so bootstrapping failures are easier to trace.  
- Add regression tests ensuring the sync route uses the JWT-only bootstrap auth and that `get_verified_token_auth` does not attempt a DB user lookup (`backend/tests/test_users_sync_id_migration.py` and `backend/tests/test_auth_middleware_jwks.py`).

### Testing
- Ran the focused tests: `python -m pytest backend/tests/test_users_sync_id_migration.py backend/tests/test_auth_middleware_jwks.py -q`, which passed.  
- Ran the full backend test suite: `python -m pytest backend/tests -q`, which completed successfully (877 passed, 1 skipped).  
- Verified the new tests assert the `/auth/users/sync` route uses `get_verified_token_auth` and that JWT-only verification does not query the DB, and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22382718108321994f5603921a1ba1)