### PR TITLE
Fix invalid User constructor kwargs in auth flows

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1101,7 +1101,6 @@ async def sync_user(
             email=request.email,
             name=request.name,
             avatar_url=request.avatar_url,
-            organization_id=None,
             status="active",
             role="member",
             last_login=datetime.utcnow(),
@@ -5146,7 +5145,6 @@ async def register_user(request: CreateUserRequest) -> CreateUserResponse:
         user = User(
             email=request.email,
             name=request.name,
-            organization_id=None,
             role="member",
         )
         session.add(user)

--- a/backend/tests/test_users_sync_id_migration.py
+++ b/backend/tests/test_users_sync_id_migration.py
@@ -174,3 +174,20 @@ def test_sync_user_route_uses_jwt_only_bootstrap_auth() -> None:
 
     assert auth.get_verified_token_auth in dependency_calls
     assert auth.get_current_auth not in dependency_calls
+
+
+def test_sync_user_first_time_constructor_uses_user_model_columns() -> None:
+    """The brand-new-user path must not pass nonexistent columns to User()."""
+    user = auth.User(
+        id=_SUPABASE_SUB,
+        email="jim@example.com",
+        name="Jim Example",
+        avatar_url="https://example.com/avatar.png",
+        status="active",
+        role="member",
+    )
+
+    assert user.id == _SUPABASE_SUB
+    assert user.email == "jim@example.com"
+    assert user.avatar_url == "https://example.com/avatar.png"
+    assert not hasattr(auth.User, "organization_id")


### PR DESCRIPTION
### Motivation
- Resolve a runtime error where auth routes constructed `User(...)` with a nonexistent `organization_id` keyword, causing invalid-constructor failures when creating new users.
- Ensure the first-time Supabase sync and legacy register flows create users using only fields defined on the `User` model to avoid future regressions.

### Description
- Removed `organization_id=None` from the first-time sync `User(...)` construction in `backend/api/routes/auth.py` so the `new_user` instantiation matches `backend/models/user.py`.
- Removed `organization_id=None` from the register/create-user `User(...)` construction in `backend/api/routes/auth.py` for the same alignment.
- Added a regression test `test_sync_user_first_time_constructor_uses_user_model_columns` in `backend/tests/test_users_sync_id_migration.py` that constructs the first-time sync user using only valid `User` model columns to prevent reintroduction of the invalid kwarg.

### Testing
- Ran `pytest backend/tests/test_users_sync_id_migration.py -q` and the suite passed (`7 passed`).
- Executed an AST-based preflight script that verifies all direct `User(...)` keyword arguments across the codebase match the `User` model columns, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22619519b883218505e9abd14cdaee)